### PR TITLE
feat: add opendataagent platform and release packaging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,20 +29,34 @@ jobs:
       matrix:
         service:
           - name: frontend
+            image: opendataworks-frontend
             context: ./frontend
             dockerfile: ./frontend/Dockerfile
             build_args: ""
           - name: backend
+            image: opendataworks-backend
             context: .
             dockerfile: ./backend/Dockerfile
             build_args: ""
           - name: dataagent-backend
+            image: opendataworks-dataagent-backend
             context: .
             dockerfile: ./dataagent/dataagent-backend/Dockerfile
             build_args: ""
           - name: portal-mcp
+            image: opendataworks-portal-mcp
             context: .
             dockerfile: ./dataagent/portal-mcp/Dockerfile
+            build_args: ""
+          - name: opendataagent-server
+            image: opendataagent-server
+            context: ./opendataagent/server
+            dockerfile: ./opendataagent/server/Dockerfile
+            build_args: ""
+          - name: opendataagent-web
+            image: opendataagent-web
+            context: ./opendataagent/web
+            dockerfile: ./opendataagent/web/Dockerfile
             build_args: ""
 
 
@@ -67,13 +81,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKER_NAMESPACE }}/opendataworks-${{ matrix.service.name }}
+          images: ${{ env.DOCKER_NAMESPACE }}/${{ matrix.service.image }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' && (github.event.inputs.version != 'latest' || github.ref == 'refs/heads/main') }}
+
+      - name: Sync root skills for opendataagent server image
+        if: matrix.service.name == 'opendataagent-server'
+        run: |
+          chmod +x opendataagent/scripts/sync-root-skills.sh
+          opendataagent/scripts/sync-root-skills.sh
 
       - name: Build and push
         id: build
@@ -116,12 +136,19 @@ jobs:
             --output "opendataworks-deployment-${VERSION}.tar.gz" \
             --platform linux/amd64
           echo "PACKAGE_PATH=opendataworks-deployment-${VERSION}.tar.gz" >> $GITHUB_ENV
+          chmod +x opendataagent/scripts/create-offline-package.sh
+          opendataagent/scripts/create-offline-package.sh \
+            --tag "$VERSION" \
+            --output "opendataagent-deployment-${VERSION}.tar.gz"
+          echo "ODA_PACKAGE_PATH=opendataagent-deployment-${VERSION}.tar.gz" >> $GITHUB_ENV
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Generate checksum
         run: |
           sha256sum "$PACKAGE_PATH" > "${PACKAGE_PATH}.sha256"
           echo "PACKAGE_SHA=${PACKAGE_PATH}.sha256" >> $GITHUB_ENV
+          sha256sum "$ODA_PACKAGE_PATH" > "${ODA_PACKAGE_PATH}.sha256"
+          echo "ODA_PACKAGE_SHA=${ODA_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
 
       - name: Create Release Body
         run: |
@@ -137,18 +164,24 @@ jobs:
             echo "### 离线部署包 (Offline Deployment Package)"
             echo "- **[opendataworks-deployment-${VERSION}.tar.gz](https://github.com/${REPO}/releases/download/${TAG}/opendataworks-deployment-${VERSION}.tar.gz)** - 适用于无外网环境"
             echo "- 校验和: \`opendataworks-deployment-${VERSION}.tar.gz.sha256\`"
+            echo "- **[opendataagent-deployment-${VERSION}.tar.gz](https://github.com/${REPO}/releases/download/${TAG}/opendataagent-deployment-${VERSION}.tar.gz)** - 独立 `opendataagent` 离线部署包"
+            echo "- 校验和: \`opendataagent-deployment-${VERSION}.tar.gz.sha256\`"
             echo ""
             echo "### Docker 镜像 (Docker Images)"
             echo "- [Frontend](https://hub.docker.com/r/${NS}/opendataworks-frontend/tags?name=${VERSION})"
             echo "- [Backend](https://hub.docker.com/r/${NS}/opendataworks-backend/tags?name=${VERSION})"
             echo "- [DataAgent Backend](https://hub.docker.com/r/${NS}/opendataworks-dataagent-backend/tags?name=${VERSION})"
             echo "- [Portal MCP](https://hub.docker.com/r/${NS}/opendataworks-portal-mcp/tags?name=${VERSION})"
+            echo "- [Opendataagent Server](https://hub.docker.com/r/${NS}/opendataagent-server/tags?name=${VERSION})"
+            echo "- [Opendataagent Web](https://hub.docker.com/r/${NS}/opendataagent-web/tags?name=${VERSION})"
             echo ""
             echo '```bash'
             echo "docker pull ${NS}/opendataworks-frontend:${VERSION}"
             echo "docker pull ${NS}/opendataworks-backend:${VERSION}"
             echo "docker pull ${NS}/opendataworks-dataagent-backend:${VERSION}"
             echo "docker pull ${NS}/opendataworks-portal-mcp:${VERSION}"
+            echo "docker pull ${NS}/opendataagent-server:${VERSION}"
+            echo "docker pull ${NS}/opendataagent-web:${VERSION}"
             echo '```'
           } > release_body.md
           echo "RELEASE_BODY_FILE=release_body.md" >> $GITHUB_ENV
