### PR TITLE
fix: stabilize ddl copy in data studio

### DIFF
--- a/frontend/src/utils/__tests__/clipboard.spec.js
+++ b/frontend/src/utils/__tests__/clipboard.spec.js
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyText } from '../clipboard'
+
+const originalClipboard = navigator.clipboard
+const originalExecCommand = document.execCommand
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  if (originalClipboard === undefined) {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  } else {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard
+    })
+  }
+
+  if (originalExecCommand === undefined) {
+    Reflect.deleteProperty(document, 'execCommand')
+  } else {
+    document.execCommand = originalExecCommand
+  }
+
+  document.body.innerHTML = ''
+})
+
+describe('copyText', () => {
+  it('uses the clipboard api when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+    document.execCommand = vi.fn()
+
+    await copyText('CREATE TABLE demo')
+
+    expect(writeText).toHaveBeenCalledWith('CREATE TABLE demo')
+    expect(document.execCommand).not.toHaveBeenCalled()
+  })
+
+  it('falls back to execCommand when clipboard api rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+    document.execCommand = vi.fn(() => true)
+
+    await copyText('CREATE TABLE demo')
+
+    expect(writeText).toHaveBeenCalledWith('CREATE TABLE demo')
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+})

--- a/frontend/src/utils/clipboard.js
+++ b/frontend/src/utils/clipboard.js
@@ -1,0 +1,41 @@
+const fallbackCopyText = (text) => {
+  if (typeof document === 'undefined' || !document.body) {
+    throw new Error('Clipboard copy is not available')
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '-9999px'
+  textarea.style.left = '-9999px'
+  textarea.style.opacity = '0'
+
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  const copied = typeof document.execCommand === 'function' && document.execCommand('copy')
+  document.body.removeChild(textarea)
+
+  if (!copied) {
+    throw new Error('Clipboard copy is not supported')
+  }
+}
+
+export const copyText = async (value) => {
+  const text = String(value ?? '')
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      fallbackCopyText(text)
+      return
+    }
+  }
+
+  fallbackCopyText(text)
+}

--- a/frontend/src/views/datastudio/DataStudioNew.vue
+++ b/frontend/src/views/datastudio/DataStudioNew.vue
@@ -1182,6 +1182,7 @@ import { businessDomainApi, dataDomainApi } from '@/api/domain'
 import PersistentTabs from '@/components/PersistentTabs.vue'
 import TaskEditDrawer from '@/views/tasks/TaskEditDrawer.vue'
 import { isDemoMode, showDemoReadonlyMessage } from '@/demo/runtime'
+import { copyText } from '@/utils/clipboard'
 import { loadEcharts } from '@/utils/loadEcharts'
 
 const SqlEditor = defineAsyncComponent({
@@ -4437,7 +4438,7 @@ const copyDdl = async (tabId) => {
   const state = tabStates[tabId]
   if (!state?.ddl) return
   try {
-    await navigator.clipboard.writeText(state.ddl)
+    await copyText(state.ddl)
     ElMessage.success('已复制')
   } catch (error) {
     ElMessage.error('复制失败')


### PR DESCRIPTION
## Summary
- fix Data Studio DDL copy failures in environments where `navigator.clipboard.writeText` is unavailable or denied
- route DDL copy through a shared clipboard helper with a fallback copy path
- add focused frontend tests for both the native clipboard path and the fallback path

## Changes
- add `frontend/src/utils/clipboard.js` with `navigator.clipboard` first and `textarea` + `document.execCommand('copy')` fallback
- update DDL copy in `frontend/src/views/datastudio/DataStudioNew.vue` to use the shared helper
- add `frontend/src/utils/__tests__/clipboard.spec.js` coverage for success and fallback behavior

## Validation
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/utils/__tests__/clipboard.spec.js` ✅
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build` ✅

## Risk
Low risk. The change is isolated to frontend clipboard behavior for DDL copy and adds a fallback only when the primary API fails.

## Rollback
Revert commit `3e70dcf` to restore the previous direct clipboard implementation.
