### PR TITLE
fix: move DataAgent runtime cwd to writable home

### DIFF
--- a/dataagent/dataagent-backend/Dockerfile
+++ b/dataagent/dataagent-backend/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV HOME=/tmp/dataagent-home
+ENV DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills
 
 WORKDIR /app/dataagent-backend
 

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -71,6 +71,7 @@ class Settings(BaseSettings):
 
     # ---- Skills ----
     skills_output_dir: str = "../.claude/skills/dataagent-nl2sql"
+    dataagent_runtime_project_cwd: str = ""
     dataagent_portal_mcp_enabled: bool = True
     dataagent_portal_mcp_base_url: str = ""
     dataagent_portal_mcp_token: str = ""

--- a/dataagent/dataagent-backend/core/skills_loader.py
+++ b/dataagent/dataagent-backend/core/skills_loader.py
@@ -91,6 +91,19 @@ def _resolve_root_dir(raw: str) -> Path:
     return (base / path).resolve()
 
 
+def _resolve_runtime_project_cwd(raw: str | None = None) -> Path:
+    base = Path(__file__).resolve().parent.parent  # dataagent-backend/
+    value = str(raw or "").strip()
+    if value:
+        path = Path(value).expanduser()
+        if path.is_absolute():
+            return path
+        return (base / path).resolve()
+
+    home = Path(os.environ.get("HOME") or str(Path.home())).expanduser()
+    return (home / ".dataagent" / "runtime" / "enabled-skills").resolve()
+
+
 def resolve_builtin_skill_root_dir() -> Path:
     cfg = get_settings()
     return _resolve_root_dir(cfg.skills_output_dir)
@@ -121,7 +134,8 @@ def resolve_agent_project_cwd() -> Path:
 
 def prepare_enabled_skills_project_cwd(enabled_folders: list[str] | tuple[str, ...]) -> Path:
     discovery_root = resolve_skill_discovery_root_dir()
-    runtime_root = Path(__file__).resolve().parent.parent / ".runtime" / "enabled-skills"
+    cfg = get_settings()
+    runtime_root = _resolve_runtime_project_cwd(cfg.dataagent_runtime_project_cwd)
     runtime_skills_dir = runtime_root / ".claude" / "skills"
     runtime_skills_dir.mkdir(parents=True, exist_ok=True)
 

--- a/dataagent/dataagent-backend/tests/test_skills_loader.py
+++ b/dataagent/dataagent-backend/tests/test_skills_loader.py
@@ -61,10 +61,16 @@ def _build_minimum_bundle(root: Path):
 @pytest.fixture(autouse=True)
 def restore_skills_dir():
     original = get_settings().skills_output_dir
+    original_runtime_cwd = get_settings().dataagent_runtime_project_cwd
     try:
         yield
     finally:
-        update_settings({"skills_output_dir": original})
+        update_settings(
+            {
+                "skills_output_dir": original,
+                "dataagent_runtime_project_cwd": original_runtime_cwd,
+            }
+        )
 
 
 def test_loader_fails_when_required_file_missing(tmp_path: Path):
