### PR TITLE
fix: wire data query mapper and error handling

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataQueryController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataQueryController.java
@@ -1,0 +1,35 @@
+package com.onedata.portal.controller;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.onedata.portal.dto.Result;
+import com.onedata.portal.dto.SqlQueryRequest;
+import com.onedata.portal.dto.SqlQueryResponse;
+import com.onedata.portal.entity.DataQueryHistory;
+import com.onedata.portal.service.DataQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 数据查询 Controller
+ */
+@RestController
+@RequestMapping("/v1/data-query")
+@RequiredArgsConstructor
+public class DataQueryController {
+
+    private final DataQueryService dataQueryService;
+
+    @PostMapping("/execute")
+    public Result<SqlQueryResponse> execute(@Validated @RequestBody SqlQueryRequest request) {
+        return Result.success(dataQueryService.executeQuery(request));
+    }
+
+    @GetMapping("/history")
+    public Result<Page<DataQueryHistory>> history(@RequestParam(value = "pageNum", required = false) Integer pageNum,
+                                                  @RequestParam(value = "pageSize", required = false) Integer pageSize,
+                                                  @RequestParam(value = "clusterId", required = false) Long clusterId,
+                                                  @RequestParam(value = "database", required = false) String database) {
+        return Result.success(dataQueryService.listHistory(pageNum, pageSize, clusterId, database));
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/dto/QueryPreview.java
+++ b/backend/src/main/java/com/onedata/portal/dto/QueryPreview.java
@@ -1,0 +1,19 @@
+package com.onedata.portal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 查询结果预览
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueryPreview {
+    private List<String> columns;
+    private List<Map<String, Object>> rows;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/SqlQueryRequest.java
+++ b/backend/src/main/java/com/onedata/portal/dto/SqlQueryRequest.java
@@ -1,0 +1,33 @@
+package com.onedata.portal.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * SQL 查询请求
+ */
+@Data
+public class SqlQueryRequest {
+
+    /**
+     * Doris 集群ID，可为空表示使用默认集群
+     */
+    private Long clusterId;
+
+    /**
+     * 目标数据库，可为空表示使用默认 database
+     */
+    private String database;
+
+    /**
+     * 查询 SQL，仅允许只读语句
+     */
+    @NotBlank(message = "SQL 不能为空")
+    private String sql;
+
+    /**
+     * 返回数据的最大行数
+     */
+    private Integer limit;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/SqlQueryResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/SqlQueryResponse.java
@@ -1,0 +1,49 @@
+package com.onedata.portal.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * SQL 查询响应
+ */
+@Data
+public class SqlQueryResponse {
+
+    /**
+     * 列名
+     */
+    private List<String> columns;
+
+    /**
+     * 数据行（预览数据）
+     */
+    private List<Map<String, Object>> rows;
+
+    /**
+     * 返回的行数
+     */
+    private Integer previewRowCount;
+
+    /**
+     * 是否还有更多数据未返回
+     */
+    private boolean hasMore;
+
+    /**
+     * 查询耗时（毫秒）
+     */
+    private Long durationMs;
+
+    /**
+     * 历史记录ID
+     */
+    private Long historyId;
+
+    /**
+     * 执行时间
+     */
+    private LocalDateTime executedAt;
+}

--- a/backend/src/main/java/com/onedata/portal/entity/DataQueryHistory.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DataQueryHistory.java
@@ -1,0 +1,41 @@
+package com.onedata.portal.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * SQL 查询历史记录
+ */
+@Data
+@TableName("data_query_history")
+public class DataQueryHistory {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private Long clusterId;
+
+    private String clusterName;
+
+    private String databaseName;
+
+    @TableField("sql_text")
+    private String sqlText;
+
+    private Integer previewRowCount;
+
+    private Long durationMs;
+
+    private Integer hasMore;
+
+    private String resultPreview;
+
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime executedAt;
+}

--- a/backend/src/main/java/com/onedata/portal/mapper/DataQueryHistoryMapper.java
+++ b/backend/src/main/java/com/onedata/portal/mapper/DataQueryHistoryMapper.java
@@ -1,0 +1,12 @@
+package com.onedata.portal.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.onedata.portal.entity.DataQueryHistory;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * SQL 查询历史 Mapper
+ */
+@Mapper
+public interface DataQueryHistoryMapper extends BaseMapper<DataQueryHistory> {
+}

--- a/backend/src/main/java/com/onedata/portal/service/DataQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataQueryService.java
@@ -1,0 +1,198 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.QueryPreview;
+import com.onedata.portal.dto.SqlQueryRequest;
+import com.onedata.portal.dto.SqlQueryResponse;
+import com.onedata.portal.entity.DataQueryHistory;
+import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.mapper.DataQueryHistoryMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * SQL 查询服务
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataQueryService {
+
+    private static final Pattern DANGEROUS_KEYWORDS = Pattern.compile("\\b(delete|drop|alter)\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ALLOWED_START = Pattern.compile("^(select|with|show|describe|explain)\\b", Pattern.CASE_INSENSITIVE);
+    private static final int MAX_LIMIT = 1000;
+    private static final int DEFAULT_LIMIT = 200;
+    private static final int PREVIEW_LIMIT = 100;
+
+    private final DorisConnectionService dorisConnectionService;
+    private final DorisClusterService dorisClusterService;
+    private final DataQueryHistoryMapper historyMapper;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 执行查询
+     */
+    public SqlQueryResponse executeQuery(SqlQueryRequest request) {
+        validateSql(request.getSql());
+        int limit = resolveLimit(request.getLimit());
+
+        long start = System.currentTimeMillis();
+        List<String> columns = new ArrayList<>();
+        List<Map<String, Object>> rows = new ArrayList<>();
+        boolean hasMore = false;
+
+        try (Connection connection = dorisConnectionService.getConnection(request.getClusterId(), request.getDatabase());
+             Statement statement = connection.createStatement()) {
+
+            statement.setMaxRows(limit + 1);
+            String sql = request.getSql().trim();
+            log.info("Executing SQL query: {}", abbreviate(sql));
+
+            try (ResultSet resultSet = statement.executeQuery(sql)) {
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnCount = metaData.getColumnCount();
+                for (int i = 1; i <= columnCount; i++) {
+                    columns.add(metaData.getColumnLabel(i));
+                }
+
+                int rowIndex = 0;
+                while (resultSet.next()) {
+                    if (rowIndex >= limit) {
+                        hasMore = true;
+                        break;
+                    }
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    for (int i = 1; i <= columnCount; i++) {
+                        row.put(columns.get(i - 1), resultSet.getObject(i));
+                    }
+                    rows.add(row);
+                    rowIndex++;
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Execute SQL query failed", e);
+            throw new RuntimeException("执行 SQL 失败: " + e.getMessage(), e);
+        }
+
+        long duration = System.currentTimeMillis() - start;
+
+        DataQueryHistory history = saveHistory(request, columns, rows, hasMore, duration);
+
+        SqlQueryResponse response = new SqlQueryResponse();
+        response.setColumns(columns);
+        response.setRows(rows);
+        response.setPreviewRowCount(rows.size());
+        response.setHasMore(hasMore);
+        response.setDurationMs(duration);
+        response.setHistoryId(history.getId());
+        response.setExecutedAt(history.getExecutedAt());
+        return response;
+    }
+
+    /**
+     * 查询历史记录
+     */
+    public Page<DataQueryHistory> listHistory(Integer pageNum, Integer pageSize, Long clusterId, String database) {
+        Page<DataQueryHistory> page = new Page<>(pageNum == null ? 1 : pageNum, pageSize == null ? 10 : pageSize);
+        LambdaQueryWrapper<DataQueryHistory> wrapper = new LambdaQueryWrapper<DataQueryHistory>()
+            .orderByDesc(DataQueryHistory::getExecutedAt);
+        if (clusterId != null) {
+            wrapper.eq(DataQueryHistory::getClusterId, clusterId);
+        }
+        if (StringUtils.hasText(database)) {
+            wrapper.eq(DataQueryHistory::getDatabaseName, database);
+        }
+        return historyMapper.selectPage(page, wrapper);
+    }
+
+    private void validateSql(String sql) {
+        if (!StringUtils.hasText(sql)) {
+            throw new RuntimeException("SQL 不能为空");
+        }
+        String trimmed = sql.trim();
+        String lowered = trimmed.toLowerCase(Locale.ROOT);
+        if (lowered.chars().filter(ch -> ch == ';').count() > 1) {
+            throw new RuntimeException("仅支持单条 SQL 执行");
+        }
+        if (DANGEROUS_KEYWORDS.matcher(lowered).find()) {
+            throw new RuntimeException("检测到危险 SQL 关键字，请检查后再执行");
+        }
+        if (!ALLOWED_START.matcher(lowered).find()) {
+            throw new RuntimeException("仅支持 SELECT/SHOW/DESCRIBE/EXPLAIN 等只读 SQL");
+        }
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, MAX_LIMIT);
+    }
+
+    private DataQueryHistory saveHistory(SqlQueryRequest request, List<String> columns, List<Map<String, Object>> rows, boolean hasMore, long duration) {
+        DataQueryHistory history = new DataQueryHistory();
+        history.setClusterId(request.getClusterId());
+        history.setClusterName(resolveClusterName(request.getClusterId()));
+        history.setDatabaseName(request.getDatabase());
+        history.setSqlText(request.getSql().trim());
+        history.setPreviewRowCount(rows.size());
+        history.setDurationMs(duration);
+        history.setHasMore(hasMore ? 1 : 0);
+        history.setResultPreview(buildPreviewJson(columns, rows));
+        history.setExecutedAt(LocalDateTime.now());
+        historyMapper.insert(history);
+        return history;
+    }
+
+    private String resolveClusterName(Long clusterId) {
+        if (clusterId == null) {
+            return "默认集群";
+        }
+        DorisCluster cluster = dorisClusterService.getById(clusterId);
+        return cluster != null ? cluster.getClusterName() : "集群#" + clusterId;
+    }
+
+    private String buildPreviewJson(List<String> columns, List<Map<String, Object>> rows) {
+        List<Map<String, Object>> previewRows = new ArrayList<>();
+        int index = 0;
+        for (Map<String, Object> row : rows) {
+            if (index >= PREVIEW_LIMIT) {
+                break;
+            }
+            previewRows.add(new LinkedHashMap<>(row));
+            index++;
+        }
+        try {
+            return objectMapper.writeValueAsString(new QueryPreview(columns, previewRows));
+        } catch (JsonProcessingException e) {
+            log.warn("Serialize query preview failed", e);
+            return null;
+        }
+    }
+
+    private String abbreviate(String sql) {
+        if (!StringUtils.hasText(sql)) {
+            return "";
+        }
+        String compressed = sql.replaceAll("\\s+", " ").trim();
+        return compressed.length() > 200 ? compressed.substring(0, 200) + "..." : compressed;
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/DorisConnectionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DorisConnectionService.java
@@ -63,6 +63,14 @@ public class DorisConnectionService {
         return getConnection(cluster, null);
     }
 
+    /**
+     * 获取连接并指定数据库
+     */
+    public Connection getConnection(Long clusterId, String database) throws SQLException {
+        DorisCluster cluster = resolveCluster(clusterId);
+        return getConnection(cluster, database);
+    }
+
     private Connection getConnection(DorisCluster cluster, String database) throws SQLException {
         String targetDb = StringUtils.hasText(database) ? database : DEFAULT_DB;
         String url = String.format(JDBC_TEMPLATE, cluster.getFeHost(), cluster.getFePort(), targetDb);

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -115,6 +115,23 @@ CREATE TABLE IF NOT EXISTS `task_execution_log` (
     KEY `idx_start_time` (`start_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='任务执行日志';
 
+-- SQL 查询历史表
+CREATE TABLE IF NOT EXISTS `data_query_history` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+    `cluster_id` BIGINT DEFAULT NULL COMMENT 'Doris 集群ID',
+    `cluster_name` VARCHAR(100) DEFAULT NULL COMMENT '集群名称',
+    `database_name` VARCHAR(100) DEFAULT NULL COMMENT '数据库名称',
+    `sql_text` TEXT NOT NULL COMMENT '执行 SQL',
+    `preview_row_count` INT DEFAULT 0 COMMENT '返回的预览行数',
+    `duration_ms` BIGINT DEFAULT 0 COMMENT '执行耗时（毫秒）',
+    `has_more` TINYINT DEFAULT 0 COMMENT '是否存在更多数据',
+    `result_preview` MEDIUMTEXT DEFAULT NULL COMMENT '结果预览(JSON)',
+    `executed_at` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '执行时间',
+    PRIMARY KEY (`id`),
+    KEY `idx_cluster_id` (`cluster_id`),
+    KEY `idx_executed_at` (`executed_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='SQL 查询历史记录';
+
 -- 插入测试数据
 -- ODS层示例表
 INSERT INTO `data_table` (`table_name`, `table_comment`, `layer`, `db_name`, `owner`, `status`)

--- a/frontend/src/api/query.js
+++ b/frontend/src/api/query.js
@@ -1,0 +1,11 @@
+import request from '@/utils/request'
+
+export const dataQueryApi = {
+  execute(data) {
+    return request.post('/v1/data-query/execute', data)
+  },
+
+  history(params) {
+    return request.get('/v1/data-query/history', { params })
+  }
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -31,6 +31,12 @@ const routes = [
         meta: { title: '表详情' }
       },
       {
+        path: '/query',
+        name: 'DataQuery',
+        component: () => import('@/views/query/DataQuery.vue'),
+        meta: { title: '数据查询' }
+      },
+      {
         path: '/domains',
         name: 'Domains',
         component: () => import('@/views/domains/DomainManagement.vue'),

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -15,6 +15,10 @@
             <el-icon><Grid /></el-icon>
             <span>表管理</span>
           </el-menu-item>
+          <el-menu-item index="/query">
+            <el-icon><Search /></el-icon>
+            <span>数据查询</span>
+          </el-menu-item>
           <el-menu-item index="/domains">
             <el-icon><Collection /></el-icon>
             <span>域管理</span>
@@ -48,13 +52,16 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { Grid, Management, Connection, Monitor, Collection, Warning } from '@element-plus/icons-vue'
+import { Grid, Management, Connection, Monitor, Collection, Warning, Search } from '@element-plus/icons-vue'
 
 const route = useRoute()
 const activeMenu = computed(() => {
   const path = route.path
   if (path.startsWith('/tables')) {
     return '/tables'
+  }
+  if (path.startsWith('/query')) {
+    return '/query'
   }
   if (path.startsWith('/domains')) {
     return '/domains'

--- a/frontend/src/views/query/DataQuery.vue
+++ b/frontend/src/views/query/DataQuery.vue
@@ -1,0 +1,505 @@
+<template>
+  <div class="data-query-page">
+    <el-card class="query-card" shadow="never">
+      <template #header>
+        <div class="card-header">
+          <span>数据查询</span>
+          <el-tag type="info" effect="plain">仅支持只读 SQL，自动拦截 DELETE/DROP/ALTER</el-tag>
+        </div>
+      </template>
+      <el-form label-width="100px" class="query-form">
+        <el-row :gutter="16">
+          <el-col :span="8" :xs="24">
+            <el-form-item label="Doris 集群">
+              <el-select v-model="queryForm.clusterId" placeholder="使用默认集群" clearable filterable>
+                <el-option
+                  v-for="cluster in clusterOptions"
+                  :key="cluster.id"
+                  :label="cluster.clusterName"
+                  :value="cluster.id"
+                />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="8" :xs="24">
+            <el-form-item label="数据库">
+              <el-input v-model="queryForm.database" placeholder="如: doris_ods" clearable />
+            </el-form-item>
+          </el-col>
+          <el-col :span="8" :xs="24">
+            <el-form-item label="返回行数">
+              <el-input-number v-model="queryForm.limit" :min="10" :max="1000" :step="10" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+        <el-form-item label="SQL 语句" class="sql-item">
+          <el-input
+            v-model="queryForm.sql"
+            type="textarea"
+            :rows="8"
+            placeholder="请输入 SELECT/SHOW/EXPLAIN 等只读 SQL"
+            resize="vertical"
+            class="sql-editor"
+          />
+        </el-form-item>
+        <div class="query-actions">
+          <el-button type="primary" :loading="queryLoading" @click="executeQuery">执行查询</el-button>
+          <el-button :disabled="!queryResult.rows.length" @click="exportResult">导出结果</el-button>
+          <el-button @click="resetForm">清空</el-button>
+        </div>
+      </el-form>
+    </el-card>
+
+    <el-card class="result-card" shadow="never">
+      <template #header>
+        <div class="card-header">
+          <span>查询结果</span>
+          <span class="result-meta" v-if="queryResult.executedAt">
+            <el-tag type="success" effect="plain">耗时 {{ formatDuration(queryResult.durationMs) }}</el-tag>
+            <el-tag type="info" effect="plain">执行于 {{ formatDate(queryResult.executedAt) }}</el-tag>
+            <el-tag v-if="queryResult.hasMore" type="warning" effect="plain">结果已截断，建议增加过滤条件</el-tag>
+          </span>
+        </div>
+      </template>
+      <el-empty v-if="!queryResult.rows.length" description="暂无查询结果" />
+      <div v-else>
+        <el-tabs v-model="activeResultTab">
+          <el-tab-pane label="表格" name="table">
+            <el-table :data="queryResult.rows" border height="400px">
+              <el-table-column
+                v-for="column in queryResult.columns"
+                :key="column"
+                :prop="column"
+                :label="column"
+                show-overflow-tooltip
+              />
+            </el-table>
+          </el-tab-pane>
+          <el-tab-pane label="图表" name="chart">
+            <div v-if="chartMessage" class="chart-message">{{ chartMessage }}</div>
+            <div v-else ref="chartRef" class="chart-container"></div>
+          </el-tab-pane>
+        </el-tabs>
+      </div>
+    </el-card>
+
+    <el-card class="history-card" shadow="never">
+      <template #header>
+        <div class="card-header">
+          <span>查询历史</span>
+        </div>
+      </template>
+      <el-table :data="historyData" v-loading="historyLoading" border>
+        <el-table-column type="expand">
+          <template #default="{ row }">
+            <div class="preview-wrapper" v-if="getHistoryPreview(row)">
+              <el-table :data="getHistoryPreview(row).rows" size="small" border>
+                <el-table-column
+                  v-for="column in getHistoryPreview(row).columns"
+                  :key="column"
+                  :prop="column"
+                  :label="column"
+                  show-overflow-tooltip
+                />
+              </el-table>
+            </div>
+            <div v-else class="preview-empty">暂无预览数据</div>
+          </template>
+        </el-table-column>
+        <el-table-column prop="sqlText" label="SQL" min-width="260">
+          <template #default="{ row }">
+            <code class="sql-text">{{ row.sqlText }}</code>
+          </template>
+        </el-table-column>
+        <el-table-column prop="clusterName" label="集群" width="140" />
+        <el-table-column prop="databaseName" label="数据库" width="140" />
+        <el-table-column prop="previewRowCount" label="返回行数" width="120" />
+        <el-table-column prop="durationMs" label="耗时" width="120">
+          <template #default="{ row }">
+            {{ formatDuration(row.durationMs) }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="executedAt" label="执行时间" width="180">
+          <template #default="{ row }">
+            {{ formatDate(row.executedAt) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="120">
+          <template #default="{ row }">
+            <el-button type="primary" link @click="useHistory(row)">复用查询</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+      <div class="history-pagination">
+        <el-pagination
+          background
+          layout="total, prev, pager, next"
+          :total="historyPager.total"
+          :page-size="historyPager.pageSize"
+          :current-page="historyPager.pageNum"
+          @current-change="handleHistoryPageChange"
+        />
+      </div>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { ElMessage } from 'element-plus'
+import * as echarts from 'echarts'
+import { dorisClusterApi } from '@/api/doris'
+import { dataQueryApi } from '@/api/query'
+
+const queryForm = reactive({
+  clusterId: null,
+  database: '',
+  limit: 200,
+  sql: ''
+})
+
+const clusterOptions = ref([])
+const queryLoading = ref(false)
+const queryResult = ref({
+  columns: [],
+  rows: [],
+  previewRowCount: 0,
+  hasMore: false,
+  durationMs: 0,
+  executedAt: ''
+})
+const activeResultTab = ref('table')
+const chartRef = ref(null)
+let chartInstance = null
+const chartMessage = ref('')
+
+const historyData = ref([])
+const historyLoading = ref(false)
+const historyPager = reactive({
+  pageNum: 1,
+  pageSize: 10,
+  total: 0
+})
+const previewCache = new Map()
+
+onMounted(() => {
+  loadClusters()
+  fetchHistory()
+  window.addEventListener('resize', resizeChart)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', resizeChart)
+  if (chartInstance) {
+    chartInstance.dispose()
+    chartInstance = null
+  }
+})
+
+watch(
+  () => queryResult.value.rows,
+  () => {
+    if (activeResultTab.value === 'chart') {
+      renderChart()
+    }
+  },
+  { deep: true }
+)
+
+watch(activeResultTab, (val) => {
+  if (val === 'chart') {
+    renderChart()
+  }
+})
+
+async function loadClusters() {
+  try {
+    clusterOptions.value = await dorisClusterApi.list()
+  } catch (err) {
+    console.error('load clusters failed', err)
+  }
+}
+
+async function executeQuery() {
+  if (!queryForm.sql || !queryForm.sql.trim()) {
+    ElMessage.warning('请输入要执行的 SQL')
+    return
+  }
+  queryLoading.value = true
+  try {
+    const payload = {
+      clusterId: queryForm.clusterId,
+      database: queryForm.database || undefined,
+      limit: queryForm.limit,
+      sql: queryForm.sql
+    }
+    const data = await dataQueryApi.execute(payload)
+    queryResult.value = {
+      columns: data.columns || [],
+      rows: data.rows || [],
+      previewRowCount: data.previewRowCount || 0,
+      hasMore: data.hasMore || false,
+      durationMs: data.durationMs || 0,
+      executedAt: data.executedAt
+    }
+    activeResultTab.value = 'table'
+    chartMessage.value = ''
+    historyPager.pageNum = 1
+    fetchHistory()
+  } catch (err) {
+    console.error('execute query failed', err)
+    const message = err?.response?.data?.message || err?.message || '执行查询失败'
+    ElMessage.error(message)
+  } finally {
+    queryLoading.value = false
+  }
+}
+
+function resetForm() {
+  queryForm.sql = ''
+  queryForm.database = ''
+  queryForm.limit = 200
+}
+
+function exportResult() {
+  if (!queryResult.value.rows.length) {
+    ElMessage.warning('暂无数据可以导出')
+    return
+  }
+  const columns = queryResult.value.columns
+  const csvRows = [columns.join(',')]
+  queryResult.value.rows.forEach((row) => {
+    const values = columns.map((column) => formatCsvValue(row[column]))
+    csvRows.push(values.join(','))
+  })
+  const blob = new Blob([csvRows.join('\n')], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `query-result-${Date.now()}.csv`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function formatCsvValue(value) {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  const stringValue = String(value)
+  if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return '"' + stringValue.replace(/"/g, '""') + '"'
+  }
+  return stringValue
+}
+
+async function fetchHistory() {
+  historyLoading.value = true
+  try {
+    const data = await dataQueryApi.history({
+      pageNum: historyPager.pageNum,
+      pageSize: historyPager.pageSize
+    })
+    previewCache.clear()
+    historyData.value = data.records || []
+    historyPager.total = data.total || 0
+  } catch (err) {
+    console.error('load history failed', err)
+    ElMessage.error(err?.response?.data?.message || err?.message || '加载历史记录失败')
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+function handleHistoryPageChange(page) {
+  historyPager.pageNum = page
+  fetchHistory()
+}
+
+function getHistoryPreview(row) {
+  if (!row || !row.resultPreview) {
+    return null
+  }
+  if (previewCache.has(row.id)) {
+    return previewCache.get(row.id)
+  }
+  try {
+    const parsed = JSON.parse(row.resultPreview)
+    if (parsed && Array.isArray(parsed.columns) && Array.isArray(parsed.rows)) {
+      previewCache.set(row.id, parsed)
+      return parsed
+    }
+  } catch (err) {
+    console.warn('parse preview failed', err)
+  }
+  previewCache.set(row.id, null)
+  return null
+}
+
+function useHistory(row) {
+  if (!row) {
+    return
+  }
+  queryForm.sql = row.sqlText
+  queryForm.database = row.databaseName || ''
+  queryForm.clusterId = row.clusterId || null
+  executeQuery()
+}
+
+function renderChart() {
+  nextTick(() => {
+    if (!chartRef.value) {
+      return
+    }
+    const rows = queryResult.value.rows
+    const columns = queryResult.value.columns
+    if (!rows.length || columns.length < 2) {
+      chartMessage.value = '暂无可视化数据，请在结果中包含至少两列且存在数值列'
+      disposeChart()
+      return
+    }
+    const categoryKey = columns[0]
+    const numericKeys = columns.slice(1).filter((column) => rows.some((row) => isNumeric(row[column])))
+    if (!numericKeys.length) {
+      chartMessage.value = '未检测到数值列，无法生成图表'
+      disposeChart()
+      return
+    }
+    chartMessage.value = ''
+    if (!chartInstance) {
+      chartInstance = echarts.init(chartRef.value)
+    }
+    const categories = rows.map((row) => row[categoryKey])
+    const series = numericKeys.map((key) => ({
+      name: key,
+      type: 'line',
+      smooth: true,
+      showSymbol: false,
+      data: rows.map((row) => (isNumeric(row[key]) ? Number(row[key]) : 0))
+    }))
+    const option = {
+      tooltip: { trigger: 'axis' },
+      legend: { data: numericKeys },
+      xAxis: { type: 'category', data: categories, boundaryGap: false },
+      yAxis: { type: 'value' },
+      series
+    }
+    chartInstance.setOption(option)
+  })
+}
+
+function resizeChart() {
+  if (chartInstance) {
+    chartInstance.resize()
+  }
+}
+
+function disposeChart() {
+  if (chartInstance) {
+    chartInstance.clear()
+  }
+}
+
+function isNumeric(value) {
+  if (value === null || value === undefined) {
+    return false
+  }
+  const number = Number(value)
+  return !Number.isNaN(number)
+}
+
+function formatDuration(duration) {
+  if (!duration && duration !== 0) {
+    return '-'
+  }
+  if (duration < 1000) {
+    return `${duration} ms`
+  }
+  return `${(duration / 1000).toFixed(2)} s`
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '-'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  const pad = (num) => `${num}`.padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+}
+</script>
+
+<style scoped>
+.data-query-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.query-form {
+  padding-top: 8px;
+}
+
+.sql-item .el-form-item__content {
+  flex: 1;
+}
+
+.sql-editor {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+}
+
+.query-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.result-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.chart-container {
+  width: 100%;
+  height: 400px;
+}
+
+.chart-message {
+  text-align: center;
+  padding: 60px 0;
+  color: #909399;
+}
+
+.preview-wrapper {
+  padding: 12px;
+  background-color: #f9fafc;
+}
+
+.preview-empty {
+  padding: 12px;
+  color: #a0a0a0;
+}
+
+.sql-text {
+  display: inline-block;
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.history-pagination {
+  margin-top: 16px;
+  text-align: right;
+}
+</style>


### PR DESCRIPTION
## Summary
- register the data query history mapper with MyBatis so the mapper bean is created
- surface API failures to console users by showing Element Plus messages when query execution or history loading fails

## Testing
- mvn -q test *(fails: Maven Central returned 403 for spring-boot-starter-parent)*
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68f60c633f1c8321bf5676c1e5a52a1a