### PR TITLE
fix: keep opendataagent provider dialog actions visible

### DIFF
--- a/opendataagent/web/src/views/settings/AgentSettingsView.vue
+++ b/opendataagent/web/src/views/settings/AgentSettingsView.vue
@@ -212,7 +212,7 @@
       </p>
     </section>
 
-    <el-dialog v-model="providerDialogVisible" title="新增供应商" width="560px">
+    <el-dialog v-model="providerDialogVisible" title="新增供应商" width="min(560px, calc(100vw - 32px))">
       <div class="space-y-5">
         <div>
           <label class="mb-2 block text-sm font-medium text-gray-700">供应商类型</label>

--- a/opendataagent/web/src/views/settings/__tests__/AgentSettingsView.spec.js
+++ b/opendataagent/web/src/views/settings/__tests__/AgentSettingsView.spec.js
@@ -1,0 +1,81 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const settingsApiMocks = vi.hoisted(() => ({
+  getAgentSettings: vi.fn(),
+  updateAgentSettings: vi.fn()
+}))
+
+vi.mock('@/api/settings', () => ({
+  settingsApi: settingsApiMocks
+}))
+
+import AgentSettingsView from '../AgentSettingsView.vue'
+
+const baseSettings = () => ({
+  default_provider_id: 'mock',
+  default_model: 'mock-model',
+  managed_skills_dir: '',
+  skills_root_dir: '',
+  session_mysql_database: '',
+  admin_token: '',
+  providers: [
+    {
+      provider_id: 'mock',
+      provider_type: 'mock',
+      display_name: 'Mock',
+      default_model: 'mock-model',
+      models: [{ name: 'mock-model', enabled: true }],
+      base_url: '',
+      api_token: '',
+      enabled: true
+    }
+  ]
+})
+
+const stubs = {
+  ProductPageShell: {
+    template: '<div><slot name="sidebar" /><slot /></div>'
+  },
+  'el-dialog': {
+    props: ['modelValue', 'title', 'width'],
+    template: `
+      <section v-if="modelValue" data-test="provider-dialog" :data-width="width">
+        <slot />
+        <footer data-test="provider-dialog-footer"><slot name="footer" /></footer>
+      </section>
+    `
+  },
+  'el-switch': {
+    props: ['modelValue', 'disabled'],
+    emits: ['update:modelValue'],
+    template: '<button :disabled="disabled" @click="$emit(\'update:modelValue\', !modelValue)"><slot /></button>'
+  },
+  Cpu: { template: '<i />' },
+  Plus: { template: '<i />' },
+  Trash2: { template: '<i />' }
+}
+
+const mountView = () => mount(AgentSettingsView, {
+  global: { stubs }
+})
+
+describe('AgentSettingsView', () => {
+  beforeEach(() => {
+    settingsApiMocks.getAgentSettings.mockReset()
+    settingsApiMocks.updateAgentSettings.mockReset()
+    settingsApiMocks.getAgentSettings.mockResolvedValue(baseSettings())
+    settingsApiMocks.updateAgentSettings.mockResolvedValue(baseSettings())
+  })
+
+  it('uses a viewport-safe width for the add provider dialog footer actions', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('button.oda-btn-secondary').trigger('click')
+
+    const dialog = wrapper.get('[data-test="provider-dialog"]')
+    expect(dialog.attributes('data-width')).toBe('min(560px, calc(100vw - 32px))')
+    expect(wrapper.get('[data-test="provider-dialog-footer"]').text()).toContain('新增')
+  })
+})


### PR DESCRIPTION
Use a viewport-safe width for the add-provider dialog so footer actions remain clickable on narrow screens, and add a focused regression test for the dialog width contract.