### PR TITLE
fix: 修复 DashboardController 泛型类型错误

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DashboardController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DashboardController.java
@@ -6,6 +6,7 @@ import com.onedata.portal.dto.Result;
 import com.onedata.portal.entity.DataDomain;
 import com.onedata.portal.entity.DataTable;
 import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.InspectionIssue;
 import com.onedata.portal.entity.TaskExecutionLog;
 import com.onedata.portal.mapper.DataDomainMapper;
 import com.onedata.portal.mapper.DataTableMapper;
@@ -102,12 +103,12 @@ public class DashboardController {
             Long openIssues = 0L;
             Long criticalIssues = 0L;
             try {
-                QueryWrapper<Object> openIssuesWrapper = new QueryWrapper<>();
+                QueryWrapper<InspectionIssue> openIssuesWrapper = new QueryWrapper<>();
                 openIssuesWrapper.eq("status", "open");
                 openIssues = inspectionIssueMapper.selectCount(openIssuesWrapper);
 
                 // 13. 统计严重问题数（critical级别且open状态）
-                QueryWrapper<Object> criticalIssuesWrapper = new QueryWrapper<>();
+                QueryWrapper<InspectionIssue> criticalIssuesWrapper = new QueryWrapper<>();
                 criticalIssuesWrapper.eq("status", "open")
                         .eq("severity", "critical");
                 criticalIssues = inspectionIssueMapper.selectCount(criticalIssuesWrapper);


### PR DESCRIPTION
修复 QueryWrapper 泛型类型不匹配的编译错误：
- 将 QueryWrapper<Object> 改为 QueryWrapper<InspectionIssue>
- 添加 InspectionIssue 实体类的 import 语句

错误信息：
- incompatible types: QueryWrapper<Object> cannot be converted to Wrapper<InspectionIssue>

修复位置：
- backend/src/main/java/com/onedata/portal/controller/DashboardController.java:107
- backend/src/main/java/com/onedata/portal/controller/DashboardController.java:113