### PR TITLE
fix(dataagent): require explicit provider configuration

### DIFF
--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -17,8 +17,8 @@ class Settings(BaseSettings):
     debug: bool = False
 
     # ---- LLM Provider / Model ----
-    llm_provider: str = "openrouter"  # anthropic | openrouter | anyrouter | anthropic_compatible
-    claude_model: str = "anthropic/claude-sonnet-4.5"
+    llm_provider: str = ""  # anthropic | openrouter | anyrouter | anthropic_compatible
+    claude_model: str = ""
     claude_max_tokens: int = 4096
     agent_timeout_seconds: int = 180
     agent_max_turns: int = 20

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -15,10 +15,10 @@ from core.skills_sync import ensure_static_skills_bundle
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_PROVIDERS = {"anthropic", "openrouter", "anyrouter", "anthropic_compatible"}
+SUPPORTED_PROVIDERS = ("anthropic", "openrouter", "anyrouter", "anthropic_compatible")
+SUPPORTED_PROVIDER_SET = set(SUPPORTED_PROVIDERS)
 MANAGED_FILE_SUFFIXES = {".json", ".md", ".markdown", ".py"}
 DEFAULT_PROVIDER_ID = "openrouter"
-DEFAULT_MODEL = "anthropic/claude-sonnet-4.5"
 
 PROVIDER_DEFINITIONS: dict[str, dict[str, Any]] = {
     "anthropic": {
@@ -123,9 +123,11 @@ def _now_iso() -> str:
     return datetime.now().isoformat(timespec="seconds")
 
 
-def _normalize_provider_id(provider_id: str | None) -> str:
+def _normalize_provider_id(provider_id: str | None, *, allow_empty: bool = False) -> str:
     value = str(provider_id or "").strip().lower()
-    return value if value in SUPPORTED_PROVIDERS else DEFAULT_PROVIDER_ID
+    if value in SUPPORTED_PROVIDER_SET:
+        return value
+    return "" if allow_empty else DEFAULT_PROVIDER_ID
 
 
 def _string_list(values: Any) -> list[str]:
@@ -168,13 +170,17 @@ def _coerce_provider_settings(raw: Any) -> dict[str, dict[str, Any]]:
         for entry in raw:
             if not isinstance(entry, dict):
                 continue
-            provider_id = _normalize_provider_id(entry.get("provider_id"))
+            provider_id = _normalize_provider_id(entry.get("provider_id"), allow_empty=True)
+            if not provider_id:
+                continue
             items[provider_id] = dict(entry)
         return items
     if isinstance(raw, dict):
         items = {}
         for provider_id, entry in raw.items():
-            normalized_id = _normalize_provider_id(provider_id)
+            normalized_id = _normalize_provider_id(provider_id, allow_empty=True)
+            if not normalized_id:
+                continue
             if isinstance(entry, dict):
                 items[normalized_id] = dict(entry)
         return items
@@ -183,23 +189,33 @@ def _coerce_provider_settings(raw: Any) -> dict[str, dict[str, Any]]:
 
 def _legacy_provider_settings(payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     data = dict(payload or {})
-    provider_id = _normalize_provider_id(data.get("provider_id"))
+    provider_id = _normalize_provider_id(data.get("provider_id"), allow_empty=True)
     model = str(data.get("model") or "").strip()
     api_key = str(data.get("anthropic_api_key") or "").strip()
     auth_token = str(data.get("anthropic_auth_token") or "").strip()
     base_url = str(data.get("anthropic_base_url") or "").strip()
 
     legacy = {pid: _default_provider_settings(pid) for pid in SUPPORTED_PROVIDERS}
-    target = legacy[provider_id]
-    if api_key:
-        target["api_key"] = api_key
-    if auth_token:
-        target["auth_token"] = auth_token
-    if base_url:
-        target["base_url"] = base_url
-    if model:
-        target["enabled_models"] = [model]
+    if provider_id:
+        target = legacy[provider_id]
+        if api_key:
+            target["api_key"] = api_key
+        if auth_token:
+            target["auth_token"] = auth_token
+        if base_url:
+            target["base_url"] = base_url
+        if model:
+            target["enabled_models"] = [model]
     return legacy
+
+
+def _enabled_provider_ids(provider_settings: dict[str, dict[str, Any]]) -> list[str]:
+    enabled: list[str] = []
+    for provider_id in SUPPORTED_PROVIDERS:
+        entry = provider_settings.get(provider_id)
+        if entry and bool(entry.get("enabled")):
+            enabled.append(provider_id)
+    return enabled
 
 
 def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previous: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -330,28 +346,32 @@ def _merge_settings_payload(current: dict[str, Any] | None, patch: dict[str, Any
         legacy_payload=base | update,
     )
 
-    provider_id = _normalize_provider_id(base.get("provider_id"))
-    provider_profile = provider_settings.get(provider_id) or _default_provider_settings(provider_id)
-    preferred_model = str(base.get("model") or "").strip()
-    if preferred_model and preferred_model not in provider_profile["supported_models"]:
+    provider_id = _normalize_provider_id(base.get("provider_id"), allow_empty=True)
+    if not provider_id:
+        enabled_provider_ids = _enabled_provider_ids(provider_settings)
+        provider_id = enabled_provider_ids[0] if enabled_provider_ids else ""
+
+    provider_profile = provider_settings.get(provider_id) if provider_id else None
+    preferred_model = str(base.get("model") or "").strip() if provider_profile else ""
+    if provider_profile and preferred_model and preferred_model not in provider_profile["supported_models"]:
         provider_profile["custom_models"] = _string_list(provider_profile["custom_models"] + [preferred_model])
         provider_settings[provider_id] = _normalize_provider_entry(provider_id, provider_profile)
         provider_profile = provider_settings[provider_id]
 
-    enabled_models = list(provider_profile.get("enabled_models") or [])
+    enabled_models = list(provider_profile.get("enabled_models") or []) if provider_profile else []
     model = preferred_model or (enabled_models[0] if enabled_models else "")
-    if model and model not in provider_profile["supported_models"]:
+    if provider_profile and model and model not in provider_profile["supported_models"]:
         model = ""
-    if not model:
-        model = enabled_models[0] if enabled_models else str(_provider_definition(provider_id).get("default_model") or DEFAULT_MODEL)
+    if not model and enabled_models:
+        model = enabled_models[0]
 
-    runtime_provider = provider_settings.get(provider_id) or _default_provider_settings(provider_id)
+    runtime_provider = provider_settings.get(provider_id) if provider_id else {}
     flattened = {
         "provider_id": provider_id,
         "model": model,
-        "anthropic_api_key": str(runtime_provider.get("api_key") or ""),
-        "anthropic_auth_token": str(runtime_provider.get("auth_token") or ""),
-        "anthropic_base_url": str(runtime_provider.get("base_url") or ""),
+        "anthropic_api_key": str(runtime_provider.get("api_key") or base.get("anthropic_api_key") or ""),
+        "anthropic_auth_token": str(runtime_provider.get("auth_token") or base.get("anthropic_auth_token") or ""),
+        "anthropic_base_url": str(runtime_provider.get("base_url") or base.get("anthropic_base_url") or ""),
         "mysql_host": str(base.get("mysql_host") or ""),
         "mysql_port": int(base.get("mysql_port") or 3306),
         "mysql_user": str(base.get("mysql_user") or ""),
@@ -405,7 +425,7 @@ def runtime_patch_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 def validate_settings_payload(payload: dict[str, Any]):
     provider_id = str(payload.get("provider_id") or "").strip().lower()
-    if provider_id and provider_id not in SUPPORTED_PROVIDERS:
+    if provider_id and provider_id not in SUPPORTED_PROVIDER_SET:
         raise ValueError("provider_id must be one of anthropic/openrouter/anyrouter/anthropic_compatible")
 
     raw_skills_dir = str(payload.get("skills_output_dir") or "").replace("\\", "/")
@@ -482,7 +502,7 @@ def list_provider_configs(*, payload: dict[str, Any] | None = None, enabled_only
 def resolved_chat_settings_payload() -> dict[str, Any]:
     resolved = current_settings_payload()
     providers = list_provider_configs(payload=resolved, enabled_only=True)
-    default_provider_id = _normalize_provider_id(resolved.get("provider_id"))
+    default_provider_id = _normalize_provider_id(resolved.get("provider_id"), allow_empty=True)
     if not any(item["provider_id"] == default_provider_id for item in providers):
         default_provider_id = providers[0]["provider_id"] if providers else ""
 
@@ -510,8 +530,13 @@ def resolved_chat_settings_payload() -> dict[str, Any]:
 
 def resolve_runtime_provider_selection(provider_id: str | None, model: str | None) -> dict[str, Any]:
     resolved = current_settings_payload()
-    normalized_provider_id = _normalize_provider_id(provider_id or resolved.get("provider_id"))
     provider_settings = _coerce_provider_settings(resolved.get("provider_settings"))
+    normalized_provider_id = _normalize_provider_id(provider_id or resolved.get("provider_id"), allow_empty=True)
+    if not normalized_provider_id:
+        enabled_provider_ids = _enabled_provider_ids(provider_settings)
+        normalized_provider_id = enabled_provider_ids[0] if enabled_provider_ids else ""
+    if not normalized_provider_id:
+        raise ValueError("尚未配置可用大模型供应商")
     provider = _normalize_provider_entry(normalized_provider_id, provider_settings.get(normalized_provider_id) or {})
 
     if not provider.get("enabled"):

--- a/dataagent/dataagent-backend/core/skill_admin_store.py
+++ b/dataagent/dataagent-backend/core/skill_admin_store.py
@@ -431,8 +431,8 @@ class SkillAdminStore:
     def _normalize_settings_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         data = dict(payload or {})
         normalized = {
-            "provider_id": str(data.get("provider_id") or "openrouter").strip() or "openrouter",
-            "model": str(data.get("model") or "anthropic/claude-sonnet-4.5").strip() or "anthropic/claude-sonnet-4.5",
+            "provider_id": str(data.get("provider_id") or "").strip(),
+            "model": str(data.get("model") or "").strip(),
             "anthropic_api_key": str(data.get("anthropic_api_key") or ""),
             "anthropic_auth_token": str(data.get("anthropic_auth_token") or ""),
             "anthropic_base_url": str(data.get("anthropic_base_url") or ""),
@@ -469,8 +469,8 @@ class SkillAdminStore:
         if not row:
             return {}
         normalized = {
-            "provider_id": str(row.get("provider_id") or "openrouter"),
-            "model": str(row.get("model_name") or "anthropic/claude-sonnet-4.5"),
+            "provider_id": str(row.get("provider_id") or ""),
+            "model": str(row.get("model_name") or ""),
             "anthropic_api_key": str(row.get("anthropic_api_key") or ""),
             "anthropic_auth_token": str(row.get("anthropic_auth_token") or ""),
             "anthropic_base_url": str(row.get("anthropic_base_url") or ""),

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
@@ -8,7 +9,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from core import skill_admin_service
-from core.skill_admin_service import _merge_provider_settings
+from core.skill_admin_service import _merge_provider_settings, _merge_settings_payload
 
 
 def test_merge_provider_settings_can_reenable_provider_with_models():
@@ -71,6 +72,71 @@ def test_merge_provider_settings_preserves_partial_capability_flag():
     assert provider["enabled"] is True
 
 
+def test_merge_settings_payload_keeps_provider_and_model_empty_without_enabled_provider():
+    merged = _merge_settings_payload(
+        {
+            "provider_id": "",
+            "model": "",
+            "skills_output_dir": "../.claude/skills/dataagent-nl2sql",
+            "session_mysql_database": "dataagent",
+        },
+        {},
+    )
+
+    assert merged["provider_id"] == ""
+    assert merged["model"] == ""
+    assert merged["validated_provider_id"] == ""
+    assert merged["validated_model"] == ""
+
+
+def test_bootstrap_admin_settings_persists_blank_provider_and_model(monkeypatch):
+    captured = {}
+
+    class FakeStore:
+        def init_schema(self):
+            return None
+
+        def load_settings_record(self):
+            return None
+
+        def save_settings_record(self, payload):
+            captured["saved"] = dict(payload)
+            return dict(payload)
+
+    monkeypatch.setattr(skill_admin_service, "get_skill_admin_store", lambda: FakeStore())
+    monkeypatch.setattr(
+        skill_admin_service,
+        "get_settings",
+        lambda: types.SimpleNamespace(
+            llm_provider="",
+            claude_model="",
+            anthropic_api_key="",
+            anthropic_auth_token="",
+            anthropic_base_url="",
+            mysql_host="",
+            mysql_port=3306,
+            mysql_user="",
+            mysql_password="",
+            mysql_database="",
+            doris_host="",
+            doris_port=9030,
+            doris_user="",
+            doris_password="",
+            doris_database="",
+            skills_output_dir="../.claude/skills/dataagent-nl2sql",
+            session_mysql_database="dataagent",
+        ),
+    )
+    monkeypatch.setattr(skill_admin_service, "update_settings", lambda patch: patch)
+
+    resolved = skill_admin_service.bootstrap_admin_settings()
+
+    assert captured["saved"]["provider_id"] == ""
+    assert captured["saved"]["model"] == ""
+    assert resolved["provider_id"] == ""
+    assert resolved["model"] == ""
+
+
 def test_resolve_runtime_provider_selection_returns_partial_capability(monkeypatch):
     monkeypatch.setattr(
         skill_admin_service,
@@ -94,3 +160,22 @@ def test_resolve_runtime_provider_selection_returns_partial_capability(monkeypat
     assert resolved["provider_id"] == "anthropic_compatible"
     assert resolved["model"] == "claude-sonnet-4.5"
     assert resolved["supports_partial_messages"] is False
+
+
+def test_resolve_runtime_provider_selection_requires_enabled_provider(monkeypatch):
+    monkeypatch.setattr(
+        skill_admin_service,
+        "current_settings_payload",
+        lambda: {
+            "provider_id": "",
+            "model": "",
+            "provider_settings": {},
+        },
+    )
+
+    try:
+        skill_admin_service.resolve_runtime_provider_selection(None, None)
+    except ValueError as exc:
+        assert str(exc) == "尚未配置可用大模型供应商"
+    else:
+        raise AssertionError("expected ValueError")

--- a/dataagent/dataagent-backend/tests/test_skill_admin_store.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_store.py
@@ -56,6 +56,19 @@ def test_normalize_settings_payload_accepts_legacy_providers_list():
     assert normalized["provider_settings"]["openrouter"]["enabled_models"] == ["anthropic/claude-sonnet-4.5"]
 
 
+def test_normalize_settings_payload_keeps_blank_provider_and_model():
+    store = SkillAdminStore()
+    normalized = store._normalize_settings_payload(
+        {
+            "provider_id": "",
+            "model": "",
+        }
+    )
+
+    assert normalized["provider_id"] == ""
+    assert normalized["model"] == ""
+
+
 def test_normalize_settings_row_keeps_provider_settings_dict():
     store = SkillAdminStore()
     normalized = store._normalize_settings_row(
@@ -112,3 +125,32 @@ def test_normalize_settings_row_accepts_legacy_providers_list():
 
     assert isinstance(normalized["provider_settings"], dict)
     assert normalized["provider_settings"]["openrouter"]["provider_id"] == "openrouter"
+
+
+def test_normalize_settings_row_keeps_blank_provider_and_model():
+    store = SkillAdminStore()
+    normalized = store._normalize_settings_row(
+        {
+            "provider_id": "",
+            "model_name": "",
+            "anthropic_api_key": "",
+            "anthropic_auth_token": "",
+            "anthropic_base_url": "",
+            "mysql_host": "",
+            "mysql_port": 3306,
+            "mysql_user": "",
+            "mysql_password": "",
+            "mysql_database": "opendataworks",
+            "doris_host": "",
+            "doris_port": 9030,
+            "doris_user": "",
+            "doris_password": "",
+            "doris_database": "",
+            "skills_output_dir": "../.claude/skills/dataagent-nl2sql",
+            "updated_at": None,
+            "raw_json": None,
+        }
+    )
+
+    assert normalized["provider_id"] == ""
+    assert normalized["model"] == ""

--- a/docs/design/2026-03-26-dataagent-remove-default-provider-bootstrap-design.md
+++ b/docs/design/2026-03-26-dataagent-remove-default-provider-bootstrap-design.md
@@ -1,0 +1,99 @@
+# DataAgent Remove Default Provider Bootstrap Design
+
+**Date:** 2026-03-26  
+**Goal:** 去掉 DataAgent 在未显式配置时自动回填 `openrouter + anthropic/claude-sonnet-4.5` 的行为，确保大模型供应商与模型选择只来自管理页已保存配置或显式运行时注入，而不是 `deploy` / 启动默认值。  
+**Tech Stack:** 前端 `Vue 3` + `Vite 5` + `Element Plus`；DataAgent 后端 `FastAPI` + `Pydantic` + `PyMySQL`。
+
+## Scope
+
+- 覆盖 `dataagent/dataagent-backend` 的配置默认值、启动回填链路、provider 选择逻辑
+- 覆盖智能问数聊天页和 DataAgent 设置页的前端初始默认值
+- 覆盖针对该行为的后端与前端回归测试
+
+不在范围内：
+
+- 不改动 provider catalog 中的候选供应商列表和模型列表
+- 不移除设置页中作为提示的默认 Base URL 占位语义
+- 不在本次变更中调整 `da_agent_settings` 表结构默认值
+
+## Current Problems
+
+- `deploy/.env.example` 与 Compose 中的 provider/model 默认值已经清掉，但 `config.py` 仍默认 `llm_provider=openrouter`、`claude_model=anthropic/claude-sonnet-4.5`
+- `main.py` 启动时会执行 `bootstrap_admin_settings()`，把运行时默认值合并并持久化到 `da_agent_settings`
+- `skill_admin_store.py` 在读写 settings 记录时也会把空值补成 `openrouter + anthropic/claude-sonnet-4.5`
+- 前端聊天页和设置页仍以内置默认值初始化，导致未配置时 UI 看起来像“已有默认供应商”
+
+结果是：
+
+- 从部署层看，系统仍然会在第一次启动时自动形成一套默认 provider/model
+- 管理页没有完成显式配置时，界面状态和真实可执行状态容易不一致
+- 用户很难判断“系统未配置”与“系统已配置但未校验通过”的区别
+
+## Target State
+
+- 未显式配置 provider/model 时：
+  - 后端运行时 `llm_provider`、`claude_model` 为空字符串
+  - `bootstrap_admin_settings()` 不再把 `openrouter` 或默认模型写入 `da_agent_settings`
+  - 管理接口返回的顶层 `provider_id`、`model` 为空
+  - 智能问数聊天页不再预选 `openrouter`
+  - 发送请求前必须来自已启用 provider 的显式选择
+- 已显式保存 provider/model 时：
+  - 继续按当前管理页配置执行
+  - provider 校验、enabled models、Base URL 推导和运行时注入逻辑保持不变
+
+## Design
+
+### 1. Runtime defaults become empty
+
+- `config.py`
+  - `llm_provider` 默认值改为空字符串
+  - `claude_model` 默认值改为空字符串
+- 健康检查与启动日志继续返回这两个字段，但允许为空
+
+### 2. Bootstrap no longer invents provider/model
+
+- `skill_admin_service.py`
+  - 区分“空 provider”与“非法 provider”
+  - 仅当 payload 中已有合法 provider，或 provider settings 中已有启用供应商时，才产生顶层 `provider_id`
+  - `model` 仅从显式值或启用模型列表中解析，不再从 provider definition 默认模型兜底
+  - `resolve_runtime_provider_selection()` 在没有任何可执行 provider 时直接报错，而不是隐式回退到 `openrouter`
+
+### 3. Settings store keeps blank values blank
+
+- `skill_admin_store.py`
+  - settings payload / row 归一化时不再把空 `provider_id`、`model` 填成 `openrouter` 或 `anthropic/claude-sonnet-4.5`
+
+### 4. Frontend defaults reflect “not configured”
+
+- `frontend/src/views/intelligence/NL2SqlChat.vue`
+  - 本地初始 `default_provider_id`、`default_model` 改为空
+  - 加载管理设置后，只选择已启用 provider
+- `frontend/src/views/settings/DataAgentConfig.vue`
+  - 保存时不再把空 provider 回退成 `openrouter`
+
+## Interfaces Affected
+
+- `GET /api/v1/nl2sql/health`
+  - `provider_id`、`model` 可能为空
+- `GET /api/v1/nl2sql-admin/settings`
+  - 顶层 `provider_id`、`model` 可能为空
+- `POST /api/v1/nl2sql/tasks` / `POST /api/v1/nl2sql/tasks/deliver-message`
+  - 在系统没有任何已启用 provider 时，会更早返回明确配置错误
+
+## Risks
+
+- 旧测试可能依赖 `openrouter` 作为默认 provider
+- 若某些脚本默认读取健康检查中的 provider/model 非空，需要同步收敛预期
+- 老数据如果已经保存了顶层 provider/model，不会自动清空；本次只保证“新启动/新保存时不再发明默认值”
+
+## Verification
+
+- 后端单测覆盖：
+  - bootstrap 空运行时不落默认 provider/model
+  - runtime selection 在无启用 provider 时失败
+  - 已保存 provider settings 仍能解析正确 provider/model
+- 前端单测覆盖：
+  - 聊天页加载未配置 settings 时不再默认选中 `openrouter`
+- 环境可用时补充本地 smoke：
+  - 启动 DataAgent 后直接访问设置接口，确认 `provider_id/model` 为空
+  - 在管理页完成 provider 配置后，再验证聊天页可以正常选择并发送

--- a/docs/plans/2026-03-26-dataagent-remove-default-provider-bootstrap-plan.md
+++ b/docs/plans/2026-03-26-dataagent-remove-default-provider-bootstrap-plan.md
@@ -1,0 +1,67 @@
+# DataAgent Remove Default Provider Bootstrap Implementation Plan
+
+> Design: [../design/2026-03-26-dataagent-remove-default-provider-bootstrap-design.md](../design/2026-03-26-dataagent-remove-default-provider-bootstrap-design.md)
+
+**Goal:** 让 DataAgent 在未显式配置大模型供应商前保持“未配置”状态，而不是在启动或保存时自动回填 `openrouter + anthropic/claude-sonnet-4.5`。
+
+## Task 1: Stop backend runtime and store defaults from inventing provider/model
+
+**Files**
+
+- `dataagent/dataagent-backend/config.py`
+- `dataagent/dataagent-backend/core/skill_admin_service.py`
+- `dataagent/dataagent-backend/core/skill_admin_store.py`
+
+**Steps**
+
+1. 将运行时默认 `llm_provider`、`claude_model` 改为空字符串
+2. 调整 settings merge 逻辑，允许顶层 `provider_id`、`model` 为空
+3. 调整 runtime provider selection，在没有可执行 provider 时返回明确错误
+4. 保留 provider catalog 和 provider-specific base URL/supported models 展示逻辑
+
+## Task 2: Remove frontend implicit selections
+
+**Files**
+
+- `frontend/src/views/intelligence/NL2SqlChat.vue`
+- `frontend/src/views/settings/DataAgentConfig.vue`
+
+**Steps**
+
+1. 聊天页本地初始 provider/model 改为空
+2. 设置加载后仅自动选择已启用 provider
+3. 设置页保存时不再把空 provider 回退成 `openrouter`
+
+## Task 3: Update regression coverage
+
+**Files**
+
+- `dataagent/dataagent-backend/tests/test_skill_admin_service.py`
+- `dataagent/dataagent-backend/tests/test_skill_admin_store.py`
+- `frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js`
+
+**Steps**
+
+1. 增加空启动 settings 不生成默认 provider/model 的测试
+2. 增加无启用 provider 时 runtime selection 报错的测试
+3. 调整聊天页 settings 加载测试，验证未配置时不再自动选中 `openrouter`
+
+## Verification
+
+- 后端：
+  - `pytest dataagent/dataagent-backend/tests/test_skill_admin_service.py dataagent/dataagent-backend/tests/test_skill_admin_store.py`
+- 前端：
+  - 先执行 `nvm use`
+  - 再跑最小相关测试
+- 若本地 DataAgent 环境可直接启动，再补 `GET /api/v1/nl2sql-admin/settings` smoke，确认顶层 `provider_id/model` 为空
+
+## Rollout
+
+1. 合入后先观察空配置环境的启动日志与 settings 接口返回
+2. 再让管理页完成显式 provider 配置
+3. 最后验证聊天页发送路径
+
+## Backout
+
+- 若需要回退，恢复 `config.py`、`skill_admin_service.py`、`skill_admin_store.py`、前端初始选择逻辑即可
+- 本次不涉及数据迁移，回退不需要回滚 schema

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -271,8 +271,8 @@ const taskSubscriptions = new Map()
 const pendingSubmitKeys = ref(new Set())
 
 const settings = reactive({
-  default_provider_id: 'openrouter',
-  default_model: 'anthropic/claude-sonnet-4.5',
+  default_provider_id: '',
+  default_model: '',
   providers: []
 })
 
@@ -864,12 +864,22 @@ const handleComposerAction = () => {
 const loadSettings = async () => {
   try {
     const payload = await adminApi.getSettings()
-    settings.default_provider_id = payload?.provider_id || payload?.default_provider_id || settings.default_provider_id
-    settings.default_model = payload?.model || payload?.default_model || settings.default_model
-    settings.providers = Array.isArray(payload?.providers) ? payload.providers : []
-    selectedProvider.value = settings.default_provider_id || settings.providers[0]?.provider_id || ''
-    const provider = settings.providers.find((item) => item.provider_id === selectedProvider.value)
-    selectedModel.value = provider?.default_model || settings.default_model || ''
+    const enabledProviders = Array.isArray(payload?.providers)
+      ? payload.providers.filter((item) => item?.enabled && Array.isArray(item?.models) && item.models.length)
+      : []
+    settings.providers = enabledProviders
+    const preferredProviderId = payload?.provider_id || payload?.default_provider_id || ''
+    const resolvedProvider = enabledProviders.find((item) => item.provider_id === preferredProviderId) || enabledProviders[0] || null
+    settings.default_provider_id = resolvedProvider?.provider_id || ''
+
+    const preferredModel = payload?.model || payload?.default_model || ''
+    const providerModels = Array.isArray(resolvedProvider?.models) ? resolvedProvider.models : []
+    settings.default_model = providerModels.includes(preferredModel)
+      ? preferredModel
+      : (resolvedProvider?.default_model || providerModels[0] || '')
+
+    selectedProvider.value = settings.default_provider_id
+    selectedModel.value = settings.default_model
   } catch (error) {
     console.warn('load settings failed', error)
   }

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -127,6 +127,7 @@ describe('NL2SqlChat', () => {
         {
           provider_id: 'anyrouter',
           display_name: 'AnyRouter',
+          enabled: true,
           models: ['claude-opus-4-6'],
           default_model: 'claude-opus-4-6',
           supports_partial_messages: true
@@ -221,6 +222,31 @@ describe('NL2SqlChat', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('shows empty config state when admin settings has no enabled provider', async () => {
+    apiMocks.adminApi.getSettings.mockResolvedValue({
+      provider_id: '',
+      model: '',
+      providers: [
+        {
+          provider_id: 'openrouter',
+          display_name: 'OpenRouter',
+          enabled: false,
+          models: [],
+          default_model: 'anthropic/claude-sonnet-4.5',
+          supports_partial_messages: true
+        }
+      ]
+    })
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await flushPromises()
+
+    expect(wrapper.find('.query-config-empty').exists()).toBe(true)
+    expect(wrapper.find('.query-model-badge').text()).toContain('未配置')
   })
 
   it('keeps streamed main text visible while tools are still running', async () => {

--- a/frontend/src/views/settings/DataAgentConfig.vue
+++ b/frontend/src/views/settings/DataAgentConfig.vue
@@ -503,7 +503,7 @@ const applySettings = (payload) => {
   providers.value = Array.isArray(payload?.providers) ? payload.providers : []
   resetProviderDrafts(providers.value)
 
-  form.provider_id = payload?.provider_id || validatedProviders.value[0]?.provider_id || providers.value[0]?.provider_id || ''
+  form.provider_id = payload?.provider_id || validatedProviders.value[0]?.provider_id || ''
   form.model = payload?.model || ''
   form.skills_output_dir = payload?.skills_output_dir || ''
 
@@ -583,7 +583,7 @@ const saveSettings = async () => {
   saving.value = true
   try {
     const payload = await dataagentApi.updateSettings({
-      provider_id: form.provider_id || selectedProviderId.value || providers.value[0]?.provider_id || 'openrouter',
+      provider_id: form.provider_id || '',
       model: form.model || '',
       skills_output_dir: form.skills_output_dir,
       providers: providers.value.map(buildProviderPayload)
@@ -597,6 +597,7 @@ const saveSettings = async () => {
 
 watch(validatedProviders, (list) => {
   if (!list.length) {
+    form.provider_id = ''
     form.model = ''
     return
   }


### PR DESCRIPTION
## Summary
- remove DataAgent startup and settings-store fallback that silently bootstrapped `openrouter + anthropic/claude-sonnet-4.5`
- keep provider/model empty until an enabled provider is explicitly configured in the admin UI
- align chat and settings UI with the new "not configured" state and document the change with matching design/plan docs

## Changes
- backend config and settings bootstrap now preserve blank `provider_id` / `model` instead of inventing defaults
- runtime provider selection now fails fast with a clear error when no enabled provider exists
- settings persistence no longer normalizes empty provider/model values back to `openrouter` and `anthropic/claude-sonnet-4.5`
- NL2SQL chat now only auto-selects enabled providers with enabled models; settings save no longer falls back to `openrouter`
- added targeted backend/frontend regression tests and design/plan docs for the behavior change

## Validation
- passed: `/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pytest dataagent/dataagent-backend/tests/test_skill_admin_service.py dataagent/dataagent-backend/tests/test_skill_admin_store.py`
- passed: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- --run src/views/intelligence/__tests__/NL2SqlChat.spec.js`
- not run: `dataagent/dataagent-backend/tests/test_admin_routes.py` in the available dependency-ready local Python environment, because the locally importable FastAPI environment here is Python 3.9 while this repo's route annotations require Python 3.10+ syntax support during collection
- not run: local DataAgent end-to-end smoke flow

## Risk
- environments that implicitly relied on startup-created provider/model defaults will now remain unconfigured until the admin page saves an enabled provider.

## Rollback
- revert this PR to restore the previous runtime/store/chat fallback behavior that auto-populated `openrouter` defaults.
