### PR TITLE
调整为定时稽核+手动比对+可选同步模式

### DIFF
--- a/backend/src/main/java/com/onedata/portal/scheduled/DorisTableSyncTask.java
+++ b/backend/src/main/java/com/onedata/portal/scheduled/DorisTableSyncTask.java
@@ -7,7 +7,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Doris 元数据同步定时任务
+ * Doris 元数据稽核定时任务
+ * 注意：这是稽核任务，只检查差异不自动同步，需要人工确认后手动同步
  */
 @Slf4j
 @Component
@@ -17,50 +18,76 @@ public class DorisTableSyncTask {
     private final DorisMetadataSyncService dorisMetadataSyncService;
 
     /**
-     * 每天凌晨 2 点执行 Doris 元数据同步
+     * 每天凌晨 2 点执行 Doris 元数据稽核
      * cron 表达式: 秒 分 时 日 月 周
      * 0 0 2 * * ? 表示每天凌晨 2 点
+     *
+     * 稽核逻辑：只比对差异不同步，发现不一致时记录日志，需要人工确认后手动同步
      */
     @Scheduled(cron = "0 0 2 * * ?")
-    public void scheduledDorisMetadataSync() {
-        log.info("=== Scheduled Doris metadata sync task started ===");
+    public void scheduledDorisMetadataAudit() {
+        log.info("=== Scheduled Doris metadata audit task started ===");
         try {
-            // 同步默认集群的元数据（clusterId 为 null 表示使用默认集群）
-            DorisMetadataSyncService.SyncResult result = dorisMetadataSyncService.syncAllMetadata(null);
+            // 稽核默认集群的元数据（clusterId 为 null 表示使用默认集群）
+            DorisMetadataSyncService.AuditResult result = dorisMetadataSyncService.auditAllMetadata(null);
 
-            log.info("=== Scheduled Doris metadata sync task completed successfully ===");
-            log.info("Sync statistics: {}", result);
+            log.info("=== Scheduled Doris metadata audit task completed successfully ===");
+            log.info("Audit result: {}", result);
 
-            // 记录详细信息
-            log.info("New tables: {}, Updated tables: {}", result.getNewTables(), result.getUpdatedTables());
-            log.info("New fields: {}, Updated fields: {}, Deleted fields: {}",
-                result.getNewFields(), result.getUpdatedFields(), result.getDeletedFields());
+            // 如果发现差异，记录详细信息
+            if (result.hasDifferences()) {
+                log.warn("发现 {} 处元数据差异，建议登录平台手动检查并同步！", result.getTotalDifferences());
+
+                // 记录每个差异的详细信息
+                for (DorisMetadataSyncService.TableDifference diff : result.getTableDifferences()) {
+                    log.warn("表 {}.{} - 差异类型: {}",
+                        diff.getDatabase(), diff.getTableName(), diff.getType());
+
+                    // 记录表级别的变更
+                    for (String change : diff.getChanges()) {
+                        log.warn("  - {}", change);
+                    }
+
+                    // 记录字段级别的变更
+                    if (!diff.getFieldDifferences().isEmpty()) {
+                        log.warn("  字段差异数量: {}", diff.getFieldDifferences().size());
+                        for (DorisMetadataSyncService.FieldDifference fieldDiff : diff.getFieldDifferences()) {
+                            log.warn("    - 字段 '{}' ({})", fieldDiff.getFieldName(), fieldDiff.getType());
+                        }
+                    }
+                }
+            } else {
+                log.info("元数据稽核通过，平台与 Doris 保持一致");
+            }
 
             // 如果有错误，记录错误信息
             if (!result.getErrors().isEmpty()) {
-                log.warn("Sync completed with {} errors:", result.getErrors().size());
+                log.error("稽核过程中发生 {} 个错误:", result.getErrors().size());
                 for (String error : result.getErrors()) {
-                    log.warn("  - {}", error);
+                    log.error("  - {}", error);
                 }
             }
         } catch (Exception e) {
-            log.error("=== Scheduled Doris metadata sync task failed ===", e);
+            log.error("=== Scheduled Doris metadata audit task failed ===", e);
         }
     }
 
     /**
-     * 测试用的定时任务 - 每 10 分钟执行一次
+     * 测试用的稽核任务 - 每 10 分钟执行一次
      * 生产环境请删除或注释掉此任务
      */
     // @Scheduled(fixedRate = 600000) // 600000 毫秒 = 10 分钟
-    // public void testScheduledDorisMetadataSync() {
-    //     log.info("=== Test Doris metadata sync task started (every 10 minutes) ===");
+    // public void testScheduledDorisMetadataAudit() {
+    //     log.info("=== Test Doris metadata audit task started (every 10 minutes) ===");
     //     try {
-    //         DorisMetadataSyncService.SyncResult result = dorisMetadataSyncService.syncAllMetadata(null);
-    //         log.info("=== Test Doris metadata sync task completed ===");
-    //         log.info("Sync statistics: {}", result);
+    //         DorisMetadataSyncService.AuditResult result = dorisMetadataSyncService.auditAllMetadata(null);
+    //         log.info("=== Test Doris metadata audit task completed ===");
+    //         log.info("Audit result: {}", result);
+    //         if (result.hasDifferences()) {
+    //             log.warn("发现 {} 处差异", result.getTotalDifferences());
+    //         }
     //     } catch (Exception e) {
-    //         log.error("=== Test Doris metadata sync task failed ===", e);
+    //         log.error("=== Test Doris metadata audit task failed ===", e);
     //     }
     // }
 }

--- a/frontend/src/api/table.js
+++ b/frontend/src/api/table.js
@@ -118,6 +118,13 @@ export const tableApi = {
     return request.delete(`/v1/tables/${id}`)
   },
 
+  // 稽核/比对 Doris 元数据（只检查差异，不同步）
+  auditMetadata(clusterId = null) {
+    return request.post('/v1/tables/audit-metadata', null, {
+      params: { clusterId }
+    })
+  },
+
   // 同步 Doris 元数据（全量同步）
   syncMetadata(clusterId = null) {
     return request.post('/v1/tables/sync-metadata', null, {


### PR DESCRIPTION
## 设计优化
按照更合理的设计理念调整元数据同步功能：
- 大部分情况不应该出现 Doris 和平台元数据不一致
- 改为稽核模式：先检查差异，再决定是否同步
- 增强用户控制：必须人工确认后才执行同步

## 后端改造

### 1. DorisMetadataSyncService 增强
新增稽核/比对功能：
- `auditAllMetadata()` - 稽核所有元数据（只检查不同步）
- `auditDatabase()` - 稽核指定数据库
- `compareTable()` - 比对单个表的差异
- `compareTableFields()` - 比对表字段差异

新增稽核结果数据结构：
- `AuditResult` - 稽核结果
- `TableDifference` - 表差异信息
- `FieldDifference` - 字段差异信息
- `DifferenceType` - 差异类型（NEW/UPDATED/REMOVED）

### 2. DorisTableSyncTask 改造
- 从"自动同步"改为"稽核模式"
- 每天凌晨 2 点执行稽核检查
- 发现差异时记录详细日志
- 需要人工登录平台确认后手动同步

### 3. DataTableController 扩展
新增稽核接口：
- `POST /v1/tables/audit-metadata` - 稽核/比对元数据
- 保留 `POST /v1/tables/sync-metadata` - 同步接口（需先稽核确认）

## 前端改造

### 1. 表管理页面优化
- 按钮调整：
  - "同步元数据" → "比对元数据"（警告色）
  - 比对后显示差异统计和操作按钮

- 差异展示：
  - 显示发现的差异数量
  - 提供"查看详情"按钮
  - 提供"确认同步"按钮

- 差异详情对话框：
  - 展开式列表显示所有差异
  - 表级别差异（注释、分桶、副本等）
  - 字段级别差异（新增、删除、更新）
  - 支持从对话框直接确认同步

### 2. 工作流程
1. 用户点击"比对元数据"
2. 系统调用稽核接口检查差异
3. 如有差异，显示统计信息和操作按钮
4. 用户可以：
   - 查看详细差异内容
   - 确认后执行同步
   - 忽略差异
5. 同步完成后刷新列表

## 核心特性

### 稽核功能
- 只读比对，不修改数据
- 详细的差异分析
- 分层差异展示（表级别+字段级别）

### 同步控制
- 必须先稽核再同步
- 二次确认机制
- 清晰的操作反馈

### 定时稽核
- 每天自动检查
- 发现差异记录日志
- 提醒管理员处理

## 技术亮点
- 安全设计：防止误操作导致数据不一致
- 透明性：完整展示所有差异细节
- 用户友好：清晰的操作流程和反馈
- 可追溯：详细的日志记录

Generated with [Claude Code](https://claude.com/claude-code)