### PR TITLE
Update documentation for relocated scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,13 +337,13 @@ cd opendataworks
 
 ```bash
 # 基本用法
-./init-database.sh -r root密码 -p 应用密码
+scripts/dev/init-database.sh -r root密码 -p 应用密码
 
 # 包含示例数据
-./init-database.sh -r root密码 -p 应用密码 -s
+scripts/dev/init-database.sh -r root密码 -p 应用密码 -s
 
 # 自定义配置
-./init-database.sh \
+scripts/dev/init-database.sh \
   -h localhost \
   -P 3306 \
   -d data_portal \
@@ -353,7 +353,7 @@ cd opendataworks
   -s
 
 # 查看所有选项
-./init-database.sh --help
+scripts/dev/init-database.sh --help
 ```
 
 **脚本功能**:
@@ -459,7 +459,7 @@ mysqldump -u root -p data_portal > data_portal_backup_$(date +%Y%m%d).sql
 
 # 删除数据库重建
 mysql -u root -p -e "DROP DATABASE data_portal;"
-./init-database.sh -r root密码 -p 应用密码
+scripts/dev/init-database.sh -r root密码 -p 应用密码
 ```
 
 #### 3. 启动 DolphinScheduler (可选)

--- a/docs/DOCKER_BUILD.md
+++ b/docs/DOCKER_BUILD.md
@@ -85,27 +85,27 @@ BUILD_DOLPHIN=true
 3. **运行构建：**
 
 ```bash
-./build-quick.sh
+scripts/build/build-quick.sh
 ```
 
 ### 方法二：直接使用命令行参数
 
 ```bash
 # 基本用法
-./build-multiarch.sh \
+scripts/build/build-multiarch.sh \
   -u your-username \
   -p your-token \
   --push
 
 # 指定版本
-./build-multiarch.sh \
+scripts/build/build-multiarch.sh \
   -u your-username \
   -p your-token \
   -v v1.0.0 \
   --push
 
 # 只构建特定服务
-./build-multiarch.sh \
+scripts/build/build-multiarch.sh \
   -u your-username \
   -p your-token \
   --no-dolphin \
@@ -166,17 +166,17 @@ export VERSION=v1.0.0
 export DOCKER_NAMESPACE=mycompany
 
 # 使用环境变量构建
-./build-multiarch.sh -u user -p pass --push
+scripts/build/build-multiarch.sh -u user -p pass --push
 ```
 
 ### 仅构建本地镜像（不推送）
 
 ```bash
 # 仅支持单一平台
-./build-multiarch.sh --platform linux/amd64
+scripts/build/build-multiarch.sh --platform linux/amd64
 
 # 多平台必须使用 --push
-./build-multiarch.sh -u user -p pass --push
+scripts/build/build-multiarch.sh -u user -p pass --push
 ```
 
 ## 使用构建的镜像
@@ -247,7 +247,7 @@ docker run --privileged --rm tonistiigi/binfmt --install all
 docker buildx create --name multiarch --use --bootstrap
 
 # 重试构建
-./build-multiarch.sh -u user -p pass --push
+scripts/build/build-multiarch.sh -u user -p pass --push
 ```
 
 ### Q3: 推送镜像时认证失败
@@ -325,7 +325,7 @@ jobs:
 
       - name: Build and Push
         run: |
