### PR TITLE
feat: load DolphinScheduler web UI URL from backend config

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataTaskController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataTaskController.java
@@ -6,12 +6,15 @@ import com.onedata.portal.dto.Result;
 import com.onedata.portal.dto.TaskExecutionStatus;
 import com.onedata.portal.entity.DataTask;
 import com.onedata.portal.service.DataTaskService;
+import com.onedata.portal.service.DolphinSchedulerService;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 任务管理 Controller
@@ -22,6 +25,7 @@ import java.util.List;
 public class DataTaskController {
 
     private final DataTaskService dataTaskService;
+    private final DolphinSchedulerService dolphinSchedulerService;
 
     /**
      * 分页查询任务列表
@@ -114,6 +118,15 @@ public class DataTaskController {
     public Result<TaskExecutionStatus> getExecutionStatus(@PathVariable Long id) {
         TaskExecutionStatus status = dataTaskService.getLatestExecutionStatus(id);
         return Result.success(status);
+    }
+
+    /**
+     * 获取 DolphinScheduler Web UI 配置
+     */
+    @GetMapping("/config/dolphin-webui")
+    public Result<Map<String, String>> getDolphinWebuiConfig() {
+        String webuiUrl = dolphinSchedulerService.getWebuiBaseUrl();
+        return Result.success(Collections.singletonMap("webuiUrl", webuiUrl));
     }
 
     /**

--- a/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
@@ -240,7 +240,8 @@ public class DolphinSchedulerService {
         if (workflowCode == null) {
             return null;
         }
-        if (properties.getWebuiUrl() == null || properties.getWebuiUrl().isEmpty()) {
+        String baseUrl = getWebuiBaseUrl();
+        if (baseUrl == null || baseUrl.isEmpty()) {
             log.warn("dolphin.webui-url is not configured, cannot generate workflow URL");
             return null;
         }
@@ -250,7 +251,7 @@ public class DolphinSchedulerService {
             return null;
         }
         return String.format("%s/ui/projects/%d/workflow/definitions/%d",
-            properties.getWebuiUrl(), projectCode, workflowCode);
+            baseUrl, projectCode, workflowCode);
     }
 
     /**
@@ -261,7 +262,8 @@ public class DolphinSchedulerService {
         if (taskCode == null) {
             return null;
         }
-        if (properties.getWebuiUrl() == null || properties.getWebuiUrl().isEmpty()) {
+        String baseUrl = getWebuiBaseUrl();
+        if (baseUrl == null || baseUrl.isEmpty()) {
             log.warn("dolphin.webui-url is not configured, cannot generate task URL");
             return null;
         }
@@ -271,7 +273,18 @@ public class DolphinSchedulerService {
             return null;
         }
         return String.format("%s/ui/projects/%d/task/definitions/%d",
-            properties.getWebuiUrl(), projectCode, taskCode);
+            baseUrl, projectCode, taskCode);
+    }
+
+    /**
+     * Return the configured DolphinScheduler Web UI base URL without trailing slashes.
+     */
+    public String getWebuiBaseUrl() {
+        String webuiUrl = properties.getWebuiUrl();
+        if (!StringUtils.hasText(webuiUrl)) {
+            return null;
+        }
+        return webuiUrl.replaceAll("/+$", "");
     }
 
     /**

--- a/frontend/src/api/task.js
+++ b/frontend/src/api/task.js
@@ -46,6 +46,11 @@ export const taskApi = {
     return request.get(`/v1/tasks/${id}/execution-status`)
   },
 
+  // 获取 DolphinScheduler WebUI 配置
+  getDolphinWebuiConfig() {
+    return request.get('/v1/tasks/config/dolphin-webui')
+  },
+
   // 获取任务血缘关系
   getTaskLineage(id) {
     return request.get(`/v1/tasks/${id}/lineage`)

--- a/frontend/src/views/tasks/TaskList.vue
+++ b/frontend/src/views/tasks/TaskList.vue
@@ -133,6 +133,8 @@ const filters = reactive({
   status: ''
 })
 
+const dolphinWebuiUrl = ref('')
+
 const loadData = async () => {
   loading.value = true
   try {
@@ -170,6 +172,20 @@ const loadExecutionStatuses = async () => {
   })
 
   await Promise.all(promises)
+}
+
+const loadDolphinConfig = async () => {
+  try {
+    const config = await taskApi.getDolphinWebuiConfig()
+    if (config?.webuiUrl) {
+      dolphinWebuiUrl.value = config.webuiUrl.replace(/\/+$/, '')
+    } else {
+      dolphinWebuiUrl.value = ''
+    }
+  } catch (error) {
+    console.error('加载 DolphinScheduler 配置失败:', error)
+    dolphinWebuiUrl.value = ''
+  }
 }
 
 const handlePublish = async (id) => {
@@ -338,16 +354,25 @@ const formatTime = (timeStr) => {
 const openDolphinWorkflow = (row) => {
   if (row.executionStatus && row.executionStatus.dolphinWorkflowUrl) {
     window.open(row.executionStatus.dolphinWorkflowUrl, '_blank')
+    return
+  }
+  if (dolphinWebuiUrl.value) {
+    window.open(dolphinWebuiUrl.value, '_blank')
   }
 }
 
 const openDolphinTask = (row) => {
   if (row.executionStatus && row.executionStatus.dolphinTaskUrl) {
     window.open(row.executionStatus.dolphinTaskUrl, '_blank')
+    return
+  }
+  if (dolphinWebuiUrl.value) {
+    window.open(dolphinWebuiUrl.value, '_blank')
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
+  await loadDolphinConfig()
   loadData()
 })
 </script>


### PR DESCRIPTION
## Summary
- expose the configured DolphinScheduler Web UI URL through the task controller
- normalise the configured Web UI base before composing workflow and task links
- have the task list page fetch the DolphinScheduler URL from the backend and fall back to it when per-task links are missing

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve spring-boot-starter-parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_690b1f58ab3c832186c072aba8a1999c