### PR TITLE
feat: 实现控制台统计页面

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DashboardController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DashboardController.java
@@ -1,0 +1,141 @@
+package com.onedata.portal.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.onedata.portal.dto.DashboardStatistics;
+import com.onedata.portal.dto.Result;
+import com.onedata.portal.entity.DataDomain;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.TaskExecutionLog;
+import com.onedata.portal.mapper.DataDomainMapper;
+import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.InspectionIssueMapper;
+import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * 控制台统计 Controller
+ */
+@RestController
+@RequestMapping("/v1/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DataTableMapper dataTableMapper;
+    private final DataTaskMapper dataTaskMapper;
+    private final DataDomainMapper dataDomainMapper;
+    private final TaskExecutionLogMapper taskExecutionLogMapper;
+    private final InspectionIssueMapper inspectionIssueMapper;
+
+    /**
+     * 获取控制台统计数据
+     */
+    @GetMapping("/statistics")
+    public Result<DashboardStatistics> getStatistics() {
+        try {
+            // 1. 统计表数量
+            Long totalTables = dataTableMapper.selectCount(null);
+
+            // 2. 统计任务数量
+            Long totalTasks = dataTaskMapper.selectCount(null);
+
+            // 3. 统计域数量
+            Long totalDomains = dataDomainMapper.selectCount(null);
+
+            // 4. 统计执行总次数
+            Long totalExecutions = taskExecutionLogMapper.selectCount(null);
+
+            // 5. 统计成功执行次数
+            QueryWrapper<TaskExecutionLog> successWrapper = new QueryWrapper<>();
+            successWrapper.eq("status", "success");
+            Long successExecutions = taskExecutionLogMapper.selectCount(successWrapper);
+
+            // 6. 统计失败执行次数
+            QueryWrapper<TaskExecutionLog> failedWrapper = new QueryWrapper<>();
+            failedWrapper.eq("status", "failed");
+            Long failedExecutions = taskExecutionLogMapper.selectCount(failedWrapper);
+
+            // 7. 统计运行中执行次数
+            QueryWrapper<TaskExecutionLog> runningWrapper = new QueryWrapper<>();
+            runningWrapper.eq("status", "running");
+            Long runningExecutions = taskExecutionLogMapper.selectCount(runningWrapper);
+
+            // 8. 计算执行成功率
+            Double executionSuccessRate = 0.0;
+            if (totalExecutions > 0) {
+                executionSuccessRate = (successExecutions * 100.0) / totalExecutions;
+                executionSuccessRate = Math.round(executionSuccessRate * 100.0) / 100.0; // 保留两位小数
+            }
+
+            // 9. 统计今日执行次数
+            LocalDateTime todayStart = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+            LocalDateTime todayEnd = LocalDateTime.of(LocalDate.now(), LocalTime.MAX);
+
+            QueryWrapper<TaskExecutionLog> todayWrapper = new QueryWrapper<>();
+            todayWrapper.ge("start_time", todayStart)
+                    .le("start_time", todayEnd);
+            Long todayExecutions = taskExecutionLogMapper.selectCount(todayWrapper);
+
+            // 10. 统计今日成功次数
+            QueryWrapper<TaskExecutionLog> todaySuccessWrapper = new QueryWrapper<>();
+            todaySuccessWrapper.eq("status", "success")
+                    .ge("start_time", todayStart)
+                    .le("start_time", todayEnd);
+            Long todaySuccessExecutions = taskExecutionLogMapper.selectCount(todaySuccessWrapper);
+
+            // 11. 统计今日失败次数
+            QueryWrapper<TaskExecutionLog> todayFailedWrapper = new QueryWrapper<>();
+            todayFailedWrapper.eq("status", "failed")
+                    .ge("start_time", todayStart)
+                    .le("start_time", todayEnd);
+            Long todayFailedExecutions = taskExecutionLogMapper.selectCount(todayFailedWrapper);
+
+            // 12. 统计待解决问题数（巡检 - open状态）
+            Long openIssues = 0L;
+            Long criticalIssues = 0L;
+            try {
+                QueryWrapper<Object> openIssuesWrapper = new QueryWrapper<>();
+                openIssuesWrapper.eq("status", "open");
+                openIssues = inspectionIssueMapper.selectCount(openIssuesWrapper);
+
+                // 13. 统计严重问题数（critical级别且open状态）
+                QueryWrapper<Object> criticalIssuesWrapper = new QueryWrapper<>();
+                criticalIssuesWrapper.eq("status", "open")
+                        .eq("severity", "critical");
+                criticalIssues = inspectionIssueMapper.selectCount(criticalIssuesWrapper);
+            } catch (Exception e) {
+                // 如果巡检表不存在或查询失败，使用默认值0
+                System.out.println("Failed to query inspection issues: " + e.getMessage());
+            }
+
+            // 构建统计结果
+            DashboardStatistics statistics = DashboardStatistics.builder()
+                    .totalTables(totalTables)
+                    .totalTasks(totalTasks)
+                    .totalDomains(totalDomains)
+                    .totalExecutions(totalExecutions)
+                    .successExecutions(successExecutions)
+                    .failedExecutions(failedExecutions)
+                    .runningExecutions(runningExecutions)
+                    .executionSuccessRate(executionSuccessRate)
+                    .openIssues(openIssues)
+                    .criticalIssues(criticalIssues)
+                    .todayExecutions(todayExecutions)
+                    .todaySuccessExecutions(todaySuccessExecutions)
+                    .todayFailedExecutions(todayFailedExecutions)
+                    .build();
+
+            return Result.success(statistics);
+        } catch (Exception e) {
+            return Result.fail("获取统计数据失败: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/dto/DashboardStatistics.java
+++ b/backend/src/main/java/com/onedata/portal/dto/DashboardStatistics.java
@@ -1,0 +1,81 @@
+package com.onedata.portal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 控制台统计数据 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DashboardStatistics {
+
+    /**
+     * 表总数
+     */
+    private Long totalTables;
+
+    /**
+     * 任务总数
+     */
+    private Long totalTasks;
+
+    /**
+     * 域总数
+     */
+    private Long totalDomains;
+
+    /**
+     * 执行总次数
+     */
+    private Long totalExecutions;
+
+    /**
+     * 成功执行次数
+     */
+    private Long successExecutions;
+
+    /**
+     * 失败执行次数
+     */
+    private Long failedExecutions;
+
+    /**
+     * 运行中执行次数
+     */
+    private Long runningExecutions;
+
+    /**
+     * 执行成功率（百分比）
+     */
+    private Double executionSuccessRate;
+
+    /**
+     * 待解决问题数（巡检）
+     */
+    private Long openIssues;
+
+    /**
+     * 严重问题数（巡检）
+     */
+    private Long criticalIssues;
+
+    /**
+     * 今日执行次数
+     */
+    private Long todayExecutions;
+
+    /**
+     * 今日成功次数
+     */
+    private Long todaySuccessExecutions;
+
+    /**
+     * 今日失败次数
+     */
+    private Long todayFailedExecutions;
+}

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,0 +1,11 @@
+import request from '../utils/request'
+
+/**
+ * 获取控制台统计数据
+ */
+export function getDashboardStatistics() {
+  return request({
+    url: '/v1/dashboard/statistics',
+    method: 'get'
+  })
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,8 +4,14 @@ const routes = [
   {
     path: '/',
     component: () => import('@/views/Layout.vue'),
-    redirect: '/tables',
+    redirect: '/dashboard',
     children: [
+      {
+        path: '/dashboard',
+        name: 'Dashboard',
+        component: () => import('@/views/dashboard/Dashboard.vue'),
+        meta: { title: '控制台' }
+      },
       {
         path: '/tables',
         name: 'Tables',

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -11,6 +11,10 @@
           mode="horizontal"
           class="menu"
         >
+          <el-menu-item index="/dashboard">
+            <el-icon><DataBoard /></el-icon>
+            <span>控制台</span>
+          </el-menu-item>
           <el-menu-item index="/tables">
             <el-icon><Grid /></el-icon>
             <span>表管理</span>
@@ -52,11 +56,14 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { Grid, Management, Connection, Monitor, Collection, Warning, Search } from '@element-plus/icons-vue'
+import { DataBoard, Grid, Management, Connection, Monitor, Collection, Warning, Search } from '@element-plus/icons-vue'
 
 const route = useRoute()
 const activeMenu = computed(() => {
   const path = route.path
+  if (path.startsWith('/dashboard')) {
+    return '/dashboard'
+  }
   if (path.startsWith('/tables')) {
     return '/tables'
   }

--- a/frontend/src/views/dashboard/Dashboard.vue
+++ b/frontend/src/views/dashboard/Dashboard.vue
@@ -1,0 +1,357 @@
+<template>
+  <div class="dashboard">
+    <el-card class="header-card">
+      <template #header>
+        <div class="card-header">
+          <span>数据平台控制台</span>
+          <div class="header-actions">
+            <el-button type="primary" :icon="Refresh" @click="refreshData">刷新</el-button>
+          </div>
+        </div>
+      </template>
+
+      <!-- 基础统计卡片 -->
+      <div class="section-title">资源统计</div>
+      <el-row :gutter="20" class="stats-row">
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon tables">
+              <el-icon><Grid /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.totalTables || 0 }}</div>
+              <div class="stat-label">数据表</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon tasks">
+              <el-icon><List /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.totalTasks || 0 }}</div>
+              <div class="stat-label">数据任务</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon domains">
+              <el-icon><Folder /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.totalDomains || 0 }}</div>
+              <div class="stat-label">数据域</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon executions">
+              <el-icon><Document /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.totalExecutions || 0 }}</div>
+              <div class="stat-label">总执行次数</div>
+            </div>
+          </div>
+        </el-col>
+      </el-row>
+
+      <!-- 执行统计卡片 -->
+      <div class="section-title" style="margin-top: 30px;">执行统计</div>
+      <el-row :gutter="20" class="stats-row">
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon success">
+              <el-icon><CircleCheck /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.successExecutions || 0 }}</div>
+              <div class="stat-label">成功次数</div>
+              <div class="stat-rate success-rate">
+                成功率 {{ statistics.executionSuccessRate || 0 }}%
+              </div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon failed">
+              <el-icon><CircleClose /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.failedExecutions || 0 }}</div>
+              <div class="stat-label">失败次数</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon running">
+              <el-icon><Loading /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.runningExecutions || 0 }}</div>
+              <div class="stat-label">运行中</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="6">
+          <div class="stat-card">
+            <div class="stat-icon issues">
+              <el-icon><WarningFilled /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.openIssues || 0 }}</div>
+              <div class="stat-label">待解决问题</div>
+              <div class="stat-rate critical-rate" v-if="statistics.criticalIssues > 0">
+                严重 {{ statistics.criticalIssues }}
+              </div>
+            </div>
+          </div>
+        </el-col>
+      </el-row>
+
+      <!-- 今日统计卡片 -->
+      <div class="section-title" style="margin-top: 30px;">今日执行</div>
+      <el-row :gutter="20" class="stats-row">
+        <el-col :span="8">
+          <div class="stat-card">
+            <div class="stat-icon today-total">
+              <el-icon><Calendar /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.todayExecutions || 0 }}</div>
+              <div class="stat-label">今日执行次数</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="8">
+          <div class="stat-card">
+            <div class="stat-icon today-success">
+              <el-icon><Select /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.todaySuccessExecutions || 0 }}</div>
+              <div class="stat-label">今日成功</div>
+            </div>
+          </div>
+        </el-col>
+        <el-col :span="8">
+          <div class="stat-card">
+            <div class="stat-icon today-failed">
+              <el-icon><CloseBold /></el-icon>
+            </div>
+            <div class="stat-info">
+              <div class="stat-value">{{ statistics.todayFailedExecutions || 0 }}</div>
+              <div class="stat-label">今日失败</div>
+            </div>
+          </div>
+        </el-col>
+      </el-row>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { ElMessage } from 'element-plus'
+import {
+  Refresh,
+  Grid,
+  List,
+  Folder,
+  Document,
+  CircleCheck,
+  CircleClose,
+  Loading,
+  WarningFilled,
+  Calendar,
+  Select,
+  CloseBold
+} from '@element-plus/icons-vue'
+import { getDashboardStatistics } from '@/api/dashboard'
+
+// 数据定义
+const statistics = ref({})
+const loading = ref(false)
+
+// 页面加载
+onMounted(() => {
+  loadStatistics()
+})
+
+// 加载统计信息
+const loadStatistics = async () => {
+  loading.value = true
+  try {
+    const res = await getDashboardStatistics()
+    statistics.value = res
+  } catch (error) {
+    console.error('Failed to load statistics:', error)
+    ElMessage.error('加载统计数据失败: ' + error.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+// 刷新数据
+const refreshData = () => {
+  loadStatistics()
+}
+</script>
+
+<style scoped>
+.dashboard {
+  padding: 6px;
+}
+
+.header-card {
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.header-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #303133;
+  margin-bottom: 15px;
+  padding-left: 10px;
+  border-left: 4px solid #409eff;
+}
+
+.stats-row {
+  margin-top: 10px;
+}
+
+.stat-card {
+  display: flex;
+  align-items: center;
+  padding: 20px;
+  background: #f8fafc;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.12);
+}
+
+.stat-icon {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 28px;
+  margin-right: 15px;
+  flex-shrink: 0;
+}
+
+/* 资源统计图标颜色 */
+.stat-icon.tables {
+  background: #e8f4fd;
+  color: #1890ff;
+}
+
+.stat-icon.tasks {
+  background: #f0f5ff;
+  color: #597ef7;
+}
+
+.stat-icon.domains {
+  background: #fff7e6;
+  color: #fa8c16;
+}
+
+.stat-icon.executions {
+  background: #f9f0ff;
+  color: #9254de;
+}
+
+/* 执行统计图标颜色 */
+.stat-icon.success {
+  background: #f6ffed;
+  color: #52c41a;
+}
+
+.stat-icon.failed {
+  background: #fff1f0;
+  color: #f5222d;
+}
+
+.stat-icon.running {
+  background: #e6f7ff;
+  color: #1890ff;
+}
+
+.stat-icon.issues {
+  background: #fff7e6;
+  color: #fa8c16;
+}
+
+/* 今日统计图标颜色 */
+.stat-icon.today-total {
+  background: #f0f5ff;
+  color: #597ef7;
+}
+
+.stat-icon.today-success {
+  background: #f6ffed;
+  color: #52c41a;
+}
+
+.stat-icon.today-failed {
+  background: #fff1f0;
+  color: #f5222d;
+}
+
+.stat-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.stat-value {
+  font-size: 28px;
+  font-weight: bold;
+  line-height: 1;
+  margin-bottom: 5px;
+  color: #303133;
+}
+
+.stat-label {
+  font-size: 14px;
+  color: #606266;
+}
+
+.stat-rate {
+  font-size: 12px;
+  margin-top: 5px;
+}
+
+.stat-rate.success-rate {
+  color: #52c41a;
+}
+
+.stat-rate.critical-rate {
+  color: #f5222d;
+  font-weight: 500;
+}
+</style>


### PR DESCRIPTION
添加数据平台控制台页面，展示关键统计指标：

后端实现：
- 新增 DashboardController：提供统计数据API接口
- 新增 DashboardStatistics DTO：统计数据传输对象
- 统计指标包括：
  * 资源统计：表数量、任务数量、域数量、总执行次数
  * 执行统计：成功次数、失败次数、运行中数量、成功率
  * 今日执行：今日执行次数、成功数、失败数
  * 巡检统计：待解决问题数、严重问题数

前端实现：
- 新增 Dashboard.vue：控制台页面组件
- 新增 dashboard.js API：前端接口调用
- 更新 Layout.vue：添加控制台导航菜单
- 更新路由配置：设置控制台为默认首页
- 使用统计卡片展示各项指标，参考ExecutionMonitor样式
- 分三个区域展示：资源统计、执行统计、今日执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)