-          ./build-multiarch.sh \
+          scripts/build/build-multiarch.sh \
             -u ${{ secrets.DOCKER_USERNAME }} \
             -p ${{ secrets.DOCKER_TOKEN }} \
             -v ${GITHUB_REF#refs/tags/} \

--- a/docs/MANUAL_TEST_GUIDE.md
+++ b/docs/MANUAL_TEST_GUIDE.md
@@ -81,7 +81,7 @@ curl -X POST "http://localhost:8081/api/v1/workflows/$WORKFLOW_CODE/delete" \
 
 ```bash
 # 运行自动化测试脚本
-./test-workflow-lifecycle.sh
+scripts/test/test-workflow-lifecycle.sh
 ```
 
 脚本会自动:

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -25,7 +25,7 @@ cd opendataworks
 docker-compose up -d
 
 # 3. 运行部署脚本
-./quick-deploy.sh
+scripts/deploy/quick-deploy.sh
 ```
 
 **脚本会自动完成**:
@@ -38,7 +38,7 @@ docker-compose up -d
 **部署选项**:
 ```bash
 # 跳过前端部署（仅部署后端服务）
-./quick-deploy.sh --skip-frontend
+scripts/deploy/quick-deploy.sh --skip-frontend
 ```
 
 ---
@@ -266,7 +266,7 @@ export default defineConfig({
 
 ```bash
 # 完整的工作流生命周期测试
-./test-workflow-lifecycle.sh
+scripts/test/test-workflow-lifecycle.sh
 
 # 或使用手动测试指南
 # 参考 docs/MANUAL_TEST_GUIDE.md
@@ -424,7 +424,7 @@ pkill -f "uvicorn.*dolphinscheduler"
 pkill -f "vite"
 
 # 然后重新运行
-./quick-deploy.sh
+scripts/deploy/quick-deploy.sh
 ```
 
 ---

--- a/docs/deployment/DOCKER_DEPLOYMENT.md
+++ b/docs/deployment/DOCKER_DEPLOYMENT.md
@@ -20,10 +20,10 @@ opendataworks/
 │   └── 03-sample_data.sql
 ├── deploy/docker-compose.prod.yml     # Docker Compose 配置文件
 ├── .env.example                # 环境变量配置示例
-├── load-images.sh              # 镜像加载脚本
-├── start.sh                    # 服务启动脚本
-├── stop.sh                     # 服务停止脚本
-└── restart.sh                  # 服务重启脚本
+├── scripts/deploy/load-images.sh   # 镜像加载脚本
+├── scripts/deploy/start.sh         # 服务启动脚本
+├── scripts/deploy/stop.sh          # 服务停止脚本
+└── scripts/deploy/restart.sh       # 服务重启脚本
 ```
 
 ## 🔧 系统要求

--- a/docs/deployment/DOCKER_QUICK_START.md
+++ b/docs/deployment/DOCKER_QUICK_START.md
@@ -28,7 +28,7 @@ unzip opendataworks-source-*.zip
 cd opendataworks
 
 # 执行构建脚本（自动构建并导出所有镜像）
-scripts/build-images.sh
+scripts/build/build-images.sh
 ```
 
 构建完成后，会在 `docker-images/` 目录生成所有镜像 tar 包。
@@ -43,10 +43,10 @@ docker-images/              # 镜像 tar 包目录
 mysql-init/                 # MySQL 初始化脚本
 docker-compose.prod.yml     # Docker Compose 配置
 .env.example                # 环境变量配置示例
-load-images.sh              # 镜像加载脚本
-start.sh                    # 启动脚本
-stop.sh                     # 停止脚本
-restart.sh                  # 重启脚本
+scripts/deploy/load-images.sh   # 镜像加载脚本
+scripts/deploy/start.sh         # 启动脚本
+scripts/deploy/stop.sh          # 停止脚本
+scripts/deploy/restart.sh       # 重启脚本
 DOCKER_DEPLOYMENT.md        # 详细部署文档
 ```
 

--- a/docs/deployment/RESTART_GUIDE.md
+++ b/docs/deployment/RESTART_GUIDE.md
@@ -166,7 +166,7 @@ python -m uvicorn dolphinscheduler_service.main:app --host 0.0.0.0 --port 5001 &
 
 1. ✅ 清理测试脚本（可选）:
 ```bash
-./cleanup-test-scripts.sh
+scripts/maintenance/cleanup-test-scripts.sh
 ```
 
 2. ✅ 提交代码（如果使用 Git）:

--- a/docs/index.html
+++ b/docs/index.html
@@ -807,10 +807,10 @@ cd opendataworks
 
 #!/bin/bash
 # 初始化数据库（自定义 root 与应用密码）
-./init-database.sh -r &lt;mysql-root&gt; -p &lt;app-password&gt;
+scripts/dev/init-database.sh -r &lt;mysql-root&gt; -p &lt;app-password&gt;
 
 # 一键启动前后端与编排服务
-./quick-deploy.sh --with-doris=false
+scripts/deploy/quick-deploy.sh --with-doris=false
 
 # 浏览器访问
 # 前端:           http://localhost:3000

--- a/docs/reports/COMPLETION_REPORT.md
+++ b/docs/reports/COMPLETION_REPORT.md
@@ -90,7 +90,7 @@ log.info("Created temporary workflow: name={} actualCode={}", ...);
 5. ✅ `COMPLETION_REPORT.md` - 本报告
 
 ### 辅助文件
-- ✅ `cleanup-test-scripts.sh` - 清理测试脚本工具
+- ✅ `scripts/maintenance/cleanup-test-scripts.sh` - 清理测试脚本工具
 
 ---
 
@@ -117,7 +117,7 @@ log.info("Created temporary workflow: name={} actualCode={}", ...);
 
 3. **清理测试脚本**:
    ```bash
-   ./cleanup-test-scripts.sh
+   scripts/maintenance/cleanup-test-scripts.sh
    ```
 
 4. **提交代码** (如果使用 Git):

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -494,10 +494,10 @@ git clone https://github.com/MingkeVan/opendataworks.git
 cd opendataworks
 
 # 2. 初始化数据库
-./init-database.sh -r root密码 -p 应用密码
+scripts/dev/init-database.sh -r root密码 -p 应用密码
 
 # 3. 启动服务（使用自动化脚本）
-./quick-deploy.sh
+scripts/deploy/quick-deploy.sh
 
 # 访问应用
 # 前端: http://localhost:3000


### PR DESCRIPTION
## Summary
- update quickstart instructions to reference `scripts/dev/init-database.sh`
- refresh deployment docs to use `scripts/deploy` and `scripts/build` script paths
- align restart and completion guides with the maintenance cleanup script location

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68f9f2fa2a5c83218d66506843d1c0e9