### PR TITLE
feat: Add DataX task type support for DolphinScheduler

### DIFF
--- a/backend/src/main/java/com/onedata/portal/entity/DataTask.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DataTask.java
@@ -28,6 +28,15 @@ public class DataTask {
 
     private String datasourceType; // datasource type: MYSQL, DORIS, etc.
 
+    // DataX-specific fields
+    private String targetDatasourceName; // target datasource for DataX
+
+    private String sourceTable; // source table name for DataX
+
+    private String targetTable; // target table name for DataX
+
+    private String columnMapping; // column mapping config for DataX (optional JSON)
+
     // clusterId and database removed during rollback
 
     @TableField("task_sql")


### PR DESCRIPTION
## Summary
Add comprehensive DataX task support to enable offline data synchronization between heterogeneous data sources in DolphinScheduler.

## Changes

### Backend
- **DataTask Entity**: Added DataX-specific fields (targetDatasourceName, sourceTable, targetTable, columnMapping)
- **DolphinSchedulerService**: Extended TaskParams with DataX support and added new buildTaskDefinition overload
- **DataTaskService**: Updated publish() method to handle DATAX node type and fetch source/target datasource IDs

### Frontend  
- **Task Type Selector**: Added dropdown for SQL, DataX, Shell, and Python task types
- **Conditional Forms**: Implemented dynamic form rendering based on selected task type
- **DataX Fields**: Added source datasource, source table, target datasource, target table, and optional column mapping
- **Validation**: Implemented dynamic validation rules that adapt to the selected task type
- **Field Management**: Added handleNodeTypeChange to clear irrelevant fields when switching task types

## Features
✅ Form-based DataX configuration with datasource selection from DolphinScheduler
✅ Optional column mapping support  
✅ Seamless integration with existing SQL/Shell/Python task types
✅ Dynamic form validation ensuring required fields are complete

## Testing
- [x] Backend builds successfully
- [x] Frontend compiles without errors
- [x] Code follows existing patterns and conventions
- [ ] Manual testing in UI (requires DolphinScheduler setup)

## Notes
- DataX requires `DATAX_HOME` environment variable configured in DolphinScheduler
- Datasources must be pre-configured in DolphinScheduler's datasource center
- Column mapping is optional; leaving it empty will sync all columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>