### PR TITLE
feat(datastudio): polish lineage UX and unify Doris metadata fields

### DIFF
--- a/backend/src/main/java/com/onedata/portal/entity/DataTable.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DataTable.java
@@ -74,7 +74,8 @@ public class DataTable {
 
     private Long rowCount;
 
-    private LocalDateTime lastUpdated;
+    @TableField("doris_update_time")
+    private LocalDateTime dorisUpdateTime;
 
     @TableField(fill = FieldFill.INSERT)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/onedata/portal/service/DataTableService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataTableService.java
@@ -133,9 +133,9 @@ public class DataTableService {
                 break;
             case "createdAt":
                 if (isAsc)
-                    wrapper.orderByAsc(DataTable::getCreatedAt);
+                    wrapper.orderByAsc(DataTable::getDorisCreateTime).orderByAsc(DataTable::getCreatedAt);
                 else
-                    wrapper.orderByDesc(DataTable::getCreatedAt);
+                    wrapper.orderByDesc(DataTable::getDorisCreateTime).orderByDesc(DataTable::getCreatedAt);
                 break;
             case "updatedAt":
                 if (isAsc)
@@ -143,11 +143,11 @@ public class DataTableService {
                 else
                     wrapper.orderByDesc(DataTable::getUpdatedAt);
                 break;
-            case "lastUpdated":
+            case "dorisUpdateTime":
                 if (isAsc)
-                    wrapper.orderByAsc(DataTable::getLastUpdated);
+                    wrapper.orderByAsc(DataTable::getDorisUpdateTime);
                 else
-                    wrapper.orderByDesc(DataTable::getLastUpdated);
+                    wrapper.orderByDesc(DataTable::getDorisUpdateTime);
                 break;
             case "rowCount":
                 if (isAsc)

--- a/backend/src/main/java/com/onedata/portal/service/DorisConnectionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DorisConnectionService.java
@@ -1085,14 +1085,10 @@ public class DorisConnectionService {
                     }
                 }
 
-                // 解析分区字段
-                if (createTableSql.contains("PARTITION BY RANGE")) {
-                    int start = createTableSql.indexOf("PARTITION BY RANGE(") + 19;
-                    int end = createTableSql.indexOf(")", start);
-                    if (start > 18 && end > start) {
-                        String partitionField = createTableSql.substring(start, end).trim();
-                        info.put("partitionField", partitionField);
-                    }
+                // 解析分区字段（兼容大小写/换行/不同分区类型）
+                String partitionField = DorisCreateTableUtils.parsePartitionField(createTableSql);
+                if (StringUtils.hasText(partitionField)) {
+                    info.put("partitionField", partitionField);
                 }
 
                 // 解析分桶字段

--- a/backend/src/main/resources/db/migration/V31__rename_last_updated_to_doris_update_time.sql
+++ b/backend/src/main/resources/db/migration/V31__rename_last_updated_to_doris_update_time.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `data_table`
+    CHANGE COLUMN `last_updated` `doris_update_time` DATETIME DEFAULT NULL COMMENT 'Doris最后更新时间';

--- a/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
@@ -5,6 +5,7 @@ import com.onedata.portal.entity.DorisCluster;
 import com.onedata.portal.mapper.DataFieldMapper;
 import com.onedata.portal.mapper.DataTableMapper;
 import com.onedata.portal.mapper.DorisClusterMapper;
+import com.onedata.portal.mapper.TableStatisticsHistoryMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,9 @@ class DorisMetadataSyncServiceTest {
 
     @Mock
     private DataFieldMapper dataFieldMapper;
+
+    @Mock
+    private TableStatisticsHistoryMapper tableStatisticsHistoryMapper;
 
     @InjectMocks
     private DorisMetadataSyncService service;


### PR DESCRIPTION
## Summary
- Improve DataStudio usability by rebalancing the left/right layout, adding draggable split controls, and polishing lineage interactions.
- Fix Doris metadata ingestion gaps (especially `PARTITION BY` parsing and empty partition fields) and persist periodic statistics snapshots for trend charts.
- Standardize Doris update timestamp naming to `doris_update_time`/`dorisUpdateTime` and remove legacy `lastUpdated` compatibility paths to reduce technical debt.

## Changes
- Frontend DataStudio layout and interaction improvements:
  - switch side panel widths to ratio-based sizing with drag handles
  - add draggable top/bottom split in right panel
  - align lineage panel sizing and bottom edge behavior
  - replace bulky text hints with compact tooltip icon hints
  - files: `frontend/src/views/datastudio/DataStudioNew.vue`, `frontend/src/views/datastudio/components/DataStudioRightPanel.vue`, `frontend/src/views/datastudio/components/DataStudioRightPanelLineage.vue`
- Lineage UX and behavior:
  - current table node style aligned with upstream/downstream node sizing rules
  - upstream/downstream table click opens a basic-info dialog first, then explicit detail navigation
  - downstream read-task/table ordering aligned by edges to reduce crossing visual noise
  - files: `frontend/src/views/datastudio/components/DataStudioRightPanelLineage.vue`
- Table metadata display/sorting:
  - add sorting options for row count, data size, and Doris update time
  - add row count/data size/create/update fields in table basic info
  - clicking row count or data size opens trend chart dialog
  - remove `lastUpdated` fallback and keep only `dorisUpdateTime`
  - files: `frontend/src/views/datastudio/DataStudioNew.vue`, `frontend/src/views/datastudio/components/DataStudioRightPanel.vue`
- Doris backend metadata fixes:
  - parse Doris `PARTITION BY` fields from CREATE TABLE SQL via utility parser
  - sync periodic statistics snapshots for trend history
  - unify timestamp field usage to `dorisUpdateTime`
  - files: `backend/src/main/java/com/onedata/portal/util/DorisCreateTableUtils.java`, `backend/src/main/java/com/onedata/portal/service/DorisConnectionService.java`, `backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java`, `backend/src/main/java/com/onedata/portal/service/DataTableService.java`, `backend/src/main/java/com/onedata/portal/service/InspectionService.java`, `backend/src/main/java/com/onedata/portal/entity/DataTable.java`
- Database migration:
  - rename `last_updated` -> `doris_update_time`
  - file: `backend/src/main/resources/db/migration/V31__rename_last_updated_to_doris_update_time.sql`
- Tests:
  - add/adjust parser and metadata sync tests
  - files: `backend/src/test/java/com/onedata/portal/util/DorisCreateTableUtilsTest.java`, `backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java`

## Validation
- `mvn -Dtest=DorisCreateTableUtilsTest,DorisMetadataSyncServiceTest test -DskipITs` ✅ Passed (`Tests run: 12, Failures: 0, Errors: 0, Skipped: 0`)
- `npm run build` ✅ Passed

## Risk
- The schema migration renaming `last_updated` to `doris_update_time` may conflict in environments with manual schema drift.

## Rollback
- Revert commit `aa6b40f` and run a reverse schema migration to rename `doris_update_time` back to `last_updated` if rollback is required.
