### PR TITLE
fix: compact skill cards in admin list

### DIFF
--- a/frontend/src/views/settings/SkillStudio.vue
+++ b/frontend/src/views/settings/SkillStudio.vue
@@ -21,7 +21,16 @@
         >
           <el-button type="primary" :loading="importLoading">导入 Skill</el-button>
         </el-upload>
-        <el-button :loading="syncLoading" @click="triggerSync">刷新目录</el-button>
+        <el-tooltip content="刷新目录" placement="top">
+          <el-button
+            class="skill-studio__sync-button"
+            :icon="Refresh"
+            :loading="syncLoading"
+            circle
+            aria-label="刷新目录"
+            @click="triggerSync"
+          />
+        </el-tooltip>
       </div>
     </div>
 
@@ -69,13 +78,6 @@
           <el-tag size="small" effect="plain">{{ skill.documentCount }} 个文件</el-tag>
         </div>
 
-        <div class="skill-card__stats">
-          <div class="skill-stat">
-            <div class="skill-stat__label">最近更新</div>
-            <div class="skill-stat__value">{{ formatTime(skill.updatedAt) }}</div>
-          </div>
-        </div>
-
         <div class="skill-card__footer">
           <el-button text type="primary" @click="openSkillDetail(skill.folder)">查看详情</el-button>
           <el-button
@@ -101,8 +103,8 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import dayjs from 'dayjs'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { Refresh } from '@element-plus/icons-vue'
 import { dataagentApi } from '@/api/dataagent'
 import { buildSkillItems, sourceLabel } from './skillAdminShared'
 
@@ -148,11 +150,6 @@ const notifyError = (error, fallbackMessage) => {
   if (!error?.__odwNotified) {
     ElMessage.error(error?.message || fallbackMessage)
   }
-}
-
-const formatTime = (value) => {
-  if (!value) return '-'
-  return dayjs(value).format('YYYY-MM-DD HH:mm:ss')
 }
 
 const isOnlyEnabledSkill = (skill) => Boolean(skill?.enabled) && enabledSkillCount.value <= 1
@@ -320,24 +317,32 @@ onMounted(async () => {
   width: 280px;
 }
 
+.skill-studio__sync-button {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+}
+
 .skill-studio__alert {
   margin-top: -4px;
 }
 
 .skill-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 300px));
+  justify-content: start;
+  gap: 14px;
   min-width: 0;
 }
 
 .skill-card {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   padding: 16px;
   border: 1px solid #dbe2ea;
-  border-radius: 10px;
+  border-radius: 8px;
   background: #fff;
   min-width: 0;
 }
@@ -383,28 +388,6 @@ onMounted(async () => {
   gap: 8px;
 }
 
-.skill-card__stats {
-  display: block;
-}
-
-.skill-stat {
-  padding: 10px 12px;
-  border-radius: 8px;
-  background: #f8fafc;
-}
-
-.skill-stat__label {
-  font-size: 12px;
-  color: #64748b;
-}
-
-.skill-stat__value {
-  margin-top: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #0f172a;
-}
-
 .skill-card__footer {
   display: flex;
   justify-content: flex-end;
@@ -424,9 +407,17 @@ onMounted(async () => {
     width: 100%;
   }
 
+  .skill-grid {
+    grid-template-columns: 1fr;
+  }
+
   .skill-studio__actions :deep(.el-upload),
-  .skill-studio__actions :deep(.el-button) {
+  .skill-studio__actions :deep(.el-upload .el-button) {
     width: 100%;
+  }
+
+  .skill-studio__sync-button {
+    align-self: flex-start;
   }
 
   .skill-card__switch {

--- a/frontend/src/views/settings/__tests__/SkillStudio.spec.js
+++ b/frontend/src/views/settings/__tests__/SkillStudio.spec.js
@@ -48,9 +48,10 @@ const stubs = {
     template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
   },
   'el-button': {
-    props: ['loading', 'disabled'],
+    props: ['loading', 'disabled', 'icon'],
     template: '<button :disabled="disabled"><slot /></button>'
   },
+  'el-tooltip': { template: '<div><slot /></div>' },
   'el-alert': { template: '<div><slot /><slot name="title" /></div>' },
   'el-tag': { template: '<span><slot /></span>' },
   'el-empty': { template: '<div><slot /></div>' },
@@ -157,6 +158,14 @@ describe('SkillStudio', () => {
     expect(wrapper.text()).toContain('已启用')
     expect(wrapper.text()).toContain('未启用')
     expect(wrapper.text()).not.toContain('当前运行')
+    expect(wrapper.text()).not.toContain('最近更新')
+    expect(wrapper.text()).not.toContain('2026-04-17')
+    expect(wrapper.find('.skill-card__stats').exists()).toBe(false)
+
+    const syncButton = wrapper.find('.skill-studio__sync-button')
+    expect(syncButton.exists()).toBe(true)
+    expect(syncButton.attributes('aria-label')).toBe('刷新目录')
+    expect(syncButton.text()).toBe('')
 
     wrapper.vm.openSkillDetail('marketing-insights')
     expect(routerPush).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- Compact the admin Skill list cards by removing the recent update timestamp block.
- Change the refresh directory action from a text button to an icon-only refresh button with tooltip and aria-label.
- Narrow the desktop card grid while preserving single-column mobile layout.

## Validation
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- SkillStudio.spec.js` passed: 6 tests.
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build` passed. Build output still reports existing Sass legacy API deprecation warnings and chunk-size warnings.

## Risk
Low: scoped to the admin Skill list component and its unit test.

## Rollback
Revert commit `e06e13f` to restore the previous card layout and text refresh button.