### PR TITLE
Fix task execution limit defaults and improve SQL validation

### DIFF
--- a/backend/src/test/java/com/onedata/portal/service/DataQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DataQueryServiceTest.java
@@ -1,0 +1,50 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.mapper.DataQueryHistoryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class DataQueryServiceTest {
+
+    private DataQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DataQueryService(
+            mock(DorisConnectionService.class),
+            mock(DorisClusterService.class),
+            mock(DataQueryHistoryMapper.class),
+            new ObjectMapper()
+        );
+    }
+
+    @Test
+    void validateSqlAllowsSemicolonsInsideStringLiterals() {
+        assertDoesNotThrow(() -> service.validateSql("SELECT ';drop table' AS col"));
+    }
+
+    @Test
+    void validateSqlAllowsDangerousWordsInsideComments() {
+        String sql = "SELECT * FROM users -- drop table";
+        assertDoesNotThrow(() -> service.validateSql(sql));
+    }
+
+    @Test
+    void validateSqlRejectsMultipleStatements() {
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> service.validateSql("SELECT 1; SELECT 2"));
+        org.junit.jupiter.api.Assertions.assertEquals("仅支持单条 SQL 执行", ex.getMessage());
+    }
+
+    @Test
+    void validateSqlRejectsDangerousKeywordOutsideLiterals() {
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> service.validateSql("DROP TABLE users"));
+        org.junit.jupiter.api.Assertions.assertEquals("检测到危险 SQL 关键字，请检查后再执行", ex.getMessage());
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/TaskExecutionServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/TaskExecutionServiceTest.java
@@ -1,0 +1,128 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.TaskExecutionLog;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TaskExecutionServiceTest {
+
+    @Mock
+    private TaskExecutionLogMapper executionLogMapper;
+
+    @Mock
+    private DataTaskMapper dataTaskMapper;
+
+    @Mock
+    private DolphinSchedulerService dolphinSchedulerService;
+
+    private TaskExecutionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TaskExecutionService(executionLogMapper, dataTaskMapper, dolphinSchedulerService);
+    }
+
+    @Test
+    void getRecentExecutionsUsesDefaultLimitWhenNull() {
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        service.getRecentExecutions(1L, null);
+
+        ArgumentCaptor<com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<TaskExecutionLog>> captor =
+            ArgumentCaptor.forClass(com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper.class);
+        verify(executionLogMapper).selectList(captor.capture());
+
+        assertEquals("LIMIT 10", captor.getValue().getLastSql());
+    }
+
+    @Test
+    void getRecentExecutionsFallbacksToDefaultLimitWhenNonPositive() {
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        service.getRecentExecutions(1L, -5);
+
+        ArgumentCaptor<com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<TaskExecutionLog>> captor =
+            ArgumentCaptor.forClass(com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper.class);
+        verify(executionLogMapper).selectList(captor.capture());
+
+        assertEquals("LIMIT 10", captor.getValue().getLastSql());
+    }
+
+    @Test
+    void getRecentExecutionsHonorsPositiveLimit() {
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        service.getRecentExecutions(1L, 5);
+
+        ArgumentCaptor<com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper<TaskExecutionLog>> captor =
+            ArgumentCaptor.forClass(com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper.class);
+        verify(executionLogMapper).selectList(captor.capture());
+
+        assertEquals("LIMIT 5", captor.getValue().getLastSql());
+    }
+
+    @Test
+    void enrichWithDolphinDataBuildsWorkflowInstanceUrlFromDefinitionsBase() throws IOException {
+        TaskExecutionLog log = new TaskExecutionLog();
+        log.setId(100L);
+        log.setTaskId(200L);
+        log.setExecutionId("exec-1");
+        log.setStatus("running");
+
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.singletonList(log));
+
+        DataTask task = new DataTask();
+        task.setId(200L);
+        task.setDolphinProcessCode(300L);
+        task.setDolphinTaskCode(400L);
+        when(dataTaskMapper.selectById(200L)).thenReturn(task);
+
+        when(dolphinSchedulerService.getWorkflowName()).thenReturn("workflow");
+        when(dolphinSchedulerService.getTaskDefinitionUrl(400L)).thenReturn("http://host/ui/projects/1/task/definitions/400");
+        when(dolphinSchedulerService.getProjectCode()).thenReturn(1L);
+        when(dolphinSchedulerService.getWorkflowDefinitionUrl(300L))
+            .thenReturn("http://host/ui/projects/1/workflow/definitions/300");
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode instanceDetail = mapper.readTree("{" +
+            "\"instanceId\":1," +
+            "\"state\":\"SUCCESS\"," +
+            "\"startTime\":\"2024-01-01 00:00:00\"," +
+            "\"endTime\":\"2024-01-01 00:10:00\"," +
+            "\"duration\":600"
+            + "}");
+        when(dolphinSchedulerService.getWorkflowInstanceStatus(300L, "exec-1"))
+            .thenReturn(instanceDetail);
+        when(executionLogMapper.updateById(any())).thenReturn(1);
+
+        List<TaskExecutionLog> result = service.getRecentExecutions(200L, 5);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        TaskExecutionLog enriched = result.get(0);
+        assertEquals("http://host/ui/projects/1/workflow/instance/300/exec-1", enriched.getWorkflowInstanceUrl());
+        verify(dolphinSchedulerService).getWorkflowInstanceStatus(300L, "exec-1");
+        verify(executionLogMapper).selectList(any());
+        verify(executionLogMapper).updateById(any());
+    }
+}


### PR DESCRIPTION
## Summary
- add defensive limit handling for recent task executions and fix DolphinScheduler instance URLs
- harden SQL validation to ignore literals/comments and enforce single-statement read-only queries
- introduce unit tests covering the new limit handling, URL generation, and SQL validation edge cases

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent POM due to 403 from Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f61a829e6c832195277aebd41b268c