@@ -161,6 +194,8 @@ jobs:
           files: |
             ${{ env.PACKAGE_PATH }}
             ${{ env.PACKAGE_SHA }}
+            ${{ env.ODA_PACKAGE_PATH }}
+            ${{ env.ODA_PACKAGE_SHA }}
 
   create-latest-release:
     needs: build-and-push
@@ -192,11 +227,18 @@ jobs:
             --output "opendataworks-deployment-${RELEASE_TAG}.tar.gz" \
             --platform linux/amd64
           echo "PACKAGE_PATH=opendataworks-deployment-${RELEASE_TAG}.tar.gz" >> $GITHUB_ENV
+          chmod +x opendataagent/scripts/create-offline-package.sh
+          opendataagent/scripts/create-offline-package.sh \
+            --tag "${IMAGE_TAG}" \
+            --output "opendataagent-deployment-${RELEASE_TAG}.tar.gz"
+          echo "ODA_PACKAGE_PATH=opendataagent-deployment-${RELEASE_TAG}.tar.gz" >> $GITHUB_ENV
 
       - name: Generate checksum
         run: |
           sha256sum "$PACKAGE_PATH" > "${PACKAGE_PATH}.sha256"
           echo "PACKAGE_SHA=${PACKAGE_PATH}.sha256" >> $GITHUB_ENV
+          sha256sum "$ODA_PACKAGE_PATH" > "${ODA_PACKAGE_PATH}.sha256"
+          echo "ODA_PACKAGE_SHA=${ODA_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
 
       - name: Create latest release body
         run: |
@@ -213,18 +255,24 @@ jobs:
             echo "### 离线部署包 (Offline Deployment Package)"
             echo "- **[${PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${PACKAGE_PATH})**"
             echo "- 校验和: \`${PACKAGE_PATH}.sha256\`"
+            echo "- **[${ODA_PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${ODA_PACKAGE_PATH})**"
+            echo "- 校验和: \`${ODA_PACKAGE_PATH}.sha256\`"
             echo ""
             echo "### Docker 镜像 (Docker Images)"
             echo "- [Frontend](https://hub.docker.com/r/${NS}/opendataworks-frontend/tags?name=${IMAGE_TAG})"
             echo "- [Backend](https://hub.docker.com/r/${NS}/opendataworks-backend/tags?name=${IMAGE_TAG})"
             echo "- [DataAgent Backend](https://hub.docker.com/r/${NS}/opendataworks-dataagent-backend/tags?name=${IMAGE_TAG})"
             echo "- [Portal MCP](https://hub.docker.com/r/${NS}/opendataworks-portal-mcp/tags?name=${IMAGE_TAG})"
+            echo "- [Opendataagent Server](https://hub.docker.com/r/${NS}/opendataagent-server/tags?name=${IMAGE_TAG})"
+            echo "- [Opendataagent Web](https://hub.docker.com/r/${NS}/opendataagent-web/tags?name=${IMAGE_TAG})"
             echo ""
             echo '```bash'
             echo "docker pull ${NS}/opendataworks-frontend:${IMAGE_TAG}"
             echo "docker pull ${NS}/opendataworks-backend:${IMAGE_TAG}"
             echo "docker pull ${NS}/opendataworks-dataagent-backend:${IMAGE_TAG}"
             echo "docker pull ${NS}/opendataworks-portal-mcp:${IMAGE_TAG}"
+            echo "docker pull ${NS}/opendataagent-server:${IMAGE_TAG}"
+            echo "docker pull ${NS}/opendataagent-web:${IMAGE_TAG}"
             echo '```'
           } > latest_release_body.md
 
