### PR TITLE
Add overload for Result success with custom message

### DIFF
--- a/backend/src/main/java/com/onedata/portal/dto/Result.java
+++ b/backend/src/main/java/com/onedata/portal/dto/Result.java
@@ -24,6 +24,14 @@ public class Result<T> {
         return result;
     }
 
+    public static <T> Result<T> success(T data, String message) {
+        Result<T> result = new Result<>();
+        result.setCode(200);
+        result.setMessage(message);
+        result.setData(data);
+        return result;
+    }
+
     public static <T> Result<T> fail(String message) {
         Result<T> result = new Result<>();
         result.setCode(500);


### PR DESCRIPTION
## Summary
- add an overload of `Result.success` that allows returning a custom success message

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central 403 while resolving spring-boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68fb50f86008832186be11e0fe70e25a