### PR TITLE
fix(dataagent): fallback to sh when odw-cli exec is denied

### DIFF
--- a/dataagent/.claude/skills/dataagent-nl2sql/scripts/_opendataworks_runtime.py
+++ b/dataagent/.claude/skills/dataagent-nl2sql/scripts/_opendataworks_runtime.py
@@ -93,6 +93,7 @@ def ensure_read_only(sql: str):
 
 def call_metadata_cli(subcommand: str, **options: Any) -> Any:
     command = metadata_cli_command(subcommand, **options)
+    cli_path = metadata_cli_bin()
 
     try:
         completed = subprocess.run(
@@ -102,9 +103,18 @@ def call_metadata_cli(subcommand: str, **options: Any) -> Any:
             text=True,
         )
     except PermissionError as exc:
-        raise RuntimeError(
-            f"metadata cli 不可执行: {metadata_cli_bin()}。请先由用户修正该路径下文件权限后再重试。"
-        ) from exc
+        # 离线部署包常见场景是文件保留了 +x，但挂载介质本身是 noexec；
+        # 这种情况下直接 exec 会被拒绝，退回 sh 解释执行仍可继续工作。
+        if command[:1] == ["sh"]:
+            raise RuntimeError(
+                f"metadata cli 不可执行: {cli_path}。请先由用户修正该路径下文件权限后再重试。"
+            ) from exc
+        completed = subprocess.run(
+            ["sh", cli_path, *command[1:]],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
 
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout or "").strip()

--- a/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
+++ b/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
@@ -113,6 +113,28 @@ def test_call_metadata_cli_non_executable_bin_falls_back_to_sh(monkeypatch):
     assert captured["command"][3:] == ["--keyword", "工作流"]
 
 
+def test_call_metadata_cli_permission_denied_falls_back_to_sh(monkeypatch):
+    runtime = _load_runtime_module()
+    cli_path = Path(runtime.metadata_cli_bin())
+    captured = {"calls": 0}
+
+    def fake_run(command, check, capture_output, text):
+        captured["calls"] += 1
+        captured["command"] = command
+        if captured["calls"] == 1:
+            raise PermissionError("Permission denied")
+        return SimpleNamespace(returncode=0, stdout='{"kind":"ok"}', stderr="")
+
+    monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+
+    payload = runtime.call_metadata_cli("inspect", keyword="工作流")
+
+    assert payload == {"kind": "ok"}
+    assert captured["calls"] == 2
+    assert captured["command"][:3] == ["sh", str(cli_path), "inspect"]
+    assert captured["command"][3:] == ["--keyword", "工作流"]
+
+
 def test_call_metadata_cli_missing_binary_requires_user_install(monkeypatch):
     runtime = _load_runtime_module()
     missing_path = SKILL_SCRIPTS_ROOT.parent / "bin" / "missing-odw-cli"


### PR DESCRIPTION
## Summary
- fix the DataAgent metadata CLI bridge so offline deployments still work when `odw-cli` has `+x` but the mounted filesystem rejects direct exec with `Permission denied`
- retry the same CLI invocation via `sh /app/.claude/skills/dataagent-nl2sql/bin/odw-cli ...` after a `PermissionError` instead of failing the NL2SQL path inside `run_sql.py`
- add a regression test covering the runtime `Permission denied` fallback path

## Changes
- update `dataagent/.claude/skills/dataagent-nl2sql/scripts/_opendataworks_runtime.py` to catch `PermissionError` from `subprocess.run()` and retry through `sh` unless the command is already in shell fallback mode
- keep the existing non-executable-file fallback behavior unchanged
- extend `dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py` with a dedicated test for the noexec-style failure mode

## Validation
- `/tmp/odw-dataagent-py311/bin/python -m pytest dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py -q`
- Result: `7 passed`

## Risk
- Low risk: the change only affects the metadata CLI execution fallback path used by DataAgent skill scripts.

## Rollback
- Revert commit `38c8e52` to restore the previous direct-exec-only behavior.
