### PR TITLE
DataStudio 目录树样式（mock tree）+ 修复排序

### DIFF
--- a/frontend/src/views/integration/DataIntegration.vue
+++ b/frontend/src/views/integration/DataIntegration.vue
@@ -22,6 +22,9 @@ import DataSourceManagement from '@/views/settings/DataSourceManagement.vue'
 
 .page-header {
   margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .page-header h2 {
@@ -31,4 +34,3 @@ import DataSourceManagement from '@/views/settings/DataSourceManagement.vue'
   color: #1a1a1a;
 }
 </style>
-


### PR DESCRIPTION
- DataStudio 左侧 schema/catalog 改为 el-tree（mock tree 风格），保留懒加载/搜索/点击/新建表/上下游/行数等行为\n- 去掉左侧 datasource/schema 文案标签与分层标签\n- 修复排序切换不生效\n- 删除数据集成页面 mock 入口