### PR TITLE
chore: 更新 Docker 镜像推送命名空间为 mikefan2019

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ on:
         default: 'latest'
 
 env:
-  DOCKER_NAMESPACE: opendataworks
+  DOCKER_NAMESPACE: mikefan2019
 
 jobs:
   build-and-push:


### PR DESCRIPTION
- 修改 DOCKER_NAMESPACE 环境变量从 opendataworks 到 mikefan2019
- 现在镜像将推送到 mikefan2019/opendataworks-* 仓库

🤖 Generated with [Claude Code](https://claude.com/claude-code)