### PR TITLE
feat: 优化数据血缘连线定位与右侧面板布局清理

### DIFF
--- a/frontend/src/views/datastudio/components/DataStudioRightPanelLineage.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanelLineage.vue
@@ -1,0 +1,742 @@
+<!-- 数据血缘连线可视化组件 -->
+<template>
+  <section class="lineage-panel">
+    <div class="lineage-header">
+      <div class="section-title">数据血缘流向</div>
+      <el-button type="primary" link size="small" @click="emit('go-lineage')">
+        查看完整血缘
+      </el-button>
+    </div>
+
+    <!-- 上游数据流入 -->
+    <div class="flow-section">
+      <div class="flow-section-title">上游数据流入</div>
+      <div class="lineage-diagram" ref="upstreamDiagramRef">
+        <div class="diagram-column">
+          <div class="column-header">
+            <el-icon><Grid /></el-icon>
+            上游表 ({{ upstreamTables.length }})
+          </div>
+          <div class="node-list">
+            <div
+              v-for="(item, index) in upstreamTables"
+              :key="`up-${item.id}`"
+              :data-node-id="`upstream-table-${item.id}`"
+              class="lineage-node table-node"
+              @click="emit('open-table', item)"
+            >
+              <el-icon class="node-icon"><Grid /></el-icon>
+              <div class="node-content">
+                <div class="node-name">{{ item.tableName }}</div>
+                <div class="node-desc">{{ item.tableComment || '-' }}</div>
+              </div>
+              <el-tag v-if="item.layer" size="small" :type="getLayerType(item.layer)">{{ item.layer }}</el-tag>
+            </div>
+            <div v-if="!upstreamTables.length" class="empty-placeholder">暂无上游表</div>
+          </div>
+        </div>
+
+        <div class="diagram-column">
+          <div class="column-header">
+            <el-icon><Operation /></el-icon>
+            写入任务 ({{ writeTasks.length }})
+          </div>
+          <div class="node-list">
+            <div
+              v-for="(task, index) in writeTasks"
+              :key="`write-${task.id}`"
+              :data-node-id="`write-task-${task.id}`"
+              class="lineage-node task-node"
+              @click="emit('open-task', task.id)"
+            >
+              <el-icon class="node-icon"><Operation /></el-icon>
+              <div class="node-content">
+                <div class="node-name">{{ task.taskName || '-' }}</div>
+                <div class="node-desc">{{ task.engine || '-' }}</div>
+              </div>
+            </div>
+            <div v-if="!writeTasks.length" class="empty-placeholder">暂无写入任务</div>
+          </div>
+          <div class="node-actions">
+            <el-button
+              type="primary"
+              size="small"
+              plain
+              :disabled="!currentTable?.id"
+              @click.stop="emit('create-task', 'write')"
+            >
+              <el-icon><Plus /></el-icon>
+              新增写入任务
+            </el-button>
+          </div>
+        </div>
+
+        <div class="diagram-column diagram-current">
+          <div class="column-header">
+            <el-icon><Grid /></el-icon>
+            当前表
+          </div>
+          <div class="current-table-node" :data-node-id="`current-table-${currentTable?.id}`">
+            <el-icon class="current-node-icon"><Grid /></el-icon>
+            <div class="current-node-content">
+              <div class="current-node-name">{{ currentTable?.tableName || '-' }}</div>
+              <div class="current-node-desc">{{ currentTable?.tableComment || '-' }}</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- SVG 连线层 -->
+        <svg class="lineage-connections-svg">
+          <defs>
+            <marker
+              id="arrowhead-upstream"
+              markerWidth="8"
+              markerHeight="6"
+              refX="0"
+              refY="3"
+              orient="auto"
+              markerUnits="userSpaceOnUse"
+            >
+              <path d="M0,0 L0,6 L8,3 z" fill="#2f6aa3" />
+            </marker>
+          </defs>
+          <path
+            v-for="line in upstreamLines"
+            :key="line.id"
+            :d="line.path"
+            class="connection-line"
+            :class="line.className"
+            marker-end="url(#arrowhead-upstream)"
+          />
+        </svg>
+      </div>
+    </div>
+
+    <!-- 下游数据流出 -->
+    <div class="flow-section">
+      <div class="flow-section-title">下游数据流出</div>
+      <div class="lineage-diagram" ref="downstreamDiagramRef">
+        <div class="diagram-column diagram-current">
+          <div class="column-header">
+            <el-icon><Grid /></el-icon>
+            当前表
+          </div>
+          <div class="current-table-node" :data-node-id="`current-table-down-${currentTable?.id}`">
+            <el-icon class="current-node-icon"><Grid /></el-icon>
+            <div class="current-node-content">
+              <div class="current-node-name">{{ currentTable?.tableName || '-' }}</div>
+              <div class="current-node-desc">{{ currentTable?.tableComment || '-' }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="diagram-column">
+          <div class="column-header">
+            <el-icon><Operation /></el-icon>
+            读取任务 ({{ readTasks.length }})
+          </div>
+          <div class="node-list">
+            <div
+              v-for="(task, index) in readTasks"
+              :key="`read-${task.id}`"
+              :data-node-id="`read-task-${task.id}`"
+              class="lineage-node task-node"
+              @click="emit('open-task', task.id)"
+            >
+              <el-icon class="node-icon"><Operation /></el-icon>
+              <div class="node-content">
+                <div class="node-name">{{ task.taskName || '-' }}</div>
+                <div class="node-desc">{{ task.engine || '-' }}</div>
+              </div>
+            </div>
+            <div v-if="!readTasks.length" class="empty-placeholder">暂无读取任务</div>
+          </div>
+          <div class="node-actions">
+            <el-button
+              type="primary"
+              size="small"
+              plain
+              :disabled="!currentTable?.id"
+              @click.stop="emit('create-task', 'read')"
+            >
+              <el-icon><Plus /></el-icon>
+              新增读取任务
+            </el-button>
+          </div>
+        </div>
+
+        <div class="diagram-column">
+          <div class="column-header">
+            <el-icon><Grid /></el-icon>
+            下游表 ({{ downstreamTables.length }})
+          </div>
+          <div class="node-list">
+            <div
+              v-for="(item, index) in downstreamTables"
+              :key="`down-${item.id}`"
+              :data-node-id="`downstream-table-${item.id}`"
+              class="lineage-node table-node"
+              @click="emit('open-table', item)"
+            >
+              <el-icon class="node-icon"><Grid /></el-icon>
+              <div class="node-content">
+                <div class="node-name">{{ item.tableName }}</div>
+                <div class="node-desc">{{ item.tableComment || '-' }}</div>
+              </div>
+              <el-tag v-if="item.layer" size="small" :type="getLayerType(item.layer)">{{ item.layer }}</el-tag>
+            </div>
+            <div v-if="!downstreamTables.length" class="empty-placeholder">暂无下游表</div>
+          </div>
+        </div>
+
+        <!-- SVG 连线层 -->
+        <svg class="lineage-connections-svg">
+          <defs>
+            <marker
+              id="arrowhead-downstream"
+              markerWidth="8"
+              markerHeight="6"
+              refX="0"
+              refY="3"
+              orient="auto"
+              markerUnits="userSpaceOnUse"
+            >
+              <path d="M0,0 L0,6 L8,3 z" fill="#2f6aa3" />
+            </marker>
+          </defs>
+          <path
+            v-for="line in downstreamLines"
+            :key="line.id"
+            :d="line.path"
+            class="connection-line"
+            :class="line.className"
+            marker-end="url(#arrowhead-downstream)"
+          />
+        </svg>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { Grid, Operation, Plus } from '@element-plus/icons-vue'
+
+const props = defineProps({
+  currentTable: {
+    type: Object,
+    default: () => ({})
+  },
+  upstreamTables: {
+    type: Array,
+    default: () => []
+  },
+  downstreamTables: {
+    type: Array,
+    default: () => []
+  },
+  writeTasks: {
+    type: Array,
+    default: () => []
+  },
+  readTasks: {
+    type: Array,
+    default: () => []
+  },
+  edges: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const emit = defineEmits(['open-table', 'open-task', 'create-task', 'go-lineage'])
+
+const upstreamDiagramRef = ref(null)
+const downstreamDiagramRef = ref(null)
+const upstreamLines = ref([])
+const downstreamLines = ref([])
+const lineagePanelRef = ref(null)
+let resizeObserver = null
+
+const getLayerType = (layer) => {
+  const typeMap = {
+    ODS: 'info',
+    DWD: 'success',
+    DIM: 'warning',
+    DWS: 'primary',
+    ADS: 'danger'
+  }
+  return typeMap[layer] || ''
+}
+
+// 获取节点右边缘中心（用于连线起点）
+const getNodeRightEdge = (container, nodeId) => {
+  if (!container) return null
+  const node = container.querySelector(`[data-node-id="${nodeId}"]`)
+  if (!node) return null
+
+  const containerRect = container.getBoundingClientRect()
+  const nodeRect = node.getBoundingClientRect()
+
+  return {
+    x: nodeRect.left - containerRect.left + nodeRect.width,
+    y: nodeRect.top - containerRect.top + nodeRect.height / 2
+  }
+}
+
+// 获取节点左边缘中心（用于连线终点）
+const getNodeLeftEdge = (container, nodeId) => {
+  if (!container) return null
+  const node = container.querySelector(`[data-node-id="${nodeId}"]`)
+  if (!node) return null
+
+  const containerRect = container.getBoundingClientRect()
+  const nodeRect = node.getBoundingClientRect()
+
+  return {
+    x: nodeRect.left - containerRect.left - 8,
+    y: nodeRect.top - containerRect.top + nodeRect.height / 2
+  }
+}
+
+// 生成贝塞尔曲线路径
+const generateCurvePath = (start, end) => {
+  if (!start || !end) return ''
+
+  const dx = end.x - start.x
+  const controlOffset = Math.abs(dx) * 0.4
+
+  return `M ${start.x} ${start.y} C ${start.x + controlOffset} ${start.y}, ${end.x - controlOffset} ${end.y}, ${end.x} ${end.y}`
+}
+
+// 计算上游连线
+const calculateUpstreamLines = () => {
+  if (!upstreamDiagramRef.value) return
+
+  const lines = []
+  const container = upstreamDiagramRef.value
+  const currentTableId = String(props.currentTable?.id || '')
+  const writeTaskIds = new Set(props.writeTasks.map(t => String(t.id)))
+  const uniqueKeys = new Set()
+
+  if (props.edges && props.edges.length > 0) {
+    // 基于 edges 的 taskId 精确连线
+    const writeEdges = props.edges.filter(e => String(e.target) === currentTableId && e.taskId)
+    const writeTaskIdSet = new Set(writeEdges.map(e => String(e.taskId)).filter(id => writeTaskIds.has(id)))
+
+    writeTaskIdSet.forEach(taskId => {
+      const readEdges = props.edges.filter(e => String(e.taskId) === taskId && String(e.source) !== currentTableId)
+      readEdges.forEach(edge => {
+        const key = `up-table-${edge.source}-task-${taskId}`
+        if (!uniqueKeys.has(key)) {
+          uniqueKeys.add(key)
+          const start = getNodeRightEdge(container, `upstream-table-${edge.source}`)
+          const end = getNodeLeftEdge(container, `write-task-${taskId}`)
+          if (start && end) {
+            lines.push({
+              id: key,
+              path: generateCurvePath(start, end),
+              className: 'connection-line-table-task'
+            })
+          }
+        }
+      })
+
+      // 写入任务 -> 当前表
+      const taskKey = `write-task-${taskId}-current`
+      if (!uniqueKeys.has(taskKey)) {
+        uniqueKeys.add(taskKey)
+        const start = getNodeRightEdge(container, `write-task-${taskId}`)
+        const end = getNodeLeftEdge(container, `current-table-${currentTableId}`)
+        if (start && end) {
+          lines.push({
+            id: taskKey,
+            path: generateCurvePath(start, end),
+            className: 'connection-line-task-table'
+          })
+        }
+      }
+    })
+  } else {
+    // 无 edges 数据时，使用全连接 fallback
+    props.upstreamTables.forEach((table) => {
+      props.writeTasks.forEach((task) => {
+        const start = getNodeRightEdge(container, `upstream-table-${table.id}`)
+        const end = getNodeLeftEdge(container, `write-task-${task.id}`)
+        if (start && end) {
+          lines.push({
+            id: `up-table-${table.id}-task-${task.id}`,
+            path: generateCurvePath(start, end),
+            className: 'connection-line-table-task'
+          })
+        }
+      })
+    })
+
+    // 写入任务 -> 当前表
+    props.writeTasks.forEach((task) => {
+      const start = getNodeRightEdge(container, `write-task-${task.id}`)
+      const end = getNodeLeftEdge(container, `current-table-${props.currentTable?.id}`)
+      if (start && end) {
+        lines.push({
+          id: `write-task-${task.id}-current`,
+          path: generateCurvePath(start, end),
+          className: 'connection-line-task-table'
+        })
+      }
+    })
+  }
+
+  upstreamLines.value = lines
+}
+
+// 计算下游连线
+const calculateDownstreamLines = () => {
+  if (!downstreamDiagramRef.value) return
+
+  const lines = []
+  const container = downstreamDiagramRef.value
+  const currentTableId = String(props.currentTable?.id || '')
+  const readTaskIds = new Set(props.readTasks.map(t => String(t.id)))
+  const uniqueKeys = new Set()
+
+  if (props.edges && props.edges.length > 0) {
+    // 基于 edges 的 taskId 精确连线
+    const readEdges = props.edges.filter(e => String(e.source) === currentTableId && e.taskId)
+    const readTaskIdSet = new Set(readEdges.map(e => String(e.taskId)).filter(id => readTaskIds.has(id)))
+
+    // 当前表 -> 读取任务
+    readTaskIdSet.forEach(taskId => {
+      const taskKey = `current-read-task-${taskId}`
+      if (!uniqueKeys.has(taskKey)) {
+        uniqueKeys.add(taskKey)
+        const start = getNodeRightEdge(container, `current-table-down-${currentTableId}`)
+        const end = getNodeLeftEdge(container, `read-task-${taskId}`)
+        if (start && end) {
+          lines.push({
+            id: taskKey,
+            path: generateCurvePath(start, end),
+            className: 'connection-line-table-task'
+          })
+        }
+      }
+
+      // 对每个读取任务，找它写入了哪些下游表
+      const writeEdges = props.edges.filter(e => String(e.taskId) === taskId && String(e.target) !== currentTableId)
+      writeEdges.forEach(edge => {
+        const key = `read-task-${taskId}-table-${edge.target}`
+        if (!uniqueKeys.has(key)) {
+          uniqueKeys.add(key)
+          const start = getNodeRightEdge(container, `read-task-${taskId}`)
+          const end = getNodeLeftEdge(container, `downstream-table-${edge.target}`)
+          if (start && end) {
+            lines.push({
+              id: key,
+              path: generateCurvePath(start, end),
+              className: 'connection-line-task-table'
+            })
+          }
+        }
+      })
+    })
+  } else {
+    // 无 edges 数据时，使用全连接 fallback
+    // 当前表 -> 读取任务
+    props.readTasks.forEach((task) => {
+      const start = getNodeRightEdge(container, `current-table-down-${props.currentTable?.id}`)
+      const end = getNodeLeftEdge(container, `read-task-${task.id}`)
+      if (start && end) {
+        lines.push({
+          id: `current-read-task-${task.id}`,
+          path: generateCurvePath(start, end),
+          className: 'connection-line-table-task'
+        })
+      }
+    })
+
+    // 读取任务 -> 下游表
+    props.readTasks.forEach((task) => {
+      props.downstreamTables.forEach((table) => {
+        const start = getNodeRightEdge(container, `read-task-${task.id}`)
+        const end = getNodeLeftEdge(container, `downstream-table-${table.id}`)
+        if (start && end) {
+          lines.push({
+            id: `read-task-${task.id}-table-${table.id}`,
+            path: generateCurvePath(start, end),
+            className: 'connection-line-task-table'
+          })
+        }
+      })
+    })
+  }
+
+  downstreamLines.value = lines
+}
+
+// 重新计算所有连线
+const recalculateLines = () => {
+  nextTick(() => {
+    calculateUpstreamLines()
+    calculateDownstreamLines()
+  })
+}
+
+// 监听数据变化，重新计算连线
+watch(
+  () => [props.upstreamTables, props.writeTasks, props.readTasks, props.downstreamTables, props.edges, props.currentTable],
+  () => {
+    recalculateLines()
+  },
+  { deep: true, immediate: true }
+)
+
+// 监听容器大小变化，动态重绘连线
+onMounted(() => {
+  resizeObserver = new ResizeObserver(() => {
+    recalculateLines()
+  })
+  // 观察上游和下游的 diagram 容器
+  if (upstreamDiagramRef.value) {
+    resizeObserver.observe(upstreamDiagramRef.value)
+  }
+  if (downstreamDiagramRef.value) {
+    resizeObserver.observe(downstreamDiagramRef.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+})
+</script>
+
+<style scoped>
+.lineage-panel {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex-shrink: 0;
+}
+
+.lineage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.section-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.flow-section {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-muted);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.flow-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--line);
+}
+
+.lineage-diagram {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+  min-height: 120px;
+}
+
+.diagram-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-sub);
+  padding-bottom: 6px;
+}
+
+.node-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  padding-right: 4px;
+}
+
+.lineage-node {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
+}
+
+.lineage-node:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(47, 106, 163, 0.15);
+}
+
+.node-icon {
+  color: var(--accent);
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.node-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.node-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.node-desc {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.diagram-current {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.current-table-node {
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent-soft);
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 0 2px 8px rgba(47, 106, 163, 0.15);
+  position: relative;
+}
+
+.current-node-icon {
+  color: var(--accent);
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.current-node-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.current-node-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+  margin-bottom: 2px;
+}
+
+.current-node-desc {
+  font-size: 11px;
+  color: var(--text-sub);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.node-actions {
+  padding-top: 4px;
+}
+
+.empty-placeholder {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 16px 8px;
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.lineage-connections-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+  overflow: visible;
+}
+
+.connection-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  opacity: 0.4;
+  transition: all 0.3s ease;
+}
+
+.connection-line-table-task {
+  stroke: #5b8ec6;
+  opacity: 0.5;
+}
+
+.connection-line-task-table {
+  stroke: #2f6aa3;
+  opacity: 0.6;
+}
+
+.connection-line:hover {
+  opacity: 1;
+  stroke-width: 3;
+}
+</style>


### PR DESCRIPTION
- 修复连线定位：用 getNodeRightEdge/getNodeLeftEdge 替代 getNodeCenter
- 箭头与线段对齐：线终点偏移箭头宽度，箭头桥接到节点边缘
- 添加 ResizeObserver 监听容器大小变化，连线动态跟随
- 移除节点列表独立滚动，改由外层面板统一滚动
- 移除右侧面板详情风格选择器，硬编码 Clean Slate
- 移除 panel-head 表名/数据源头部
- 精简嵌套层级，移除多余 padding/background