@@ -252,6 +300,8 @@ jobs:
           files: |
             ${{ env.PACKAGE_PATH }}
             ${{ env.PACKAGE_SHA }}
+            ${{ env.ODA_PACKAGE_PATH }}
+            ${{ env.ODA_PACKAGE_SHA }}
 
   summary:
     needs: build-and-push
@@ -267,6 +317,8 @@ jobs:
           echo "- \`${{ env.DOCKER_NAMESPACE }}/opendataworks-backend\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.DOCKER_NAMESPACE }}/opendataworks-dataagent-backend\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.DOCKER_NAMESPACE }}/opendataworks-portal-mcp\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.DOCKER_NAMESPACE }}/opendataagent-server\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.DOCKER_NAMESPACE }}/opendataagent-web\`" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Platforms supported:" >> $GITHUB_STEP_SUMMARY
@@ -279,5 +331,7 @@ jobs:
           echo "docker pull ${{ env.DOCKER_NAMESPACE }}/opendataworks-backend:latest" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.DOCKER_NAMESPACE }}/opendataworks-dataagent-backend:latest" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.DOCKER_NAMESPACE }}/opendataworks-portal-mcp:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.DOCKER_NAMESPACE }}/opendataagent-server:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.DOCKER_NAMESPACE }}/opendataagent-web:latest" >> $GITHUB_STEP_SUMMARY
 
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/docs/design/2026-04-15-opendataagent-offline-package-design.md
+++ b/docs/design/2026-04-15-opendataagent-offline-package-design.md
@@ -36,6 +36,8 @@
 - 离线包包含根 `skills/` 的只读快照，供 `opendataagent` 使用
 - 离线包提供 `load-images.sh`、`start.sh`、`stop.sh`、`restart.sh`、`load-package-and-start.sh`
 - 文档明确离线包格式、生成命令、安装命令和路径约定
+- GitHub Release 在 tag 发布与 latest 发布时都上传 `opendataagent` 离线包，并在 release body 中提供下载链接
+- GitHub Actions 同时构建并推送 `mikefan2019/opendataagent-server` 与 `mikefan2019/opendataagent-web`，并在 release body 中提供镜像链接与 `docker pull` 命令
 
 ## Non-Goals
 
@@ -127,6 +129,16 @@ opendataagent-deployment/
 - 现有 `build-release.sh` 继续负责源码发布包
 - 新增离线包脚本单独负责镜像型交付物
 - 两者互补，不强行合并成单一脚本，避免把“无容器环境的源码构建”和“需要容器运行时的镜像导出”绑死在一起
+- GitHub Actions `docker-build.yml` 继续负责主仓库的镜像与主离线包，同时额外调用 `opendataagent/scripts/create-offline-package.sh`
+- 同一 workflow 额外把 `opendataagent-server` 与 `opendataagent-web` 纳入 build-and-push 矩阵
+- Release 附件中同时保留：
+  - `opendataworks-deployment-<tag>.tar.gz`
+  - `opendataagent-deployment-<tag>.tar.gz`
+  - 对应 `.sha256` 文件
+- Release 正文中的 Docker 镜像区同时保留：
+  - `opendataworks-*`
+  - `opendataagent-server`
+  - `opendataagent-web`
 
 ## Tradeoffs
 

--- a/docs/handbook/release-process.md
+++ b/docs/handbook/release-process.md
@@ -79,9 +79,10 @@ git push origin v1.0.0
 
 工作流将依次执行：
 
-1. **构建并推送 Docker 镜像**：`mikefan2019/opendataworks-frontend`、`mikefan2019/opendataworks-backend`、`mikefan2019/opendataworks-dataagent-backend`、`mikefan2019/opendataworks-portal-mcp`，打上版本 tag
+1. **构建并推送 Docker 镜像**：`mikefan2019/opendataworks-frontend`、`mikefan2019/opendataworks-backend`、`mikefan2019/opendataworks-dataagent-backend`、`mikefan2019/opendataworks-portal-mcp`、`mikefan2019/opendataagent-server`、`mikefan2019/opendataagent-web`，打上版本 tag
 2. **生成离线部署包**：调用 `scripts/create-offline-package.sh --tag 1.0.0`
