### PR TITLE
feat: improve workflow publish diff preview

### DIFF
--- a/frontend/src/views/workflows/WorkflowDetail.vue
+++ b/frontend/src/views/workflows/WorkflowDetail.vue
@@ -765,7 +765,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted, nextTick, watch } from 'vue'
+import { ref, reactive, computed, onMounted, nextTick, watch, h } from 'vue'
 import { useRoute } from 'vue-router'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, Link, Delete, Edit, Plus, Close } from '@element-plus/icons-vue'
@@ -776,8 +776,8 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import WorkflowTaskManager from './WorkflowTaskManager.vue'
 import WorkflowBackfillDialog from './WorkflowBackfillDialog.vue'
 import WorkflowVersionComparePanel from './WorkflowVersionComparePanel.vue'
+import WorkflowPublishPreviewDialog from './WorkflowPublishPreviewDialog.vue'
 import {
-  buildPublishPreviewHtml,
   buildPublishRepairHtml,
   firstPreviewErrorMessage,
   isDialogCancel,
@@ -1979,14 +1979,13 @@ const previewPublishAndConfirm = async (row) => {
   }
   try {
     await ElMessageBox.confirm(
-      buildPublishPreviewHtml(preview),
+      h(WorkflowPublishPreviewDialog, { preview }),
       '发布变更确认',
       {
         type: 'warning',
-        customClass: 'workflow-publish-message-box',
+        customClass: 'workflow-publish-message-box workflow-publish-message-box--preview',
         confirmButtonText: '确认发布',
-        cancelButtonText: '取消',
-        dangerouslyUseHTMLString: true
+        cancelButtonText: '取消'
       }
     )
     return true
@@ -2515,11 +2514,4 @@ onMounted(() => {
   cursor: pointer;
 }
 
-</style>
-
-<style>
-.workflow-publish-message-box {
-  width: min(1080px, 92vw) !important;
-  max-width: 92vw !important;
-}
 </style>

--- a/frontend/src/views/workflows/WorkflowList.vue
+++ b/frontend/src/views/workflows/WorkflowList.vue
@@ -233,7 +233,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, watch } from 'vue'
+import { ref, reactive, onMounted, watch, h } from 'vue'
 import dayjs from 'dayjs'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
@@ -241,8 +241,8 @@ import { Search, Link, Plus } from '@element-plus/icons-vue'
 import { workflowApi } from '@/api/workflow'
 import { taskApi } from '@/api/task'
 import { isDemoMode, showDemoReadonlyMessage } from '@/demo/runtime'
+import WorkflowPublishPreviewDialog from './WorkflowPublishPreviewDialog.vue'
 import {
-  buildPublishPreviewHtml,
   buildPublishRepairHtml,
   firstPreviewErrorMessage,
   isDialogCancel,
@@ -598,14 +598,13 @@ const previewPublishAndConfirm = async (row) => {
   }
   try {
     await ElMessageBox.confirm(
-      buildPublishPreviewHtml(preview),
+      h(WorkflowPublishPreviewDialog, { preview }),
       '发布变更确认',
       {
         type: 'warning',
-        customClass: 'workflow-publish-message-box',
+        customClass: 'workflow-publish-message-box workflow-publish-message-box--preview',
         confirmButtonText: '确认发布',
-        cancelButtonText: '取消',
-        dangerouslyUseHTMLString: true
+        cancelButtonText: '取消'
       }
     )
     return true
@@ -959,11 +958,4 @@ onMounted(() => {
   justify-content: flex-end;
 }
 
-</style>
-
-<style>
-.workflow-publish-message-box {
-  width: min(1080px, 92vw) !important;
-  max-width: 92vw !important;
-}
 </style>

--- a/frontend/src/views/workflows/WorkflowPublishPreviewDialog.vue
+++ b/frontend/src/views/workflows/WorkflowPublishPreviewDialog.vue
@@ -1,0 +1,694 @@
+<template>
+  <div class="publish-preview-dialog">
+    <el-scrollbar class="publish-preview-dialog__scrollbar">
+      <div class="publish-preview-dialog__content">
+        <div class="publish-preview-dialog__intro">
+          检测到平台定义与 Dolphin 运行态存在差异，确认后将按平台定义发布。
+        </div>
+        <div class="publish-preview-dialog__tip">
+          变更前为 Dolphin 运行态当前值，变更后为平台本次发布目标值。
+        </div>
+
+        <section v-if="warnings.length" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">预检告警</div>
+          <div class="publish-preview-dialog__warning-list">
+            <div
+              v-for="(issue, index) in warnings"
+              :key="`warning-${index}`"
+              class="publish-preview-dialog__warning-item"
+            >
+              <el-tag v-if="issue?.code" size="small" type="warning" effect="plain">
+                {{ issue.code }}
+              </el-tag>
+              <span class="publish-preview-dialog__warning-text">{{ formatIssueText(issue) }}</span>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="workflowFieldSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">
+            Workflow 字段变更（{{ workflowFieldSection.count }}）
+          </div>
+          <div class="publish-preview-dialog__value-table">
+            <div class="publish-preview-dialog__value-row is-head">
+              <div>字段</div>
+              <div>变更前（运行态）</div>
+              <div>变更后（平台）</div>
+            </div>
+            <div
+              v-for="(change, index) in workflowFieldSection.items"
+              :key="`workflow-field-${index}`"
+              class="publish-preview-dialog__value-row"
+            >
+              <div class="publish-preview-dialog__field-name">{{ change?.field || '-' }}</div>
+              <div class="publish-preview-dialog__value-text">{{ formatSimpleFieldValue(change?.before) }}</div>
+              <div class="publish-preview-dialog__value-text">{{ formatSimpleFieldValue(change?.after) }}</div>
+            </div>
+          </div>
+          <div v-if="workflowFieldSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ workflowFieldSection.remain }} 项
+          </div>
+        </section>
+
+        <section v-if="taskAddedSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">任务新增（{{ taskAddedSection.count }}）</div>
+          <div class="publish-preview-dialog__tag-list">
+            <el-tag
+              v-for="(task, index) in taskAddedSection.items"
+              :key="`task-added-${index}`"
+              size="small"
+              type="success"
+              effect="plain"
+            >
+              {{ formatTaskLabel(task) }}
+            </el-tag>
+          </div>
+          <div v-if="taskAddedSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ taskAddedSection.remain }} 项
+          </div>
+        </section>
+
+        <section v-if="taskRemovedSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">任务删除（{{ taskRemovedSection.count }}）</div>
+          <div class="publish-preview-dialog__tag-list">
+            <el-tag
+              v-for="(task, index) in taskRemovedSection.items"
+              :key="`task-removed-${index}`"
+              size="small"
+              type="danger"
+              effect="plain"
+            >
+              {{ formatTaskLabel(task) }}
+            </el-tag>
+          </div>
+          <div v-if="taskRemovedSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ taskRemovedSection.remain }} 项
+          </div>
+        </section>
+
+        <section v-if="taskModifiedSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">任务修改（{{ taskModifiedSection.count }}）</div>
+
+          <div
+            v-for="(task, taskIndex) in taskModifiedSection.items"
+            :key="`task-modified-${taskIndex}`"
+            class="publish-preview-dialog__task-card"
+          >
+            <div class="publish-preview-dialog__task-header">
+              <div class="publish-preview-dialog__task-title">{{ formatTaskLabel(task) }}</div>
+              <el-tag size="small" type="warning" effect="plain">
+                字段 {{ task.fieldChangesCount }}
+              </el-tag>
+            </div>
+
+            <div
+              v-for="(fieldChange, fieldIndex) in task.fieldChanges"
+              :key="`task-field-${taskIndex}-${fieldIndex}`"
+              class="publish-preview-dialog__task-field"
+            >
+              <div class="publish-preview-dialog__task-field-header">
+                <div class="publish-preview-dialog__field-name">{{ fieldChange?.field || '-' }}</div>
+                <div class="publish-preview-dialog__stat-tags">
+                  <el-tag
+                    v-if="fieldChange.stats.added"
+                    size="small"
+                    type="success"
+                    effect="plain"
+                  >
+                    新增 {{ fieldChange.stats.added }}
+                  </el-tag>
+                  <el-tag
+                    v-if="fieldChange.stats.removed"
+                    size="small"
+                    type="danger"
+                    effect="plain"
+                  >
+                    删除 {{ fieldChange.stats.removed }}
+                  </el-tag>
+                  <el-tag
+                    v-if="fieldChange.stats.modified"
+                    size="small"
+                    type="warning"
+                    effect="plain"
+                  >
+                    修改 {{ fieldChange.stats.modified }}
+                  </el-tag>
+                </div>
+              </div>
+
+              <div class="publish-preview-dialog__diff-header">
+                <div>变更前（运行态）</div>
+                <div>变更后（平台）</div>
+              </div>
+
+              <el-scrollbar :max-height="360" class="publish-preview-dialog__diff-scrollbar">
+                <div class="publish-preview-dialog__diff-table">
+                  <div
+                    v-for="row in fieldChange.rows"
+                    :key="row.key"
+                    class="publish-preview-dialog__diff-row"
+                    :class="`is-${row.type}`"
+                  >
+                    <div
+                      :class="[
+                        'publish-preview-dialog__diff-cell',
+                        'is-left',
+                        `is-${resolveCellType(row, 'left')}`
+                      ]"
+                    >
+                      <template v-if="row.left">
+                        <span class="publish-preview-dialog__diff-line-no">{{ row.left.lineNumber }}</span>
+                        <span class="publish-preview-dialog__diff-line">
+                          <span class="publish-preview-dialog__diff-prefix">{{ row.left.prefix }}</span>
+                          <template
+                            v-for="(segment, segmentIndex) in resolveCellSegments(row.left)"
+                            :key="`${row.key}-left-${segmentIndex}`"
+                          >
+                            <span
+                              :class="[
+                                'publish-preview-dialog__diff-segment',
+                                { 'is-inline-changed': segment.changed }
+                              ]"
+                            >
+                              {{ segment.text || ' ' }}
+                            </span>
+                          </template>
+                        </span>
+                      </template>
+                    </div>
+
+                    <div
+                      :class="[
+                        'publish-preview-dialog__diff-cell',
+                        'is-right',
+                        `is-${resolveCellType(row, 'right')}`
+                      ]"
+                    >
+                      <template v-if="row.right">
+                        <span class="publish-preview-dialog__diff-line-no">{{ row.right.lineNumber }}</span>
+                        <span class="publish-preview-dialog__diff-line">
+                          <span class="publish-preview-dialog__diff-prefix">{{ row.right.prefix }}</span>
+                          <template
+                            v-for="(segment, segmentIndex) in resolveCellSegments(row.right)"
+                            :key="`${row.key}-right-${segmentIndex}`"
+                          >
+                            <span
+                              :class="[
+                                'publish-preview-dialog__diff-segment',
+                                { 'is-inline-changed': segment.changed }
+                              ]"
+                            >
+                              {{ segment.text || ' ' }}
+                            </span>
+                          </template>
+                        </span>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+              </el-scrollbar>
+
+              <div v-if="fieldChange.rows.length === 0" class="publish-preview-dialog__empty">
+                未检测到可展示的行级差异
+              </div>
+            </div>
+
+            <div v-if="task.fieldChangesRemain" class="publish-preview-dialog__more">
+              ... 另有 {{ task.fieldChangesRemain }} 个字段修改
+            </div>
+          </div>
+
+          <div v-if="taskModifiedSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ taskModifiedSection.remain }} 个任务修改
+          </div>
+        </section>
+
+        <section v-if="edgeSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">边变更</div>
+          <div v-if="edgeSection.added.length" class="publish-preview-dialog__edge-group">
+            <div class="publish-preview-dialog__edge-title is-added">边新增（{{ edgeSection.addedCount }}）</div>
+            <div class="publish-preview-dialog__tag-list">
+              <el-tag
+                v-for="(item, index) in edgeSection.added"
+                :key="`edge-added-${index}`"
+                size="small"
+                type="success"
+                effect="plain"
+              >
+                {{ formatRelationLabel(item) }}
+              </el-tag>
+            </div>
+          </div>
+          <div v-if="edgeSection.removed.length" class="publish-preview-dialog__edge-group">
+            <div class="publish-preview-dialog__edge-title is-removed">边删除（{{ edgeSection.removedCount }}）</div>
+            <div class="publish-preview-dialog__tag-list">
+              <el-tag
+                v-for="(item, index) in edgeSection.removed"
+                :key="`edge-removed-${index}`"
+                size="small"
+                type="danger"
+                effect="plain"
+              >
+                {{ formatRelationLabel(item) }}
+              </el-tag>
+            </div>
+          </div>
+          <div v-if="edgeSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ edgeSection.remain }} 项
+          </div>
+        </section>
+
+        <section v-if="scheduleFieldSection.count" class="publish-preview-dialog__section">
+          <div class="publish-preview-dialog__section-title">
+            调度变更（{{ scheduleFieldSection.count }}）
+          </div>
+          <div class="publish-preview-dialog__value-table">
+            <div class="publish-preview-dialog__value-row is-head">
+              <div>字段</div>
+              <div>变更前（运行态）</div>
+              <div>变更后（平台）</div>
+            </div>
+            <div
+              v-for="(change, index) in scheduleFieldSection.items"
+              :key="`schedule-field-${index}`"
+              class="publish-preview-dialog__value-row"
+            >
+              <div class="publish-preview-dialog__field-name">{{ change?.field || '-' }}</div>
+              <div class="publish-preview-dialog__value-text">{{ formatSimpleFieldValue(change?.before) }}</div>
+              <div class="publish-preview-dialog__value-text">{{ formatSimpleFieldValue(change?.after) }}</div>
+            </div>
+          </div>
+          <div v-if="scheduleFieldSection.remain" class="publish-preview-dialog__more">
+            ... 另有 {{ scheduleFieldSection.remain }} 项
+          </div>
+        </section>
+      </div>
+    </el-scrollbar>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { MAX_RENDER_COUNT, formatFieldValue, formatRelation, formatTask } from './publishPreviewHelper'
+import { buildTaskFieldDiffRows, summarizeTaskFieldDiffRows } from './publishPreviewDiffHelper'
+
+const props = defineProps({
+  preview: {
+    type: Object,
+    default: null
+  }
+})
+
+const normalizeArray = (value) => (Array.isArray(value) ? value : [])
+
+const createSectionState = (value, limit = MAX_RENDER_COUNT) => {
+  const items = normalizeArray(value)
+  return {
+    items: items.slice(0, limit),
+    count: items.length,
+    remain: Math.max(items.length - limit, 0)
+  }
+}
+
+const summary = computed(() => props.preview?.diffSummary || {})
+const warnings = computed(() => normalizeArray(props.preview?.warnings))
+const workflowFieldSection = computed(() => createSectionState(summary.value.workflowFieldChanges))
+const taskAddedSection = computed(() => createSectionState(summary.value.taskAdded))
+const taskRemovedSection = computed(() => createSectionState(summary.value.taskRemoved))
+const scheduleFieldSection = computed(() => createSectionState(summary.value.scheduleChanges))
+
+const taskModifiedSection = computed(() => {
+  const section = createSectionState(summary.value.taskModified)
+  return {
+    ...section,
+    items: section.items.map((task) => {
+      const fieldChanges = normalizeArray(task?.fieldChanges)
+      return {
+        ...task,
+        fieldChangesCount: fieldChanges.length,
+        fieldChangesRemain: Math.max(fieldChanges.length - 10, 0),
+        fieldChanges: fieldChanges.slice(0, 10).map((fieldChange) => {
+          const rows = buildTaskFieldDiffRows(fieldChange?.before, fieldChange?.after)
+          return {
+            ...fieldChange,
+            rows,
+            stats: summarizeTaskFieldDiffRows(rows)
+          }
+        })
+      }
+    })
+  }
+})
+
+const edgeSection = computed(() => {
+  const addedSection = createSectionState(summary.value.edgeAdded)
+  const removedSection = createSectionState(summary.value.edgeRemoved)
+  return {
+    added: addedSection.items,
+    removed: removedSection.items,
+    addedCount: addedSection.count,
+    removedCount: removedSection.count,
+    count: addedSection.count + removedSection.count,
+    remain: addedSection.remain + removedSection.remain
+  }
+})
+
+const formatSimpleFieldValue = (value) => formatFieldValue(value)
+const formatTaskLabel = (task) => formatTask(task)
+const formatRelationLabel = (relation) => formatRelation(relation)
+
+const formatIssueText = (issue) => {
+  const parts = []
+  if (issue?.taskName) {
+    parts.push(`任务: ${issue.taskName}`)
+  }
+  if (issue?.message) {
+    parts.push(issue.message)
+  }
+  return parts.length ? parts.join(' | ') : '-'
+}
+
+const resolveCellType = (row, side) => {
+  if (row?.type === 'modified') {
+    return 'modified'
+  }
+  if (side === 'left') {
+    return row?.type === 'removed' ? 'removed' : 'empty'
+  }
+  return row?.type === 'added' ? 'added' : 'empty'
+}
+
+const resolveCellSegments = (cell) => {
+  return Array.isArray(cell?.segments) && cell.segments.length
+    ? cell.segments
+    : [{ text: cell?.text || '', changed: false }]
+}
+</script>
+
+<style scoped lang="scss">
+.publish-preview-dialog {
+  min-width: 0;
+}
+
+.publish-preview-dialog__scrollbar {
+  height: min(72vh, 860px);
+}
+
+.publish-preview-dialog__content {
+  padding-right: 8px;
+}
+
+.publish-preview-dialog__intro {
+  color: #303133;
+  font-weight: 500;
+}
+
+.publish-preview-dialog__tip {
+  margin-top: 6px;
+  color: #909399;
+  font-size: 13px;
+}
+
+.publish-preview-dialog__section {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px solid #ebeef5;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.publish-preview-dialog__section-title {
+  color: #303133;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.publish-preview-dialog__warning-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.publish-preview-dialog__warning-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  color: #e6a23c;
+  line-height: 1.5;
+}
+
+.publish-preview-dialog__warning-text {
+  color: #606266;
+}
+
+.publish-preview-dialog__value-table {
+  margin-top: 10px;
+  border: 1px solid #ebeef5;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.publish-preview-dialog__value-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 220px) minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.publish-preview-dialog__value-row + .publish-preview-dialog__value-row {
+  border-top: 1px solid #ebeef5;
+}
+
+.publish-preview-dialog__value-row > div {
+  min-width: 0;
+  padding: 10px 12px;
+  color: #606266;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.publish-preview-dialog__value-row > div + div {
+  border-left: 1px solid #ebeef5;
+}
+
+.publish-preview-dialog__value-row.is-head > div {
+  background: #f5f7fa;
+  color: #303133;
+  font-weight: 600;
+}
+
+.publish-preview-dialog__field-name {
+  color: #303133;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.publish-preview-dialog__value-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.publish-preview-dialog__tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.publish-preview-dialog__task-card {
+  margin-top: 12px;
+  padding: 14px;
+  border: 1px solid #ebeef5;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.publish-preview-dialog__task-header,
+.publish-preview-dialog__task-field-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.publish-preview-dialog__task-title {
+  color: #303133;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.publish-preview-dialog__task-field {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid #ebeef5;
+}
+
+.publish-preview-dialog__stat-tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.publish-preview-dialog__diff-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.publish-preview-dialog__diff-header > div {
+  padding: 8px 12px;
+  border: 1px solid #ebeef5;
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
+  background: #f5f7fa;
+  color: #303133;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.publish-preview-dialog__diff-scrollbar {
+  border: 1px solid #ebeef5;
+  border-radius: 0 0 8px 8px;
+  background: #fff;
+}
+
+.publish-preview-dialog__diff-table {
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 12px;
+}
+
+.publish-preview-dialog__diff-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 0 12px;
+}
+
+.publish-preview-dialog__diff-row + .publish-preview-dialog__diff-row {
+  border-top: 1px solid #ebeef5;
+}
+
+.publish-preview-dialog__diff-cell {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  min-height: 36px;
+}
+
+.publish-preview-dialog__diff-line-no {
+  padding: 8px 10px;
+  border-right: 1px solid rgba(0, 0, 0, 0.06);
+  color: #909399;
+  text-align: right;
+  user-select: none;
+}
+
+.publish-preview-dialog__diff-line {
+  min-width: 0;
+  padding: 8px 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+}
+
+.publish-preview-dialog__diff-prefix {
+  display: inline-block;
+  width: 14px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.publish-preview-dialog__diff-segment.is-inline-changed {
+  padding: 0 1px;
+  border-radius: 3px;
+}
+
+.publish-preview-dialog__diff-cell.is-added {
+  background: #f0f9eb;
+}
+
+.publish-preview-dialog__diff-cell.is-added .publish-preview-dialog__diff-prefix,
+.publish-preview-dialog__edge-title.is-added {
+  color: #67c23a;
+}
+
+.publish-preview-dialog__diff-cell.is-removed {
+  background: #fef0f0;
+}
+
+.publish-preview-dialog__diff-cell.is-removed .publish-preview-dialog__diff-prefix,
+.publish-preview-dialog__edge-title.is-removed {
+  color: #f56c6c;
+}
+
+.publish-preview-dialog__diff-cell.is-modified {
+  background: #fdf6ec;
+}
+
+.publish-preview-dialog__diff-cell.is-modified .publish-preview-dialog__diff-prefix {
+  color: #e6a23c;
+}
+
+.publish-preview-dialog__diff-cell.is-modified .publish-preview-dialog__diff-segment.is-inline-changed {
+  background: rgba(230, 162, 60, 0.22);
+}
+
+.publish-preview-dialog__diff-cell.is-added .publish-preview-dialog__diff-segment.is-inline-changed {
+  background: rgba(103, 194, 58, 0.18);
+}
+
+.publish-preview-dialog__diff-cell.is-removed .publish-preview-dialog__diff-segment.is-inline-changed {
+  background: rgba(245, 108, 108, 0.18);
+}
+
+.publish-preview-dialog__diff-cell.is-empty {
+  background: #fafafa;
+}
+
+.publish-preview-dialog__edge-group + .publish-preview-dialog__edge-group {
+  margin-top: 12px;
+}
+
+.publish-preview-dialog__edge-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.publish-preview-dialog__empty,
+.publish-preview-dialog__more {
+  margin-top: 8px;
+  color: #909399;
+  font-size: 12px;
+}
+
+@media (max-width: 960px) {
+  .publish-preview-dialog__value-row,
+  .publish-preview-dialog__diff-row,
+  .publish-preview-dialog__diff-header {
+    grid-template-columns: 1fr;
+  }
+
+  .publish-preview-dialog__diff-row {
+    gap: 0;
+    padding: 0;
+  }
+
+  .publish-preview-dialog__diff-cell + .publish-preview-dialog__diff-cell {
+    border-top: 1px solid #ebeef5;
+  }
+}
+
+:global(.workflow-publish-message-box) {
+  width: min(1240px, 96vw) !important;
+  max-width: 96vw !important;
+}
+
+:global(.workflow-publish-message-box--preview .el-message-box__message) {
+  width: 100%;
+  margin: 0;
+}
+
+:global(.workflow-publish-message-box--preview .el-message-box__content) {
+  overflow: hidden;
+}
+</style>

--- a/frontend/src/views/workflows/__tests__/publishPreviewHelper.spec.js
+++ b/frontend/src/views/workflows/__tests__/publishPreviewHelper.spec.js
@@ -1,4 +1,5 @@
 import { buildPublishPreviewHtml, resolvePublishVersionId } from '../publishPreviewHelper'
+import { buildTaskFieldDiffRows } from '../publishPreviewDiffHelper'
 
 describe('publishPreviewHelper', () => {
   it('renders explicit before and after values for task field changes', () => {
@@ -26,6 +27,25 @@ describe('publishPreviewHelper', () => {
     expect(html).toContain('sql_task (1001)')
     expect(html).toContain('from ods.user_old')
     expect(html).toContain('from ods.user_new')
+  })
+
+  it('classifies added removed and modified task diff rows', () => {
+    const rows = buildTaskFieldDiffRows(
+      'select id\nfrom ods.user_old\nwhere dt = ${bizdate}',
+      'select user_id\nfrom ods.user_new\nwhere dt = ${bizdate}\nlimit 10'
+    )
+
+    expect(rows.map(row => row.type)).toEqual(['modified', 'modified', 'added'])
+    expect(rows[0].left.lineNumber).toBe(1)
+    expect(rows[0].right.lineNumber).toBe(1)
+    expect(rows.some((row) => (
+      row.type === 'modified'
+      && (
+        row.left.segments.some(segment => segment.changed)
+        || row.right.segments.some(segment => segment.changed)
+      )
+    ))).toBe(true)
+    expect(rows[2].right.text).toBe('limit 10')
   })
 
   it('prefers last published version when resolving publish version id', () => {

--- a/frontend/src/views/workflows/publishPreviewDiffHelper.js
+++ b/frontend/src/views/workflows/publishPreviewDiffHelper.js
@@ -1,0 +1,180 @@
+import { formatFieldValue } from './publishPreviewHelper'
+import { buildInlineChangeSegments } from './workflowRawDiffHelper'
+
+export const PUBLISH_DIFF_ROW_TYPES = {
+  ADDED: 'added',
+  REMOVED: 'removed',
+  MODIFIED: 'modified'
+}
+
+const splitLines = (value) => {
+  const normalized = String(value ?? '').replace(/\r\n/g, '\n')
+  if (!normalized) {
+    return []
+  }
+  const lines = normalized.split('\n')
+  if (lines.length > 1 && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+  return lines
+}
+
+const buildLcsMatrix = (leftLines, rightLines) => {
+  const rowCount = leftLines.length
+  const columnCount = rightLines.length
+  const matrix = Array.from({ length: rowCount + 1 }, () => Array(columnCount + 1).fill(0))
+
+  for (let leftIndex = rowCount - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = columnCount - 1; rightIndex >= 0; rightIndex -= 1) {
+      matrix[leftIndex][rightIndex] = leftLines[leftIndex] === rightLines[rightIndex]
+        ? matrix[leftIndex + 1][rightIndex + 1] + 1
+        : Math.max(matrix[leftIndex + 1][rightIndex], matrix[leftIndex][rightIndex + 1])
+    }
+  }
+
+  return matrix
+}
+
+const createSegments = (text) => [{ text, changed: false }]
+
+const createLineCell = (text, lineNumber) => ({
+  text,
+  lineNumber,
+  segments: createSegments(text)
+})
+
+const pairDiffBlock = (rows, removedBlock, addedBlock) => {
+  const pairCount = Math.max(removedBlock.length, addedBlock.length)
+
+  for (let index = 0; index < pairCount; index += 1) {
+    const left = removedBlock[index] || null
+    const right = addedBlock[index] || null
+
+    if (left && right) {
+      const inlineSegments = buildInlineChangeSegments(left.text, right.text)
+      rows.push({
+        key: `modified-${left.lineNumber}-${right.lineNumber}-${index}`,
+        type: PUBLISH_DIFF_ROW_TYPES.MODIFIED,
+        left: {
+          ...left,
+          prefix: '~',
+          segments: inlineSegments.removed
+        },
+        right: {
+          ...right,
+          prefix: '~',
+          segments: inlineSegments.added
+        }
+      })
+      continue
+    }
+
+    if (left) {
+      rows.push({
+        key: `removed-${left.lineNumber}-${index}`,
+        type: PUBLISH_DIFF_ROW_TYPES.REMOVED,
+        left: {
+          ...left,
+          prefix: '-'
+        },
+        right: null
+      })
+      continue
+    }
+
+    rows.push({
+      key: `added-${right?.lineNumber || index}-${index}`,
+      type: PUBLISH_DIFF_ROW_TYPES.ADDED,
+      left: null,
+      right: {
+        ...right,
+        prefix: '+'
+      }
+    })
+  }
+}
+
+export const buildTaskFieldDiffRows = (beforeValue, afterValue) => {
+  const beforeText = formatFieldValue(beforeValue, { preserveEmpty: true })
+  const afterText = formatFieldValue(afterValue, { preserveEmpty: true })
+  const leftLines = splitLines(beforeText)
+  const rightLines = splitLines(afterText)
+
+  if (!leftLines.length && !rightLines.length) {
+    return []
+  }
+
+  const matrix = buildLcsMatrix(leftLines, rightLines)
+  const rows = []
+  let leftIndex = 0
+  let rightIndex = 0
+  let leftLineNumber = 1
+  let rightLineNumber = 1
+
+  while (leftIndex < leftLines.length && rightIndex < rightLines.length) {
+    if (leftLines[leftIndex] === rightLines[rightIndex]) {
+      leftIndex += 1
+      rightIndex += 1
+      leftLineNumber += 1
+      rightLineNumber += 1
+      continue
+    }
+
+    const removedBlock = []
+    const addedBlock = []
+
+    while (
+      leftIndex < leftLines.length
+      && rightIndex < rightLines.length
+      && leftLines[leftIndex] !== rightLines[rightIndex]
+    ) {
+      if (matrix[leftIndex + 1][rightIndex] >= matrix[leftIndex][rightIndex + 1]) {
+        removedBlock.push(createLineCell(leftLines[leftIndex], leftLineNumber))
+        leftIndex += 1
+        leftLineNumber += 1
+      } else {
+        addedBlock.push(createLineCell(rightLines[rightIndex], rightLineNumber))
+        rightIndex += 1
+        rightLineNumber += 1
+      }
+    }
+
+    pairDiffBlock(rows, removedBlock, addedBlock)
+  }
+
+  const remainingRemoved = []
+  const remainingAdded = []
+
+  while (leftIndex < leftLines.length) {
+    remainingRemoved.push(createLineCell(leftLines[leftIndex], leftLineNumber))
+    leftIndex += 1
+    leftLineNumber += 1
+  }
+
+  while (rightIndex < rightLines.length) {
+    remainingAdded.push(createLineCell(rightLines[rightIndex], rightLineNumber))
+    rightIndex += 1
+    rightLineNumber += 1
+  }
+
+  pairDiffBlock(rows, remainingRemoved, remainingAdded)
+
+  return rows
+}
+
+export const summarizeTaskFieldDiffRows = (rows = []) => {
+  return rows.reduce((summary, row) => {
+    if (row?.type === PUBLISH_DIFF_ROW_TYPES.ADDED) {
+      summary.added += 1
+    } else if (row?.type === PUBLISH_DIFF_ROW_TYPES.REMOVED) {
+      summary.removed += 1
+    } else if (row?.type === PUBLISH_DIFF_ROW_TYPES.MODIFIED) {
+      summary.modified += 1
+    }
+    return summary
+  }, {
+    added: 0,
+    removed: 0,
+    modified: 0
+  })
+}

--- a/frontend/src/views/workflows/publishPreviewHelper.js
+++ b/frontend/src/views/workflows/publishPreviewHelper.js
@@ -1,4 +1,4 @@
-const MAX_RENDER_COUNT = 20
+export const MAX_RENDER_COUNT = 20
 
 const escapeHtml = (text) => {
   const raw = String(text ?? '')
@@ -10,12 +10,15 @@ const escapeHtml = (text) => {
     .replaceAll("'", '&#39;')
 }
 
-const formatFieldValue = (value) => {
+export const formatFieldValue = (value, options = {}) => {
+  const preserveEmpty = options?.preserveEmpty === true
+  const prettyObject = options?.prettyObject !== false
+
   if (value === null || value === undefined || value === '') {
-    return '-'
+    return preserveEmpty ? '' : '-'
   }
   if (typeof value === 'object') {
-    return JSON.stringify(value)
+    return prettyObject ? JSON.stringify(value, null, 2) : JSON.stringify(value)
   }
   return String(value)
 }
@@ -28,14 +31,14 @@ const renderValueCell = (value) => {
   `
 }
 
-const formatTask = (task) => {
+export const formatTask = (task) => {
   if (!task) return '-'
   const code = task.taskCode ?? '-'
   const name = task.taskName || '-'
   return `${name} (${code})`
 }
 
-const formatRelation = (relation) => {
+export const formatRelation = (relation) => {
   if (!relation) return '-'
   const pre = relation.entryEdge || relation.preTaskCode === 0
     ? '入口'


### PR DESCRIPTION
## Summary
- Improve the workflow publish confirmation dialog so task modifications show readable line-level additions, deletions, and modifications before release.
- Replace the old HTML-string message box content with a Vue dialog component that uses Element Plus scrollbars and a larger preview layout.

## What Changed

### Behavior Changes
- Publish confirmation in workflow list/detail now renders through a dedicated Vue component instead of `dangerouslyUseHTMLString`.
- Task field changes now show side-by-side line diffs with line numbers, added/removed/modified badges, and inline change highlighting.
- The publish confirmation dialog uses Element Plus scrollbar styling and a taller/wider viewport for long diffs.
- Added regression coverage for task-field diff row classification.

### Key Files
- `frontend/src/views/workflows/WorkflowPublishPreviewDialog.vue`: new component for the publish confirmation UI and diff rendering.
- `frontend/src/views/workflows/publishPreviewDiffHelper.js`: line-level diff helper for task field changes.
- `frontend/src/views/workflows/WorkflowList.vue`: switches publish confirm flow to the new component.
- `frontend/src/views/workflows/WorkflowDetail.vue`: switches publish confirm flow to the new component.
- `frontend/src/views/workflows/publishPreviewHelper.js`: exports shared formatting helpers used by the new component.
- `frontend/src/views/workflows/__tests__/publishPreviewHelper.spec.js`: adds regression coverage for diff row classification.

## Validation
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run test -- src/views/workflows/__tests__/publishPreviewHelper.spec.js`
  Result: pass
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build`
  Result: pass

## Risks
- Main regression risk: publish preview rendering now depends on the new diff component path, so unexpected backend diff payload shapes may surface as empty sections instead of the previous raw HTML tables.

## Rollback
- Fast rollback path: revert commit `a6f626e` to restore the original HTML-string publish preview implementation.

## Checklist
- [x] No secrets/credentials committed.
- [x] Compatibility impact reviewed.
- [x] Docs/config updates completed when required.
