### PR TITLE
feat: simplify model service provider configuration flow

### DIFF
--- a/dataagent/dataagent-backend/api/admin_routes.py
+++ b/dataagent/dataagent-backend/api/admin_routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 from core.skill_admin_service import (
     compare_document_versions,
     current_settings_payload,
+    detect_model_availability,
     get_document_detail,
     list_documents,
     list_provider_configs,
@@ -17,6 +18,8 @@ from core.skills_loader import resolve_skills_root_dir
 from models.schemas import (
     AdminSettingsResponse,
     AdminSettingsUpdateRequest,
+    ModelDetectionRequest,
+    ModelDetectionResponse,
     ProviderConfig,
     SkillDocumentCompareRequest,
     SkillDocumentCompareResponse,
@@ -71,10 +74,19 @@ async def get_admin_settings():
 @settings_router.put("/settings", response_model=AdminSettingsResponse)
 async def update_admin_settings(request: AdminSettingsUpdateRequest):
     try:
-        saved = persist_admin_settings(request.model_dump(exclude_none=True))
+        saved = persist_admin_settings(request.model_dump(exclude_none=True, exclude_unset=True))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _build_admin_settings_response(updated_at=str(saved.get("updated_at") or ""))
+
+
+@settings_router.post("/model-detections", response_model=ModelDetectionResponse)
+async def create_model_detection(request: ModelDetectionRequest):
+    try:
+        result = await detect_model_availability(request.model_dump(exclude_none=True, exclude_unset=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ModelDetectionResponse.model_validate(result)
 
 
 @skills_router.get("/skills/documents", response_model=list[SkillDocumentSummary])

--- a/dataagent/dataagent-backend/core/nl2sql_agent.py
+++ b/dataagent/dataagent-backend/core/nl2sql_agent.py
@@ -16,6 +16,8 @@ from urllib.parse import urlparse
 import anyio
 
 from config import get_settings
+from core.provider_runtime import build_provider_env as _build_provider_env
+from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.skill_admin_service import resolve_runtime_provider_selection
 from core.skills_loader import resolve_agent_project_cwd, resolve_builtin_skill_root_dir
 from core.stream_events import EventSequencer
@@ -849,55 +851,6 @@ def _append_delta(current: str, incoming: str) -> tuple[str, str]:
     if current.endswith(new):
         return current, ""
     return current + new, new
-
-
-def _normalize_provider_id(raw: str | None, base_url: str | None = None) -> str:
-    value = str(raw or "").strip().lower()
-    if value in {"anthropic", "openrouter", "anyrouter", "anthropic_compatible"}:
-        return value
-    base = str(base_url or "").lower()
-    if "openrouter.ai" in base:
-        return "openrouter"
-    if "anyrouter" in base or ".fcapp.run" in base:
-        return "anyrouter"
-    if base:
-        return "anthropic_compatible"
-    return "anthropic"
-
-
-def _build_provider_env(provider_id: str, *, api_key: str, auth_token: str, base_url: str) -> dict[str, str]:
-    if provider_id == "openrouter":
-        return {
-            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
-            "ANTHROPIC_API_KEY": "",
-            "ANTHROPIC_BASE_URL": str(base_url or "https://openrouter.ai/api").strip(),
-            "DISABLE_PROMPT_CACHING": "",
-        }
-
-    if provider_id == "anyrouter":
-        return {
-            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
-            "ANTHROPIC_API_KEY": "",
-            "ANTHROPIC_BASE_URL": str(base_url or "https://a-ocnfniawgw.cn-shanghai.fcapp.run").strip(),
-            "DISABLE_PROMPT_CACHING": "",
-        }
-
-    if provider_id == "anthropic_compatible":
-        return {
-            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
-            "ANTHROPIC_API_KEY": "",
-            "ANTHROPIC_BASE_URL": str(base_url or "").strip(),
-            # Third-party Anthropic-compatible relays often reject Claude Code's
-            # automatic prompt caching beta headers.
-            "DISABLE_PROMPT_CACHING": "1",
-        }
-
-    return {
-        "ANTHROPIC_AUTH_TOKEN": "",
-        "ANTHROPIC_API_KEY": str(api_key or "").strip(),
-        "ANTHROPIC_BASE_URL": str(base_url or "").strip(),
-        "DISABLE_PROMPT_CACHING": "",
-    }
 
 
 def _build_runtime_env(cfg, provider_env: dict[str, str], params: AgentRunInput | None = None) -> dict[str, str]:

--- a/dataagent/dataagent-backend/core/provider_runtime.py
+++ b/dataagent/dataagent-backend/core/provider_runtime.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+
+def normalize_provider_id(raw: str | None, base_url: str | None = None) -> str:
+    value = str(raw or "").strip().lower()
+    if value in {"anthropic", "openrouter", "anyrouter", "anthropic_compatible"}:
+        return value
+    base = str(base_url or "").lower()
+    if "openrouter.ai" in base:
+        return "openrouter"
+    if "anyrouter" in base or ".fcapp.run" in base:
+        return "anyrouter"
+    if base:
+        return "anthropic_compatible"
+    return "anthropic"
+
+
+def build_provider_env(provider_id: str, *, api_key: str, auth_token: str, base_url: str) -> dict[str, str]:
+    if provider_id == "openrouter":
+        return {
+            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
+            "ANTHROPIC_API_KEY": "",
+            "ANTHROPIC_BASE_URL": str(base_url or "https://openrouter.ai/api").strip(),
+            "DISABLE_PROMPT_CACHING": "",
+        }
+
+    if provider_id == "anyrouter":
+        return {
+            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
+            "ANTHROPIC_API_KEY": "",
+            "ANTHROPIC_BASE_URL": str(base_url or "https://a-ocnfniawgw.cn-shanghai.fcapp.run").strip(),
+            "DISABLE_PROMPT_CACHING": "",
+        }
+
+    if provider_id == "anthropic_compatible":
+        return {
+            "ANTHROPIC_AUTH_TOKEN": str(auth_token or api_key).strip(),
+            "ANTHROPIC_API_KEY": "",
+            "ANTHROPIC_BASE_URL": str(base_url or "").strip(),
+            "DISABLE_PROMPT_CACHING": "1",
+        }
+
+    return {
+        "ANTHROPIC_AUTH_TOKEN": "",
+        "ANTHROPIC_API_KEY": str(api_key or "").strip(),
+        "ANTHROPIC_BASE_URL": str(base_url or "").strip(),
+        "DISABLE_PROMPT_CACHING": "",
+    }

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import difflib
 import hashlib
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import anyio
+
 from config import get_settings, update_settings
+from core.provider_runtime import build_provider_env, normalize_provider_id as normalize_runtime_provider_id
 from core.semantic_layer import get_semantic_layer
 from core.skill_admin_store import get_skill_admin_store
-from core.skills_loader import resolve_skills_root_dir, validate_skills_bundle
+from core.skills_loader import resolve_agent_project_cwd, resolve_skills_root_dir, validate_skills_bundle
 from core.skills_sync import ensure_static_skills_bundle
 
 logger = logging.getLogger(__name__)
@@ -19,6 +23,7 @@ SUPPORTED_PROVIDERS = ("anthropic", "openrouter", "anyrouter", "anthropic_compat
 SUPPORTED_PROVIDER_SET = set(SUPPORTED_PROVIDERS)
 MANAGED_FILE_SUFFIXES = {".json", ".md", ".markdown", ".py"}
 DEFAULT_PROVIDER_ID = "openrouter"
+MODEL_DETECTION_TIMEOUT_SECONDS = 30
 
 PROVIDER_DEFINITIONS: dict[str, dict[str, Any]] = {
     "anthropic": {
@@ -144,6 +149,29 @@ def _string_list(values: Any) -> list[str]:
     return result
 
 
+def _normalize_model_detections(raw: Any) -> dict[str, dict[str, str]]:
+    if not isinstance(raw, dict):
+        return {}
+    normalized: dict[str, dict[str, str]] = {}
+    for model, item in raw.items():
+        model_name = str(model or "").strip()
+        if not model_name or not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "unverified").strip()
+        if status not in {"verified", "failed", "unverified"}:
+            status = "unverified"
+        normalized[model_name] = {
+            "status": status,
+            "message": str(item.get("message") or "").strip(),
+            "checked_at": str(item.get("checked_at") or "").strip(),
+        }
+    return normalized
+
+
+def _model_detection_verified(model_detections: dict[str, dict[str, str]], model: str) -> bool:
+    return str((model_detections.get(model) or {}).get("status") or "") == "verified"
+
+
 def _provider_definition(provider_id: str) -> dict[str, Any]:
     return dict(PROVIDER_DEFINITIONS.get(provider_id) or PROVIDER_DEFINITIONS[DEFAULT_PROVIDER_ID])
 
@@ -152,14 +180,16 @@ def _default_provider_settings(provider_id: str) -> dict[str, Any]:
     definition = _provider_definition(provider_id)
     return {
         "provider_id": provider_id,
+        "provider_enabled": False,
         "api_key": "",
         "auth_token": "",
         "base_url": str(definition.get("default_base_url") or ""),
         "supports_partial_messages": provider_id != "anthropic_compatible",
         "enabled_models": [],
         "custom_models": [],
+        "model_detections": {},
         "validation_status": "unverified",
-        "validation_message": "未填写凭证",
+        "validation_message": "供应商未启用",
         "validated_at": "",
     }
 
@@ -225,11 +255,33 @@ def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previou
         base.update(dict(previous))
     base.update(dict(payload or {}))
 
-    enabled_models = _string_list(base.get("enabled_models") or base.get("models"))
+    provider_enabled_raw = None
+    for source in (payload, previous):
+        if not isinstance(source, dict):
+            continue
+        if "provider_enabled" in source:
+            provider_enabled_raw = source.get("provider_enabled")
+            break
+        if "enabled" in source:
+            provider_enabled_raw = source.get("enabled")
+            break
+    if provider_enabled_raw is None:
+        provider_enabled_raw = base.get("enabled", False)
+    provider_enabled = bool(provider_enabled_raw)
+    requested_enabled_models = _string_list(base.get("enabled_models") or base.get("models"))
     custom_models = _string_list(base.get("custom_models"))
+    model_detections = _normalize_model_detections(base.get("model_detections"))
     supported_models = _string_list(
-        list(definition.get("supported_models") or []) + custom_models + enabled_models
+        list(definition.get("supported_models") or [])
+        + custom_models
+        + requested_enabled_models
+        + list(model_detections.keys())
     )
+    enabled_models = [
+        model
+        for model in requested_enabled_models
+        if _model_detection_verified(model_detections, model)
+    ]
     base_url = str(base.get("base_url") or definition.get("default_base_url") or "").strip()
     api_key = str(base.get("api_key") or "").strip()
     auth_token = str(base.get("auth_token") or "").strip()
@@ -237,6 +289,7 @@ def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previou
 
     status, message = _compute_provider_validation(
         provider_id,
+        provider_enabled=provider_enabled,
         api_key=api_key,
         auth_token=auth_token,
         base_url=base_url,
@@ -251,6 +304,7 @@ def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previou
 
     return {
         "provider_id": provider_id,
+        "provider_enabled": provider_enabled,
         "api_key": api_key,
         "auth_token": auth_token,
         "base_url": base_url,
@@ -258,21 +312,25 @@ def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previou
         "enabled_models": enabled_models,
         "custom_models": custom_models,
         "supported_models": supported_models,
+        "model_detections": model_detections,
         "validation_status": status,
         "validation_message": message,
         "validated_at": validated_at,
-        "enabled": bool(enabled_models) and status == "verified",
+        "enabled": provider_enabled and bool(enabled_models) and status == "verified",
     }
 
 
 def _compute_provider_validation(
     provider_id: str,
     *,
+    provider_enabled: bool,
     api_key: str,
     auth_token: str,
     base_url: str,
     enabled_models: list[str],
 ) -> tuple[str, str]:
+    if not provider_enabled:
+        return ("unverified", "供应商未启用")
     token_ready = bool(api_key) if provider_id == "anthropic" else bool(auth_token or api_key)
     if provider_id == "anthropic_compatible" and not str(base_url or "").strip():
         return ("unverified", "请填写兼容网关地址")
@@ -281,8 +339,8 @@ def _compute_provider_validation(
             return ("unverified", "请填写 API Key")
         return ("unverified", "请填写 Token")
     if not enabled_models:
-        return ("unverified", "请至少开启一个模型")
-    return ("verified", "已完成本地配置校验")
+        return ("unverified", "请先检测并启用至少一个模型")
+    return ("verified", "模型服务已可用")
 
 
 def _merge_provider_settings(
@@ -300,6 +358,10 @@ def _merge_provider_settings(
         current_entry = dict(merged.get(provider_id) or _default_provider_settings(provider_id))
         update = dict(entry or {})
 
+        if "provider_enabled" in update:
+            current_entry["provider_enabled"] = bool(update.get("provider_enabled"))
+        elif "enabled" in update:
+            current_entry["provider_enabled"] = bool(update.get("enabled"))
         if "api_key" in update:
             api_key = str(update.get("api_key") or "").strip()
             if api_key:
@@ -316,6 +378,8 @@ def _merge_provider_settings(
             current_entry["enabled_models"] = _string_list(update.get("enabled_models"))
         if "custom_models" in update:
             current_entry["custom_models"] = _string_list(update.get("custom_models"))
+        if "model_detections" in update:
+            current_entry["model_detections"] = _normalize_model_detections(update.get("model_detections"))
         if update.get("enabled") is False:
             current_entry["enabled_models"] = []
 
@@ -433,6 +497,138 @@ def validate_settings_payload(payload: dict[str, Any]):
         raise ValueError("skills_output_dir must be under .claude/skills")
 
 
+def _short_error(exc: Exception) -> str:
+    text = str(exc or "").strip()
+    return text[:500] if text else type(exc).__name__
+
+
+def _model_detection_result(status: str, message: str, *, provider_id: str, model: str) -> dict[str, str]:
+    return {
+        "provider_id": provider_id,
+        "model": model,
+        "status": status,
+        "message": message,
+        "checked_at": _now_iso(),
+    }
+
+
+def _detection_preflight(
+    provider_id: str,
+    *,
+    api_key: str,
+    auth_token: str,
+    base_url: str,
+    model: str,
+) -> str:
+    if not model:
+        return "请选择模型"
+    if provider_id == "anthropic_compatible" and not str(base_url or "").strip():
+        return "Base URL 缺失"
+    token_ready = bool(api_key) if provider_id == "anthropic" else bool(auth_token or api_key)
+    if not token_ready:
+        return "API 密钥缺失" if provider_id == "anthropic" else "Token 缺失"
+    return ""
+
+
+async def _run_model_detection(
+    *,
+    provider_id: str,
+    model: str,
+    api_key: str,
+    auth_token: str,
+    base_url: str,
+    supports_partial_messages: bool,
+) -> tuple[str, str]:
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query as claude_query
+    except ImportError as exc:
+        return "failed", f"claude-agent-sdk 未安装: {_short_error(exc)}"
+
+    normalized_provider = normalize_runtime_provider_id(provider_id, base_url)
+    provider_env = build_provider_env(
+        normalized_provider,
+        api_key=api_key,
+        auth_token=auth_token,
+        base_url=base_url,
+    )
+    runtime_env = dict(os.environ)
+    runtime_env.update(provider_env)
+    options = ClaudeAgentOptions(
+        system_prompt="你是模型服务连通性检测程序。只需用最短文本回答检测请求。",
+        model=model,
+        cwd=str(resolve_agent_project_cwd()),
+        setting_sources=["project"],
+        max_turns=1,
+        allowed_tools=[],
+        mcp_servers={},
+        include_partial_messages=supports_partial_messages,
+        env=runtime_env,
+        stderr=lambda line: logger.error(
+            "model_detection.stderr provider=%s model=%s %s",
+            provider_id,
+            model,
+            str(line or "").rstrip(),
+        ),
+    )
+
+    try:
+        with anyio.fail_after(MODEL_DETECTION_TIMEOUT_SECONDS):
+            async for msg in claude_query(prompt="请直接回复 model-service-ok。", options=options):
+                if type(msg).__name__ == "ResultMessage":
+                    subtype = str(getattr(msg, "subtype", "") or "")
+                    if subtype.startswith("error"):
+                        return "failed", "模型服务返回异常"
+        return "verified", "模型检测通过"
+    except TimeoutError:
+        return "failed", f"模型检测超时（{MODEL_DETECTION_TIMEOUT_SECONDS}s）"
+    except Exception as exc:
+        return "failed", f"模型检测失败: {_short_error(exc)}"
+
+
+async def detect_model_availability(payload: dict[str, Any]) -> dict[str, str]:
+    provider_id = _normalize_provider_id(payload.get("provider_id"), allow_empty=True)
+    if not provider_id:
+        raise ValueError("provider_id must be one of anthropic/openrouter/anyrouter/anthropic_compatible")
+
+    model = str(payload.get("model") or "").strip()
+    if not model:
+        raise ValueError("model is required")
+
+    current = current_settings_payload()
+    provider_settings = _coerce_provider_settings(current.get("provider_settings"))
+    current_entry = _normalize_provider_entry(provider_id, provider_settings.get(provider_id) or {})
+
+    api_key = str(payload.get("api_key") or current_entry.get("api_key") or "").strip()
+    auth_token = str(payload.get("auth_token") or current_entry.get("auth_token") or "").strip()
+    base_url = str(payload.get("base_url") or current_entry.get("base_url") or "").strip()
+    supports_partial_messages = (
+        bool(payload.get("supports_partial_messages"))
+        if payload.get("supports_partial_messages") is not None
+        else bool(current_entry.get("supports_partial_messages", provider_id != "anthropic_compatible"))
+    )
+
+    preflight_message = _detection_preflight(
+        provider_id,
+        api_key=api_key,
+        auth_token=auth_token,
+        base_url=base_url,
+        model=model,
+    )
+    if preflight_message:
+        result = _model_detection_result("failed", preflight_message, provider_id=provider_id, model=model)
+    else:
+        status, message = await _run_model_detection(
+            provider_id=provider_id,
+            model=model,
+            api_key=api_key,
+            auth_token=auth_token,
+            base_url=base_url,
+            supports_partial_messages=supports_partial_messages,
+        )
+        result = _model_detection_result(status, message, provider_id=provider_id, model=model)
+    return result
+
+
 def bootstrap_admin_settings() -> dict[str, Any]:
     store = get_skill_admin_store()
     store.init_schema()
@@ -484,11 +680,13 @@ def list_provider_configs(*, payload: dict[str, Any] | None = None, enabled_only
                 "models": list(item.get("enabled_models") or []),
                 "supported_models": list(item.get("supported_models") or []),
                 "custom_models": list(item.get("custom_models") or []),
+                "model_detections": dict(item.get("model_detections") or {}),
                 "default_model": (
                     (item.get("enabled_models") or [None])[0]
                     or str(definition.get("default_model") or "")
                 ),
                 "enabled": bool(item.get("enabled")),
+                "provider_enabled": bool(item.get("provider_enabled")),
                 "supports_partial_messages": bool(item.get("supports_partial_messages", provider_id != "anthropic_compatible")),
                 "validation_status": str(item.get("validation_status") or "unverified"),
                 "validation_message": str(item.get("validation_message") or ""),

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -115,12 +115,14 @@ class MessageScheduleLogsQueryRequest(BaseModel):
 class ProviderSettingsUpdate(BaseModel):
     provider_id: str
     enabled: Optional[bool] = None
+    provider_enabled: Optional[bool] = None
     enabled_models: List[str] = Field(default_factory=list)
     custom_models: List[str] = Field(default_factory=list)
     api_key: Optional[str] = None
     auth_token: Optional[str] = None
     base_url: Optional[str] = None
     supports_partial_messages: Optional[bool] = None
+    model_detections: Optional[Dict[str, "ModelDetectionState"]] = None
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -153,6 +155,12 @@ class SqlExecutionResult(BaseModel):
     error: Optional[str] = None
 
 
+class ModelDetectionState(BaseModel):
+    status: str = "unverified"
+    message: str = ""
+    checked_at: str = ""
+
+
 class ProviderConfig(BaseModel):
     provider_id: str
     display_name: str
@@ -165,9 +173,28 @@ class ProviderConfig(BaseModel):
     custom_models: List[str] = Field(default_factory=list)
     default_model: str = ""
     enabled: bool = False
+    provider_enabled: bool = False
     supports_partial_messages: bool = True
     validation_status: str = "unverified"
     validation_message: str = ""
+    model_detections: Dict[str, ModelDetectionState] = Field(default_factory=dict)
+
+
+class ModelDetectionRequest(BaseModel):
+    provider_id: str
+    model: str
+    api_key: Optional[str] = None
+    auth_token: Optional[str] = None
+    base_url: Optional[str] = None
+    supports_partial_messages: Optional[bool] = None
+
+
+class ModelDetectionResponse(BaseModel):
+    provider_id: str
+    model: str
+    status: str
+    message: str
+    checked_at: str
 
 
 class SettingsResponse(BaseModel):

--- a/dataagent/dataagent-backend/tests/test_admin_routes.py
+++ b/dataagent/dataagent-backend/tests/test_admin_routes.py
@@ -64,8 +64,16 @@ def test_admin_settings_contract(monkeypatch):
                 supported_models=["anthropic/claude-sonnet-4.5"],
                 default_model="anthropic/claude-sonnet-4.5",
                 enabled=True,
+                provider_enabled=True,
                 supports_partial_messages=False,
                 validation_status="verified",
+                model_detections={
+                    "anthropic/claude-sonnet-4.5": {
+                        "status": "verified",
+                        "message": "模型检测通过",
+                        "checked_at": "2026-04-17T10:00:00",
+                    }
+                },
             )
         ],
     )
@@ -81,6 +89,7 @@ def test_admin_settings_contract(monkeypatch):
     assert response.status_code == 200
     assert response.json()["provider_id"] == "openrouter"
     assert response.json()["providers"][0]["supports_partial_messages"] is False
+    assert response.json()["providers"][0]["model_detections"]["anthropic/claude-sonnet-4.5"]["status"] == "verified"
 
     update = client.put(
         "/api/v1/nl2sql-admin/settings",
@@ -100,6 +109,38 @@ def test_admin_settings_contract(monkeypatch):
     assert update.json()["updated_at"] == "2026-03-06T12:00:00"
     assert captured["payload"]["providers"][0]["supports_partial_messages"] is False
     assert client.get("/api/v1/dataagent/settings").status_code == 404
+
+
+def test_model_detection_route_contract(monkeypatch):
+    captured = {}
+
+    async def _detect(payload):
+        captured["payload"] = payload
+        return {
+            "provider_id": payload["provider_id"],
+            "model": payload["model"],
+            "status": "verified",
+            "message": "模型检测通过",
+            "checked_at": "2026-04-17T10:00:00",
+        }
+
+    monkeypatch.setattr(admin_routes, "detect_model_availability", _detect)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/nl2sql-admin/model-detections",
+        json={
+            "provider_id": "openrouter",
+            "model": "anthropic/claude-sonnet-4.5",
+            "auth_token": "token",
+            "base_url": "https://openrouter.ai/api",
+            "supports_partial_messages": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "verified"
+    assert captured["payload"]["supports_partial_messages"] is False
 
 
 def test_skill_document_routes_contract(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -4,6 +4,8 @@ import sys
 import types
 from pathlib import Path
 
+import anyio
+
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
@@ -18,20 +20,30 @@ def test_merge_provider_settings_can_reenable_provider_with_models():
             "provider_id": "anyrouter",
             "auth_token": "existing-token",
             "base_url": "https://a-ocnfniawgw.cn-shanghai.fcapp.run",
+            "provider_enabled": True,
             "enabled_models": [],
             "custom_models": [],
+            "model_detections": {},
             "enabled": False,
             "validation_status": "unverified",
-            "validation_message": "请至少开启一个模型",
+            "validation_message": "请先检测并启用至少一个模型",
         }
     }
     patch = {
         "anyrouter": {
             "provider_id": "anyrouter",
+            "provider_enabled": True,
             "auth_token": "existing-token",
             "base_url": "https://a-ocnfniawgw.cn-shanghai.fcapp.run",
             "enabled_models": ["claude-opus-4-6"],
             "custom_models": [],
+            "model_detections": {
+                "claude-opus-4-6": {
+                    "status": "verified",
+                    "message": "模型检测通过",
+                    "checked_at": "2026-04-17T10:00:00",
+                }
+            },
         }
     }
 
@@ -54,7 +66,15 @@ def test_merge_provider_settings_preserves_partial_capability_flag():
                 "provider_id": "anthropic_compatible",
                 "auth_token": "relay-token",
                 "base_url": "https://relay.example.invalid",
+                "provider_enabled": True,
                 "enabled_models": ["claude-sonnet-4.5"],
+                "model_detections": {
+                    "claude-sonnet-4.5": {
+                        "status": "verified",
+                        "message": "模型检测通过",
+                        "checked_at": "2026-04-17T10:00:00",
+                    }
+                },
                 "supports_partial_messages": True,
             }
         },
@@ -70,6 +90,27 @@ def test_merge_provider_settings_preserves_partial_capability_flag():
     assert provider["supports_partial_messages"] is False
     assert provider["validation_status"] == "verified"
     assert provider["enabled"] is True
+
+
+def test_merge_provider_settings_requires_verified_model_detection():
+    merged = _merge_provider_settings(
+        {},
+        {
+            "openrouter": {
+                "provider_id": "openrouter",
+                "provider_enabled": True,
+                "auth_token": "token",
+                "base_url": "https://openrouter.ai/api",
+                "enabled_models": ["anthropic/claude-sonnet-4.5"],
+                "model_detections": {},
+            }
+        },
+    )
+
+    provider = merged["openrouter"]
+    assert provider["enabled_models"] == []
+    assert provider["validation_status"] == "unverified"
+    assert provider["enabled"] is False
 
 
 def test_merge_settings_payload_keeps_provider_and_model_empty_without_enabled_provider():
@@ -147,9 +188,17 @@ def test_resolve_runtime_provider_selection_returns_partial_capability(monkeypat
             "provider_settings": {
                 "anthropic_compatible": {
                     "provider_id": "anthropic_compatible",
+                    "provider_enabled": True,
                     "auth_token": "relay-token",
                     "base_url": "https://relay.example.invalid",
                     "enabled_models": ["claude-sonnet-4.5"],
+                    "model_detections": {
+                        "claude-sonnet-4.5": {
+                            "status": "verified",
+                            "message": "模型检测通过",
+                            "checked_at": "2026-04-17T10:00:00",
+                        }
+                    },
                     "supports_partial_messages": False,
                 }
             },
@@ -179,3 +228,86 @@ def test_resolve_runtime_provider_selection_requires_enabled_provider(monkeypatc
         assert str(exc) == "尚未配置可用大模型供应商"
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_detect_model_availability_returns_verified_detection(monkeypatch):
+    captured = {}
+
+    class FakeOptions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    async def fake_query(prompt, options):
+        captured["prompt"] = prompt
+        captured["options"] = options.kwargs
+        yield types.SimpleNamespace(subtype="")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "claude_agent_sdk",
+        types.SimpleNamespace(ClaudeAgentOptions=FakeOptions, query=fake_query),
+    )
+    monkeypatch.setattr(skill_admin_service, "resolve_agent_project_cwd", lambda: Path("/tmp"))
+    monkeypatch.setattr(
+        skill_admin_service,
+        "current_settings_payload",
+        lambda: {
+            "provider_id": "openrouter",
+            "model": "",
+            "provider_settings": {
+                "openrouter": {
+                    "provider_id": "openrouter",
+                    "provider_enabled": True,
+                    "auth_token": "saved-token",
+                    "base_url": "https://openrouter.ai/api",
+                    "enabled_models": [],
+                    "custom_models": [],
+                    "model_detections": {},
+                }
+            },
+        },
+    )
+
+    result = anyio.run(
+        skill_admin_service.detect_model_availability,
+        {
+            "provider_id": "openrouter",
+            "model": "anthropic/claude-sonnet-4.5",
+        },
+    )
+
+    assert result["status"] == "verified"
+    assert captured["options"]["model"] == "anthropic/claude-sonnet-4.5"
+
+
+def test_detect_model_availability_returns_failed_without_token(monkeypatch):
+    monkeypatch.setattr(
+        skill_admin_service,
+        "current_settings_payload",
+        lambda: {
+            "provider_id": "openrouter",
+            "model": "",
+            "provider_settings": {
+                "openrouter": {
+                    "provider_id": "openrouter",
+                    "provider_enabled": True,
+                    "auth_token": "",
+                    "base_url": "https://openrouter.ai/api",
+                    "enabled_models": [],
+                    "custom_models": [],
+                    "model_detections": {},
+                }
+            },
+        },
+    )
+
+    result = anyio.run(
+        skill_admin_service.detect_model_availability,
+        {
+            "provider_id": "openrouter",
+            "model": "anthropic/claude-sonnet-4.5",
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "Token" in result["message"]

--- a/docs/design/2026-04-17-model-service-config-design.md
+++ b/docs/design/2026-04-17-model-service-config-design.md
@@ -1,0 +1,59 @@
+# Model Service Config Design
+
+## Current State
+
+The administrator settings page currently exposes DataAgent runtime details together with model provider settings. Provider validation is local: a provider is treated as verified when credentials, Base URL requirements, and at least one enabled model are present. The UI does not have a real model availability check.
+
+## Problem
+
+Users need a simpler model service configuration page that focuses on provider selection, API credentials, model detection, model enablement, and default model selection. Runtime internals such as Skill paths and DataAgent storage should not be exposed in this UI. Enabling a model should require a real service check so the saved configuration reflects usable provider/model pairs. The page should also avoid a separate top-level page header layer and make save scope match the visible provider.
+
+## Scope
+
+This change covers the DataAgent admin settings API, model detection state in existing provider settings JSON, and the Vue settings page under the `dataagent` configuration tab. It does not change the intelligent-query chat entrypoint or add new database tables.
+
+## Solution
+
+- Rename the settings tab label from `智能问数` to `模型服务` while keeping the existing `dataagent` tab key and route query.
+- Replace the current settings page with a two-column model service console:
+  - left provider list with provider name, status, and enabled model count
+  - right provider header with provider name, save button, and provider enable switch
+  - compact form for API Key or Token, Base URL, and streaming capability
+  - model rows with detection status, a detection button, and an enable switch
+  - default model selector limited to enabled models for the selected provider
+- Remove the outer page card/header (`模型服务 / 刷新 / 保存配置`) so the page opens directly into the provider workbench.
+- Keep a manual save button, but scope it to the currently visible provider. Unsaved changes are tracked per provider draft and surfaced through the current save button and provider-switch confirmation.
+- Add `POST /api/v1/nl2sql-admin/model-detections` for real model checks using the same provider environment mapping as runtime DataAgent execution.
+- Store model detection results inside `provider_settings` in `da_agent_settings.raw_json`, under each provider entry, when the current provider is saved. Detection itself returns a live result and does not directly persist draft credentials or detection state.
+- A model can be enabled only after its detection status is `verified`. Provider usability still requires provider switch on, at least one enabled model, and locally valid credentials/base URL.
+
+## Interfaces
+
+`POST /api/v1/nl2sql-admin/model-detections`
+
+Request fields:
+
+- `provider_id`
+- `model`
+- `api_key`
+- `auth_token`
+- `base_url`
+- `supports_partial_messages`
+
+Response fields:
+
+- `provider_id`
+- `model`
+- `status`: `verified` or `failed`
+- `message`
+- `checked_at`
+
+The request may omit credentials. The backend resolves missing credentials from saved provider settings for that provider.
+
+## Tradeoffs
+
+The detection endpoint performs a real external model call, so it can be slower or fail because of provider/network conditions. This is intentional because the UI contract is “key plus model is usable,” not “form fields are non-empty.” The timeout is bounded at 30 seconds. Detection no longer persists provider drafts on its own; that keeps discard-and-switch behavior coherent at the cost of requiring an explicit save after a successful check.
+
+## Rollback
+
+Rollback can remove the detection endpoint usage from the UI and return to local validation. Persisted `model_detections` fields are additive JSON fields and can be ignored by older code.

--- a/docs/plans/2026-04-17-model-service-config-plan.md
+++ b/docs/plans/2026-04-17-model-service-config-plan.md
@@ -1,0 +1,27 @@
+# Model Service Config Plan
+
+## Tasks
+
+1. Add backend schemas for model detection request/response and persisted per-model detection status.
+2. Add a DataAgent admin route for `POST /api/v1/nl2sql-admin/model-detections`.
+3. Extend provider settings normalization to carry provider enable state and `model_detections` without adding database tables.
+4. Refactor the Vue settings page into a simplified model service console, remove runtime details from the UI, drop the outer page header layer, and move save into the current provider title bar.
+5. Update the configuration tab label from `智能问数` to `模型服务`.
+6. Change provider save scope from whole-page save to current-provider save with per-provider dirty state and switch-away confirmation.
+7. Keep model detection as a real check, but return the detection result without persisting provider draft changes until the current provider is explicitly saved.
+8. Add targeted backend and frontend tests for detection state, enablement rules, dirty-state behavior, and API contract.
+
+## Verification
+
+- Run DataAgent pytest for admin routes and settings service tests.
+- Run frontend tests for the model service settings page, including current-provider save and discard-on-switch behavior.
+- Run `nvm use` and `npm --prefix frontend run build`.
+- Use local mock data to visually check `/settings?tab=dataagent` on desktop and narrow viewports.
+
+## Rollout
+
+This is an admin UI and DataAgent API change. No migration is needed because detection data is stored in existing JSON settings. Existing saved provider settings remain readable; models without detection state will appear as not detected and cannot be newly enabled until detection succeeds. Detection remains a separate API call, but draft edits only become persistent when the current provider is saved.
+
+## Backout
+
+Revert the frontend page and admin route changes. Existing extra JSON fields under `provider_settings.model_detections` are ignored if not read.

--- a/frontend/src/api/dataagent.js
+++ b/frontend/src/api/dataagent.js
@@ -24,6 +24,10 @@ export const dataagentApi = {
     return dataagentRequest.put('/v1/nl2sql-admin/settings', data)
   },
 
+  detectModel(data) {
+    return dataagentRequest.post('/v1/nl2sql-admin/model-detections', data)
+  },
+
   listSkillDocuments() {
     return dataagentRequest.get('/v1/dataagent/skills/documents')
   },

--- a/frontend/src/views/settings/ConfigurationManagement.vue
+++ b/frontend/src/views/settings/ConfigurationManagement.vue
@@ -12,7 +12,7 @@
         <el-tab-pane label="MinIO 环境" name="minio">
           <MinioConfigManagement />
         </el-tab-pane>
-        <el-tab-pane label="智能问数" name="dataagent">
+        <el-tab-pane label="模型服务" name="dataagent">
           <DataAgentConfig />
         </el-tab-pane>
         <el-tab-pane label="Skill 管理" name="skills">

--- a/frontend/src/views/settings/DataAgentConfig.vue
+++ b/frontend/src/views/settings/DataAgentConfig.vue
@@ -1,305 +1,243 @@
 <template>
   <div class="dataagent-config">
-    <el-row :gutter="16" class="summary-row">
-      <el-col :xs="24" :md="8">
-        <el-card shadow="never" class="summary-card">
-          <div class="summary-label">配置存储</div>
-          <div class="summary-value">DataAgent 数据库 / 运行时</div>
-          <div class="summary-hint">不再依赖 project `.claude/settings.json`</div>
-        </el-card>
-      </el-col>
-      <el-col :xs="24" :md="8">
-        <el-card shadow="never" class="summary-card">
-          <div class="summary-label">内置 Skill 目录</div>
-          <div class="summary-value path">{{ settingsMeta.skills_root_dir || '-' }}</div>
-        </el-card>
-      </el-col>
-      <el-col :xs="24" :md="8">
-        <el-card shadow="never" class="summary-card">
-          <div class="summary-label">DataAgent 库</div>
-          <div class="summary-value">{{ settingsMeta.session_mysql_database || 'dataagent' }}</div>
-        </el-card>
-      </el-col>
-    </el-row>
+    <div v-loading="loading" class="provider-workbench">
+      <aside class="provider-nav">
+        <div
+          v-for="group in groupedProviders"
+          :key="group.group"
+          class="provider-group"
+        >
+          <div class="provider-group-title">{{ group.group }}</div>
+          <button
+            v-for="provider in group.items"
+            :key="provider.provider_id"
+            type="button"
+            class="provider-card"
+            :class="{ active: provider.provider_id === selectedProviderId }"
+            @click="selectProvider(provider.provider_id)"
+          >
+            <div class="provider-card-head">
+              <div class="provider-card-main">
+                <div class="provider-card-name-row">
+                  <div class="provider-card-name">{{ provider.display_name }}</div>
+                  <span
+                    v-if="provider.provider_id === selectedProviderId && isProviderDirty(provider.provider_id)"
+                    class="provider-dirty-mark"
+                  >
+                    未保存
+                  </span>
+                </div>
+                <div class="provider-card-id">{{ provider.provider_id }}</div>
+              </div>
+              <span class="provider-status" :class="statusClass(providerPreview(provider).status)">
+                {{ statusLabel(providerPreview(provider).status, providerPreview(provider).providerEnabled) }}
+              </span>
+            </div>
+            <div class="provider-card-meta">
+              <span>{{ providerPreview(provider).enabledModels.length }} 个已启用模型</span>
+              <span>{{ credentialSummary(provider) }}</span>
+            </div>
+          </button>
+        </div>
+      </aside>
 
-    <el-card shadow="never" class="config-card">
-      <template #header>
-        <div class="card-header">
-          <div>
-            <div class="card-title">模型接入与候选管理</div>
-            <div class="card-subtitle">按供应商分组管理 Token 与模型候选。Token 不回显，留空表示保持现有值。</div>
+      <section v-if="currentProvider && currentDraft" class="provider-detail">
+        <div class="provider-titlebar">
+          <div class="provider-title-main">
+            <div class="provider-kicker">{{ currentProvider.provider_group || '模型供应商' }}</div>
+            <h3>{{ currentProvider.display_name }}</h3>
+            <p>{{ currentProviderPreview.message }}</p>
           </div>
-          <div class="actions">
-            <el-button @click="loadSettings" :loading="loading">刷新</el-button>
-            <el-button type="primary" @click="saveSettings" :loading="saving">保存配置</el-button>
+          <div class="provider-title-actions">
+            <el-button
+              type="primary"
+              :icon="Check"
+              :loading="isSavingCurrentProvider"
+              :disabled="!currentProviderDirty || isSavingCurrentProvider"
+              @click="saveCurrentProvider"
+            >
+              {{ saveButtonText }}
+            </el-button>
+            <div class="provider-switch">
+              <span>启用供应商</span>
+              <el-switch v-model="currentDraft.provider_enabled" />
+            </div>
           </div>
         </div>
-      </template>
 
-      <div v-loading="loading" class="provider-workbench">
-        <aside class="provider-nav">
-          <div
-            v-for="group in groupedProviders"
-            :key="group.group"
-            class="provider-group"
-          >
-            <div class="provider-group-title">{{ group.group }}</div>
-            <button
-              v-for="provider in group.items"
-              :key="provider.provider_id"
-              type="button"
-              class="provider-card"
-              :class="{ active: provider.provider_id === selectedProviderId }"
-              @click="selectedProviderId = provider.provider_id"
-            >
-              <div class="provider-card-head">
-                <div>
-                  <div class="provider-card-name">{{ provider.display_name }}</div>
-                  <div class="provider-card-id">{{ provider.provider_id }}</div>
-                </div>
-                <span class="provider-status" :class="statusClass(providerPreview(provider).status)">
-                  {{ statusLabel(providerPreview(provider).status) }}
-                </span>
-              </div>
-              <div class="provider-card-meta">
-                <span>{{ getDraft(provider.provider_id).enabled_models.length }} 个已开模型</span>
-                <span>{{ credentialSummary(provider) }}</span>
-              </div>
-            </button>
-          </div>
-        </aside>
-
-        <section v-if="currentProvider && currentDraft" class="provider-detail">
-          <div class="provider-hero">
-            <div>
-              <div class="provider-kicker">{{ currentProvider.provider_group }}</div>
-              <h3>{{ currentProvider.display_name }}</h3>
-              <p>{{ currentProviderPreview.message }}</p>
-              <div v-if="currentProviderCompatibilityHint" class="provider-compatibility-note">
-                {{ currentProviderCompatibilityHint }}
-              </div>
-            </div>
-            <div class="provider-hero-status">
-              <span class="provider-status" :class="statusClass(currentProviderPreview.status)">
-                {{ statusLabel(currentProviderPreview.status) }}
-              </span>
-              <strong>{{ currentProviderPreview.enabled ? '会出现在问数对话框' : '暂不会出现在问数对话框' }}</strong>
-            </div>
+        <div class="service-section">
+          <div class="section-heading">
+            <div class="section-title">连接配置</div>
           </div>
 
-          <div class="provider-settings-grid">
-            <div class="provider-panel">
-              <div class="panel-title">供应商配置</div>
-              <div class="panel-subtitle">预留凭证由用户填写，保存时仅在后端配置存储中更新。</div>
-
-              <el-form label-position="top" class="provider-form">
-                <el-form-item :label="credentialLabel(currentProvider.provider_id)">
+          <el-form label-position="top" class="provider-form">
+            <el-row :gutter="16">
+              <el-col :xs="24" :md="12">
+                <el-form-item>
+                  <template #label>
+                    <span class="field-label">
+                      {{ credentialLabel(currentProvider.provider_id) }}
+                      <el-tooltip content="供应商控制台生成的访问凭证。留空表示继续使用后端已保存的凭证。" placement="top">
+                        <el-icon><QuestionFilled /></el-icon>
+                      </el-tooltip>
+                    </span>
+                  </template>
                   <el-input
                     v-model="currentDraft.token"
                     type="password"
                     show-password
                     :placeholder="credentialPlaceholder(currentProvider.provider_id)"
+                    @input="clearCurrentDetections"
                   />
                 </el-form-item>
-                <el-form-item label="Base URL">
+              </el-col>
+              <el-col :xs="24" :md="12">
+                <el-form-item>
+                  <template #label>
+                    <span class="field-label">
+                      Base URL
+                      <el-tooltip content="供应商或兼容网关的 API 服务地址。官方供应商可使用默认地址。" placement="top">
+                        <el-icon><QuestionFilled /></el-icon>
+                      </el-tooltip>
+                    </span>
+                  </template>
                   <el-input
                     v-model="currentDraft.base_url"
                     :placeholder="baseUrlPlaceholder(currentProvider.provider_id)"
+                    @input="clearCurrentDetections"
                   />
                 </el-form-item>
-                <el-form-item label="流式能力">
-                  <div class="provider-capability-row">
-                    <el-switch
-                      v-model="currentDraft.supports_partial_messages"
-                      inline-prompt
-                      active-text="细粒度"
-                      inactive-text="兼容"
-                    />
-                    <div class="provider-capability-copy">
-                      <strong>{{ currentDraft.supports_partial_messages ? '开启 Claude partial stream' : '兼容模式' }}</strong>
-                      <span>
-                        {{ currentDraft.supports_partial_messages
-                          ? '展示实时思考增量和更细粒度的流式事件。'
-                          : '关闭实时思考增量，保留工具调用和最终回答。' }}
-                      </span>
-                    </div>
-                  </div>
-                </el-form-item>
-                <div class="provider-inline-hints">
-                  <span>{{ storedCredentialHint(currentProvider) }}</span>
-                  <span v-if="currentProvider.provider_id === 'anthropic_compatible'">兼容网关必须填写 Base URL</span>
-                </div>
-              </el-form>
-            </div>
+              </el-col>
+            </el-row>
 
-            <div class="provider-panel">
-              <div class="panel-title">支持模型列表</div>
-              <div class="panel-subtitle">参考 Cherry Studio 的供应商分组方式，模型启用由用户自己控制。</div>
-
-              <div class="custom-model-row">
-                <el-input
-                  v-model="customModelInput"
-                  placeholder="追加自定义模型，例如 qwen/qwen3-coder"
-                  @keyup.enter="addCustomModel"
+            <el-form-item>
+              <template #label>
+                <span class="field-label">
+                  流式能力
+                  <el-tooltip content="用于控制模型响应事件粒度。供应商兼容性不完整时可切换为兼容模式。" placement="top">
+                    <el-icon><QuestionFilled /></el-icon>
+                  </el-tooltip>
+                </span>
+              </template>
+              <div class="stream-mode-row">
+                <el-switch
+                  v-model="currentDraft.supports_partial_messages"
+                  inline-prompt
+                  active-text="细粒度"
+                  inactive-text="兼容"
                 />
-                <el-button @click="addCustomModel">追加</el-button>
+                <span>{{ currentDraft.supports_partial_messages ? '细粒度响应事件' : '兼容响应事件' }}</span>
               </div>
+            </el-form-item>
+          </el-form>
+        </div>
 
-              <div v-if="currentDraft.custom_models.length" class="custom-model-list">
-                <div
-                  v-for="model in currentDraft.custom_models"
-                  :key="model"
-                  class="custom-model-item"
-                >
-                  <span>{{ model }}</span>
-                  <button type="button" class="candidate-remove" @click="removeCustomModel(model)">
-                    删除
-                  </button>
-                </div>
-              </div>
-
-              <div class="model-chip-grid">
-                <button
-                  v-for="model in currentSupportedModels"
-                  :key="model"
-                  type="button"
-                  class="model-chip"
-                  :class="{ active: currentDraft.enabled_models.includes(model) }"
-                  @click="toggleModel(model)"
-                >
-                  <span>{{ model }}</span>
-                  <strong>{{ currentDraft.enabled_models.includes(model) ? '已开启' : '加入候选' }}</strong>
-                </button>
-              </div>
+        <div class="service-section">
+          <div class="section-heading model-heading">
+            <div class="section-title">模型列表</div>
+            <div class="custom-model-row">
+              <el-input
+                v-model="customModelInput"
+                placeholder="追加自定义模型"
+                @keyup.enter="addCustomModel"
+              />
+              <el-button :icon="Plus" @click="addCustomModel">追加</el-button>
             </div>
           </div>
 
-          <div class="provider-panel candidate-panel">
-            <div class="panel-title">已验证候选</div>
-            <div class="panel-subtitle">只有通过校验且已开启的模型，才会进入智能问数对话框。</div>
-
-            <div v-if="currentProviderPreview.enabledModels.length && currentProviderPreview.enabled" class="candidate-list">
-              <div
-                v-for="model in currentProviderPreview.enabledModels"
-                :key="model"
-                class="candidate-item"
-              >
+          <div v-if="currentSupportedModels.length" class="model-table">
+            <div class="model-row model-row-head">
+              <span>模型</span>
+              <span>检测状态</span>
+              <span>检测</span>
+              <span>启用</span>
+            </div>
+            <div
+              v-for="model in currentSupportedModels"
+              :key="model"
+              class="model-row"
+            >
+              <div class="model-name-cell">
                 <span>{{ model }}</span>
                 <button
                   v-if="currentDraft.custom_models.includes(model)"
                   type="button"
-                  class="candidate-remove"
+                  class="text-danger"
                   @click="removeCustomModel(model)"
                 >
-                  移除自定义
+                  删除
                 </button>
               </div>
-            </div>
-            <div v-else class="candidate-empty">
-              <div class="candidate-empty-title">当前供应商还没有可用候选</div>
-              <div class="candidate-empty-text">{{ currentProviderPreview.message }}</div>
+              <div>
+                <span class="model-detection" :class="detectionClass(model)">
+                  {{ detectionLabel(model) }}
+                </span>
+              </div>
+              <div>
+                <el-button
+                  size="small"
+                  :loading="isDetecting(model)"
+                  :disabled="!canDetectCurrentProvider"
+                  @click="detectModel(model)"
+                >
+                  检测
+                </el-button>
+              </div>
+              <div>
+                <el-switch
+                  :model-value="isModelEnabled(model)"
+                  :disabled="!canEnableModel(model)"
+                  @update:model-value="setModelEnabled(model, $event)"
+                />
+              </div>
             </div>
           </div>
-        </section>
-      </div>
-
-      <el-form
-        ref="formRef"
-        :model="form"
-        :rules="rules"
-        label-position="top"
-        class="config-form"
-      >
-        <div class="form-section">
-          <div class="section-title">问数默认入口</div>
-          <div class="section-subtitle">对话框只展示这里可见的供应商与模型。</div>
-          <el-row :gutter="16">
-            <el-col :xs="24" :md="12">
-              <el-form-item label="默认供应商">
-                <el-select v-model="form.provider_id" placeholder="请先开启可用供应商" :disabled="!validatedProviders.length">
-                  <el-option
-                    v-for="provider in validatedProviders"
-                    :key="provider.provider_id"
-                    :label="provider.display_name"
-                    :value="provider.provider_id"
-                  />
-                </el-select>
-              </el-form-item>
-            </el-col>
-            <el-col :xs="24" :md="12">
-              <el-form-item label="默认模型">
-                <el-select v-model="form.model" placeholder="请先开启可用模型" :disabled="!validatedModels.length">
-                  <el-option
-                    v-for="model in validatedModels"
-                    :key="model"
-                    :label="model"
-                    :value="model"
-                  />
-                </el-select>
-              </el-form-item>
-            </el-col>
-          </el-row>
-          <div v-if="!validatedProviders.length" class="section-note">
-            还没有通过校验的候选模型。请先为供应商填写 Token，并在“支持模型列表”中开启模型。
-          </div>
+          <div v-else class="empty-block">当前供应商暂无模型，请追加自定义模型。</div>
         </div>
 
-        <div class="form-section">
-          <div class="section-title">数据源说明与内置 Skill</div>
-          <div class="section-subtitle">MySQL / Doris 连接信息不在此页维护；这里配置的是 DataAgent 当前使用的内置 skill 目录。</div>
-          <el-row :gutter="16">
-            <el-col :xs="24" :md="12">
-              <el-form-item label="内置 Skill 输出目录" prop="skills_output_dir">
-                <el-input v-model="form.skills_output_dir" placeholder="../.claude/skills/dataagent-nl2sql" />
-              </el-form-item>
-            </el-col>
-            <el-col :xs="24" :md="12">
-              <el-form-item label="DataAgent 库">
-                <el-input :model-value="settingsMeta.session_mysql_database" disabled />
-              </el-form-item>
-            </el-col>
-          </el-row>
-          <div class="datasource-notes">
-            <div class="datasource-note-title">执行与推理约束</div>
-            <div class="datasource-note-item">托管数据表与数据库归属优先从 `opendataworks.data_table` 判断。</div>
-            <div class="datasource-note-item">数据源主机、端口、类型、用户名从 `opendataworks.doris_cluster` 查询。</div>
-            <div class="datasource-note-item">若需要库级只读账号，再查询 `opendataworks.doris_database_users`。</div>
-            <div class="datasource-note-item">仓库根目录的本地扩展 skill 不在此页管理，也不会自动进入当前运行时。</div>
-          </div>
+        <div class="service-section default-section">
+          <div class="section-title">默认模型</div>
+          <el-select
+            v-model="currentDefaultModel"
+            placeholder="请先启用可用模型"
+            :disabled="!currentEnabledModels.length"
+          >
+            <el-option
+              v-for="model in currentEnabledModels"
+              :key="model"
+              :label="model"
+              :value="model"
+            />
+          </el-select>
         </div>
-      </el-form>
-    </el-card>
+      </section>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Check, Plus, QuestionFilled } from '@element-plus/icons-vue'
 import { dataagentApi } from '@/api/dataagent'
 
-const formRef = ref(null)
 const loading = ref(false)
-const saving = ref(false)
+const savingProviderId = ref('')
 const providers = ref([])
 const selectedProviderId = ref('')
 const customModelInput = ref('')
 
 const providerDrafts = reactive({})
-const settingsMeta = reactive({
-  skills_root_dir: '',
-  session_mysql_database: '',
-  updated_at: ''
-})
-
+const providerSnapshots = reactive({})
+const detectingModels = reactive({})
 const form = reactive({
   provider_id: '',
-  model: '',
-  skills_output_dir: ''
+  model: ''
 })
-
-const rules = {
-  skills_output_dir: [{ required: true, message: '请输入 Skills 输出目录', trigger: 'blur' }]
-}
+const savedSelection = reactive({
+  provider_id: '',
+  model: ''
+})
 
 const uniqueStrings = (values = []) => {
   const result = []
@@ -313,15 +251,64 @@ const uniqueStrings = (values = []) => {
   return result
 }
 
-const statusLabel = (status) => {
-  if (status === 'verified') return '已验证'
-  if (status === 'invalid') return '异常'
-  return '待校验'
+const normalizeDetections = (raw = {}) => {
+  const result = {}
+  if (!raw || typeof raw !== 'object') return result
+  Object.entries(raw)
+    .sort(([left], [right]) => String(left).localeCompare(String(right)))
+    .forEach(([model, item]) => {
+      if (!model || !item || typeof item !== 'object') return
+      result[model] = {
+        status: item.status || 'unverified',
+        message: item.message || '',
+        checked_at: item.checked_at || ''
+      }
+    })
+  return result
+}
+
+const buildProviderDraft = (provider) => {
+  const customModels = uniqueStrings(provider.custom_models || [])
+  const modelDetections = normalizeDetections(provider.model_detections || {})
+  return {
+    provider_id: provider.provider_id,
+    provider_enabled: Boolean(provider.provider_enabled || provider.enabled),
+    token: '',
+    base_url: provider.base_url || '',
+    supports_partial_messages: provider.supports_partial_messages !== false,
+    enabled_models: uniqueStrings(provider.models || []).filter((model) => modelDetections[model]?.status === 'verified'),
+    custom_models: customModels,
+    base_supported_models: uniqueStrings(provider.supported_models || []).filter((model) => !customModels.includes(model)),
+    model_detections: modelDetections
+  }
+}
+
+const buildProviderSnapshot = (draft) => {
+  const modelDetections = normalizeDetections(draft?.model_detections)
+  const enabledModels = uniqueStrings(draft?.enabled_models).filter((model) => modelDetections[model]?.status === 'verified')
+  return {
+    provider_enabled: Boolean(draft?.provider_enabled),
+    token: String(draft?.token || '').trim(),
+    base_url: String(draft?.base_url || '').trim(),
+    supports_partial_messages: draft?.supports_partial_messages !== false,
+    enabled_models: enabledModels,
+    custom_models: uniqueStrings(draft?.custom_models),
+    model_detections: modelDetections
+  }
+}
+
+const snapshotEquals = (left, right) => JSON.stringify(left) === JSON.stringify(right)
+
+const statusLabel = (status, providerEnabled = true) => {
+  if (!providerEnabled) return '未启用'
+  if (status === 'verified') return '可用'
+  if (status === 'invalid' || status === 'failed') return '异常'
+  return '待配置'
 }
 
 const statusClass = (status) => {
   if (status === 'verified') return 'is-verified'
-  if (status === 'invalid') return 'is-invalid'
+  if (status === 'invalid' || status === 'failed') return 'is-invalid'
   return 'is-pending'
 }
 
@@ -339,15 +326,10 @@ const groupedProviders = computed(() => {
   const groups = new Map()
   providers.value.forEach((provider) => {
     const groupName = provider.provider_group || '其他'
-    if (!groups.has(groupName)) {
-      groups.set(groupName, [])
-    }
+    if (!groups.has(groupName)) groups.set(groupName, [])
     groups.get(groupName).push(provider)
   })
-  return Array.from(groups.entries()).map(([group, items]) => ({
-    group,
-    items
-  }))
+  return Array.from(groups.entries()).map(([group, items]) => ({ group, items }))
 })
 
 const currentProvider = computed(() => {
@@ -359,15 +341,57 @@ const currentDraft = computed(() => {
   return providerDrafts[currentProvider.value.provider_id] || null
 })
 
+const currentProviderId = computed(() => currentProvider.value?.provider_id || '')
+
+const currentDefaultModel = computed({
+  get() {
+    if (!currentProvider.value || form.provider_id !== currentProvider.value.provider_id) return ''
+    return currentEnabledModels.value.includes(form.model) ? form.model : ''
+  },
+  set(model) {
+    if (!currentProvider.value) return
+    form.provider_id = currentProvider.value.provider_id
+    form.model = model || ''
+  }
+})
+
+const currentProviderDirty = computed(() => {
+  return Boolean(currentProviderId.value) && isProviderDirty(currentProviderId.value)
+})
+
+const saveButtonText = computed(() => (currentProviderDirty.value ? '保存改动' : '保存配置'))
+const isSavingCurrentProvider = computed(() => savingProviderId.value === currentProviderId.value)
+
 const getDraft = (providerId) => {
   return providerDrafts[providerId] || {
+    provider_enabled: false,
     enabled_models: [],
     custom_models: [],
     base_supported_models: [],
     token: '',
     base_url: '',
-    supports_partial_messages: true
+    supports_partial_messages: true,
+    model_detections: {}
   }
+}
+
+const defaultModelForProvider = (selection, providerId) => {
+  return selection.provider_id === providerId ? String(selection.model || '') : ''
+}
+
+const hasProviderFieldChanges = (providerId) => {
+  const draft = providerDrafts[providerId]
+  const snapshot = providerSnapshots[providerId]
+  if (!draft || !snapshot) return false
+  return !snapshotEquals(buildProviderSnapshot(draft), snapshot)
+}
+
+const hasProviderSelectionChanges = (providerId) => {
+  return defaultModelForProvider(form, providerId) !== defaultModelForProvider(savedSelection, providerId)
+}
+
+function isProviderDirty(providerId) {
+  return hasProviderFieldChanges(providerId) || hasProviderSelectionChanges(providerId)
 }
 
 const supportedModelsFor = (providerId) => {
@@ -375,7 +399,8 @@ const supportedModelsFor = (providerId) => {
   return uniqueStrings([
     ...(draft.base_supported_models || []),
     ...(draft.custom_models || []),
-    ...(draft.enabled_models || [])
+    ...(draft.enabled_models || []),
+    ...Object.keys(draft.model_detections || {})
   ])
 }
 
@@ -384,6 +409,28 @@ const currentSupportedModels = computed(() => {
   return supportedModelsFor(currentProvider.value.provider_id)
 })
 
+const modelDetection = (model) => {
+  return currentDraft.value?.model_detections?.[model] || {
+    status: 'unverified',
+    message: '待检测',
+    checked_at: ''
+  }
+}
+
+const detectionLabel = (model) => {
+  const detection = modelDetection(model)
+  if (detection.status === 'verified') return '检测通过'
+  if (detection.status === 'failed') return detection.message || '检测失败'
+  return '未检测'
+}
+
+const detectionClass = (model) => {
+  const status = modelDetection(model).status
+  if (status === 'verified') return 'is-verified'
+  if (status === 'failed') return 'is-invalid'
+  return 'is-pending'
+}
+
 const providerHasCredential = (provider, draft) => {
   const typed = String(draft?.token || '').trim()
   if (typed) return true
@@ -391,22 +438,38 @@ const providerHasCredential = (provider, draft) => {
   return Boolean(provider.auth_token_set || provider.api_key_set)
 }
 
+const providerBaseUrlReady = (provider, draft) => {
+  return provider.provider_id !== 'anthropic_compatible' || Boolean(String(draft?.base_url || '').trim())
+}
+
 const providerPreview = (provider) => {
   const draft = providerDrafts[provider.provider_id]
   if (!draft) {
     return {
       status: provider.validation_status || 'unverified',
-      message: provider.validation_message || '待校验',
+      message: provider.validation_message || '待配置',
+      providerEnabled: Boolean(provider.provider_enabled || provider.enabled),
       enabled: Boolean(provider.enabled),
       enabledModels: uniqueStrings(provider.models || [])
     }
   }
 
-  const enabledModels = uniqueStrings(draft.enabled_models)
-  if (provider.provider_id === 'anthropic_compatible' && !String(draft.base_url || '').trim()) {
+  const providerEnabled = Boolean(draft.provider_enabled)
+  const enabledModels = uniqueStrings(draft.enabled_models).filter((model) => draft.model_detections?.[model]?.status === 'verified')
+  if (!providerEnabled) {
     return {
       status: 'unverified',
-      message: '请填写兼容网关地址',
+      message: '供应商未启用',
+      providerEnabled,
+      enabled: false,
+      enabledModels: []
+    }
+  }
+  if (!providerBaseUrlReady(provider, draft)) {
+    return {
+      status: 'unverified',
+      message: 'Base URL 缺失',
+      providerEnabled,
       enabled: false,
       enabledModels: []
     }
@@ -415,6 +478,7 @@ const providerPreview = (provider) => {
     return {
       status: 'unverified',
       message: provider.provider_id === 'anthropic' ? '请填写 API Key' : '请填写 Token',
+      providerEnabled,
       enabled: false,
       enabledModels: []
     }
@@ -422,16 +486,16 @@ const providerPreview = (provider) => {
   if (!enabledModels.length) {
     return {
       status: 'unverified',
-      message: '请至少开启一个模型',
+      message: '请先检测并启用至少一个模型',
+      providerEnabled,
       enabled: false,
       enabledModels: []
     }
   }
   return {
     status: 'verified',
-    message: draft.supports_partial_messages === false
-      ? '已完成本地配置校验，保存后会进入智能问数候选。当前以兼容模式运行，不展示实时思考增量。'
-      : '已完成本地配置校验，保存后会进入智能问数候选',
+    message: '模型服务已可用',
+    providerEnabled,
     enabled: true,
     enabledModels
   }
@@ -442,6 +506,7 @@ const currentProviderPreview = computed(() => {
     return {
       status: 'unverified',
       message: '请选择供应商',
+      providerEnabled: false,
       enabled: false,
       enabledModels: []
     }
@@ -449,11 +514,264 @@ const currentProviderPreview = computed(() => {
   return providerPreview(currentProvider.value)
 })
 
-const currentProviderCompatibilityHint = computed(() => {
-  if (!currentProvider.value || !currentDraft.value) return ''
-  if (currentDraft.value.supports_partial_messages !== false) return ''
-  return '兼容模式：关闭实时思考增量，保留工具调用与最终回答。适合不支持 Claude partial stream 的 relay。'
+const currentEnabledModels = computed(() => currentProviderPreview.value.enabledModels)
+
+const canDetectCurrentProvider = computed(() => {
+  if (!currentProvider.value || !currentDraft.value) return false
+  return providerHasCredential(currentProvider.value, currentDraft.value) && providerBaseUrlReady(currentProvider.value, currentDraft.value)
 })
+
+const credentialSummary = (provider) => {
+  const draft = providerDrafts[provider.provider_id]
+  if (String(draft?.token || '').trim()) return '本次有新凭证'
+  return providerHasCredential(provider, draft) ? '凭证已保存' : '未配置凭证'
+}
+
+const isModelEnabled = (model) => Boolean(currentDraft.value?.enabled_models?.includes(model))
+
+const canEnableModel = (model) => {
+  return Boolean(currentDraft.value?.provider_enabled) && modelDetection(model).status === 'verified'
+}
+
+const setModelEnabled = (model, enabled) => {
+  if (!currentDraft.value) return
+  const list = new Set(currentDraft.value.enabled_models)
+  if (enabled) {
+    if (!canEnableModel(model)) return
+    list.add(model)
+  } else {
+    list.delete(model)
+  }
+  currentDraft.value.enabled_models = Array.from(list)
+}
+
+const detectKey = (model) => `${currentProvider.value?.provider_id || ''}::${model}`
+const isDetecting = (model) => Boolean(detectingModels[detectKey(model)])
+
+const clearCurrentDetections = () => {
+  if (!currentDraft.value) return
+  currentDraft.value.model_detections = {}
+  currentDraft.value.enabled_models = []
+  if (form.provider_id === currentProvider.value?.provider_id) {
+    form.model = ''
+  }
+}
+
+const resetProviderState = (items) => {
+  Object.keys(providerDrafts).forEach((key) => {
+    delete providerDrafts[key]
+  })
+  Object.keys(providerSnapshots).forEach((key) => {
+    delete providerSnapshots[key]
+  })
+  items.forEach((provider) => {
+    const draft = buildProviderDraft(provider)
+    providerDrafts[provider.provider_id] = draft
+    providerSnapshots[provider.provider_id] = buildProviderSnapshot(draft)
+  })
+}
+
+const mergeProviderState = (items, refreshedProviderId = '') => {
+  const providerIds = new Set(items.map((item) => item.provider_id))
+  Object.keys(providerDrafts).forEach((providerId) => {
+    if (providerIds.has(providerId)) return
+    delete providerDrafts[providerId]
+    delete providerSnapshots[providerId]
+  })
+  items.forEach((provider) => {
+    if (!providerDrafts[provider.provider_id] || provider.provider_id === refreshedProviderId) {
+      const draft = buildProviderDraft(provider)
+      providerDrafts[provider.provider_id] = draft
+      providerSnapshots[provider.provider_id] = buildProviderSnapshot(draft)
+    }
+  })
+}
+
+const applySettings = (payload) => {
+  providers.value = Array.isArray(payload?.providers) ? payload.providers : []
+  resetProviderState(providers.value)
+
+  savedSelection.provider_id = payload?.provider_id || ''
+  savedSelection.model = payload?.model || ''
+  form.provider_id = savedSelection.provider_id
+  form.model = savedSelection.model
+
+  selectedProviderId.value = providers.value.find((item) => item.provider_id === savedSelection.provider_id)?.provider_id
+    || providers.value[0]?.provider_id
+    || ''
+  customModelInput.value = ''
+}
+
+const applySavedProvider = (payload, providerId) => {
+  providers.value = Array.isArray(payload?.providers) ? payload.providers : []
+  mergeProviderState(providers.value, providerId)
+
+  savedSelection.provider_id = payload?.provider_id || ''
+  savedSelection.model = payload?.model || ''
+  form.provider_id = savedSelection.provider_id
+  form.model = savedSelection.model
+
+  if (!providers.value.some((item) => item.provider_id === selectedProviderId.value)) {
+    selectedProviderId.value = providerId || savedSelection.provider_id || providers.value[0]?.provider_id || ''
+  }
+  customModelInput.value = ''
+}
+
+const restoreProviderDraft = (providerId) => {
+  const provider = providers.value.find((item) => item.provider_id === providerId)
+  if (!provider) return
+  const draft = buildProviderDraft(provider)
+  providerDrafts[providerId] = draft
+  providerSnapshots[providerId] = buildProviderSnapshot(draft)
+  form.provider_id = savedSelection.provider_id
+  form.model = savedSelection.model
+  customModelInput.value = ''
+}
+
+const loadSettings = async () => {
+  loading.value = true
+  try {
+    const payload = await dataagentApi.getSettings()
+    applySettings(payload)
+  } finally {
+    loading.value = false
+  }
+}
+
+const selectProvider = async (providerId) => {
+  if (!providerId || providerId === selectedProviderId.value || isSavingCurrentProvider.value) return
+  const currentId = currentProviderId.value
+  if (currentId && isProviderDirty(currentId)) {
+    try {
+      await ElMessageBox.confirm(
+        '当前供应商有未保存改动，放弃后将恢复为上次保存内容。',
+        '未保存改动',
+        {
+          confirmButtonText: '放弃改动',
+          cancelButtonText: '继续编辑',
+          type: 'warning',
+          distinguishCancelAndClose: true
+        }
+      )
+      restoreProviderDraft(currentId)
+    } catch {
+      return
+    }
+  }
+  selectedProviderId.value = providerId
+  customModelInput.value = ''
+}
+
+const addCustomModel = () => {
+  if (!currentDraft.value) return
+  const model = String(customModelInput.value || '').trim()
+  if (!model) return
+  currentDraft.value.custom_models = uniqueStrings([...(currentDraft.value.custom_models || []), model])
+  if (!currentDraft.value.model_detections[model]) {
+    currentDraft.value.model_detections[model] = {
+      status: 'unverified',
+      message: '待检测',
+      checked_at: ''
+    }
+  }
+  customModelInput.value = ''
+}
+
+const removeCustomModel = (model) => {
+  if (!currentDraft.value) return
+  currentDraft.value.custom_models = currentDraft.value.custom_models.filter((item) => item !== model)
+  currentDraft.value.enabled_models = currentDraft.value.enabled_models.filter((item) => item !== model)
+  delete currentDraft.value.model_detections[model]
+  if (form.model === model && form.provider_id === currentProvider.value?.provider_id) {
+    form.model = ''
+  }
+}
+
+const detectModel = async (model) => {
+  if (!currentProvider.value || !currentDraft.value) return
+  const key = detectKey(model)
+  detectingModels[key] = true
+  try {
+    const token = String(currentDraft.value.token || '').trim()
+    const payload = {
+      provider_id: currentProvider.value.provider_id,
+      model,
+      base_url: currentDraft.value.base_url,
+      supports_partial_messages: currentDraft.value.supports_partial_messages !== false
+    }
+    if (token) {
+      if (currentProvider.value.provider_id === 'anthropic') {
+        payload.api_key = token
+      } else {
+        payload.auth_token = token
+      }
+    }
+    const result = await dataagentApi.detectModel(payload)
+    currentDraft.value.model_detections[model] = {
+      status: result.status || 'failed',
+      message: result.message || '',
+      checked_at: result.checked_at || ''
+    }
+    if (result.status !== 'verified') {
+      currentDraft.value.enabled_models = currentDraft.value.enabled_models.filter((item) => item !== model)
+      ElMessage.error(result.message || '模型检测失败')
+      return
+    }
+    ElMessage.success('模型检测通过')
+  } finally {
+    detectingModels[key] = false
+  }
+}
+
+const buildProviderPayload = (providerId) => {
+  const provider = providers.value.find((item) => item.provider_id === providerId)
+  const draft = providerDrafts[providerId]
+  const enabledModels = uniqueStrings(draft.enabled_models).filter((model) => draft.model_detections?.[model]?.status === 'verified')
+  const payload = {
+    provider_id: providerId,
+    provider_enabled: Boolean(draft.provider_enabled),
+    base_url: draft.base_url,
+    supports_partial_messages: draft.supports_partial_messages !== false,
+    enabled_models: enabledModels,
+    custom_models: uniqueStrings(draft.custom_models),
+    model_detections: normalizeDetections(draft.model_detections)
+  }
+  const token = String(draft.token || '').trim()
+  if (token) {
+    if (provider?.provider_id === 'anthropic') {
+      payload.api_key = token
+    } else {
+      payload.auth_token = token
+    }
+  }
+  return payload
+}
+
+const shouldPersistSelectionWithProvider = (providerId) => {
+  return savedSelection.provider_id === providerId || form.provider_id === providerId
+}
+
+const saveCurrentProvider = async () => {
+  if (!currentProvider.value || !currentProviderDirty.value) return
+  const providerId = currentProvider.value.provider_id
+  savingProviderId.value = providerId
+  try {
+    const payload = {
+      providers: [buildProviderPayload(providerId)]
+    }
+    if (shouldPersistSelectionWithProvider(providerId)) {
+      payload.provider_id = form.provider_id || ''
+      payload.model = form.model || ''
+    }
+    const saved = await dataagentApi.updateSettings(payload)
+    applySavedProvider(saved, providerId)
+    ElMessage.success('模型服务配置已保存')
+  } catch (error) {
+    ElMessage.error(error?.message || '保存失败，请重试')
+  } finally {
+    savingProviderId.value = ''
+  }
+}
 
 const validatedProviders = computed(() => {
   return providers.value
@@ -469,132 +787,6 @@ const validatedModels = computed(() => {
   const provider = validatedProviders.value.find((item) => item.provider_id === form.provider_id)
   return provider ? provider.models : []
 })
-
-const storedCredentialHint = (provider) => {
-  if (provider.provider_id === 'anthropic') {
-    return provider.api_key_set ? '后端已保存 API Key，可留空不改' : '当前未保存 API Key'
-  }
-  return provider.auth_token_set || provider.api_key_set ? '后端已保存 Token，可留空不改' : '当前未保存 Token'
-}
-
-const credentialSummary = (provider) => {
-  const draft = providerDrafts[provider.provider_id]
-  if (String(draft?.token || '').trim()) return '本次有新凭证'
-  return providerHasCredential(provider, draft) ? '凭证已保存' : '未配置凭证'
-}
-
-const resetProviderDrafts = (items) => {
-  Object.keys(providerDrafts).forEach((key) => {
-    delete providerDrafts[key]
-  })
-  items.forEach((provider) => {
-    providerDrafts[provider.provider_id] = {
-      provider_id: provider.provider_id,
-      token: '',
-      base_url: provider.base_url || '',
-      supports_partial_messages: provider.supports_partial_messages !== false,
-      enabled_models: [...(provider.models || [])],
-      custom_models: [...(provider.custom_models || [])],
-      base_supported_models: (provider.supported_models || []).filter((model) => !(provider.custom_models || []).includes(model))
-    }
-  })
-}
-
-const applySettings = (payload) => {
-  providers.value = Array.isArray(payload?.providers) ? payload.providers : []
-  resetProviderDrafts(providers.value)
-
-  form.provider_id = payload?.provider_id || validatedProviders.value[0]?.provider_id || ''
-  form.model = payload?.model || ''
-  form.skills_output_dir = payload?.skills_output_dir || ''
-
-  settingsMeta.skills_root_dir = payload?.skills_root_dir || ''
-  settingsMeta.session_mysql_database = payload?.session_mysql_database || ''
-  settingsMeta.updated_at = payload?.updated_at || ''
-
-  selectedProviderId.value = providers.value.find((item) => item.provider_id === payload?.provider_id)?.provider_id
-    || providers.value[0]?.provider_id
-    || ''
-  customModelInput.value = ''
-}
-
-const loadSettings = async () => {
-  loading.value = true
-  try {
-    const payload = await dataagentApi.getSettings()
-    applySettings(payload)
-  } finally {
-    loading.value = false
-  }
-}
-
-const toggleModel = (model) => {
-  if (!currentDraft.value) return
-  const list = new Set(currentDraft.value.enabled_models)
-  if (list.has(model)) {
-    list.delete(model)
-  } else {
-    list.add(model)
-  }
-  currentDraft.value.enabled_models = Array.from(list)
-}
-
-const addCustomModel = () => {
-  if (!currentDraft.value) return
-  const model = String(customModelInput.value || '').trim()
-  if (!model) return
-  currentDraft.value.custom_models = uniqueStrings([...(currentDraft.value.custom_models || []), model])
-  currentDraft.value.enabled_models = uniqueStrings([...(currentDraft.value.enabled_models || []), model])
-  customModelInput.value = ''
-}
-
-const removeCustomModel = (model) => {
-  if (!currentDraft.value) return
-  currentDraft.value.custom_models = currentDraft.value.custom_models.filter((item) => item !== model)
-  currentDraft.value.enabled_models = currentDraft.value.enabled_models.filter((item) => item !== model)
-}
-
-const buildProviderPayload = (provider) => {
-  const draft = providerDrafts[provider.provider_id]
-  const payload = {
-    provider_id: provider.provider_id,
-    base_url: draft.base_url,
-    supports_partial_messages: draft.supports_partial_messages !== false,
-    enabled_models: uniqueStrings(draft.enabled_models),
-    custom_models: uniqueStrings(draft.custom_models)
-  }
-  const token = String(draft.token || '').trim()
-  if (token) {
-    if (provider.provider_id === 'anthropic') {
-      payload.api_key = token
-    } else {
-      payload.auth_token = token
-    }
-  }
-  return payload
-}
-
-const saveSettings = async () => {
-  try {
-    await formRef.value?.validate()
-  } catch {
-    return
-  }
-
-  saving.value = true
-  try {
-    const payload = await dataagentApi.updateSettings({
-      provider_id: form.provider_id || '',
-      model: form.model || '',
-      skills_output_dir: form.skills_output_dir,
-      providers: providers.value.map(buildProviderPayload)
-    })
-    applySettings(payload)
-    ElMessage.success('DataAgent 配置已保存')
-  } finally {
-    saving.value = false
-  }
-}
 
 watch(validatedProviders, (list) => {
   if (!list.length) {
@@ -624,96 +816,20 @@ onMounted(() => {
 
 <style scoped>
 .dataagent-config {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.summary-row {
-  margin: 0 !important;
-}
-
-.summary-card {
-  height: 100%;
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at top right, rgba(249, 115, 22, 0.14), transparent 36%),
-    linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-}
-
-.summary-label {
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #94a3b8;
-}
-
-.summary-value {
-  margin-top: 10px;
-  font-size: 16px;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.summary-value.path {
-  font-size: 13px;
-  line-height: 1.6;
-  word-break: break-all;
-}
-
-.summary-hint {
-  margin-top: 10px;
-  font-size: 12px;
-  color: #64748b;
-}
-
-.config-card {
-  border-radius: 22px;
-  border: 1px solid #e2e8f0;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.98) 100%),
-    radial-gradient(circle at top, rgba(245, 158, 11, 0.12), transparent 36%);
-}
-
-.card-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.card-title {
-  font-size: 18px;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.card-subtitle {
-  margin-top: 6px;
-  max-width: 680px;
-  font-size: 13px;
-  color: #64748b;
-}
-
-.actions {
-  display: flex;
-  gap: 8px;
+  color: #1f2937;
 }
 
 .provider-workbench {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: 304px minmax(0, 1fr);
   gap: 18px;
-  margin-bottom: 18px;
 }
 
 .provider-nav {
-  padding: 18px;
-  border-radius: 20px;
-  border: 1px solid #e2e8f0;
-  background:
-    linear-gradient(180deg, #fff7ed 0%, #ffffff 65%),
-    radial-gradient(circle at bottom, rgba(245, 158, 11, 0.18), transparent 38%);
+  padding: 16px;
+  border: 1px solid #d8e3ef;
+  border-radius: 8px;
+  background: #f7faff;
 }
 
 .provider-group + .provider-group {
@@ -724,28 +840,31 @@ onMounted(() => {
   margin-bottom: 8px;
   font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #9a3412;
+  letter-spacing: 0.04em;
+  color: #4f6680;
 }
 
 .provider-card {
   width: 100%;
   margin-bottom: 10px;
-  padding: 14px;
-  border: 1px solid #fed7aa;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.8);
+  padding: 13px 14px;
+  border: 1px solid #d8e3ef;
+  border-radius: 8px;
+  background: #ffffff;
   text-align: left;
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
   cursor: pointer;
 }
 
-.provider-card:hover,
+.provider-card:hover {
+  border-color: #9bb9d8;
+  background: #fbfdff;
+}
+
 .provider-card.active {
-  transform: translateY(-1px);
-  border-color: #fb923c;
-  box-shadow: 0 16px 32px rgba(249, 115, 22, 0.12);
+  border-color: #1f5f99;
+  background: #f2f7fc;
+  box-shadow: inset 3px 0 0 #1f5f99, 0 1px 4px rgba(31, 95, 153, 0.12);
 }
 
 .provider-card-head {
@@ -754,355 +873,320 @@ onMounted(() => {
   gap: 12px;
 }
 
+.provider-card-main {
+  min-width: 0;
+}
+
+.provider-card-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .provider-card-name {
+  min-width: 0;
   font-size: 15px;
   font-weight: 700;
-  color: #111827;
+  color: #1d2f43;
+}
+
+.provider-dirty-mark {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #fff3d8;
+  color: #8a5a12;
+  font-size: 11px;
+  font-weight: 700;
 }
 
 .provider-card-id {
   margin-top: 3px;
   font-size: 12px;
-  color: #9ca3af;
+  color: #71839a;
+  word-break: break-word;
 }
 
 .provider-card-meta {
   display: flex;
   justify-content: space-between;
+  gap: 10px;
   margin-top: 12px;
   font-size: 12px;
-  color: #6b7280;
+  color: #66788a;
 }
 
-.provider-status {
+.provider-status,
+.model-detection {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: 999px;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 4px;
   font-size: 12px;
   font-weight: 700;
   white-space: nowrap;
 }
 
-.provider-status.is-verified {
-  color: #166534;
-  background: #dcfce7;
+.provider-status::before,
+.model-detection::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  content: '';
 }
 
-.provider-status.is-pending {
-  color: #92400e;
-  background: #fef3c7;
+.is-verified {
+  color: #146c43;
+  background: #eaf7ef;
+  border: 1px solid #b8e3c6;
 }
 
-.provider-status.is-invalid {
-  color: #991b1b;
-  background: #fee2e2;
+.is-verified::before {
+  background: #1f9d55;
+}
+
+.is-pending {
+  color: #8a5a12;
+  background: #fff8e6;
+  border: 1px solid #f0d894;
+}
+
+.is-pending::before {
+  background: #d99016;
+}
+
+.is-invalid {
+  color: #a12828;
+  background: #fff1f1;
+  border: 1px solid #efc2c2;
+}
+
+.is-invalid::before {
+  background: #d14343;
 }
 
 .provider-detail {
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.provider-hero {
+.provider-titlebar {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 22px;
-  border-radius: 22px;
-  border: 1px solid #e2e8f0;
-  background:
-    radial-gradient(circle at top left, rgba(14, 165, 233, 0.14), transparent 30%),
-    linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
+  padding: 18px 20px;
+  border: 1px solid #cddceb;
+  border-left: 4px solid #1f5f99;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f4f8fc 0%, #ffffff 72%);
+}
+
+.provider-title-main {
+  min-width: 0;
 }
 
 .provider-kicker {
   font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #0369a1;
+  letter-spacing: 0.04em;
+  color: #2c659b;
 }
 
-.provider-hero h3 {
-  margin: 8px 0 6px;
-  font-size: 24px;
+.provider-titlebar h3 {
+  margin: 7px 0 6px;
+  font-size: 22px;
   font-weight: 700;
-  color: #0f172a;
+  color: #16324f;
 }
 
-.provider-hero p {
+.provider-titlebar p {
   margin: 0;
   font-size: 14px;
-  color: #475569;
+  color: #53677e;
 }
 
-.provider-compatibility-note {
+.provider-title-actions {
   display: inline-flex;
-  margin-top: 12px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: rgba(14, 165, 233, 0.12);
-  color: #0f4c81;
-  font-size: 12px;
-  font-weight: 600;
+  align-items: center;
+  gap: 12px;
+  flex: none;
 }
 
-.provider-hero-status {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+.provider-title-actions :deep(.el-button--primary) {
+  --el-button-bg-color: #1f5f99;
+  --el-button-border-color: #1f5f99;
+  --el-button-hover-bg-color: #2c74b8;
+  --el-button-hover-border-color: #2c74b8;
+  --el-button-active-bg-color: #184d7d;
+  --el-button-active-border-color: #184d7d;
+}
+
+.provider-switch {
+  display: inline-flex;
+  align-items: center;
   gap: 10px;
-  text-align: right;
+  color: #40566e;
   font-size: 13px;
-  color: #334155;
+  white-space: nowrap;
 }
 
-.provider-settings-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.service-section {
+  padding: 18px;
+  border: 1px solid #d8e3ef;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 16px;
+  margin-bottom: 14px;
 }
 
-.provider-panel,
-.form-section {
-  padding: 20px;
-  border-radius: 20px;
-  border: 1px solid #e2e8f0;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.96) 100%);
-}
-
-.panel-title,
 .section-title {
   font-size: 15px;
   font-weight: 700;
-  color: #0f172a;
+  color: #16324f;
 }
 
-.panel-subtitle,
-.section-subtitle {
-  margin-top: 6px;
+.field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.field-label .el-icon {
+  color: #71839a;
+}
+
+.provider-form :deep(.el-form-item) {
+  margin-bottom: 16px;
+}
+
+.stream-mode-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: #53677e;
   font-size: 13px;
-  color: #64748b;
 }
 
-.provider-form {
-  margin-top: 14px;
-}
-
-.provider-capability-row {
-  display: flex;
+.model-heading {
   align-items: flex-start;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  border: 1px dashed #cbd5e1;
-  background: #f8fafc;
-}
-
-.provider-capability-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.provider-capability-copy strong {
-  font-size: 13px;
-  color: #0f172a;
-}
-
-.provider-capability-copy span {
-  font-size: 12px;
-  color: #64748b;
-}
-
-.provider-inline-hints {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: 12px;
-  color: #64748b;
 }
 
 .custom-model-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 12px;
-  margin-top: 14px;
-}
-
-.model-chip-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.custom-model-list {
-  display: flex;
-  flex-wrap: wrap;
+  grid-template-columns: minmax(180px, 260px) auto;
   gap: 10px;
-  margin-top: 14px;
 }
 
-.custom-model-item {
-  display: inline-flex;
+.model-table {
+  border: 1px solid #d8e3ef;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.model-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(150px, 220px) 86px 72px;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 14px;
+  border-top: 1px solid #e4eaf2;
+}
+
+.model-row:first-child {
+  border-top: none;
+}
+
+.model-row-head {
+  background: #f7faff;
+  color: #4f6680;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.model-name-cell {
+  min-width: 0;
+  display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  border: 1px solid #cbd5e1;
-  background: #f8fafc;
-  font-size: 12px;
-  color: #334155;
 }
 
-.model-chip {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px;
-  border: 1px solid #dbeafe;
-  border-radius: 18px;
-  background: #f8fbff;
-  text-align: left;
-  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
-  cursor: pointer;
-}
-
-.model-chip span {
-  font-size: 14px;
+.model-name-cell span {
+  min-width: 0;
   font-weight: 600;
-  color: #0f172a;
+  color: #1d2f43;
   word-break: break-word;
 }
 
-.model-chip strong {
-  font-size: 12px;
-  color: #1d4ed8;
-}
-
-.model-chip:hover,
-.model-chip.active {
-  transform: translateY(-1px);
-  border-color: #38bdf8;
-  box-shadow: 0 14px 28px rgba(14, 165, 233, 0.14);
-}
-
-.model-chip.active {
-  background: linear-gradient(180deg, #eff6ff 0%, #dbeafe 100%);
-}
-
-.candidate-panel {
-  border-style: dashed;
-}
-
-.candidate-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin-top: 16px;
-}
-
-.candidate-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  background: #f8fafc;
-  border: 1px solid #cbd5e1;
-  font-size: 14px;
-  color: #0f172a;
-}
-
-.candidate-remove {
+.text-danger {
   border: none;
   background: none;
-  color: #dc2626;
+  color: #b42318;
+  font-weight: 600;
   cursor: pointer;
 }
 
-.candidate-empty {
-  margin-top: 18px;
+.empty-block {
   padding: 20px;
-  border-radius: 16px;
-  background: #fff7ed;
-  color: #9a3412;
+  border: 1px dashed #b7cbe1;
+  border-radius: 8px;
+  background: #f7faff;
+  color: #53677e;
 }
 
-.candidate-empty-title {
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.candidate-empty-text {
-  margin-top: 6px;
-  font-size: 13px;
-}
-
-.config-form {
-  display: flex;
-  flex-direction: column;
+.default-section {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 420px);
   gap: 16px;
-}
-
-.section-note {
-  margin-top: 8px;
-  font-size: 12px;
-  color: #b45309;
-}
-
-.datasource-notes {
-  margin-top: 6px;
-  padding: 16px 18px;
-  border-radius: 16px;
-  border: 1px dashed #cbd5e1;
-  background: #f8fafc;
-}
-
-.datasource-note-title {
-  font-size: 13px;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.datasource-note-item {
-  margin-top: 6px;
-  font-size: 12px;
-  color: #475569;
+  align-items: center;
 }
 
 @media (max-width: 1100px) {
   .provider-workbench {
     grid-template-columns: 1fr;
   }
-
-  .provider-settings-grid {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 768px) {
-  .card-header,
-  .provider-hero {
+  .provider-titlebar,
+  .section-heading,
+  .provider-title-actions {
     flex-direction: column;
+    align-items: stretch;
   }
 
-  .provider-hero-status {
-    align-items: flex-start;
-    text-align: left;
-  }
-
-  .actions {
+  .provider-title-actions {
     width: 100%;
   }
 
-  .custom-model-row {
+  .provider-switch {
+    justify-content: space-between;
+  }
+
+  .custom-model-row,
+  .default-section {
     grid-template-columns: 1fr;
+  }
+
+  .model-row,
+  .model-row-head {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .model-row-head {
+    display: none;
   }
 }
 </style>

--- a/frontend/src/views/settings/__tests__/DataAgentConfig.spec.js
+++ b/frontend/src/views/settings/__tests__/DataAgentConfig.spec.js
@@ -1,0 +1,266 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  detectModel: vi.fn()
+}))
+
+const messageMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn()
+}))
+
+const messageBoxMocks = vi.hoisted(() => ({
+  confirm: vi.fn()
+}))
+
+vi.mock('@/api/dataagent', () => ({
+  dataagentApi: apiMocks
+}))
+
+vi.mock('element-plus', async (importOriginal) => ({
+  ...(await importOriginal()),
+  ElMessage: messageMocks,
+  ElMessageBox: messageBoxMocks
+}))
+
+import DataAgentConfig from '../DataAgentConfig.vue'
+
+const stubs = {
+  'el-row': { template: '<div><slot /></div>' },
+  'el-col': { template: '<div><slot /></div>' },
+  'el-button': {
+    props: ['disabled', 'loading'],
+    template: '<button :disabled="disabled"><slot /></button>'
+  },
+  'el-switch': {
+    props: ['modelValue', 'disabled'],
+    emits: ['update:modelValue'],
+    template: '<button :disabled="disabled" @click="$emit(\'update:modelValue\', !modelValue)"><slot /></button>'
+  },
+  'el-form': { template: '<form><slot /></form>' },
+  'el-form-item': { template: '<label><slot name="label" /><slot /></label>' },
+  'el-input': {
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'input'],
+    template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event.target.value)" />'
+  },
+  'el-select': {
+    props: ['modelValue', 'disabled'],
+    emits: ['update:modelValue'],
+    template: '<select :disabled="disabled"><slot /></select>'
+  },
+  'el-option': { template: '<option />' },
+  'el-tooltip': { template: '<span><slot /></span>' },
+  'el-icon': { template: '<i><slot /></i>' },
+  QuestionFilled: { template: '<i />' }
+}
+
+const mountConfig = () => shallowMount(DataAgentConfig, {
+  global: { stubs }
+})
+
+const basePayload = () => ({
+  provider_id: 'openrouter',
+  model: 'anthropic/claude-sonnet-4.5',
+  providers: [
+    {
+      provider_id: 'openrouter',
+      display_name: 'OpenRouter',
+      provider_group: '聚合路由',
+      enabled: true,
+      provider_enabled: true,
+      auth_token_set: true,
+      api_key_set: false,
+      base_url: 'https://openrouter.ai/api',
+      models: ['anthropic/claude-sonnet-4.5'],
+      supported_models: ['anthropic/claude-sonnet-4.5'],
+      custom_models: [],
+      model_detections: {
+        'anthropic/claude-sonnet-4.5': {
+          status: 'verified',
+          message: '模型检测通过',
+          checked_at: '2026-04-17T10:00:00'
+        }
+      },
+      supports_partial_messages: true,
+      validation_status: 'verified',
+      validation_message: '模型服务已可用'
+    },
+    {
+      provider_id: 'anyrouter',
+      display_name: 'AnyRouter',
+      provider_group: '聚合路由',
+      enabled: false,
+      provider_enabled: false,
+      auth_token_set: false,
+      api_key_set: false,
+      base_url: 'https://a-ocnfniawgw.cn-shanghai.fcapp.run',
+      models: [],
+      supported_models: ['claude-opus-4-6'],
+      custom_models: [],
+      model_detections: {},
+      supports_partial_messages: true,
+      validation_status: 'unverified',
+      validation_message: '供应商未启用'
+    }
+  ]
+})
+
+const clone = (value) => JSON.parse(JSON.stringify(value))
+
+describe('DataAgentConfig', () => {
+  beforeEach(() => {
+    apiMocks.getSettings.mockReset()
+    apiMocks.updateSettings.mockReset()
+    apiMocks.detectModel.mockReset()
+    messageMocks.success.mockReset()
+    messageMocks.error.mockReset()
+    messageBoxMocks.confirm.mockReset()
+
+    apiMocks.getSettings.mockResolvedValue(basePayload())
+    apiMocks.updateSettings.mockImplementation(async (payload) => {
+      const current = basePayload()
+      const patch = payload.providers?.[0]
+      const providers = current.providers.map((provider) => {
+        if (!patch || provider.provider_id !== patch.provider_id) return provider
+        return {
+          ...provider,
+          ...patch,
+          auth_token_set: provider.auth_token_set || Boolean(patch.auth_token),
+          api_key_set: provider.api_key_set || Boolean(patch.api_key),
+          models: patch.enabled_models || provider.models,
+          supported_models: Array.from(new Set([
+            ...(provider.supported_models || []),
+            ...(patch.custom_models || []),
+            ...(patch.enabled_models || []),
+            ...Object.keys(patch.model_detections || {})
+          ])),
+          custom_models: patch.custom_models || [],
+          model_detections: patch.model_detections || provider.model_detections,
+          provider_enabled: patch.provider_enabled ?? provider.provider_enabled,
+          enabled: Boolean((patch.provider_enabled ?? provider.provider_enabled) && (patch.enabled_models || []).length),
+          validation_status: Boolean((patch.provider_enabled ?? provider.provider_enabled) && (patch.enabled_models || []).length)
+            ? 'verified'
+            : 'unverified',
+          validation_message: Boolean((patch.provider_enabled ?? provider.provider_enabled) && (patch.enabled_models || []).length)
+            ? '模型服务已可用'
+            : '请先检测并启用至少一个模型'
+        }
+      })
+      return {
+        ...current,
+        provider_id: Object.prototype.hasOwnProperty.call(payload, 'provider_id') ? payload.provider_id : current.provider_id,
+        model: Object.prototype.hasOwnProperty.call(payload, 'model') ? payload.model : current.model,
+        providers
+      }
+    })
+  })
+
+  it('removes top page header actions', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('刷新')
+    expect(wrapper.text()).not.toContain('配置供应商、检测模型可用性，并选择默认模型。')
+  })
+
+  it('requires verified detection before enabling a model', async () => {
+    const payload = basePayload()
+    payload.providers[0].models = []
+    payload.providers[0].enabled = false
+    payload.providers[0].validation_status = 'unverified'
+    payload.providers[0].validation_message = '请先检测并启用至少一个模型'
+    payload.providers[0].model_detections = {}
+    apiMocks.getSettings.mockResolvedValue(payload)
+
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    const model = 'anthropic/claude-sonnet-4.5'
+    expect(wrapper.vm.canEnableModel(model)).toBe(false)
+
+    apiMocks.detectModel.mockResolvedValue({
+      provider_id: 'openrouter',
+      model,
+      status: 'verified',
+      message: '模型检测通过',
+      checked_at: '2026-04-17T10:00:00'
+    })
+
+    await wrapper.vm.detectModel(model)
+    await flushPromises()
+
+    expect(wrapper.vm.canEnableModel(model)).toBe(true)
+    wrapper.vm.setModelEnabled(model, true)
+    expect(wrapper.vm.currentDraft.enabled_models).toEqual([model])
+  })
+
+  it('saves only the current provider patch and updates dirty button state', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    wrapper.vm.currentDraft.supports_partial_messages = false
+
+    expect(wrapper.vm.currentProviderDirty).toBe(true)
+    expect(wrapper.vm.saveButtonText).toBe('保存改动')
+    expect(wrapper.vm.isProviderDirty('anyrouter')).toBe(false)
+
+    await wrapper.vm.saveCurrentProvider()
+    await flushPromises()
+
+    expect(apiMocks.updateSettings).toHaveBeenCalledTimes(1)
+    expect(apiMocks.updateSettings.mock.calls[0][0].providers).toHaveLength(1)
+    expect(apiMocks.updateSettings.mock.calls[0][0].providers[0].provider_id).toBe('openrouter')
+    expect(apiMocks.updateSettings.mock.calls[0][0].provider_id).toBe('openrouter')
+    expect(apiMocks.updateSettings.mock.calls[0][0].model).toBe('anthropic/claude-sonnet-4.5')
+    expect(wrapper.vm.currentProviderDirty).toBe(false)
+    expect(wrapper.vm.saveButtonText).toBe('保存配置')
+  })
+
+  it('confirms before switching provider with unsaved changes and restores discarded draft', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    wrapper.vm.currentDraft.supports_partial_messages = false
+    messageBoxMocks.confirm.mockResolvedValue('confirm')
+
+    await wrapper.vm.selectProvider('anyrouter')
+    await flushPromises()
+
+    expect(messageBoxMocks.confirm).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.selectedProviderId).toBe('anyrouter')
+    expect(wrapper.vm.providerDrafts.openrouter.supports_partial_messages).toBe(true)
+    expect(wrapper.vm.form.provider_id).toBe('openrouter')
+    expect(wrapper.vm.form.model).toBe('anthropic/claude-sonnet-4.5')
+  })
+
+  it('stays on the current provider when discard confirmation is canceled', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    wrapper.vm.currentDraft.provider_enabled = false
+    messageBoxMocks.confirm.mockRejectedValue(new Error('cancel'))
+
+    await wrapper.vm.selectProvider('anyrouter')
+    await flushPromises()
+
+    expect(wrapper.vm.selectedProviderId).toBe('openrouter')
+    expect(wrapper.vm.currentDraft.provider_enabled).toBe(false)
+  })
+
+  it('clears detection state when connection fields change and marks current provider dirty', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    const before = clone(wrapper.vm.providerSnapshots.openrouter)
+    wrapper.vm.clearCurrentDetections()
+
+    expect(wrapper.vm.currentDraft.model_detections).toEqual({})
+    expect(wrapper.vm.currentDraft.enabled_models).toEqual([])
+    expect(wrapper.vm.isProviderDirty('openrouter')).toBe(true)
+    expect(before.model_detections['anthropic/claude-sonnet-4.5'].status).toBe('verified')
+  })
+})


### PR DESCRIPTION
## Summary
- Simplify the model service settings page so it opens directly into the provider workbench instead of a separate outer page header/card layer.
- Change the save flow from whole-page save to current-provider save with per-provider dirty state, discard-on-switch handling, and real model detection aligned with explicit save.

## What Changed

### Behavior Changes
- Reworked the `dataagent` settings tab UI into a flatter provider workbench and removed the outer `模型服务 / 刷新 / 保存配置` header layer.
- Moved `保存配置` into the current provider title bar and limited it to saving only the visible provider patch.
- Added per-provider unsaved-change tracking, button state changes (`保存配置` / `保存改动`), and confirmation before discarding edits when switching providers.
- Kept real model detection, but stopped persisting draft credentials and detection state during detection itself; the provider draft is now persisted only when the user explicitly saves.
- Added shared provider runtime env normalization for admin detection and runtime execution paths.
- Updated design/plan docs and expanded frontend/backend tests around detection, enablement rules, and provider-scoped save behavior.

### Key Files
- `frontend/src/views/settings/DataAgentConfig.vue`: rebuilt the page layout, provider-scoped dirty/save logic, and discard-on-switch flow.
- `dataagent/dataagent-backend/core/skill_admin_service.py`: adjusted model detection behavior and provider settings persistence semantics.
- `dataagent/dataagent-backend/core/provider_runtime.py`: added shared provider runtime env helpers used by detection and runtime execution.
- `frontend/src/views/settings/__tests__/DataAgentConfig.spec.js`: added focused tests for provider-scoped save and unsaved-change behavior.
- `docs/design/2026-04-17-model-service-config-design.md`, `docs/plans/2026-04-17-model-service-config-plan.md`: synced the implementation contract and rollout notes.

## Validation
- Command: `dataagent/dataagent-backend/.venv/bin/python -m pytest dataagent/dataagent-backend/tests/test_admin_routes.py dataagent/dataagent-backend/tests/test_skill_admin_service.py -q`
  Result: pass (`12 passed`)
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run test -- DataAgentConfig.spec.js`
  Result: pass (`1 file, 6 tests`)
- Command: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build`
  Result: pass (Vite production build completed; existing Sass legacy API and large chunk warnings remain)
- Command: `git diff --check`
  Result: pass

## Risks
- Main regression risk: provider-scoped dirty-state handling could regress default-model selection or discard logic when users switch providers after local edits.

## Rollback
- Revert commit `e2560fb` or close the PR; persisted `model_detections` data remains additive JSON and older behavior can ignore it after rollback.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updated when required.