-3. **创建 GitHub Release**：上传离线包为 Release 附件，并自动生成 Release Notes（含提交记录）
+3. **生成 Opendataagent 离线部署包**：调用 `opendataagent/scripts/create-offline-package.sh --tag 1.0.0`
+4. **创建 GitHub Release**：上传两份离线包为 Release 附件，并自动生成 Release Notes（含提交记录）
 
 ---
 
@@ -101,10 +102,13 @@ scripts/create-offline-package.sh --tag 1.0.0 --output opendataworks-deployment-
 GitHub Release 中应包含：
 
 - **Release Notes**：GitHub Actions 自动生成（包含提交记录）
-- **下载区块**：由工作流写入 Release 正文，包含 Docker 镜像拉取命令与离线包链接
+- **下载区块**：由工作流写入 Release 正文，包含 Docker 镜像拉取命令与两份离线包链接
+- **Docker 镜像区块**：包含 `opendataworks-*` 和 `opendataagent-*` 的 Docker Hub 链接与 `docker pull` 示例
 - **附件**：
   - `opendataworks-deployment-1.0.0.tar.gz`（离线部署包）
+  - `opendataagent-deployment-1.0.0.tar.gz`（独立 `opendataagent` 离线部署包）
   - 可选：`opendataworks-deployment-1.0.0.tar.gz.sha256`（校验和）
+  - 可选：`opendataagent-deployment-1.0.0.tar.gz.sha256`（校验和）
 
 ### 4.3 用户下载方式
 
@@ -114,9 +118,12 @@ GitHub Release 中应包含：
    docker pull mikefan2019/opendataworks-backend:1.0.0
    docker pull mikefan2019/opendataworks-dataagent-backend:1.0.0
    docker pull mikefan2019/opendataworks-portal-mcp:1.0.0
+   docker pull mikefan2019/opendataagent-server:1.0.0
+   docker pull mikefan2019/opendataagent-web:1.0.0
    ```
 
-2. **离线部署包**：在 Release 页面下载 `opendataworks-deployment-1.0.0.tar.gz`，按 [deploy/README.md](../../deploy/README.md) 进行离线部署。
+2. **主系统离线部署包**：在 Release 页面下载 `opendataworks-deployment-1.0.0.tar.gz`，按 [deploy/README.md](../../deploy/README.md) 进行离线部署。
+3. **Opendataagent 离线部署包**：在 Release 页面下载 `opendataagent-deployment-1.0.0.tar.gz`，按 [opendataagent/deploy/README.md](../../opendataagent/deploy/README.md) 进行离线部署。
 
 ---
 
@@ -137,7 +144,7 @@ GitHub Release 中应包含：
        ↓
 3. git commit、git tag v1.0.0、git push
        ↓
-4. CI 构建镜像、生成离线包、创建 Release 并上传附件
+4. CI 构建镜像、生成两份离线包、创建 Release 并上传附件
        ↓
 5. 检查 Release 页面，确认下载可用
 ```

--- a/docs/plans/2026-04-15-opendataagent-offline-package-plan.md
+++ b/docs/plans/2026-04-15-opendataagent-offline-package-plan.md
@@ -12,6 +12,8 @@
 - 新增 `opendataagent` 离线镜像加载与启动脚本
 - 新增离线包目录结构与共享 skills 复制逻辑
 - 更新 `opendataagent` 部署文档和 README
+- 更新 GitHub release workflow，把 `opendataagent` 离线包纳入 tag/latest release 附件与正文链接
+- 更新 GitHub release workflow，把 `opendataagent-server/web` 镜像纳入构建推送矩阵与 release 正文链接
 - 做脚本 help / compose config / 打包级别验证
 
 本轮不覆盖：
@@ -64,13 +66,35 @@
   - 离线包生成
   - 离线包安装与启动
 
-### Phase 4: 验证
+### Phase 4: GitHub Release 集成
+
+- 更新 `.github/workflows/docker-build.yml`
+- 在 `build-and-push` 矩阵中新增：
+  - `opendataagent-server`
+  - `opendataagent-web`
+- `opendataagent-server` 构建前执行 `opendataagent/scripts/sync-root-skills.sh`
+- 在 tag release 中新增：
+  - `opendataagent/scripts/create-offline-package.sh`
+  - `opendataagent-deployment-<version>.tar.gz`
+  - 对应 checksum
+  - release body 下载链接
+  - `opendataagent-server/web` 镜像链接与 `docker pull` 示例
+- 在 latest release 中新增：
+  - `opendataagent-deployment-latest.tar.gz`
+  - 对应 checksum
+  - latest release body 下载链接
+  - `opendataagent-server/web` latest 镜像链接与 `docker pull` 示例
+
+### Phase 5: 验证
 
 - 脚本帮助输出：
   - `create-offline-package.sh --help`
   - `load-package-and-start.sh --help`
 - compose 配置校验：
   - `docker compose config` 或 `podman compose config`
