### PR TITLE
feat: align workflow version compare with export parity sync

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/WorkflowController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/WorkflowController.java
@@ -13,6 +13,7 @@ import com.onedata.portal.dto.workflow.WorkflowPublishRequest;
 import com.onedata.portal.dto.workflow.WorkflowQueryRequest;
 import com.onedata.portal.dto.workflow.WorkflowVersionRollbackRequest;
 import com.onedata.portal.dto.workflow.WorkflowVersionRollbackResponse;
+import com.onedata.portal.dto.workflow.WorkflowVersionDeleteResponse;
 import com.onedata.portal.dto.workflow.WorkflowScheduleRequest;
 import com.onedata.portal.dto.workflow.runtime.RuntimeSyncRecordDetailResponse;
 import com.onedata.portal.dto.workflow.runtime.RuntimeSyncRecordListItem;
@@ -81,6 +82,12 @@ public class WorkflowController {
                                                                    @PathVariable Long versionId,
                                                                    @RequestBody WorkflowVersionRollbackRequest request) {
         return Result.success(workflowVersionOperationService.rollback(id, versionId, request));
+    }
+
+    @DeleteMapping("/{id}/versions/{versionId}")
+    public Result<WorkflowVersionDeleteResponse> deleteVersion(@PathVariable Long id,
+                                                               @PathVariable Long versionId) {
+        return Result.success(workflowVersionOperationService.deleteVersion(id, versionId));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionCompareResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionCompareResponse.java
@@ -27,4 +27,9 @@ public class WorkflowVersionCompareResponse {
     private WorkflowVersionDiffSection unchanged = new WorkflowVersionDiffSection();
 
     private WorkflowVersionDiffSummary summary = new WorkflowVersionDiffSummary();
+
+    /**
+     * 原始快照文本差异（unified diff）
+     */
+    private String rawDiff;
 }

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionDeleteResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.onedata.portal.dto.workflow;
+
+import lombok.Data;
+
+/**
+ * 版本删除响应
+ */
+@Data
+public class WorkflowVersionDeleteResponse {
+
+    private Long workflowId;
+
+    private Long deletedVersionId;
+
+    private Integer deletedVersionNo;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionErrorCodes.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowVersionErrorCodes.java
@@ -13,4 +13,6 @@ public final class WorkflowVersionErrorCodes {
     public static final String VERSION_SNAPSHOT_UNSUPPORTED = "VERSION_SNAPSHOT_UNSUPPORTED";
     public static final String VERSION_TASK_NOT_FOUND = "VERSION_TASK_NOT_FOUND";
     public static final String VERSION_ROLLBACK_FAILED = "VERSION_ROLLBACK_FAILED";
+    public static final String VERSION_DELETE_FORBIDDEN = "VERSION_DELETE_FORBIDDEN";
+    public static final String VERSION_DELETE_FAILED = "VERSION_DELETE_FAILED";
 }

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncErrorCodes.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncErrorCodes.java
@@ -17,6 +17,7 @@ public final class RuntimeSyncErrorCodes {
     public static final String TASK_CODE_DUPLICATE = "TASK_CODE_DUPLICATE";
     public static final String WORKFLOW_BINDING_CONFLICT = "WORKFLOW_BINDING_CONFLICT";
     public static final String EDGE_MISMATCH_CONFIRM_REQUIRED = "EDGE_MISMATCH_CONFIRM_REQUIRED";
+    public static final String DEFINITION_PARITY_MISMATCH = "DEFINITION_PARITY_MISMATCH";
     public static final String RUNTIME_SYNC_DISABLED = "RUNTIME_SYNC_DISABLED";
     public static final String RUNTIME_WORKFLOW_NOT_FOUND = "RUNTIME_WORKFLOW_NOT_FOUND";
     public static final String SYNC_FAILED = "SYNC_FAILED";

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncExecuteResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncExecuteResponse.java
@@ -13,6 +13,21 @@ public class RuntimeSyncExecuteResponse {
 
     private Boolean success = false;
 
+    /**
+     * 运行态定义采集模式: legacy/export_shadow/export_only
+     */
+    private String ingestMode;
+
+    /**
+     * 一致性状态: not_checked/consistent/inconsistent
+     */
+    private String parityStatus = "not_checked";
+
+    /**
+     * 导出路径与旧路径一致性摘要
+     */
+    private RuntimeSyncParitySummary paritySummary;
+
     private Long workflowId;
 
     private Integer versionNo;

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncParitySummary.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncParitySummary.java
@@ -1,0 +1,37 @@
+package com.onedata.portal.dto.workflow.runtime;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 导出路径与旧路径一致性摘要
+ */
+@Data
+public class RuntimeSyncParitySummary {
+
+    private String status = "not_checked";
+
+    private Boolean changed = false;
+
+    private String primaryHash;
+
+    private String shadowHash;
+
+    private Integer workflowFieldDiffCount = 0;
+
+    private Integer taskAddedDiffCount = 0;
+
+    private Integer taskRemovedDiffCount = 0;
+
+    private Integer taskModifiedDiffCount = 0;
+
+    private Integer edgeAddedDiffCount = 0;
+
+    private Integer edgeRemovedDiffCount = 0;
+
+    private Integer scheduleDiffCount = 0;
+
+    private List<String> sampleMismatches = new ArrayList<>();
+}

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncPreviewResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncPreviewResponse.java
@@ -13,6 +13,21 @@ public class RuntimeSyncPreviewResponse {
 
     private Boolean canSync = false;
 
+    /**
+     * 运行态定义采集模式: legacy/export_shadow/export_only
+     */
+    private String ingestMode;
+
+    /**
+     * 一致性状态: not_checked/consistent/inconsistent
+     */
+    private String parityStatus = "not_checked";
+
+    /**
+     * 导出路径与旧路径一致性摘要
+     */
+    private RuntimeSyncParitySummary paritySummary;
+
     private List<RuntimeSyncIssue> errors = new ArrayList<>();
 
     private List<RuntimeSyncIssue> warnings = new ArrayList<>();

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncRecordDetailResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncRecordDetailResponse.java
@@ -22,6 +22,31 @@ public class RuntimeSyncRecordDetailResponse {
 
     private String status;
 
+    /**
+     * 运行态定义采集模式: legacy/export_shadow/export_only
+     */
+    private String ingestMode;
+
+    /**
+     * 一致性状态: not_checked/consistent/inconsistent
+     */
+    private String parityStatus;
+
+    /**
+     * 一致性详情JSON
+     */
+    private String parityDetailJson;
+
+    /**
+     * 原始运行态定义JSON（导出结果）
+     */
+    private String rawDefinitionJson;
+
+    /**
+     * 一致性摘要（由 parityDetailJson 反序列化）
+     */
+    private RuntimeSyncParitySummary paritySummary;
+
     private String snapshotHash;
 
     private String snapshotJson;

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncRecordListItem.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/runtime/RuntimeSyncRecordListItem.java
@@ -22,6 +22,16 @@ public class RuntimeSyncRecordListItem {
 
     private String status;
 
+    /**
+     * 运行态定义采集模式: legacy/export_shadow/export_only
+     */
+    private String ingestMode;
+
+    /**
+     * 一致性状态: not_checked/consistent/inconsistent
+     */
+    private String parityStatus;
+
     private String snapshotHash;
 
     private RuntimeDiffSummary diffSummary;

--- a/backend/src/main/java/com/onedata/portal/entity/WorkflowRuntimeSyncRecord.java
+++ b/backend/src/main/java/com/onedata/portal/entity/WorkflowRuntimeSyncRecord.java
@@ -37,6 +37,26 @@ public class WorkflowRuntimeSyncRecord {
     private Long versionId;
 
     /**
+     * 运行态定义采集模式: legacy/export_shadow/export_only
+     */
+    private String ingestMode;
+
+    /**
+     * 一致性状态: not_checked/consistent/inconsistent
+     */
+    private String parityStatus;
+
+    /**
+     * 一致性详情JSON
+     */
+    private String parityDetailJson;
+
+    /**
+     * 原始运行态定义JSON（导出结果）
+     */
+    private String rawDefinitionJson;
+
+    /**
      * success / failed
      */
     private String status;

--- a/backend/src/main/java/com/onedata/portal/service/RuntimeSyncParityService.java
+++ b/backend/src/main/java/com/onedata/portal/service/RuntimeSyncParityService.java
@@ -1,0 +1,156 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.workflow.runtime.RuntimeDiffSummary;
+import com.onedata.portal.dto.workflow.runtime.RuntimeSyncParitySummary;
+import com.onedata.portal.dto.workflow.runtime.RuntimeTaskEdge;
+import com.onedata.portal.dto.workflow.runtime.RuntimeWorkflowDefinition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 运行态导出路径与旧路径一致性比对服务
+ */
+@Service
+@RequiredArgsConstructor
+public class RuntimeSyncParityService {
+
+    public static final String STATUS_NOT_CHECKED = "not_checked";
+    public static final String STATUS_CONSISTENT = "consistent";
+    public static final String STATUS_INCONSISTENT = "inconsistent";
+
+    private static final int MAX_SAMPLE_MISMATCHES = 12;
+
+    private final WorkflowRuntimeDiffService runtimeDiffService;
+    private final ObjectMapper objectMapper;
+
+    public RuntimeSyncParitySummary compare(RuntimeWorkflowDefinition primary, RuntimeWorkflowDefinition shadow) {
+        RuntimeSyncParitySummary summary = new RuntimeSyncParitySummary();
+        summary.setStatus(STATUS_NOT_CHECKED);
+        summary.setChanged(false);
+
+        if (primary == null || shadow == null) {
+            return summary;
+        }
+
+        WorkflowRuntimeDiffService.RuntimeSnapshot primarySnapshot =
+                runtimeDiffService.buildSnapshot(primary, normalizeEdges(primary.getExplicitEdges()));
+        WorkflowRuntimeDiffService.RuntimeSnapshot shadowSnapshot =
+                runtimeDiffService.buildSnapshot(shadow, normalizeEdges(shadow.getExplicitEdges()));
+
+        RuntimeDiffSummary diff = runtimeDiffService.buildDiff(shadowSnapshot.getSnapshotJson(), primarySnapshot);
+        summary.setPrimaryHash(primarySnapshot.getSnapshotHash());
+        summary.setShadowHash(shadowSnapshot.getSnapshotHash());
+        summary.setWorkflowFieldDiffCount(size(diff.getWorkflowFieldChanges()));
+        summary.setTaskAddedDiffCount(size(diff.getTaskAdded()));
+        summary.setTaskRemovedDiffCount(size(diff.getTaskRemoved()));
+        summary.setTaskModifiedDiffCount(size(diff.getTaskModified()));
+        summary.setEdgeAddedDiffCount(size(diff.getEdgeAdded()));
+        summary.setEdgeRemovedDiffCount(size(diff.getEdgeRemoved()));
+        summary.setScheduleDiffCount(size(diff.getScheduleChanges()));
+
+        int mismatchCount = summary.getWorkflowFieldDiffCount()
+                + summary.getTaskAddedDiffCount()
+                + summary.getTaskRemovedDiffCount()
+                + summary.getTaskModifiedDiffCount()
+                + summary.getEdgeAddedDiffCount()
+                + summary.getEdgeRemovedDiffCount()
+                + summary.getScheduleDiffCount();
+        summary.setChanged(mismatchCount > 0);
+        summary.setStatus(mismatchCount > 0 ? STATUS_INCONSISTENT : STATUS_CONSISTENT);
+        summary.setSampleMismatches(buildSampleMismatches(diff));
+        return summary;
+    }
+
+    public String toJson(RuntimeSyncParitySummary summary) {
+        if (summary == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(summary);
+        } catch (JsonProcessingException ex) {
+            return null;
+        }
+    }
+
+    public RuntimeSyncParitySummary parse(String json) {
+        if (!StringUtils.hasText(json)) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, RuntimeSyncParitySummary.class);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    public boolean isInconsistent(String status) {
+        return STATUS_INCONSISTENT.equalsIgnoreCase(String.valueOf(status));
+    }
+
+    private int size(List<String> values) {
+        return values == null ? 0 : values.size();
+    }
+
+    private List<String> buildSampleMismatches(RuntimeDiffSummary diff) {
+        if (diff == null) {
+            return Collections.emptyList();
+        }
+        List<String> samples = new ArrayList<>();
+        appendSamples(samples, "workflow", diff.getWorkflowFieldChanges());
+        appendSamples(samples, "task_added", diff.getTaskAdded());
+        appendSamples(samples, "task_removed", diff.getTaskRemoved());
+        appendSamples(samples, "task_modified", diff.getTaskModified());
+        appendSamples(samples, "edge_added", diff.getEdgeAdded());
+        appendSamples(samples, "edge_removed", diff.getEdgeRemoved());
+        appendSamples(samples, "schedule", diff.getScheduleChanges());
+        return samples;
+    }
+
+    private void appendSamples(List<String> collector, String section, List<String> items) {
+        if (CollectionUtils.isEmpty(items) || collector.size() >= MAX_SAMPLE_MISMATCHES) {
+            return;
+        }
+        for (String item : items) {
+            if (!StringUtils.hasText(item)) {
+                continue;
+            }
+            collector.add(section + ": " + item);
+            if (collector.size() >= MAX_SAMPLE_MISMATCHES) {
+                return;
+            }
+        }
+    }
+
+    private List<RuntimeTaskEdge> normalizeEdges(List<RuntimeTaskEdge> edges) {
+        if (CollectionUtils.isEmpty(edges)) {
+            return Collections.emptyList();
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        List<RuntimeTaskEdge> normalized = new ArrayList<>();
+        for (RuntimeTaskEdge edge : edges) {
+            if (edge == null || edge.getUpstreamTaskCode() == null || edge.getDownstreamTaskCode() == null) {
+                continue;
+            }
+            String key = edge.getUpstreamTaskCode() + "->" + edge.getDownstreamTaskCode();
+            if (!seen.add(key)) {
+                continue;
+            }
+            normalized.add(new RuntimeTaskEdge(edge.getUpstreamTaskCode(), edge.getDownstreamTaskCode()));
+        }
+        normalized.sort(Comparator
+                .comparing(RuntimeTaskEdge::getUpstreamTaskCode, Comparator.nullsLast(Long::compareTo))
+                .thenComparing(RuntimeTaskEdge::getDownstreamTaskCode, Comparator.nullsLast(Long::compareTo)));
+        return normalized;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -61,4 +61,5 @@ auth:
 
 workflow:
   runtime-sync:
-    enabled: false
+    enabled: true
+    ingest-mode: export_shadow

--- a/backend/src/main/resources/db/migration/V35__runtime_sync_export_parity_fields.sql
+++ b/backend/src/main/resources/db/migration/V35__runtime_sync_export_parity_fields.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `workflow_runtime_sync_record`
+    ADD COLUMN `ingest_mode` VARCHAR(32) DEFAULT NULL COMMENT '运行态定义采集模式: legacy/export_shadow/export_only',
+    ADD COLUMN `parity_status` VARCHAR(32) DEFAULT NULL COMMENT '导出与旧路径一致性: not_checked/consistent/inconsistent',
+    ADD COLUMN `parity_detail_json` LONGTEXT DEFAULT NULL COMMENT '一致性详情JSON',
+    ADD COLUMN `raw_definition_json` LONGTEXT DEFAULT NULL COMMENT '原始导出定义JSON';
+
+CREATE INDEX `idx_sync_record_parity_status`
+    ON `workflow_runtime_sync_record` (`parity_status`);

--- a/backend/src/test/java/com/onedata/portal/service/DolphinExportDefinitionParserTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DolphinExportDefinitionParserTest.java
@@ -1,0 +1,147 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.onedata.portal.dto.workflow.runtime.RuntimeTaskDefinition;
+import com.onedata.portal.dto.workflow.runtime.RuntimeWorkflowDefinition;
+import com.onedata.portal.service.dolphin.DolphinOpenApiClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DolphinExportDefinitionParserTest {
+
+    @Mock
+    private DolphinOpenApiClient openApiClient;
+
+    @Mock
+    private DolphinSchedulerService dolphinSchedulerService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private DolphinRuntimeDefinitionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DolphinRuntimeDefinitionService(openApiClient, dolphinSchedulerService, objectMapper);
+    }
+
+    @Test
+    void shouldParseWorkflowDefinitionExportForDs34() {
+        ObjectNode exported = objectMapper.createObjectNode();
+        ObjectNode workflowDefinition = exported.putObject("workflowDefinition");
+        workflowDefinition.put("code", 1001L);
+        workflowDefinition.put("name", "wf_export_34");
+        workflowDefinition.put("description", "desc_34");
+        workflowDefinition.put("releaseState", "ONLINE");
+        workflowDefinition.put("globalParams", "[{\"prop\":\"bizdate\",\"value\":\"2026-01-01\"}]");
+
+        ArrayNode taskDefinitions = exported.putArray("taskDefinitionList");
+        ObjectNode task = taskDefinitions.addObject();
+        task.put("code", 2001L);
+        task.put("name", "task_sql");
+        task.put("taskType", "SQL");
+        task.put("taskParams", "{\"sql\":\"select 1\",\"datasource\":10,\"type\":\"DORIS\"}");
+
+        ArrayNode relations = exported.putArray("workflowTaskRelationList");
+        ObjectNode relation = relations.addObject();
+        relation.put("preTaskCode", 2001L);
+        relation.put("postTaskCode", 2002L);
+
+        ObjectNode schedule = exported.putObject("schedule");
+        schedule.put("id", 301L);
+        schedule.put("crontab", "0 0 1 * * ?");
+        schedule.put("timezoneId", "Asia/Shanghai");
+        schedule.put("releaseState", "ONLINE");
+
+        when(openApiClient.exportDefinitionByCode(1L, 1001L)).thenReturn(exported);
+
+        RuntimeWorkflowDefinition definition = service.loadRuntimeDefinitionFromExport(1L, 1001L);
+
+        assertEquals(1L, definition.getProjectCode());
+        assertEquals(1001L, definition.getWorkflowCode());
+        assertEquals("wf_export_34", definition.getWorkflowName());
+        assertEquals("desc_34", definition.getDescription());
+        assertEquals("ONLINE", definition.getReleaseState());
+        assertEquals(1, definition.getTasks().size());
+        assertEquals(1, definition.getExplicitEdges().size());
+        assertNotNull(definition.getSchedule());
+        assertEquals(301L, definition.getSchedule().getScheduleId());
+        assertNotNull(definition.getRawDefinitionJson());
+    }
+
+    @Test
+    void shouldParseProcessDefinitionExportForDs32() {
+        ObjectNode exported = objectMapper.createObjectNode();
+        ObjectNode processDefinition = exported.putObject("processDefinition");
+        processDefinition.put("code", 1002L);
+        processDefinition.put("name", "wf_export_32");
+        processDefinition.put("description", "desc_32");
+        processDefinition.put("releaseState", "OFFLINE");
+        processDefinition.put("globalParams", "[{\"prop\":\"dt\",\"value\":\"2026-02-01\"}]");
+
+        ArrayNode taskDefinitions = exported.putArray("taskDefinitionList");
+        ObjectNode task = taskDefinitions.addObject();
+        task.put("code", 2101L);
+        task.put("name", "task_sql_32");
+        task.put("taskType", "SQL");
+        task.put("taskParams", "{\"sql\":\"select * from ods.t1\",\"datasource\":11,\"type\":\"MYSQL\"}");
+
+        ArrayNode relations = exported.putArray("processTaskRelationList");
+        ObjectNode relation = relations.addObject();
+        relation.put("preTaskCode", 2101L);
+        relation.put("postTaskCode", 2102L);
+
+        when(openApiClient.exportDefinitionByCode(1L, 1002L)).thenReturn(exported);
+
+        RuntimeWorkflowDefinition definition = service.loadRuntimeDefinitionFromExport(1L, 1002L);
+
+        assertEquals(1002L, definition.getWorkflowCode());
+        assertEquals("wf_export_32", definition.getWorkflowName());
+        assertEquals("desc_32", definition.getDescription());
+        assertEquals("OFFLINE", definition.getReleaseState());
+        assertEquals(1, definition.getTasks().size());
+        RuntimeTaskDefinition taskDefinition = definition.getTasks().get(0);
+        assertEquals(2101L, taskDefinition.getTaskCode());
+        assertEquals("task_sql_32", taskDefinition.getTaskName());
+        assertEquals("select * from ods.t1", taskDefinition.getSql());
+        assertEquals(1, definition.getExplicitEdges().size());
+    }
+
+    @Test
+    void shouldFallbackToDefinitionTaskJsonWhenTaskDefinitionListMissing() {
+        ObjectNode exported = objectMapper.createObjectNode();
+        ObjectNode workflowDefinition = exported.putObject("workflowDefinition");
+        workflowDefinition.put("code", 1003L);
+        workflowDefinition.put("name", "wf_fallback");
+        workflowDefinition.put("taskDefinitionJson",
+                "[{\"code\":2301,\"name\":\"task_from_inline\",\"taskType\":\"SQL\",\"taskParams\":\"{\\\"sql\\\":\\\"select 2\\\",\\\"datasource\\\":12,\\\"type\\\":\\\"MYSQL\\\"}\"}]");
+
+        when(openApiClient.exportDefinitionByCode(1L, 1003L)).thenReturn(exported);
+
+        RuntimeWorkflowDefinition definition = service.loadRuntimeDefinitionFromExport(1L, 1003L);
+
+        assertEquals(1, definition.getTasks().size());
+        assertEquals("task_from_inline", definition.getTasks().get(0).getTaskName());
+    }
+
+    @Test
+    void shouldThrowWhenExportPayloadIsEmpty() {
+        when(openApiClient.exportDefinitionByCode(1L, 1004L)).thenReturn(null);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.loadRuntimeDefinitionFromExport(1L, 1004L));
+        assertTrue(ex.getMessage().contains("导出工作流定义"));
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/RuntimeSyncParityServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/RuntimeSyncParityServiceTest.java
@@ -1,0 +1,104 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.workflow.runtime.RuntimeSyncParitySummary;
+import com.onedata.portal.dto.workflow.runtime.RuntimeTaskDefinition;
+import com.onedata.portal.dto.workflow.runtime.RuntimeTaskEdge;
+import com.onedata.portal.dto.workflow.runtime.RuntimeWorkflowDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeSyncParityServiceTest {
+
+    private final RuntimeSyncParityService service = new RuntimeSyncParityService(
+            new WorkflowRuntimeDiffService(new ObjectMapper()),
+            new ObjectMapper());
+
+    @Test
+    void compareShouldReturnConsistentWhenSnapshotsAreEqual() {
+        RuntimeWorkflowDefinition primary = definition("wf_a");
+        RuntimeWorkflowDefinition shadow = definition("wf_a");
+
+        RuntimeTaskDefinition task = task(1L, "task_a", "SELECT 1");
+        primary.setTasks(Collections.singletonList(task));
+        shadow.setTasks(Collections.singletonList(task(1L, "task_a", "SELECT 1")));
+        primary.setExplicitEdges(Collections.singletonList(new RuntimeTaskEdge(1L, 1L)));
+        shadow.setExplicitEdges(Collections.singletonList(new RuntimeTaskEdge(1L, 1L)));
+
+        RuntimeSyncParitySummary summary = service.compare(primary, shadow);
+
+        assertEquals(RuntimeSyncParityService.STATUS_CONSISTENT, summary.getStatus());
+        assertFalse(Boolean.TRUE.equals(summary.getChanged()));
+        assertNotNull(summary.getPrimaryHash());
+        assertNotNull(summary.getShadowHash());
+        assertTrue(summary.getSampleMismatches().isEmpty());
+    }
+
+    @Test
+    void compareShouldReturnInconsistentWhenSnapshotsDiffer() {
+        RuntimeWorkflowDefinition primary = definition("wf_new");
+        RuntimeWorkflowDefinition shadow = definition("wf_old");
+
+        primary.setTasks(Arrays.asList(
+                task(1L, "task_a", "SELECT id FROM ods.user"),
+                task(2L, "task_b", "INSERT INTO dwd.user SELECT * FROM ods.user")
+        ));
+        shadow.setTasks(Collections.singletonList(task(1L, "task_a", "SELECT * FROM ods.user")));
+
+        primary.setExplicitEdges(Collections.singletonList(new RuntimeTaskEdge(1L, 2L)));
+        shadow.setExplicitEdges(Collections.emptyList());
+
+        RuntimeSyncParitySummary summary = service.compare(primary, shadow);
+
+        assertEquals(RuntimeSyncParityService.STATUS_INCONSISTENT, summary.getStatus());
+        assertTrue(Boolean.TRUE.equals(summary.getChanged()));
+        assertTrue(summary.getWorkflowFieldDiffCount() > 0 || summary.getTaskModifiedDiffCount() > 0);
+        assertTrue(summary.getTaskAddedDiffCount() > 0 || summary.getEdgeAddedDiffCount() > 0);
+        assertFalse(summary.getSampleMismatches().isEmpty());
+    }
+
+    @Test
+    void toJsonAndParseShouldRoundTrip() {
+        RuntimeSyncParitySummary source = new RuntimeSyncParitySummary();
+        source.setStatus(RuntimeSyncParityService.STATUS_INCONSISTENT);
+        source.setChanged(true);
+        source.setWorkflowFieldDiffCount(2);
+        source.getSampleMismatches().add("workflow: workflow.workflowName: wf_a -> wf_b");
+
+        String json = service.toJson(source);
+        RuntimeSyncParitySummary parsed = service.parse(json);
+
+        assertNotNull(parsed);
+        assertEquals(source.getStatus(), parsed.getStatus());
+        assertEquals(source.getWorkflowFieldDiffCount(), parsed.getWorkflowFieldDiffCount());
+        assertEquals(source.getSampleMismatches().size(), parsed.getSampleMismatches().size());
+    }
+
+    private RuntimeWorkflowDefinition definition(String workflowName) {
+        RuntimeWorkflowDefinition definition = new RuntimeWorkflowDefinition();
+        definition.setProjectCode(1L);
+        definition.setWorkflowCode(1001L);
+        definition.setWorkflowName(workflowName);
+        definition.setGlobalParams("[]");
+        return definition;
+    }
+
+    private RuntimeTaskDefinition task(Long code, String name, String sql) {
+        RuntimeTaskDefinition task = new RuntimeTaskDefinition();
+        task.setTaskCode(code);
+        task.setTaskName(name);
+        task.setNodeType("SQL");
+        task.setSql(sql);
+        task.setDatasourceId(10L);
+        task.setDatasourceName("doris_ds");
+        task.setDatasourceType("DORIS");
+        return task;
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowRuntimeSyncRealIntegrationTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowRuntimeSyncRealIntegrationTest.java
@@ -98,6 +98,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("integration")
 @TestPropertySource(properties = {
         "workflow.runtime-sync.enabled=true",
+        "workflow.runtime-sync.ingest-mode=legacy",
         "spring.task.scheduling.enabled=false"
 })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowVersionComparePersistenceIntegrationTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowVersionComparePersistenceIntegrationTest.java
@@ -1,0 +1,447 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.onedata.portal.dto.workflow.WorkflowDefinitionRequest;
+import com.onedata.portal.dto.workflow.WorkflowTaskBinding;
+import com.onedata.portal.dto.workflow.WorkflowVersionCompareRequest;
+import com.onedata.portal.dto.workflow.WorkflowVersionCompareResponse;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.WorkflowVersion;
+import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.DataWorkflowMapper;
+import com.onedata.portal.mapper.WorkflowVersionMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@TestPropertySource(properties = {
+        "spring.task.scheduling.enabled=false",
+        "workflow.runtime-sync.enabled=false"
+})
+@DisplayName("工作流版本快照持久化集成测试")
+class WorkflowVersionComparePersistenceIntegrationTest {
+
+    @Autowired
+    private WorkflowService workflowService;
+
+    @Autowired
+    private WorkflowVersionOperationService workflowVersionOperationService;
+
+    @Autowired
+    private DataTaskService dataTaskService;
+
+    @Autowired
+    private DataTableMapper dataTableMapper;
+
+    @Autowired
+    private DataTaskMapper dataTaskMapper;
+
+    @Autowired
+    private DataWorkflowMapper dataWorkflowMapper;
+
+    @Autowired
+    private WorkflowVersionMapper workflowVersionMapper;
+
+    @Test
+    @DisplayName("单侧多次保存后版本对比应识别核心变更")
+    void compareShouldRevealCoreChangesAcrossSingleSideMultipleSaves() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String operator = "it-version-compare";
+
+        Long tableA = createTable("it_vcmp_a_" + suffix, "ods");
+        Long tableB = createTable("it_vcmp_b_" + suffix, "dwd");
+        Long tableC = createTable("it_vcmp_c_" + suffix, "dws");
+        Long tableD = createTable("it_vcmp_d_" + suffix, "dws");
+
+        Long task1Id = createSqlTask(
+                "it_vcmp_t1_" + suffix,
+                "extract_user_" + suffix,
+                "select id,name from it_vcmp_a_" + suffix,
+                "doris_ds",
+                Collections.singletonList(tableA),
+                Collections.singletonList(tableB),
+                operator
+        );
+        Long task2Id = createSqlTask(
+                "it_vcmp_t2_" + suffix,
+                "load_user_" + suffix,
+                "insert into it_vcmp_c_" + suffix + " select * from it_vcmp_b_" + suffix,
+                "doris_ds",
+                Collections.singletonList(tableB),
+                Collections.singletonList(tableC),
+                operator
+        );
+        Long task3Id = createSqlTask(
+                "it_vcmp_t3_" + suffix,
+                "agg_user_" + suffix,
+                "insert into it_vcmp_d_" + suffix + " select count(*) from it_vcmp_c_" + suffix,
+                "doris_ds",
+                Collections.singletonList(tableC),
+                Collections.singletonList(tableD),
+                operator
+        );
+
+        String workflowName = "it_workflow_" + suffix;
+        DataWorkflow createdWorkflow = workflowService.createWorkflow(buildWorkflowRequest(
+                workflowName,
+                "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha",
+                operator,
+                Arrays.asList(task1Id, task2Id)
+        ));
+        Long workflowId = createdWorkflow.getId();
+        assertNotNull(workflowId);
+
+        Long v1 = requireCurrentVersionId(workflowId);
+
+        Long v2 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id, task3Id));
+        Long v3 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateSqlTask(task1Id,
+                "extract_user_" + suffix,
+                "select id,name from it_vcmp_a_" + suffix + " where dt='${bizdate}'",
+                "doris_ds",
+                Collections.singletonList(tableA),
+                Collections.singletonList(tableB));
+        Long v4 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateSqlTask(task1Id,
+                "extract_user_" + suffix,
+                "select id,name from it_vcmp_a_" + suffix + " where dt='${bizdate}'",
+                "doris_ds_v2",
+                Collections.singletonList(tableA),
+                Collections.singletonList(tableB));
+        Long v5 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        String renamedTask1 = "extract_user_v2_" + suffix;
+        updateSqlTask(task1Id,
+                renamedTask1,
+                "select id,name from it_vcmp_a_" + suffix + " where dt='${bizdate}'",
+                "doris_ds_v2",
+                Collections.singletonList(tableA),
+                Collections.singletonList(tableB));
+        Long v6 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateSqlTask(task1Id,
+                renamedTask1,
+                "select id,name from it_vcmp_d_" + suffix + " where dt='${bizdate}'",
+                "doris_ds_v2",
+                Collections.singletonList(tableD),
+                Collections.singletonList(tableB));
+        Long v7 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateSqlTask(task2Id,
+                "load_user_" + suffix,
+                "insert into it_vcmp_d_" + suffix + " select * from it_vcmp_a_" + suffix,
+                "doris_ds",
+                Collections.singletonList(tableA),
+                Collections.singletonList(tableD));
+        Long v8 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateWorkflowSchedule(workflowId,
+                "0 0 1 * * ?",
+                "Asia/Shanghai",
+                LocalDateTime.parse("2026-02-01T00:00:00"),
+                LocalDateTime.parse("2026-12-31T23:59:59"),
+                "CONTINUE",
+                "NONE",
+                101L,
+                "MEDIUM",
+                "default",
+                "default",
+                1L,
+                true);
+        Long v9 = saveWorkflow(workflowId, workflowName, "desc-v1",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-01\"}]",
+                "tg-alpha", operator, Arrays.asList(task1Id, task2Id));
+
+        updateWorkflowSchedule(workflowId,
+                "0 30 2 * * ?",
+                "UTC",
+                LocalDateTime.parse("2026-03-01T00:00:00"),
+                LocalDateTime.parse("2027-01-31T23:59:59"),
+                "END",
+                "FAILURE",
+                202L,
+                "HIGHEST",
+                "high-mem",
+                "tenant_a",
+                9L,
+                false);
+        Long v10 = saveWorkflow(workflowId, workflowName, "desc-v2",
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-02\"}]",
+                "tg-beta", operator, Arrays.asList(task1Id, task2Id));
+
+        updateWorkflowSchedule(workflowId,
+                "0 30 2 * * ?",
+                "UTC",
+                LocalDateTime.parse("2026-03-01T00:00:00"),
+                null,
+                "END",
+                "FAILURE",
+                202L,
+                "HIGHEST",
+                "high-mem",
+                "tenant_a",
+                9L,
+                false);
+        Long v11 = saveWorkflow(workflowId, workflowName, null,
+                "[{\"prop\":\"bizdate\",\"value\":\"2026-02-02\"}]",
+                "tg-beta", operator, Arrays.asList(task1Id, task2Id));
+
+        WorkflowVersionCompareResponse addTask = compare(workflowId, v1, v2);
+        assertListContains(addTask.getAdded().getTasks(), task3Id + ":agg_user_" + suffix, "新增任务应被识别");
+
+        WorkflowVersionCompareResponse removeTask = compare(workflowId, v2, v3);
+        assertListContains(removeTask.getRemoved().getTasks(), task3Id + ":agg_user_" + suffix, "删除任务应被识别");
+
+        WorkflowVersionCompareResponse modifySql = compare(workflowId, v3, v4);
+        assertListContains(modifySql.getModified().getTasks(), task1Id + ":extract_user_" + suffix, "SQL 修改应被识别");
+
+        WorkflowVersionCompareResponse modifyDatasource = compare(workflowId, v4, v5);
+        assertListContains(modifyDatasource.getModified().getTasks(),
+                task1Id + ":extract_user_" + suffix, "任务数据源修改应被识别");
+
+        WorkflowVersionCompareResponse modifyTaskName = compare(workflowId, v5, v6);
+        assertListContains(modifyTaskName.getModified().getTasks(),
+                task1Id + ":" + renamedTask1, "任务名称修改应被识别");
+
+        WorkflowVersionCompareResponse modifyInputOutput = compare(workflowId, v6, v7);
+        assertListContains(modifyInputOutput.getModified().getTasks(),
+                task1Id + ":" + renamedTask1, "任务输入输出修改应被识别");
+
+        WorkflowVersionCompareResponse modifyRelation = compare(workflowId, v7, v8);
+        assertListContains(modifyRelation.getAdded().getEdges(), task2Id + "->" + task1Id, "任务关系新增边应被识别");
+        assertListContains(modifyRelation.getRemoved().getEdges(), task1Id + "->" + task2Id, "任务关系删除边应被识别");
+
+        WorkflowVersionCompareResponse modifyWorkflowAndSchedule = compare(workflowId, v9, v10);
+        assertListContains(modifyWorkflowAndSchedule.getModified().getWorkflowFields(),
+                "workflow.globalParams", "全局变量修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getWorkflowFields(),
+                "workflow.description", "工作流描述修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getWorkflowFields(),
+                "workflow.taskGroupName", "工作流任务组修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleCron", "调度 cron 修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleTimezone", "调度时区修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleStartTime", "调度开始时间修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleEndTime", "调度结束时间修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleFailureStrategy", "调度失败策略修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleWarningType", "调度告警类型修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleWarningGroupId", "调度告警组修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleProcessInstancePriority", "调度优先级修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleWorkerGroup", "调度 workerGroup 修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleTenantCode", "调度租户修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleEnvironmentCode", "调度环境修改应被识别");
+        assertListContains(modifyWorkflowAndSchedule.getModified().getSchedules(),
+                "schedule.scheduleAutoOnline", "调度自动上线开关修改应被识别");
+
+        WorkflowVersionCompareResponse removeWorkflowAndSchedule = compare(workflowId, v10, v11);
+        assertListContains(removeWorkflowAndSchedule.getRemoved().getWorkflowFields(),
+                "workflow.description", "工作流字段删除应被识别");
+        assertListContains(removeWorkflowAndSchedule.getRemoved().getSchedules(),
+                "schedule.scheduleEndTime", "调度字段删除应被识别");
+
+        List<WorkflowVersion> versions = workflowVersionMapper.selectList(
+                Wrappers.<WorkflowVersion>lambdaQuery()
+                        .eq(WorkflowVersion::getWorkflowId, workflowId)
+                        .orderByAsc(WorkflowVersion::getVersionNo));
+        assertEquals(11, versions.size(), "连续保存后版本数应递增");
+    }
+
+    private Long createTable(String tableName, String layer) {
+        DataTable table = new DataTable();
+        table.setTableName(tableName);
+        table.setDbName("test_db");
+        table.setLayer(layer);
+        table.setTableComment("workflow-version-compare-it");
+        table.setOwner("it-version-compare");
+        table.setStatus("active");
+        dataTableMapper.insert(table);
+        assertNotNull(table.getId());
+        return table.getId();
+    }
+
+    private Long createSqlTask(String taskCode,
+                               String taskName,
+                               String sql,
+                               String datasourceName,
+                               List<Long> inputTableIds,
+                               List<Long> outputTableIds,
+                               String owner) {
+        DataTask task = new DataTask();
+        task.setTaskCode(taskCode);
+        task.setTaskName(taskName);
+        task.setTaskType("batch");
+        task.setEngine("dolphin");
+        task.setDolphinNodeType("SQL");
+        task.setDatasourceName(datasourceName);
+        task.setDatasourceType("MYSQL");
+        task.setTaskSql(sql);
+        task.setTaskDesc("workflow-version-compare-it");
+        task.setPriority(5);
+        task.setTimeoutSeconds(600);
+        task.setRetryTimes(1);
+        task.setRetryInterval(60);
+        task.setOwner(owner);
+        DataTask created = dataTaskService.create(task, inputTableIds, outputTableIds);
+        assertNotNull(created.getId());
+        return created.getId();
+    }
+
+    private void updateSqlTask(Long taskId,
+                               String taskName,
+                               String sql,
+                               String datasourceName,
+                               List<Long> inputTableIds,
+                               List<Long> outputTableIds) {
+        DataTask task = dataTaskMapper.selectById(taskId);
+        assertNotNull(task);
+        task.setTaskName(taskName);
+        task.setTaskSql(sql);
+        task.setDatasourceName(datasourceName);
+        task.setDatasourceType("MYSQL");
+        task.setDolphinNodeType("SQL");
+        task.setEngine("dolphin");
+        dataTaskService.update(task, inputTableIds, outputTableIds);
+    }
+
+    private void updateWorkflowSchedule(Long workflowId,
+                                        String scheduleCron,
+                                        String scheduleTimezone,
+                                        LocalDateTime scheduleStartTime,
+                                        LocalDateTime scheduleEndTime,
+                                        String scheduleFailureStrategy,
+                                        String scheduleWarningType,
+                                        Long scheduleWarningGroupId,
+                                        String scheduleProcessInstancePriority,
+                                        String scheduleWorkerGroup,
+                                        String scheduleTenantCode,
+                                        Long scheduleEnvironmentCode,
+                                        Boolean scheduleAutoOnline) {
+        int updated = dataWorkflowMapper.update(
+                null,
+                Wrappers.<DataWorkflow>lambdaUpdate()
+                        .eq(DataWorkflow::getId, workflowId)
+                        .set(DataWorkflow::getScheduleCron, scheduleCron)
+                        .set(DataWorkflow::getScheduleTimezone, scheduleTimezone)
+                        .set(DataWorkflow::getScheduleStartTime, scheduleStartTime)
+                        .set(DataWorkflow::getScheduleEndTime, scheduleEndTime)
+                        .set(DataWorkflow::getScheduleFailureStrategy, scheduleFailureStrategy)
+                        .set(DataWorkflow::getScheduleWarningType, scheduleWarningType)
+                        .set(DataWorkflow::getScheduleWarningGroupId, scheduleWarningGroupId)
+                        .set(DataWorkflow::getScheduleProcessInstancePriority, scheduleProcessInstancePriority)
+                        .set(DataWorkflow::getScheduleWorkerGroup, scheduleWorkerGroup)
+                        .set(DataWorkflow::getScheduleTenantCode, scheduleTenantCode)
+                        .set(DataWorkflow::getScheduleEnvironmentCode, scheduleEnvironmentCode)
+                        .set(DataWorkflow::getScheduleAutoOnline, scheduleAutoOnline));
+        assertEquals(1, updated, "调度字段更新失败");
+    }
+
+    private Long saveWorkflow(Long workflowId,
+                              String workflowName,
+                              String description,
+                              String globalParams,
+                              String taskGroupName,
+                              String operator,
+                              List<Long> taskIds) {
+        workflowService.updateWorkflow(workflowId, buildWorkflowRequest(
+                workflowName,
+                description,
+                globalParams,
+                taskGroupName,
+                operator,
+                taskIds));
+        return requireCurrentVersionId(workflowId);
+    }
+
+    private WorkflowDefinitionRequest buildWorkflowRequest(String workflowName,
+                                                           String description,
+                                                           String globalParams,
+                                                           String taskGroupName,
+                                                           String operator,
+                                                           List<Long> taskIds) {
+        WorkflowDefinitionRequest request = new WorkflowDefinitionRequest();
+        request.setWorkflowName(workflowName);
+        request.setDescription(description);
+        request.setGlobalParams(globalParams);
+        request.setTaskGroupName(taskGroupName);
+        request.setDefinitionJson("{}");
+        request.setProjectCode(9527L);
+        request.setOperator(operator);
+        request.setTriggerSource("it_workflow_save");
+        request.setTasks(taskIds.stream().map(this::toBinding).collect(Collectors.toList()));
+        return request;
+    }
+
+    private WorkflowTaskBinding toBinding(Long taskId) {
+        WorkflowTaskBinding binding = new WorkflowTaskBinding();
+        binding.setTaskId(taskId);
+        return binding;
+    }
+
+    private Long requireCurrentVersionId(Long workflowId) {
+        DataWorkflow workflow = dataWorkflowMapper.selectById(workflowId);
+        assertNotNull(workflow);
+        assertNotNull(workflow.getCurrentVersionId());
+        return workflow.getCurrentVersionId();
+    }
+
+    private WorkflowVersionCompareResponse compare(Long workflowId, Long leftVersionId, Long rightVersionId) {
+        WorkflowVersionCompareRequest request = new WorkflowVersionCompareRequest();
+        request.setLeftVersionId(leftVersionId);
+        request.setRightVersionId(rightVersionId);
+        return workflowVersionOperationService.compare(workflowId, request);
+    }
+
+    private void assertListContains(List<String> values, String expectedPart, String message) {
+        assertTrue(values.stream().anyMatch(item -> item.contains(expectedPart)),
+                message + "，期待包含: " + expectedPart + "，实际: " + values);
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowVersionOperationServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowVersionOperationServiceTest.java
@@ -1,28 +1,55 @@
 package com.onedata.portal.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.onedata.portal.dto.workflow.WorkflowVersionCompareRequest;
 import com.onedata.portal.dto.workflow.WorkflowVersionCompareResponse;
+import com.onedata.portal.dto.workflow.WorkflowVersionDeleteResponse;
 import com.onedata.portal.dto.workflow.WorkflowVersionErrorCodes;
 import com.onedata.portal.dto.workflow.WorkflowVersionRollbackRequest;
 import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.WorkflowPublishRecord;
+import com.onedata.portal.entity.WorkflowRuntimeSyncRecord;
 import com.onedata.portal.entity.WorkflowVersion;
 import com.onedata.portal.mapper.DataTaskMapper;
 import com.onedata.portal.mapper.DataWorkflowMapper;
+import com.onedata.portal.mapper.WorkflowPublishRecordMapper;
+import com.onedata.portal.mapper.WorkflowRuntimeSyncRecordMapper;
 import com.onedata.portal.mapper.WorkflowVersionMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WorkflowVersionOperationServiceTest {
+
+    static {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new MybatisConfiguration(), "");
+        TableInfoHelper.initTableInfo(assistant, DataWorkflow.class);
+        TableInfoHelper.initTableInfo(assistant, WorkflowVersion.class);
+        TableInfoHelper.initTableInfo(assistant, WorkflowPublishRecord.class);
+        TableInfoHelper.initTableInfo(assistant, WorkflowRuntimeSyncRecord.class);
+    }
 
     @Mock
     private WorkflowVersionMapper workflowVersionMapper;
@@ -34,10 +61,18 @@ class WorkflowVersionOperationServiceTest {
     private DataTaskMapper dataTaskMapper;
 
     @Mock
+    private WorkflowPublishRecordMapper workflowPublishRecordMapper;
+
+    @Mock
+    private WorkflowRuntimeSyncRecordMapper workflowRuntimeSyncRecordMapper;
+
+    @Mock
     private DataTaskService dataTaskService;
 
     @Mock
     private WorkflowService workflowService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private WorkflowVersionOperationService service;
 
@@ -47,9 +82,11 @@ class WorkflowVersionOperationServiceTest {
                 workflowVersionMapper,
                 dataWorkflowMapper,
                 dataTaskMapper,
+                workflowPublishRecordMapper,
+                workflowRuntimeSyncRecordMapper,
                 dataTaskService,
                 workflowService,
-                new ObjectMapper());
+                objectMapper);
     }
 
     @Test
@@ -68,6 +105,9 @@ class WorkflowVersionOperationServiceTest {
 
         assertEquals(1L, response.getLeftVersionId());
         assertEquals(2L, response.getRightVersionId());
+        assertNotNull(response.getRawDiff());
+        assertTrue(response.getRawDiff().contains("--- v1"));
+        assertTrue(response.getRawDiff().contains("+++ v2"));
     }
 
     @Test
@@ -95,6 +135,8 @@ class WorkflowVersionOperationServiceTest {
         assertTrue(Boolean.TRUE.equals(response.getChanged()));
         assertTrue((response.getAdded().getTasks().size() + response.getAdded().getWorkflowFields().size()) > 0);
         assertEquals(0, response.getSummary().getRemoved());
+        assertNotNull(response.getRawDiff());
+        assertTrue(response.getRawDiff().contains("--- empty"));
     }
 
     @Test
@@ -117,6 +159,397 @@ class WorkflowVersionOperationServiceTest {
         assertTrue(ex.getMessage().contains(WorkflowVersionErrorCodes.VERSION_SNAPSHOT_UNSUPPORTED));
     }
 
+    @Test
+    void deleteShouldFailWhenTargetIsLatestSuccessfulPublishedVersion() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(11L);
+        workflow.setCurrentVersionId(5L);
+        WorkflowVersion target = version(4L, 11L, 4, canonicalSnapshot("wf", "task_a"));
+        WorkflowPublishRecord latestSuccess = new WorkflowPublishRecord();
+        latestSuccess.setId(99L);
+        latestSuccess.setWorkflowId(11L);
+        latestSuccess.setVersionId(4L);
+        latestSuccess.setStatus("success");
+
+        when(dataWorkflowMapper.selectById(11L)).thenReturn(workflow);
+        when(workflowVersionMapper.selectById(4L)).thenReturn(target);
+        when(workflowPublishRecordMapper.selectOne(any())).thenReturn(latestSuccess);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.deleteVersion(11L, 4L));
+        assertTrue(ex.getMessage().contains(WorkflowVersionErrorCodes.VERSION_DELETE_FORBIDDEN));
+        verify(workflowVersionMapper, never()).delete(any());
+    }
+
+    @Test
+    void deleteShouldFailWhenTargetIsCurrentVersion() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(11L);
+        workflow.setCurrentVersionId(5L);
+        WorkflowVersion target = version(5L, 11L, 5, canonicalSnapshot("wf", "task_a"));
+        WorkflowPublishRecord latestSuccess = new WorkflowPublishRecord();
+        latestSuccess.setId(102L);
+        latestSuccess.setWorkflowId(11L);
+        latestSuccess.setVersionId(4L);
+        latestSuccess.setStatus("success");
+
+        when(dataWorkflowMapper.selectById(11L)).thenReturn(workflow);
+        when(workflowVersionMapper.selectById(5L)).thenReturn(target);
+        when(workflowPublishRecordMapper.selectOne(any())).thenReturn(latestSuccess);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.deleteVersion(11L, 5L));
+        assertTrue(ex.getMessage().contains(WorkflowVersionErrorCodes.VERSION_DELETE_FORBIDDEN));
+        verify(workflowVersionMapper, never()).delete(any());
+    }
+
+    @Test
+    void deleteShouldSucceedForDeletablePublishedHistoryVersion() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(11L);
+        workflow.setCurrentVersionId(6L);
+        WorkflowVersion target = version(4L, 11L, 4, canonicalSnapshot("wf", "task_a"));
+
+        WorkflowPublishRecord latestSuccess = new WorkflowPublishRecord();
+        latestSuccess.setId(101L);
+        latestSuccess.setWorkflowId(11L);
+        latestSuccess.setVersionId(6L);
+        latestSuccess.setStatus("success");
+
+        when(dataWorkflowMapper.selectById(11L)).thenReturn(workflow);
+        when(workflowVersionMapper.selectById(4L)).thenReturn(target);
+        when(workflowPublishRecordMapper.selectOne(any())).thenReturn(latestSuccess);
+        when(workflowVersionMapper.delete(any())).thenReturn(1);
+
+        WorkflowVersionDeleteResponse response = service.deleteVersion(11L, 4L);
+
+        assertEquals(11L, response.getWorkflowId());
+        assertEquals(4L, response.getDeletedVersionId());
+        assertEquals(4, response.getDeletedVersionNo());
+        verify(workflowVersionMapper).delete(any());
+        verify(dataWorkflowMapper, never()).update(any(), any());
+    }
+
+    @Test
+    void compareShouldDetectCoreDiffsAcrossMultipleWorkflowSaves() {
+        final long workflowId = 11L;
+
+        WorkflowVersion v1 = version(101L, workflowId, 1, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user", "select id,name from ods.user", "ods_ds",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v2 = version(102L, workflowId, 2, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user", "select id,name from ods.user", "ods_ds",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L)),
+                        taskNode(3L, "agg_user", "insert into ads.user_cnt select count(*) from dwd.user", "ads_ds",
+                                Arrays.asList(30L), Arrays.asList(40L))
+                ),
+                Arrays.asList(edgeNode(1L, 2L), edgeNode(2L, 3L))
+        ));
+
+        WorkflowVersion v3 = version(103L, workflowId, 3, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user", "select id,name from ods.user", "ods_ds",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v4 = version(104L, workflowId, 4, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user", "select id,name from ods.user where dt='${bizdate}'", "ods_ds",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v5 = version(105L, workflowId, 5, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user", "select id,name from ods.user where dt='${bizdate}'", "ods_ds_v2",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v6 = version(106L, workflowId, 6, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user_v2", "select id,name from ods.user where dt='${bizdate}'", "ods_ds_v2",
+                                Arrays.asList(10L), Arrays.asList(20L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v7 = version(107L, workflowId, 7, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user_v2", "select id,name from ods.user where dt='${bizdate}'", "ods_ds_v2",
+                                Arrays.asList(11L), Arrays.asList(21L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(1L, 2L))
+        ));
+
+        WorkflowVersion v8 = version(108L, workflowId, 8, canonicalSnapshot(
+                "wf",
+                Arrays.asList(
+                        taskNode(1L, "extract_user_v2", "select id,name from ods.user where dt='${bizdate}'", "ods_ds_v2",
+                                Arrays.asList(11L), Arrays.asList(21L)),
+                        taskNode(2L, "load_dwd_user", "insert into dwd.user select * from tmp.user", "dwd_ds",
+                                Arrays.asList(20L), Arrays.asList(30L))
+                ),
+                Collections.singletonList(edgeNode(2L, 1L))
+        ));
+
+        Map<Long, WorkflowVersion> versions = new LinkedHashMap<>();
+        versions.put(v1.getId(), v1);
+        versions.put(v2.getId(), v2);
+        versions.put(v3.getId(), v3);
+        versions.put(v4.getId(), v4);
+        versions.put(v5.getId(), v5);
+        versions.put(v6.getId(), v6);
+        versions.put(v7.getId(), v7);
+        versions.put(v8.getId(), v8);
+        when(workflowVersionMapper.selectById(any())).thenAnswer(invocation -> {
+            Long versionId = invocation.getArgument(0);
+            return versions.get(versionId);
+        });
+
+        WorkflowVersionCompareResponse addTask = compare(workflowId, v1.getId(), v2.getId());
+        assertListContains(addTask.getAdded().getTasks(), "3:agg_user", "新增任务应被识别");
+
+        WorkflowVersionCompareResponse removeTask = compare(workflowId, v2.getId(), v3.getId());
+        assertListContains(removeTask.getRemoved().getTasks(), "3:agg_user", "删除任务应被识别");
+
+        WorkflowVersionCompareResponse modifySql = compare(workflowId, v3.getId(), v4.getId());
+        assertListContains(modifySql.getModified().getTasks(), "1:extract_user", "任务 SQL 修改应被识别");
+
+        WorkflowVersionCompareResponse modifyDatasource = compare(workflowId, v4.getId(), v5.getId());
+        assertListContains(modifyDatasource.getModified().getTasks(), "1:extract_user", "任务数据源修改应被识别");
+
+        WorkflowVersionCompareResponse modifyTaskName = compare(workflowId, v5.getId(), v6.getId());
+        assertListContains(modifyTaskName.getModified().getTasks(), "1:extract_user_v2", "任务名称修改应被识别");
+
+        WorkflowVersionCompareResponse modifyInputOutput = compare(workflowId, v6.getId(), v7.getId());
+        assertListContains(modifyInputOutput.getModified().getTasks(), "1:extract_user_v2", "输入输出表修改应被识别");
+
+        WorkflowVersionCompareResponse modifyRelation = compare(workflowId, v7.getId(), v8.getId());
+        assertListContains(modifyRelation.getAdded().getEdges(), "2->1", "任务关系新增边应被识别");
+        assertListContains(modifyRelation.getRemoved().getEdges(), "1->2", "任务关系删除边应被识别");
+    }
+
+    @Test
+    void compareShouldDetectWorkflowAndScheduleDiffsAcrossMultipleWorkflowSaves() {
+        final long workflowId = 22L;
+        List<Map<String, Object>> tasks = Collections.singletonList(
+                taskNode(1L, "extract_user", "select id,name from ods.user", "ods_ds",
+                        Collections.singletonList(10L), Collections.singletonList(20L))
+        );
+        List<Map<String, Object>> edges = Collections.emptyList();
+
+        WorkflowVersion v1 = version(201L, workflowId, 1, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v1",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-01\"}]", "tg-alpha"),
+                tasks,
+                edges,
+                scheduleNode("0 0 1 * * ?", "Asia/Shanghai",
+                        "2026-01-01 00:00:00", "2026-12-31 23:59:59",
+                        "CONTINUE", "NONE", 101L,
+                        "MEDIUM", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v2 = version(202L, workflowId, 2, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v1",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-alpha"),
+                tasks,
+                edges,
+                scheduleNode("0 0 1 * * ?", "Asia/Shanghai",
+                        "2026-01-01 00:00:00", "2026-12-31 23:59:59",
+                        "CONTINUE", "NONE", 101L,
+                        "MEDIUM", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v3 = version(203L, workflowId, 3, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v2",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-alpha"),
+                tasks,
+                edges,
+                scheduleNode("0 0 1 * * ?", "Asia/Shanghai",
+                        "2026-01-01 00:00:00", "2026-12-31 23:59:59",
+                        "CONTINUE", "NONE", 101L,
+                        "MEDIUM", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v4 = version(204L, workflowId, 4, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v2",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 0 1 * * ?", "Asia/Shanghai",
+                        "2026-01-01 00:00:00", "2026-12-31 23:59:59",
+                        "CONTINUE", "NONE", 101L,
+                        "MEDIUM", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v5 = version(205L, workflowId, 5, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v2",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 30 2 * * ?", "UTC",
+                        "2026-02-01 00:00:00", "2027-01-31 23:59:59",
+                        "CONTINUE", "NONE", 101L,
+                        "MEDIUM", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v6 = version(206L, workflowId, 6, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v2",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 30 2 * * ?", "UTC",
+                        "2026-02-01 00:00:00", "2027-01-31 23:59:59",
+                        "END", "FAILURE", 202L,
+                        "HIGHEST", "default", "default",
+                        1L, true)
+        ));
+
+        WorkflowVersion v7 = version(207L, workflowId, 7, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v2",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 30 2 * * ?", "UTC",
+                        "2026-02-01 00:00:00", "2027-01-31 23:59:59",
+                        "END", "FAILURE", 202L,
+                        "HIGHEST", "high-mem", "tenant_a",
+                        9L, false)
+        ));
+
+        WorkflowVersion v8 = version(208L, workflowId, 8, canonicalSnapshot(
+                workflowNode("wf_schedule", null,
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 30 2 * * ?", "UTC",
+                        "2026-02-01 00:00:00", null,
+                        "END", "FAILURE", 202L,
+                        "HIGHEST", "high-mem", "tenant_a",
+                        9L, false)
+        ));
+
+        WorkflowVersion v9 = version(209L, workflowId, 9, canonicalSnapshot(
+                workflowNode("wf_schedule", "desc-v3",
+                        "[{\"prop\":\"bizdate\",\"value\":\"2026-01-02\"}]", "tg-beta"),
+                tasks,
+                edges,
+                scheduleNode("0 30 2 * * ?", "UTC",
+                        "2026-02-01 00:00:00", "2027-12-31 23:59:59",
+                        "END", "FAILURE", 202L,
+                        "HIGHEST", "high-mem", "tenant_a",
+                        9L, false)
+        ));
+
+        Map<Long, WorkflowVersion> versions = new LinkedHashMap<>();
+        versions.put(v1.getId(), v1);
+        versions.put(v2.getId(), v2);
+        versions.put(v3.getId(), v3);
+        versions.put(v4.getId(), v4);
+        versions.put(v5.getId(), v5);
+        versions.put(v6.getId(), v6);
+        versions.put(v7.getId(), v7);
+        versions.put(v8.getId(), v8);
+        versions.put(v9.getId(), v9);
+        when(workflowVersionMapper.selectById(any())).thenAnswer(invocation -> {
+            Long versionId = invocation.getArgument(0);
+            return versions.get(versionId);
+        });
+
+        WorkflowVersionCompareResponse modifyGlobalParams = compare(workflowId, v1.getId(), v2.getId());
+        assertListContains(modifyGlobalParams.getModified().getWorkflowFields(),
+                "workflow.globalParams", "全局变量修改应被识别");
+        assertListContains(modifyGlobalParams.getUnchanged().getTasks(),
+                "1:extract_user", "仅改全局变量时任务应保持不变");
+
+        WorkflowVersionCompareResponse modifyDescription = compare(workflowId, v2.getId(), v3.getId());
+        assertListContains(modifyDescription.getModified().getWorkflowFields(),
+                "workflow.description", "工作流描述修改应被识别");
+
+        WorkflowVersionCompareResponse modifyTaskGroup = compare(workflowId, v3.getId(), v4.getId());
+        assertListContains(modifyTaskGroup.getModified().getWorkflowFields(),
+                "workflow.taskGroupName", "工作流任务组修改应被识别");
+
+        WorkflowVersionCompareResponse modifyScheduleCore = compare(workflowId, v4.getId(), v5.getId());
+        assertListContains(modifyScheduleCore.getModified().getSchedules(),
+                "schedule.scheduleCron", "调度 cron 修改应被识别");
+        assertListContains(modifyScheduleCore.getModified().getSchedules(),
+                "schedule.scheduleTimezone", "调度时区修改应被识别");
+        assertListContains(modifyScheduleCore.getModified().getSchedules(),
+                "schedule.scheduleStartTime", "调度开始时间修改应被识别");
+        assertListContains(modifyScheduleCore.getModified().getSchedules(),
+                "schedule.scheduleEndTime", "调度结束时间修改应被识别");
+
+        WorkflowVersionCompareResponse modifySchedulePolicy = compare(workflowId, v5.getId(), v6.getId());
+        assertListContains(modifySchedulePolicy.getModified().getSchedules(),
+                "schedule.scheduleFailureStrategy", "调度失败策略修改应被识别");
+        assertListContains(modifySchedulePolicy.getModified().getSchedules(),
+                "schedule.scheduleWarningType", "调度告警类型修改应被识别");
+        assertListContains(modifySchedulePolicy.getModified().getSchedules(),
+                "schedule.scheduleWarningGroupId", "调度告警组修改应被识别");
+        assertListContains(modifySchedulePolicy.getModified().getSchedules(),
+                "schedule.scheduleProcessInstancePriority", "调度优先级修改应被识别");
+
+        WorkflowVersionCompareResponse modifyScheduleRuntime = compare(workflowId, v6.getId(), v7.getId());
+        assertListContains(modifyScheduleRuntime.getModified().getSchedules(),
+                "schedule.scheduleWorkerGroup", "调度 workerGroup 修改应被识别");
+        assertListContains(modifyScheduleRuntime.getModified().getSchedules(),
+                "schedule.scheduleTenantCode", "调度租户修改应被识别");
+        assertListContains(modifyScheduleRuntime.getModified().getSchedules(),
+                "schedule.scheduleEnvironmentCode", "调度环境修改应被识别");
+        assertListContains(modifyScheduleRuntime.getModified().getSchedules(),
+                "schedule.scheduleAutoOnline", "调度自动上线开关修改应被识别");
+
+        WorkflowVersionCompareResponse removeWorkflowAndScheduleField = compare(workflowId, v7.getId(), v8.getId());
+        assertListContains(removeWorkflowAndScheduleField.getRemoved().getWorkflowFields(),
+                "workflow.description", "工作流描述删除应被识别");
+        assertListContains(removeWorkflowAndScheduleField.getRemoved().getSchedules(),
+                "schedule.scheduleEndTime", "调度结束时间删除应被识别");
+
+        WorkflowVersionCompareResponse addWorkflowAndScheduleField = compare(workflowId, v8.getId(), v9.getId());
+        assertListContains(addWorkflowAndScheduleField.getAdded().getWorkflowFields(),
+                "workflow.description", "工作流描述新增应被识别");
+        assertListContains(addWorkflowAndScheduleField.getAdded().getSchedules(),
+                "schedule.scheduleEndTime", "调度结束时间新增应被识别");
+    }
+
     private WorkflowVersion version(Long id, Long workflowId, Integer versionNo, String snapshot) {
         WorkflowVersion version = new WorkflowVersion();
         version.setId(id);
@@ -126,13 +559,116 @@ class WorkflowVersionOperationServiceTest {
         return version;
     }
 
+    private WorkflowVersionCompareResponse compare(Long workflowId, Long leftVersionId, Long rightVersionId) {
+        WorkflowVersionCompareRequest request = new WorkflowVersionCompareRequest();
+        request.setLeftVersionId(leftVersionId);
+        request.setRightVersionId(rightVersionId);
+        return service.compare(workflowId, request);
+    }
+
+    private void assertListContains(List<String> values, String expectedPart, String message) {
+        assertTrue(values.stream().anyMatch(item -> item.contains(expectedPart)),
+                message + "，实际内容: " + values);
+    }
+
+    private Map<String, Object> taskNode(Long taskId,
+                                         String taskName,
+                                         String taskSql,
+                                         String datasourceName,
+                                         List<Long> inputTableIds,
+                                         List<Long> outputTableIds) {
+        Map<String, Object> node = new LinkedHashMap<>();
+        node.put("taskId", taskId);
+        node.put("taskName", taskName);
+        node.put("taskSql", taskSql);
+        node.put("datasourceName", datasourceName);
+        node.put("inputTableIds", new ArrayList<>(inputTableIds));
+        node.put("outputTableIds", new ArrayList<>(outputTableIds));
+        return node;
+    }
+
+    private Map<String, Object> edgeNode(Long upstreamTaskId, Long downstreamTaskId) {
+        Map<String, Object> edge = new LinkedHashMap<>();
+        edge.put("upstreamTaskId", upstreamTaskId);
+        edge.put("downstreamTaskId", downstreamTaskId);
+        return edge;
+    }
+
     private String canonicalSnapshot(String workflowName, String taskName) {
-        return "{"
-                + "\"schemaVersion\":2,"
-                + "\"workflow\":{\"workflowName\":\"" + workflowName + "\"},"
-                + "\"tasks\":[{\"taskId\":1,\"taskName\":\"" + taskName + "\",\"inputTableIds\":[1],\"outputTableIds\":[2]}],"
-                + "\"edges\":[],"
-                + "\"schedule\":{}"
-                + "}";
+        return canonicalSnapshot(
+                workflowName,
+                Collections.singletonList(taskNode(
+                        1L,
+                        taskName,
+                        "select 1",
+                        "default_ds",
+                        Collections.singletonList(1L),
+                        Collections.singletonList(2L)
+                )),
+                Collections.emptyList()
+        );
+    }
+
+    private String canonicalSnapshot(String workflowName,
+                                     List<Map<String, Object>> tasks,
+                                     List<Map<String, Object>> edges) {
+        return canonicalSnapshot(workflowNode(workflowName, null, null, null), tasks, edges, new LinkedHashMap<>());
+    }
+
+    private String canonicalSnapshot(Map<String, Object> workflow,
+                                     List<Map<String, Object>> tasks,
+                                     List<Map<String, Object>> edges,
+                                     Map<String, Object> schedule) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("schemaVersion", 2);
+        root.put("workflow", workflow);
+        root.put("tasks", tasks);
+        root.put("edges", edges);
+        root.put("schedule", schedule == null ? new LinkedHashMap<>() : schedule);
+        try {
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception ex) {
+            throw new IllegalStateException("构建测试快照失败", ex);
+        }
+    }
+
+    private Map<String, Object> workflowNode(String workflowName,
+                                             String description,
+                                             String globalParams,
+                                             String taskGroupName) {
+        Map<String, Object> workflow = new LinkedHashMap<>();
+        workflow.put("workflowName", workflowName);
+        workflow.put("description", description);
+        workflow.put("globalParams", globalParams);
+        workflow.put("taskGroupName", taskGroupName);
+        return workflow;
+    }
+
+    private Map<String, Object> scheduleNode(String scheduleCron,
+                                             String scheduleTimezone,
+                                             String scheduleStartTime,
+                                             String scheduleEndTime,
+                                             String scheduleFailureStrategy,
+                                             String scheduleWarningType,
+                                             Long scheduleWarningGroupId,
+                                             String scheduleProcessInstancePriority,
+                                             String scheduleWorkerGroup,
+                                             String scheduleTenantCode,
+                                             Long scheduleEnvironmentCode,
+                                             Boolean scheduleAutoOnline) {
+        Map<String, Object> schedule = new LinkedHashMap<>();
+        schedule.put("scheduleCron", scheduleCron);
+        schedule.put("scheduleTimezone", scheduleTimezone);
+        schedule.put("scheduleStartTime", scheduleStartTime);
+        schedule.put("scheduleEndTime", scheduleEndTime);
+        schedule.put("scheduleFailureStrategy", scheduleFailureStrategy);
+        schedule.put("scheduleWarningType", scheduleWarningType);
+        schedule.put("scheduleWarningGroupId", scheduleWarningGroupId);
+        schedule.put("scheduleProcessInstancePriority", scheduleProcessInstancePriority);
+        schedule.put("scheduleWorkerGroup", scheduleWorkerGroup);
+        schedule.put("scheduleTenantCode", scheduleTenantCode);
+        schedule.put("scheduleEnvironmentCode", scheduleEnvironmentCode);
+        schedule.put("scheduleAutoOnline", scheduleAutoOnline);
+        return schedule;
     }
 }

--- a/frontend/src/api/workflow.js
+++ b/frontend/src/api/workflow.js
@@ -69,6 +69,10 @@ export const workflowApi = {
     return request.post(`/v1/workflows/${id}/versions/${versionId}/rollback`, payload)
   },
 
+  deleteVersion(id, versionId) {
+    return request.delete(`/v1/workflows/${id}/versions/${versionId}`)
+  },
+
   listRuntimeSyncRecords(id, params = {}) {
     return request.get(`/v1/workflows/${id}/runtime-sync-records`, { params })
   },

--- a/frontend/src/views/workflows/WorkflowVersionBlockList.vue
+++ b/frontend/src/views/workflows/WorkflowVersionBlockList.vue
@@ -19,11 +19,6 @@
       </div>
       <div class="version-meta">{{ formatDateTime(version.createdAt) }}</div>
       <div class="version-meta">{{ version.createdBy || '-' }}</div>
-      <div class="version-actions" @click.stop>
-        <el-button link type="danger" size="small" :loading="rollbackLoadingId === version.id" @click="$emit('rollback', version)">
-          恢复到此版本
-        </el-button>
-      </div>
     </div>
   </div>
 </template>
@@ -43,14 +38,10 @@ const props = defineProps({
   rightVersionId: {
     type: Number,
     default: null
-  },
-  rollbackLoadingId: {
-    type: Number,
-    default: null
   }
 })
 
-const emit = defineEmits(['select-right', 'rollback'])
+const emit = defineEmits(['select-right'])
 
 const handleSelect = (version) => {
   if (!version?.id) {
@@ -110,9 +101,5 @@ const formatDateTime = (value) => {
   font-size: 12px;
   color: #909399;
   line-height: 1.5;
-}
-
-.version-actions {
-  margin-top: 6px;
 }
 </style>

--- a/frontend/src/views/workflows/WorkflowVersionComparePanel.vue
+++ b/frontend/src/views/workflows/WorkflowVersionComparePanel.vue
@@ -2,62 +2,89 @@
   <div class="version-compare-panel" v-loading="loading">
     <div class="toolbar">
       <el-button @click="$emit('back')">返回记录列表</el-button>
-      <div class="step-actions">
-        <el-button size="small" @click="$emit('step', 'left')">向左</el-button>
-        <el-button size="small" @click="$emit('step', 'right')">向右</el-button>
+    </div>
+
+    <div class="version-navigator" v-if="compareResult">
+      <el-button
+        circle
+        size="small"
+        :icon="ArrowLeft"
+        :disabled="!canStepLeft"
+        @click="$emit('step', 'left')"
+      />
+      <div class="version-pair">
+        <div class="version-card is-left">
+          <div class="version-card-title">左侧版本</div>
+          <div class="version-card-no">{{ leftVersionLabel }}</div>
+          <div class="version-card-meta">{{ formatDateTime(leftVersionMeta?.createdAt) }}</div>
+          <div class="version-card-meta">{{ leftVersionMeta?.createdBy || '-' }}</div>
+        </div>
+        <div class="version-card is-right">
+          <div class="version-card-title">右侧版本</div>
+          <div class="version-card-no">{{ rightVersionLabel }}</div>
+          <div class="version-card-meta">{{ formatDateTime(rightVersionMeta?.createdAt) }}</div>
+          <div class="version-card-meta">{{ rightVersionMeta?.createdBy || '-' }}</div>
+        </div>
       </div>
+      <el-button
+        circle
+        size="small"
+        :icon="ArrowRight"
+        :disabled="!canStepRight"
+        @click="$emit('step', 'right')"
+      />
     </div>
-
-    <div class="version-hint" v-if="compareResult">
-      <el-tag size="small" type="info">左侧版本: {{ compareResult.leftVersionNo ?? '空基线' }}</el-tag>
-      <el-tag size="small" type="primary">右侧版本: {{ compareResult.rightVersionNo }}</el-tag>
-      <el-tag size="small" :type="compareResult.changed ? 'warning' : 'success'">
-        {{ compareResult.changed ? '有变化' : '无变化' }}
-      </el-tag>
-    </div>
-
-    <WorkflowVersionBlockList
-      :versions="versions"
-      :left-version-id="leftVersionId"
-      :right-version-id="rightVersionId"
-      :rollback-loading-id="rollbackLoadingId"
-      @select-right="$emit('select-right', $event)"
-      @rollback="$emit('rollback', $event)"
-    />
 
     <div v-if="compareResult" class="summary-row">
       <span>新增: {{ compareResult.summary?.added || 0 }}</span>
       <span>删除: {{ compareResult.summary?.removed || 0 }}</span>
       <span>修改: {{ compareResult.summary?.modified || 0 }}</span>
       <span>不变: {{ compareResult.summary?.unchanged || 0 }}</span>
+      <el-tag size="small" :type="compareResult.changed ? 'warning' : 'success'">
+        {{ compareResult.changed ? '有变化' : '无变化' }}
+      </el-tag>
     </div>
 
-    <div class="diff-sections" v-if="compareResult">
-      <div class="diff-card">
-        <div class="diff-title">新增</div>
-        <DiffSectionView :section="compareResult.added" type="success" />
-      </div>
-      <div class="diff-card">
-        <div class="diff-title">删除</div>
-        <DiffSectionView :section="compareResult.removed" type="danger" />
-      </div>
-      <div class="diff-card">
-        <div class="diff-title">修改</div>
-        <DiffSectionView :section="compareResult.modified" type="warning" />
-      </div>
-      <div class="diff-card">
-        <div class="diff-title">不变</div>
-        <DiffSectionView :section="compareResult.unchanged" type="info" />
-      </div>
-    </div>
+    <el-tabs v-if="compareResult" v-model="activeView" class="compare-tabs">
+      <el-tab-pane label="结构化差异" name="structured">
+        <div class="functional-sections">
+          <div v-for="area in areaSections" :key="area.key" class="area-card">
+            <div class="area-title">{{ area.label }}</div>
+            <div class="status-grid">
+              <div v-for="status in statusConfigs" :key="`${area.key}-${status.key}`" class="status-col">
+                <div class="status-title">{{ status.label }} ({{ area[status.key].length }})</div>
+                <div v-if="area[status.key].length" class="tag-wrap">
+                  <el-tag
+                    v-for="(item, index) in area[status.key]"
+                    :key="`${area.key}-${status.key}-${index}`"
+                    :type="status.type"
+                    size="small"
+                    class="item-tag"
+                  >
+                    {{ item }}
+                  </el-tag>
+                </div>
+                <span v-else class="empty-text">-</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </el-tab-pane>
+      <el-tab-pane label="原始JSON差异" name="raw">
+        <div class="raw-diff-wrap">
+          <pre class="raw-diff-text">{{ compareResult.rawDiff || '-' }}</pre>
+        </div>
+      </el-tab-pane>
+    </el-tabs>
   </div>
 </template>
 
 <script setup>
-import WorkflowVersionBlockList from './WorkflowVersionBlockList.vue'
-import DiffSectionView from './WorkflowVersionDiffSectionView.vue'
+import { computed, ref, watch } from 'vue'
+import dayjs from 'dayjs'
+import { ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
 
-defineProps({
+const props = defineProps({
   versions: {
     type: Array,
     default: () => []
@@ -77,14 +104,140 @@ defineProps({
   loading: {
     type: Boolean,
     default: false
-  },
-  rollbackLoadingId: {
-    type: Number,
-    default: null
   }
 })
 
-defineEmits(['back', 'step', 'select-right', 'rollback'])
+defineEmits(['back', 'step'])
+
+const activeView = ref('structured')
+
+watch(
+  () => props.compareResult,
+  () => {
+    activeView.value = 'structured'
+  }
+)
+
+const statusConfigs = [
+  { key: 'added', label: '新增', type: 'success' },
+  { key: 'removed', label: '删除', type: 'danger' },
+  { key: 'modified', label: '修改', type: 'warning' },
+  { key: 'unchanged', label: '不变', type: 'info' }
+]
+
+const orderedVersions = computed(() => {
+  return [...(props.versions || [])].sort((a, b) => (a.versionNo || 0) - (b.versionNo || 0))
+})
+
+const versionMap = computed(() => {
+  return orderedVersions.value.reduce((acc, item) => {
+    if (item?.id) {
+      acc[Number(item.id)] = item
+    }
+    return acc
+  }, {})
+})
+
+const rightVersionIndex = computed(() => {
+  const rightId = Number(props.rightVersionId)
+  if (!Number.isFinite(rightId)) {
+    return -1
+  }
+  return orderedVersions.value.findIndex((item) => Number(item.id) === rightId)
+})
+
+const canStepLeft = computed(() => rightVersionIndex.value > 1)
+const canStepRight = computed(() => {
+  if (rightVersionIndex.value < 0) {
+    return false
+  }
+  return rightVersionIndex.value < orderedVersions.value.length - 1
+})
+
+const leftVersionMeta = computed(() => {
+  const id = Number(props.leftVersionId)
+  return Number.isFinite(id) ? (versionMap.value[id] || null) : null
+})
+
+const rightVersionMeta = computed(() => {
+  const id = Number(props.rightVersionId)
+  return Number.isFinite(id) ? (versionMap.value[id] || null) : null
+})
+
+const leftVersionLabel = computed(() => {
+  if (props.compareResult?.leftVersionNo === null || props.compareResult?.leftVersionNo === undefined) {
+    return '空基线'
+  }
+  return `v${props.compareResult.leftVersionNo}`
+})
+
+const rightVersionLabel = computed(() => {
+  if (props.compareResult?.rightVersionNo === null || props.compareResult?.rightVersionNo === undefined) {
+    return '-'
+  }
+  return `v${props.compareResult.rightVersionNo}`
+})
+
+const isGlobalField = (item) => String(item || '').includes('workflow.globalParams')
+
+const getSectionArray = (statusKey, sectionKey) => {
+  const section = props.compareResult?.[statusKey]
+  const list = section?.[sectionKey]
+  return Array.isArray(list) ? list : []
+}
+
+const pickWorkflowFields = (statusKey, includeGlobalField) => {
+  const fields = getSectionArray(statusKey, 'workflowFields')
+  return fields.filter((item) => {
+    if (includeGlobalField) {
+      return isGlobalField(item)
+    }
+    return !isGlobalField(item)
+  })
+}
+
+const buildAreaSection = (key, label, resolver) => {
+  return {
+    key,
+    label,
+    added: resolver('added'),
+    removed: resolver('removed'),
+    modified: resolver('modified'),
+    unchanged: resolver('unchanged')
+  }
+}
+
+const hasAnyItems = (section) => {
+  return ['added', 'removed', 'modified', 'unchanged']
+    .some((statusKey) => (section?.[statusKey] || []).length > 0)
+}
+
+const areaSections = computed(() => {
+  if (!props.compareResult) {
+    return []
+  }
+  const sections = [
+    buildAreaSection('global-params', '全局变量', (statusKey) => pickWorkflowFields(statusKey, true)),
+    buildAreaSection('schedule', '定时调度', (statusKey) => getSectionArray(statusKey, 'schedules')),
+    buildAreaSection('task-list', '任务列表', (statusKey) => getSectionArray(statusKey, 'edges')),
+    buildAreaSection('task-definitions', '任务定义', (statusKey) => getSectionArray(statusKey, 'tasks'))
+  ]
+
+  const workflowFields = buildAreaSection(
+    'workflow-fields',
+    '工作流属性',
+    (statusKey) => pickWorkflowFields(statusKey, false)
+  )
+
+  if (hasAnyItems(workflowFields)) {
+    sections.push(workflowFields)
+  }
+  return sections
+})
+
+const formatDateTime = (value) => {
+  return value ? dayjs(value).format('YYYY-MM-DD HH:mm:ss') : '-'
+}
 </script>
 
 <style scoped>
@@ -94,45 +247,156 @@ defineEmits(['back', 'step', 'select-right', 'rollback'])
 
 .toolbar {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   margin-bottom: 10px;
 }
 
-.step-actions {
+.version-navigator {
   display: flex;
+  align-items: stretch;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.version-pair {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
   gap: 8px;
 }
 
-.version-hint {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 10px;
+.version-card {
+  border: 1px solid #ebeef5;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #fff;
+}
+
+.version-card.is-left {
+  border-color: #67c23a;
+}
+
+.version-card.is-right {
+  border-color: #409eff;
+}
+
+.version-card-title {
+  font-size: 12px;
+  color: #909399;
+  margin-bottom: 4px;
+}
+
+.version-card-no {
+  font-size: 16px;
+  font-weight: 600;
+  color: #303133;
+  margin-bottom: 4px;
+}
+
+.version-card-meta {
+  font-size: 12px;
+  color: #909399;
+  line-height: 1.5;
 }
 
 .summary-row {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 14px;
   margin: 12px 0;
   color: #606266;
   font-size: 13px;
 }
 
-.diff-sections {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(260px, 1fr));
+.compare-tabs {
+  margin-top: 8px;
+}
+
+.functional-sections {
+  display: flex;
+  flex-direction: column;
   gap: 10px;
 }
 
-.diff-card {
+.area-card {
   border: 1px solid #ebeef5;
   border-radius: 6px;
   padding: 10px;
   background: #fff;
 }
 
-.diff-title {
+.area-title {
   font-weight: 600;
   margin-bottom: 8px;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.status-col {
+  border: 1px solid #f0f2f5;
+  border-radius: 6px;
+  background: #fafafa;
+  padding: 8px;
+  min-height: 72px;
+}
+
+.status-title {
+  font-size: 12px;
+  color: #606266;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.tag-wrap {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.item-tag {
+  margin: 0 6px 6px 0;
+}
+
+.empty-text {
+  color: #c0c4cc;
+  font-size: 12px;
+}
+
+.raw-diff-wrap {
+  border: 1px solid #ebeef5;
+  border-radius: 6px;
+  background: #fafafa;
+  padding: 10px;
+}
+
+.raw-diff-text {
+  margin: 0;
+  white-space: pre;
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #303133;
+  max-height: 540px;
+}
+
+@media (max-width: 1200px) {
+  .status-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 900px) {
+  .version-pair {
+    grid-template-columns: 1fr;
+  }
+
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更背景
本 PR 对齐工作流版本历史/版本对比与 Dolphin 导出 JSON 主路方案，落地“导出主路 + 影子一致性 + 可视化 + 阻断策略”，并完善版本比较与删除规则。

## 主要改动
### 1) 运行态采集改为导出 JSON 主路（兼容 DS 3.2/3.4）
- 新增 `DolphinOpenApiClient.exportDefinitionByCode(projectCode, workflowCode)`，自动探测：
  - `POST /projects/{projectCode}/workflow-definition/batch-export`
  - `POST /projects/{projectCode}/process-definition/batch-export`
- 解析 blob JSON 并映射为 `RuntimeWorkflowDefinition`，导出异常时（仅影子阶段）回退旧路径。

### 2) 引入 ingest 模式与 parity 比对
- 模式：`legacy` / `export_shadow` / `export_only`
- 默认配置：`workflow.runtime-sync.ingest-mode=export_shadow`
- `export_shadow` 下：
  - 预检可见一致性告警
  - 执行同步遇不一致阻断，返回 `DEFINITION_PARITY_MISMATCH`
- 新增 `RuntimeSyncParityService` 负责 hash+分区差异统计与示例输出。

### 3) 扩展同步记录持久化与接口返回
- migration: `V35__runtime_sync_export_parity_fields.sql`
- `workflow_runtime_sync_record` 新增列：
  - `ingest_mode`
  - `parity_status`
  - `parity_detail_json`
  - `raw_definition_json`
- 预检/执行/记录列表/记录详情 DTO 均扩展上述字段（向后兼容）。

### 4) 版本历史与版本对比对齐
- 历史列表以版本展示并支持“最多勾选两条”比较：
  - 勾选两条后其他行禁选
  - 顶部+底部“比较所选版本”同逻辑（仅恰好2条可用）
- 删除规则收敛：
  - 当前版本不可删
  - 最后一次成功发布版本不可删
  - 其余版本可删
- 比较页保留结构化分区展示，并新增原始 `rawDiff` 页签用于精查。

### 5) 同步记录页可视化增强
- 列表新增“采集模式”“一致性结果”
- 详情抽屉展示 parity 摘要、hash、示例、parity 详情 JSON、raw definition JSON。

## 测试与验证
### 后端编译
- `mvn -f backend/pom.xml -DskipTests compile` ✅

### 目标测试集
- `mvn -f backend/pom.xml -Dtest=RuntimeSyncParityServiceTest,DolphinExportDefinitionParserTest,WorkflowRuntimeSyncServicePreviewTest,WorkflowVersionOperationServiceTest,WorkflowVersionComparePersistenceIntegrationTest test` ✅

### 真实 Dolphin 全链路集成（Docker 环境）
- `mvn -f backend/pom.xml -Dtest=WorkflowRuntimeSyncRealIntegrationTest,WorkflowVersionComparePersistenceIntegrationTest,WorkflowVersionOperationServiceTest,WorkflowRuntimeSyncServicePreviewTest test` ✅
- 结果：`Tests run: 19, Failures: 0, Errors: 0, Skipped: 0`

### 前端构建
- `npm --prefix frontend run build` ✅

## 兼容性说明
- 未更改现有接口路径，仅扩展响应字段。
- compare/rollback 等旧能力保持兼容。
