### PR TITLE
feat: add Flyway migration for DataX task fields

### DIFF
--- a/backend/src/main/resources/db/migration/V7__add_datax_fields_to_data_task.sql
+++ b/backend/src/main/resources/db/migration/V7__add_datax_fields_to_data_task.sql
@@ -1,0 +1,18 @@
+-- Add DataX-specific fields to data_task table
+-- Migration for DataX task type support
+
+-- Add target datasource name for DataX tasks
+ALTER TABLE data_task
+ADD COLUMN target_datasource_name VARCHAR(255) COMMENT 'Target datasource name for DataX tasks';
+
+-- Add source table name for DataX tasks
+ALTER TABLE data_task
+ADD COLUMN source_table VARCHAR(255) COMMENT 'Source table name for DataX tasks';
+
+-- Add target table name for DataX tasks
+ALTER TABLE data_task
+ADD COLUMN target_table VARCHAR(255) COMMENT 'Target table name for DataX tasks';
+
+-- Add column mapping configuration for DataX tasks (optional JSON)
+ALTER TABLE data_task
+ADD COLUMN column_mapping TEXT COMMENT 'Column mapping configuration for DataX tasks (optional JSON format)';


### PR DESCRIPTION
## Summary
Add database migration script to support DataX task fields in the `data_task` table.

This PR adds the Flyway migration that was missing from the initial DataX feature implementation (PR #17).

## Changes
- Add `V7__add_datax_fields_to_data_task.sql` migration script
- Creates 4 new columns in `data_task` table:
  - `target_datasource_name` - Target datasource name for DataX tasks
  - `source_table` - Source table name for DataX tasks
  - `target_table` - Target table name for DataX tasks
  - `column_mapping` - Column mapping configuration (optional JSON format)

## Related
- Follows up on PR #17 (DataX task type support)
- Required for DataX task functionality to work with database schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)