@@ -100,3 +106,19 @@ def test_prepare_enabled_skills_project_cwd_exposes_only_enabled_skills(tmp_path
     assert (runtime_skills / "dataagent-nl2sql" / "SKILL.md").exists()
     assert (runtime_skills / "marketing-insights" / "SKILL.md").exists()
     assert not (runtime_skills / "disabled-skill").exists()
+
+
+def test_prepare_enabled_skills_project_cwd_uses_writable_home_runtime_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    project = tmp_path / "project"
+    skills_root = project / ".claude" / "skills"
+    _build_minimum_bundle(skills_root / "dataagent-nl2sql")
+    update_settings({"skills_output_dir": str(skills_root / "dataagent-nl2sql")})
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    runtime_cwd = prepare_enabled_skills_project_cwd(["dataagent-nl2sql"])
+
+    assert runtime_cwd == home / ".dataagent" / "runtime" / "enabled-skills"
+    assert (runtime_cwd / ".claude" / "skills" / "dataagent-nl2sql" / "SKILL.md").exists()

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -61,6 +61,7 @@ DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME=X-Portal-MCP-Token
 # 生产容器默认以非 root 身份运行；如挂载目录权限不匹配，可改成宿主机目录拥有者的 UID/GID
 DATAAGENT_RUNTIME_UID=1000
 DATAAGENT_RUNTIME_GID=1000
+DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills
 
 # 挂载路径（相对于 deploy/）
 # Skills 根目录：源码部署默认指向仓库内 dataagent/.claude/skills；离线包会自动改写到 deploy/dataagent-runtime/skills

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -80,8 +80,8 @@ Use this method if you have internet access and are deploying directly from the 
    - `opendataagent` 不随这里的 compose 自动启动，需要单独进入 `opendataagent/deploy/` 部署
    - `skills/` 根目录中的共享 skill 主要服务 `opendataagent`；它不会替代当前生产智能问数使用的 `dataagent/.claude/skills/dataagent-nl2sql` 主链
    - 主前端默认通过同源 `/api` 代理访问 DataAgent 后端，无需额外配置前端地址
-   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件。当前镜像内 `HOME=/tmp/dataagent-home`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
-   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
+   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件，以及启用 skill 过滤后的运行时 cwd。当前镜像内 `HOME=/tmp/dataagent-home`，`DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
+   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件和运行时 cwd 都会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
 
    > **💡 数据库自动初始化**: MySQL 容器首次启动时，会自动执行 `deploy/database/mysql/` 目录下的初始化脚本，创建 `opendataworks` / `dataagent` 数据库，并分别初始化 `opendataworks`、`dataagent` 两个应用用户。DataAgent 容器启动时会先执行 `alembic upgrade head`，再启动服务。
    >
@@ -146,8 +146,8 @@ Use this method for isolated environments without internet access. You will use 
    - `scripts/start.sh` 会在启动前对挂载的 `odw-cli` 执行一次宿主机侧 `chmod +x`；即使 bind mount 丢了执行位，DataAgent runtime 也会回退为 `sh /app/.claude/skills/dataagent-nl2sql/bin/odw-cli ...`
    - `portal-mcp` 作为独立远程 MCP 服务一并部署，客户端需带 `X-Portal-MCP-Token`
    - `opendataagent` 需要用它自己的部署包或 compose 单独部署，不包含在这里的离线包主链描述中
-   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件。当前镜像内 `HOME=/tmp/dataagent-home`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
-   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
+   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件，以及启用 skill 过滤后的运行时 cwd。当前镜像内 `HOME=/tmp/dataagent-home`，`DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
+   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件和运行时 cwd 都会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
 
    > **💡 数据库自动初始化**: MySQL 容器首次启动时，会自动执行 `deploy/database/mysql/` 目录下的初始化脚本，创建 `opendataworks` / `dataagent` 数据库，并分别初始化 `opendataworks`、`dataagent` 两个应用用户。DataAgent 容器启动时会先执行 `alembic upgrade head`，再启动服务。
    >

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -101,6 +101,7 @@ services:
     environment:
       PYTHONUNBUFFERED: "1"
       HOME: /tmp/dataagent-home
+      DATAAGENT_RUNTIME_PROJECT_CWD: ${DATAAGENT_RUNTIME_PROJECT_CWD:-/tmp/dataagent-home/.dataagent/runtime/enabled-skills}
       HOST: 0.0.0.0
       PORT: 8900
       MYSQL_HOST: mysql

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -104,6 +104,7 @@ services:
     environment:
       PYTHONUNBUFFERED: "1"
       HOME: /tmp/dataagent-home
+      DATAAGENT_RUNTIME_PROJECT_CWD: ${DATAAGENT_RUNTIME_PROJECT_CWD:-/tmp/dataagent-home/.dataagent/runtime/enabled-skills}
       HOST: 0.0.0.0
       PORT: 8900
       MYSQL_HOST: mysql

--- a/docs/design/2026-04-27-dataagent-runtime-cwd-permission-design.md
+++ b/docs/design/2026-04-27-dataagent-runtime-cwd-permission-design.md
@@ -1,0 +1,58 @@
+# 2026-04-27 DataAgent Runtime CWD Permission Design
+
+## Current State
+
+The DataAgent task executor prepares a filtered Claude Agent SDK project cwd before each run. The cwd contains only enabled skills under `.claude/skills`.
+
+Today `prepare_enabled_skills_project_cwd()` hardcodes that filtered cwd under `dataagent-backend/.runtime/enabled-skills`.
+
+The Docker Compose deployment runs `dataagent-backend` as `DATAAGENT_RUNTIME_UID:GID`, defaulting to `1000:1000`. The image content under `/app/dataagent-backend` is owned by root, while `/tmp/dataagent-home` is the writable persisted runtime volume.
+
+## Problem
+
+When a user asks an intelligent-query question, the backend prepares the SDK project cwd and tries to create `/app/dataagent-backend/.runtime`. Under the default non-root deployment this fails with permission denied.
+
+The failure happens before or during task execution, so the UI can show a save/run failure even though the session database and skills volume are otherwise available.
+
+## Scope
+
+In scope:
+
+- DataAgent backend runtime cwd resolution
+- Docker Compose and image runtime environment defaults
+- deployment documentation for where runtime files are written
+- focused regression tests for the cwd location
+
+Out of scope:
+
+- changing skill discovery or skill-edit storage
+- changing Claude SDK session id persistence
+- redesigning DataAgent task coordination
+
+## Proposed Solution
+
+Use a writable runtime cwd by default:
+
+- default filtered project cwd: `HOME/.dataagent/runtime/enabled-skills`
+- in Docker Compose, `HOME` remains `/tmp/dataagent-home`, backed by the existing `dataagent-home` volume
+- expose `DATAAGENT_RUNTIME_PROJECT_CWD` for deployments that need to pin the cwd explicitly
+- keep the enabled-skill filtering behavior unchanged: the runtime cwd still contains symlinks from `.claude/skills/<folder>` to the configured skills discovery root
+
+## Tradeoffs
+
+Pros:
+
+- works with the existing non-root container user
+- keeps runtime-only files out of the application install directory
+- reuses the persisted `dataagent-home` volume already required by SDK session resume
+
+Cons:
+
+- the SDK project cwd path changes for deployments that previously wrote successfully to `dataagent-backend/.runtime`
+- old SDK local session files are still in `HOME`, but their project subdirectory may differ if the cwd path changed
+
+## Affected Stacks
+
+- DataAgent backend: `core/skills_loader.py`, `config.py`
+- Deployment: `Dockerfile`, `deploy/docker-compose.dev.yml`, `deploy/docker-compose.prod.yml`, `deploy/.env.example`, `deploy/README.md`
+- Tests: `dataagent/dataagent-backend/tests/test_skills_loader.py`

--- a/docs/plans/2026-04-27-dataagent-runtime-cwd-permission-plan.md
+++ b/docs/plans/2026-04-27-dataagent-runtime-cwd-permission-plan.md
@@ -1,0 +1,30 @@
+# 2026-04-27 DataAgent Runtime CWD Permission Plan
+
+## Goal
+
+Stop intelligent-query runs from writing runtime-only SDK project files under `/app/dataagent-backend`, so the default non-root container deployment can ask questions without permission denied errors.
+
+## Tasks
+
+1. Add regression coverage.
+   - Assert enabled-skill runtime cwd defaults to `HOME/.dataagent/runtime/enabled-skills`
+   - Verify enabled-skill symlinks are still exposed under the runtime cwd
+
+2. Update runtime cwd resolution.
+   - Add a `DATAAGENT_RUNTIME_PROJECT_CWD` setting
+   - Resolve relative override paths from `dataagent-backend`
+   - Default to the writable `HOME` runtime path
+
+3. Update deployment defaults and docs.
+   - Set the runtime cwd explicitly in compose and image defaults
+   - Document that `dataagent-home` now stores both SDK session files and the filtered runtime cwd
+
+4. Verify.
+   - Run targeted `tests/test_skills_loader.py`
+   - Confirm no untracked `.runtime` directory remains under `dataagent-backend`
+
+## Backout
+
+- Remove the `DATAAGENT_RUNTIME_PROJECT_CWD` setting
+- Revert `prepare_enabled_skills_project_cwd()` to the old backend-local `.runtime` path
+- Remove the compose/image environment default and documentation updates


### PR DESCRIPTION
## Summary

Fix DataAgent intelligent-query runs failing with `permission denied` when the runtime tries to create `/app/dataagent-backend/.runtime` under the default non-root container user.

## Changes

- Move the enabled-skill Claude SDK project cwd default to `HOME/.dataagent/runtime/enabled-skills`.
- Add `DATAAGENT_RUNTIME_PROJECT_CWD` so deployments can pin the runtime cwd explicitly.
- Set dev/prod compose and image defaults to `/tmp/dataagent-home/.dataagent/runtime/enabled-skills`.
- Add regression coverage for the writable HOME runtime cwd and update deployment docs/design/plan notes.

## Validation

- `./.venv/bin/python -m pytest` in `dataagent/dataagent-backend`: 92 passed.
- Python YAML check verified `DATAAGENT_RUNTIME_PROJECT_CWD` in both `deploy/docker-compose.dev.yml` and `deploy/docker-compose.prod.yml`.
- `git diff --check`: passed.

## Risk and Rollback

Risk is limited to the DataAgent Claude SDK runtime cwd location; existing skill discovery and session storage remain unchanged. Roll back by reverting this commit to return the runtime cwd to the prior backend-local `.runtime` path.