+- workflow 结构校验：
+  - YAML 可解析
+  - release job 包含 `opendataagent` 资产变量和文件列表
 - 打包级验证：
   - 在可用容器运行时下执行一次离线包生成
   - 检查 tar.gz 内是否包含 `deploy/docker-images`、`shared-skills`


### PR DESCRIPTION
## Summary
- Add an independent `opendataagent` product line to the repository, keeping the existing intelligent-query module in the main portal production-safe and running in parallel.
- Add standalone deployment, offline package, and GitHub release packaging support for `opendataagent`, including release links for both offline bundles and container images.

## What Changed

### Behavior Changes
- Added a new standalone `opendataagent/` project:
  - `opendataagent/server`: Go agent backend on `agentsdk-go`
  - `opendataagent/web`: Vue 3 console for chat, skills, MCP, model settings, and runtime settings
- Kept the existing portal intelligent-query path intact:
  - restored `/intelligent-query`
  - kept the existing menu and settings entry in the main frontend
  - documented the long-term parallel model: Python DataAgent in the portal, Go SDK agent as an independent product
- Added shared root `skills/` and CLI-based platform skills for `opendataagent`:
  - `skills/platform/opendataworks-platform`
  - `skills/platform/opendataworks-readonly-sql`
  - `skills/generic/python-analysis`
  - `skills/generic/chart-visualization`
- Added `opendataagent` release packaging and offline deployment support:
  - dedicated offline bundle script
  - image load/start/stop/restart helpers
  - independent deploy README
- Moved `opendata-frontend-skill` out of runtime-loaded skills into project-local `.claude/skills/`
- Updated GitHub release workflow to publish:
  - `opendataworks-deployment-*`
  - `opendataagent-deployment-*`
  - `opendataagent-server` / `opendataagent-web` image links and pull commands in release notes

### Key Files
- `opendataagent/server/internal/*`
  - Go runtime, model factory, compat provider, settings, skills, store, and HTTP API
- `opendataagent/web/src/*`
  - full frontend console implementation
- `opendataagent/deploy/docker-compose.yml`
  - standalone deploy stack
- `opendataagent/scripts/create-offline-package.sh`
  - offline package builder for `opendataagent`
- `.github/workflows/docker-build.yml`
  - release workflow now includes `opendataagent` offline assets and image links
- `frontend/src/router/index.js`
- `frontend/src/views/Layout.vue`
- `frontend/src/views/settings/ConfigurationManagement.vue`
  - keep the existing intelligent-query mainline active in the portal
- `skills/`
  - shared platform and generic skill sources for `opendataagent`
- `.claude/skills/opendata-frontend-skill/SKILL.md`
  - repository-local frontend design skill

## Validation
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use >/dev/null && npm --prefix frontend run build`
  Result: pass
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use >/dev/null && npm --prefix opendataagent/web run build`
  Result: pass
- Command: `source ~/.zshrc && cd opendataagent/server && go test ./internal/agent/... ./internal/runtime/... ./internal/skills/...`
  Result: pass
- Command: `bash opendataagent/scripts/create-offline-package.sh --help`
  Result: pass
- Command: `bash opendataagent/scripts/load-package-and-start.sh --help`
  Result: pass
- Command: `podman compose -f opendataagent/deploy/docker-compose.yml --env-file opendataagent/deploy/.env config`
  Result: pass
- Command: `ruby -e 'require "yaml"; data = YAML.load_file(".github/workflows/docker-build.yml"); puts data["jobs"]["build-and-push"]["strategy"]["matrix"]["service"].map{|s| s["name"]}.join(",")'`
  Result: pass, matrix includes `opendataagent-server,opendataagent-web`

## Risks
- The offline package and release workflow are wired end to end, but a full clean `opendataagent` image export/build run still depends on the CI/container environment; local Podman build behavior on this machine was not used as final release proof.

## Rollback
- Revert this branch or selectively back out `opendataagent/`, release workflow changes, and portal coexistence docs if the repository should return to the previous single-agent release model.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updated when required.
