### PR TITLE
fix: make model detection optional for enablement

### DIFF
--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -215,10 +215,6 @@ def _normalize_model_detections(raw: Any) -> dict[str, dict[str, str]]:
     return normalized
 
 
-def _model_detection_verified(model_detections: dict[str, dict[str, str]], model: str) -> bool:
-    return str((model_detections.get(model) or {}).get("status") or "") == "verified"
-
-
 def _provider_definition(provider_id: str) -> dict[str, Any]:
     return dict(PROVIDER_DEFINITIONS.get(provider_id) or PROVIDER_DEFINITIONS[DEFAULT_PROVIDER_ID])
 
@@ -324,11 +320,7 @@ def _normalize_provider_entry(provider_id: str, payload: dict[str, Any], previou
         + requested_enabled_models
         + list(model_detections.keys())
     )
-    enabled_models = [
-        model
-        for model in requested_enabled_models
-        if _model_detection_verified(model_detections, model)
-    ]
+    enabled_models = requested_enabled_models
     base_url = str(base.get("base_url") or definition.get("default_base_url") or "").strip()
     api_key = str(base.get("api_key") or "").strip()
     auth_token = str(base.get("auth_token") or "").strip()
@@ -386,7 +378,7 @@ def _compute_provider_validation(
             return ("unverified", "请填写 API Key")
         return ("unverified", "请填写 Token")
     if not enabled_models:
-        return ("unverified", "请先检测并启用至少一个模型")
+        return ("unverified", "请启用至少一个模型")
     return ("verified", "模型服务已可用")
 
 
@@ -798,7 +790,7 @@ def resolve_runtime_provider_selection(provider_id: str | None, model: str | Non
     if not selected_model:
         selected_model = enabled_models[0] if enabled_models else ""
     if selected_model not in enabled_models:
-        raise ValueError("所选模型未加入已验证候选")
+        raise ValueError("所选模型未加入已启用模型")
 
     return {
         "provider_id": normalized_provider_id,

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -121,7 +121,7 @@ def test_merge_provider_settings_can_reenable_provider_with_models():
             "model_detections": {},
             "enabled": False,
             "validation_status": "unverified",
-            "validation_message": "请先检测并启用至少一个模型",
+            "validation_message": "请启用至少一个模型",
         }
     }
     patch = {
@@ -187,7 +187,7 @@ def test_merge_provider_settings_preserves_partial_capability_flag():
     assert provider["enabled"] is True
 
 
-def test_merge_provider_settings_requires_verified_model_detection():
+def test_merge_provider_settings_allows_enabled_model_without_detection():
     merged = _merge_provider_settings(
         {},
         {
@@ -203,9 +203,9 @@ def test_merge_provider_settings_requires_verified_model_detection():
     )
 
     provider = merged["openrouter"]
-    assert provider["enabled_models"] == []
-    assert provider["validation_status"] == "unverified"
-    assert provider["enabled"] is False
+    assert provider["enabled_models"] == ["anthropic/claude-sonnet-4.5"]
+    assert provider["validation_status"] == "verified"
+    assert provider["enabled"] is True
 
 
 def test_merge_settings_payload_keeps_provider_and_model_empty_without_enabled_provider():
@@ -287,13 +287,7 @@ def test_resolve_runtime_provider_selection_returns_partial_capability(monkeypat
                     "auth_token": "relay-token",
                     "base_url": "https://relay.example.invalid",
                     "enabled_models": ["claude-sonnet-4.5"],
-                    "model_detections": {
-                        "claude-sonnet-4.5": {
-                            "status": "verified",
-                            "message": "模型检测通过",
-                            "checked_at": "2026-04-17T10:00:00",
-                        }
-                    },
+                    "model_detections": {},
                     "supports_partial_messages": False,
                 }
             },

--- a/docs/design/2026-04-17-model-service-config-design.md
+++ b/docs/design/2026-04-17-model-service-config-design.md
@@ -6,7 +6,7 @@ The administrator settings page currently exposes DataAgent runtime details toge
 
 ## Problem
 
-Users need a simpler model service configuration page that focuses on provider selection, API credentials, model detection, model enablement, and default model selection. Runtime internals such as Skill paths and DataAgent storage should not be exposed in this UI. Enabling a model should require a real service check so the saved configuration reflects usable provider/model pairs. The page should also avoid a separate top-level page header layer and make save scope match the visible provider.
+Users need a simpler model service configuration page that focuses on provider selection, API credentials, optional model detection, model enablement, and default model selection. Runtime internals such as Skill paths and DataAgent storage should not be exposed in this UI. Model detection should help administrators check connectivity, but failed or skipped detection must not block enablement because detection is advisory. The page should also avoid a separate top-level page header layer and make save scope match the visible provider.
 
 ## Scope
 
@@ -25,7 +25,7 @@ This change covers the DataAgent admin settings API, model detection state in ex
 - Keep a manual save button, but scope it to the currently visible provider. Unsaved changes are tracked per provider draft and surfaced through the current save button and provider-switch confirmation.
 - Add `POST /api/v1/nl2sql-admin/model-detections` for real model checks using the same provider environment mapping as runtime DataAgent execution.
 - Store model detection results inside `provider_settings` in `da_agent_settings.raw_json`, under each provider entry, when the current provider is saved. Detection itself returns a live result and does not directly persist draft credentials or detection state.
-- A model can be enabled only after its detection status is `verified`. Provider usability still requires provider switch on, at least one enabled model, and locally valid credentials/base URL.
+- Model detection is optional. A model can be enabled when the provider switch is on, regardless of `model_detections` status. Provider usability still requires provider switch on, at least one enabled model, and locally valid credentials/base URL.
 
 ## Interfaces
 
@@ -52,8 +52,8 @@ The request may omit credentials. The backend resolves missing credentials from 
 
 ## Tradeoffs
 
-The detection endpoint performs a real external model call, so it can be slower or fail because of provider/network conditions. This is intentional because the UI contract is “key plus model is usable,” not “form fields are non-empty.” The timeout is bounded at 30 seconds. Detection no longer persists provider drafts on its own; that keeps discard-and-switch behavior coherent at the cost of requiring an explicit save after a successful check.
+The detection endpoint performs a real external model call, so it can be slower or fail because of provider/network conditions. Detection is advisory rather than required for enablement; this avoids blocking administrators when the check is skipped or transiently fails. The timeout is bounded at 30 seconds. Detection no longer persists provider drafts on its own; that keeps discard-and-switch behavior coherent at the cost of requiring an explicit save if the administrator wants to keep the latest detection result.
 
 ## Rollback
 
-Rollback can remove the detection endpoint usage from the UI and return to local validation. Persisted `model_detections` fields are additive JSON fields and can be ignored by older code.
+Rollback can remove the detection endpoint usage from the UI and keep local provider validation based on credentials, Base URL, and enabled models. Persisted `model_detections` fields are additive JSON fields and can be ignored by older code.

--- a/docs/plans/2026-04-17-model-service-config-plan.md
+++ b/docs/plans/2026-04-17-model-service-config-plan.md
@@ -8,8 +8,8 @@
 4. Refactor the Vue settings page into a simplified model service console, remove runtime details from the UI, drop the outer page header layer, and move save into the current provider title bar.
 5. Update the configuration tab label from `智能问数` to `模型服务`.
 6. Change provider save scope from whole-page save to current-provider save with per-provider dirty state and switch-away confirmation.
-7. Keep model detection as a real check, but return the detection result without persisting provider draft changes until the current provider is explicitly saved.
-8. Add targeted backend and frontend tests for detection state, enablement rules, dirty-state behavior, and API contract.
+7. Keep model detection as a real optional check, but return the detection result without persisting provider draft changes until the current provider is explicitly saved.
+8. Add targeted backend and frontend tests for advisory detection state, enablement rules, dirty-state behavior, and API contract.
 
 ## Verification
 
@@ -20,7 +20,7 @@
 
 ## Rollout
 
-This is an admin UI and DataAgent API change. No migration is needed because detection data is stored in existing JSON settings. Existing saved provider settings remain readable; models without detection state will appear as not detected and cannot be newly enabled until detection succeeds. Detection remains a separate API call, but draft edits only become persistent when the current provider is saved.
+This is an admin UI and DataAgent API change. No migration is needed because detection data is stored in existing JSON settings. Existing saved provider settings remain readable; models without detection state appear as not detected but can still be enabled. Detection remains a separate API call, but draft edits only become persistent when the current provider is saved.
 
 ## Backout
 

--- a/frontend/src/views/settings/DataAgentConfig.vue
+++ b/frontend/src/views/settings/DataAgentConfig.vue
@@ -276,7 +276,7 @@ const buildProviderDraft = (provider) => {
     token: '',
     base_url: provider.base_url || '',
     supports_partial_messages: provider.supports_partial_messages !== false,
-    enabled_models: uniqueStrings(provider.models || []).filter((model) => modelDetections[model]?.status === 'verified'),
+    enabled_models: uniqueStrings(provider.models || []),
     custom_models: customModels,
     base_supported_models: uniqueStrings(provider.supported_models || []).filter((model) => !customModels.includes(model)),
     model_detections: modelDetections
@@ -285,7 +285,7 @@ const buildProviderDraft = (provider) => {
 
 const buildProviderSnapshot = (draft) => {
   const modelDetections = normalizeDetections(draft?.model_detections)
-  const enabledModels = uniqueStrings(draft?.enabled_models).filter((model) => modelDetections[model]?.status === 'verified')
+  const enabledModels = uniqueStrings(draft?.enabled_models)
   return {
     provider_enabled: Boolean(draft?.provider_enabled),
     token: String(draft?.token || '').trim(),
@@ -455,7 +455,7 @@ const providerPreview = (provider) => {
   }
 
   const providerEnabled = Boolean(draft.provider_enabled)
-  const enabledModels = uniqueStrings(draft.enabled_models).filter((model) => draft.model_detections?.[model]?.status === 'verified')
+  const enabledModels = uniqueStrings(draft.enabled_models)
   if (!providerEnabled) {
     return {
       status: 'unverified',
@@ -486,7 +486,7 @@ const providerPreview = (provider) => {
   if (!enabledModels.length) {
     return {
       status: 'unverified',
-      message: '请先检测并启用至少一个模型',
+      message: '请启用至少一个模型',
       providerEnabled,
       enabled: false,
       enabledModels: []
@@ -530,7 +530,7 @@ const credentialSummary = (provider) => {
 const isModelEnabled = (model) => Boolean(currentDraft.value?.enabled_models?.includes(model))
 
 const canEnableModel = (model) => {
-  return Boolean(currentDraft.value?.provider_enabled) && modelDetection(model).status === 'verified'
+  return Boolean(currentDraft.value?.provider_enabled)
 }
 
 const setModelEnabled = (model, enabled) => {
@@ -551,10 +551,6 @@ const isDetecting = (model) => Boolean(detectingModels[detectKey(model)])
 const clearCurrentDetections = () => {
   if (!currentDraft.value) return
   currentDraft.value.model_detections = {}
-  currentDraft.value.enabled_models = []
-  if (form.provider_id === currentProvider.value?.provider_id) {
-    form.model = ''
-  }
 }
 
 const resetProviderState = (items) => {
@@ -713,7 +709,6 @@ const detectModel = async (model) => {
       checked_at: result.checked_at || ''
     }
     if (result.status !== 'verified') {
-      currentDraft.value.enabled_models = currentDraft.value.enabled_models.filter((item) => item !== model)
       ElMessage.error(result.message || '模型检测失败')
       return
     }
@@ -726,7 +721,7 @@ const detectModel = async (model) => {
 const buildProviderPayload = (providerId) => {
   const provider = providers.value.find((item) => item.provider_id === providerId)
   const draft = providerDrafts[providerId]
-  const enabledModels = uniqueStrings(draft.enabled_models).filter((model) => draft.model_detections?.[model]?.status === 'verified')
+  const enabledModels = uniqueStrings(draft.enabled_models)
   const payload = {
     provider_id: providerId,
     provider_enabled: Boolean(draft.provider_enabled),

--- a/frontend/src/views/settings/__tests__/DataAgentConfig.spec.js
+++ b/frontend/src/views/settings/__tests__/DataAgentConfig.spec.js
@@ -147,7 +147,7 @@ describe('DataAgentConfig', () => {
             : 'unverified',
           validation_message: Boolean((patch.provider_enabled ?? provider.provider_enabled) && (patch.enabled_models || []).length)
             ? '模型服务已可用'
-            : '请先检测并启用至少一个模型'
+            : '请启用至少一个模型'
         }
       })
       return {
@@ -167,12 +167,12 @@ describe('DataAgentConfig', () => {
     expect(wrapper.text()).not.toContain('配置供应商、检测模型可用性，并选择默认模型。')
   })
 
-  it('requires verified detection before enabling a model', async () => {
+  it('allows enabling a model before detection succeeds', async () => {
     const payload = basePayload()
     payload.providers[0].models = []
     payload.providers[0].enabled = false
     payload.providers[0].validation_status = 'unverified'
-    payload.providers[0].validation_message = '请先检测并启用至少一个模型'
+    payload.providers[0].validation_message = '请启用至少一个模型'
     payload.providers[0].model_detections = {}
     apiMocks.getSettings.mockResolvedValue(payload)
 
@@ -180,22 +180,31 @@ describe('DataAgentConfig', () => {
     await flushPromises()
 
     const model = 'anthropic/claude-sonnet-4.5'
-    expect(wrapper.vm.canEnableModel(model)).toBe(false)
+    expect(wrapper.vm.canEnableModel(model)).toBe(true)
+    wrapper.vm.setModelEnabled(model, true)
+    expect(wrapper.vm.currentDraft.enabled_models).toEqual([model])
+  })
+
+  it('keeps an enabled model when detection fails', async () => {
+    const wrapper = mountConfig()
+    await flushPromises()
+
+    const model = 'anthropic/claude-sonnet-4.5'
+    expect(wrapper.vm.currentDraft.enabled_models).toEqual([model])
 
     apiMocks.detectModel.mockResolvedValue({
       provider_id: 'openrouter',
       model,
-      status: 'verified',
-      message: '模型检测通过',
+      status: 'failed',
+      message: '模型检测失败',
       checked_at: '2026-04-17T10:00:00'
     })
 
     await wrapper.vm.detectModel(model)
     await flushPromises()
 
-    expect(wrapper.vm.canEnableModel(model)).toBe(true)
-    wrapper.vm.setModelEnabled(model, true)
     expect(wrapper.vm.currentDraft.enabled_models).toEqual([model])
+    expect(messageMocks.error).toHaveBeenCalledWith('模型检测失败')
   })
 
   it('saves only the current provider patch and updates dirty button state', async () => {
@@ -251,7 +260,7 @@ describe('DataAgentConfig', () => {
     expect(wrapper.vm.currentDraft.provider_enabled).toBe(false)
   })
 
-  it('clears detection state when connection fields change and marks current provider dirty', async () => {
+  it('clears detection state when connection fields change without disabling models', async () => {
     const wrapper = mountConfig()
     await flushPromises()
 
@@ -259,7 +268,8 @@ describe('DataAgentConfig', () => {
     wrapper.vm.clearCurrentDetections()
 
     expect(wrapper.vm.currentDraft.model_detections).toEqual({})
-    expect(wrapper.vm.currentDraft.enabled_models).toEqual([])
+    expect(wrapper.vm.currentDraft.enabled_models).toEqual(['anthropic/claude-sonnet-4.5'])
+    expect(wrapper.vm.form.model).toBe('anthropic/claude-sonnet-4.5')
     expect(wrapper.vm.isProviderDirty('openrouter')).toBe(true)
     expect(before.model_detections['anthropic/claude-sonnet-4.5'].status).toBe('verified')
   })


### PR DESCRIPTION
## Summary
- Treat model detection as advisory in the model service settings UI, so undetected or failed models can still be enabled.
- Preserve enabled model selections in DataAgent backend normalization and runtime provider selection without requiring `model_detections.status=verified`.
- Update regression tests and the existing model service design/plan docs to match the optional detection contract.

## Validation
- `cd dataagent/dataagent-backend && .venv/bin/python -m pytest tests/test_skill_admin_service.py tests/test_admin_routes.py` - 25 passed
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/views/settings/__tests__/DataAgentConfig.spec.js` - 7 passed
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build` - passed; emitted existing Sass legacy API and chunk-size warnings

## Risk
Low: behavior is scoped to DataAgent model service enablement and keeps credential/Base URL/local enabled-model validation intact.

## Rollback
Revert this PR to restore verified-detection gating for model enablement.