### PR TITLE
fix: refine OpenDataAgent business blue UI

### DIFF
--- a/opendataagent/web/src/App.vue
+++ b/opendataagent/web/src/App.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex h-screen flex-col overflow-hidden bg-[#f9fafb] text-gray-900">
-    <header class="shrink-0 bg-white">
+  <div class="flex h-screen min-w-0 flex-col overflow-hidden bg-[#f6f8fc] text-slate-900">
+    <header class="shrink-0 overflow-hidden border-b border-blue-100 bg-white">
       <div class="px-4 sm:px-5 lg:px-6">
-        <div class="grid min-h-[84px] grid-cols-1 gap-4 py-3 xl:grid-cols-[220px_minmax(0,1fr)_220px] xl:items-center">
-          <div class="flex items-center gap-3">
+        <div class="flex min-h-[76px] min-w-0 flex-wrap items-center gap-4 py-3 lg:flex-nowrap">
+          <div class="flex min-w-[210px] shrink-0 items-center gap-3">
             <button
               type="button"
-              class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-700 text-white shadow-sm"
+              class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-800 text-white shadow-sm shadow-blue-950/10"
               @click="navigateTo('/chat')"
             >
               <Bot class="h-[18px] w-[18px]" />
@@ -14,12 +14,12 @@
 
             <div class="min-w-0">
               <button type="button" class="text-left" @click="navigateTo('/chat')">
-                <div class="text-[18px] font-semibold tracking-tight text-gray-900">Opendataagent</div>
+                <div class="text-[18px] font-semibold tracking-tight text-blue-950">OpenDataAgent</div>
               </button>
             </div>
           </div>
 
-          <div class="overflow-x-auto xl:flex xl:justify-center">
+          <nav class="oda-top-nav min-w-0 flex-1 overflow-hidden lg:flex lg:justify-center" aria-label="主导航">
             <el-menu
               class="oda-top-menu border-none bg-transparent"
               mode="horizontal"
@@ -36,9 +36,7 @@
                 <span>{{ item.label }}</span>
               </el-menu-item>
             </el-menu>
-          </div>
-
-          <div class="hidden xl:block" />
+          </nav>
         </div>
       </div>
     </header>
@@ -57,7 +55,6 @@ import {
   Bot,
   Boxes,
   MessageSquareText,
-  PlugZap,
   Settings,
   Settings2
 } from 'lucide-vue-next'
@@ -70,7 +67,6 @@ const activeMenu = computed(() => route.path.startsWith('/skills') || route.path
 const navItems = [
   { to: '/chat', label: 'Agent 对话', icon: MessageSquareText },
   { to: '/skills', label: 'Skills', icon: Boxes },
-  { to: '/mcps', label: 'MCP 管理', icon: PlugZap },
   { to: '/models', label: '模型设置', icon: Settings2 },
   { to: '/settings', label: '设置', icon: Settings }
 ]
@@ -86,9 +82,11 @@ const navigateTo = async (target) => {
   --el-menu-border-color: transparent;
   border-bottom: 0 !important;
   box-shadow: none !important;
-  width: max-content;
+  width: auto;
+  max-width: 100%;
   justify-content: center;
   background: transparent !important;
+  overflow: hidden;
 }
 
 .oda-top-menu.el-menu--horizontal {
@@ -97,58 +95,62 @@ const navigateTo = async (target) => {
 }
 
 .oda-top-menu:deep(.el-menu-item) {
-  height: 62px;
-  margin: 0 24px;
-  padding: 0 8px;
+  height: 56px;
+  margin: 0 16px;
+  padding: 0 6px;
   border: none;
   border-radius: 0;
-  color: #4b5563;
+  color: #475569;
   background: transparent;
-  line-height: 62px;
-  font-size: 18px;
+  line-height: 56px;
+  font-size: 17px;
   font-weight: 550;
+  white-space: nowrap;
 }
 
 .oda-top-menu:deep(.el-menu-item:hover) {
-  color: #1d4ed8;
+  color: #1e40af;
   background: transparent;
 }
 
 .oda-top-menu:deep(.el-menu-item.is-active) {
   background: transparent;
-  color: #1d4ed8;
+  color: #1e40af;
 }
 
 .oda-top-menu:deep(.el-menu-item.is-active svg) {
-  color: #1d4ed8;
+  color: #1e40af;
 }
 
 .oda-top-menu:deep(.el-menu-item svg) {
   width: 19px;
   height: 19px;
   margin-right: 11px;
-  color: #6b7280;
+  color: #64748b;
 }
 
 .oda-top-menu:deep(.el-menu-item.is-active::after) {
   height: 3px;
   border-radius: 999px;
-  background-color: #2563eb;
-}
-
-@media (max-width: 1280px) {
-  .oda-top-menu:deep(.el-menu) {
-    width: max-content;
-  }
+  background-color: #1d4ed8;
 }
 
 @media (max-width: 768px) {
+  .oda-top-nav {
+    flex: 0 0 100%;
+    width: 100%;
+  }
+
+  .oda-top-menu {
+    width: 100%;
+  }
+
   .oda-top-menu:deep(.el-menu-item) {
-    height: 56px;
-    margin: 0 16px;
+    height: 48px;
+    margin: 0 10px;
     padding: 0 6px;
-    line-height: 56px;
-    font-size: 16px;
+    line-height: 48px;
+    font-size: 15px;
   }
 }
 </style>

--- a/opendataagent/web/src/styles.css
+++ b/opendataagent/web/src/styles.css
@@ -5,36 +5,49 @@
 }
 
 @layer base {
+  :root {
+    --el-color-primary: #1e40af;
+    --el-color-primary-light-3: #2563eb;
+    --el-color-primary-light-5: #3b82f6;
+    --el-color-primary-light-7: #93c5fd;
+    --el-color-primary-light-8: #bfdbfe;
+    --el-color-primary-light-9: #dbeafe;
+    --el-color-primary-dark-2: #1e3a8a;
+  }
+
   html {
     font-family: var(--font-sans);
-    background: #f9fafb;
-    color: #111827;
+    background: #f6f8fc;
+    color: #0f172a;
+    overflow: hidden;
   }
 
   body {
-    @apply min-h-screen bg-gray-50 text-gray-900 antialiased;
+    @apply min-h-screen bg-slate-50 text-slate-900 antialiased;
+    overflow: hidden;
   }
 
   #app {
     @apply min-h-screen;
+    overflow: hidden;
   }
 
   * {
-    border-color: #e5e7eb;
+    border-color: #dbe4f0;
   }
 }
 
 @layer components {
   .oda-card {
-    @apply rounded-lg border border-gray-200 bg-white shadow-sm;
+    @apply rounded-lg border border-blue-100 bg-white shadow-sm shadow-blue-950/5;
   }
 
   .oda-card-muted {
-    @apply rounded-lg border border-gray-200 bg-gray-50/70 shadow-sm;
+    @apply rounded-lg border border-blue-100 bg-blue-50/40 shadow-sm shadow-blue-950/5;
   }
 
   .oda-kicker {
-    @apply text-xs font-semibold uppercase tracking-[0.16em] text-gray-500;
+    @apply text-xs font-semibold uppercase tracking-[0.16em] text-blue-700;
   }
 
   .oda-title {
@@ -54,19 +67,19 @@
   }
 
   .oda-input {
-    @apply h-11 w-full rounded-lg border border-gray-200 bg-white px-4 text-[15px] text-gray-900 placeholder:text-gray-400 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600/10;
+    @apply h-11 w-full rounded-lg border border-blue-100 bg-white px-4 text-[15px] text-slate-900 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700/10;
   }
 
   .oda-textarea {
-    @apply w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-[15px] leading-relaxed text-gray-900 placeholder:text-gray-400 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600/10;
+    @apply w-full rounded-lg border border-blue-100 bg-white px-4 py-3 text-[15px] leading-relaxed text-slate-900 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700/10;
   }
 
   .oda-btn-primary {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-blue-700 px-4 text-[15px] font-medium text-white transition hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300;
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-blue-800 px-4 text-[15px] font-medium text-white shadow-sm shadow-blue-950/10 transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300;
   }
 
   .oda-btn-secondary {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-4 text-[15px] font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-gray-400;
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-blue-100 bg-white px-4 text-[15px] font-medium text-blue-900 transition hover:border-blue-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:text-slate-400;
   }
 
   .oda-btn-danger {
@@ -74,23 +87,23 @@
   }
 
   .oda-chip {
-    @apply inline-flex items-center rounded-md bg-gray-100 px-2.5 py-1 text-[13px] font-medium text-gray-600;
+    @apply inline-flex items-center rounded-md bg-blue-50 px-2.5 py-1 text-[13px] font-medium text-blue-800;
   }
 
   .oda-chip-success {
-    @apply inline-flex items-center rounded-md bg-emerald-50 px-2.5 py-1 text-[13px] font-medium text-emerald-700;
+    @apply inline-flex items-center rounded-md bg-blue-100 px-2.5 py-1 text-[13px] font-medium text-blue-900;
   }
 
   .oda-chip-warning {
-    @apply inline-flex items-center rounded-md bg-amber-50 px-2.5 py-1 text-[13px] font-medium text-amber-700;
+    @apply inline-flex items-center rounded-md bg-sky-50 px-2.5 py-1 text-[13px] font-medium text-sky-800;
   }
 
   .oda-chip-neutral {
-    @apply inline-flex items-center rounded-md bg-blue-50 px-2.5 py-1 text-[13px] font-medium text-blue-700;
+    @apply inline-flex items-center rounded-md bg-slate-100 px-2.5 py-1 text-[13px] font-medium text-slate-600;
   }
 
   .oda-icon-button {
-    @apply inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition hover:bg-gray-50 hover:text-gray-700;
+    @apply inline-flex h-9 w-9 items-center justify-center rounded-md border border-blue-100 bg-white text-blue-700 transition hover:bg-blue-50 hover:text-blue-900;
   }
 
   .oda-prose {

--- a/opendataagent/web/src/views/market/SkillMarketView.vue
+++ b/opendataagent/web/src/views/market/SkillMarketView.vue
@@ -13,8 +13,8 @@
             type="button"
             class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition"
             :class="filters.source === option.value
-              ? 'border-blue-700 bg-blue-700 text-white'
-              : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'"
+              ? 'border-blue-800 bg-blue-800 text-white'
+              : 'border-blue-100 bg-white text-blue-900 hover:bg-blue-50/40'"
             @click="setSourceFilter(option.value)"
           >
             <span>{{ option.label }}</span>
@@ -53,7 +53,7 @@
         <article
           v-for="item in installedItems"
           :key="item.id"
-          class="oda-card cursor-pointer p-5 transition hover:border-gray-300"
+          class="oda-card cursor-pointer p-5 transition hover:border-blue-200"
           tabindex="0"
           @click="openSkillDetail(item)"
           @keydown.enter.prevent="openSkillDetail(item)"
@@ -61,7 +61,7 @@
         >
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-3">
-              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700">
+              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-800">
                 <component :is="iconForItem(item)" class="h-5 w-5" />
               </div>
               <div class="min-w-0">
@@ -98,7 +98,7 @@
         <article
           v-for="item in availableItems"
           :key="item.id"
-          class="oda-card cursor-pointer p-5 transition hover:border-gray-300"
+          class="oda-card cursor-pointer p-5 transition hover:border-blue-200"
           tabindex="0"
           @click="openSkillDetail(item)"
           @keydown.enter.prevent="openSkillDetail(item)"
@@ -106,7 +106,7 @@
         >
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-3">
-              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-gray-100 text-gray-600">
+              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
                 <component :is="iconForItem(item)" class="h-5 w-5" />
               </div>
               <div class="min-w-0">
@@ -144,7 +144,7 @@
     </section>
 
     <section v-if="!loading && !items.length" class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
         <PackageSearch class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">还没有可展示的 Skill</div>
@@ -168,7 +168,7 @@
           <label class="mb-2 block text-sm font-medium text-gray-700">上传文件</label>
           <input
             ref="fileInputRef"
-            class="block w-full rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm text-gray-600"
+            class="block w-full rounded-lg border border-dashed border-blue-200 bg-blue-50/40 px-4 py-4 text-sm text-blue-900"
             type="file"
             accept=".zip,.md,.markdown,text/markdown,application/zip"
             @change="handleImportFileChange"

--- a/opendataagent/web/src/views/settings/AgentSettingsView.vue
+++ b/opendataagent/web/src/views/settings/AgentSettingsView.vue
@@ -19,14 +19,14 @@
           </div>
         </div>
 
-        <div class="mt-5 overflow-hidden rounded-lg border border-gray-200 bg-white">
-          <div class="grid grid-cols-[minmax(0,1fr)_84px_84px] gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
+        <div class="mt-5 overflow-hidden rounded-lg border border-blue-100 bg-white">
+          <div class="grid grid-cols-[minmax(0,1fr)_84px_84px] gap-3 border-b border-blue-100 bg-blue-50/40 px-4 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
             <span>供应商</span>
             <span class="text-center">启用</span>
             <span class="text-center">默认</span>
           </div>
 
-          <div class="divide-y divide-gray-200">
+          <div class="divide-y divide-blue-100">
             <div
               v-for="provider in orderedProviders"
               :key="provider.provider_id"
@@ -44,7 +44,7 @@
                   </div>
                   <span
                     v-if="provider.provider_id === inspectedProviderId"
-                    class="rounded-md bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700"
+                    class="rounded-md bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-800"
                   >
                     当前
                   </span>
@@ -73,7 +73,7 @@
 
     <template v-if="selectedProvider">
       <form class="oda-card p-6" @submit.prevent>
-        <div class="flex flex-col gap-5 border-b border-gray-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">
               {{ selectedProvider.display_name || selectedProvider.provider_id }}
@@ -99,7 +99,7 @@
           </div>
         </div>
 
-        <div v-if="selectedProvider.provider_id !== 'mock'" class="mt-5 border-t border-gray-200 pt-5">
+        <div v-if="selectedProvider.provider_id !== 'mock'" class="mt-5 border-t border-blue-100 pt-5">
           <div class="text-base font-semibold text-gray-900">Base URL</div>
           <div class="mt-2 text-sm leading-relaxed text-gray-500">
             当前供应商的模型请求地址。
@@ -130,11 +130,11 @@
           </div>
         </div>
 
-        <div v-else class="mt-5 border-t border-gray-200 pt-5 text-sm leading-relaxed text-gray-600">
+        <div v-else class="mt-5 border-t border-blue-100 pt-5 text-sm leading-relaxed text-gray-600">
           Mock Runtime 仅用于本地调试，不需要配置 Base URL 或 API Token。
         </div>
 
-        <div class="mt-5 border-t border-gray-200 pt-5">
+        <div class="mt-5 border-t border-blue-100 pt-5">
           <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div class="min-w-0">
               <div class="text-base font-semibold text-gray-900">模型</div>
@@ -149,14 +149,14 @@
           </div>
 
           <div class="mt-4">
-            <div class="grid grid-cols-[minmax(0,1fr)_112px_112px_auto] gap-3 border-b border-gray-200 px-1 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
+            <div class="grid grid-cols-[minmax(0,1fr)_112px_112px_auto] gap-3 border-b border-blue-100 px-1 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
               <span>模型名称</span>
               <span class="text-center">是否启用</span>
               <span class="text-center">是否默认</span>
               <span class="text-right">操作</span>
             </div>
 
-            <div v-if="(selectedProvider.models || []).length" class="divide-y divide-gray-200">
+            <div v-if="(selectedProvider.models || []).length" class="divide-y divide-blue-100">
               <div
                 v-for="model in selectedProvider.models || []"
                 :key="model.name"
@@ -185,7 +185,7 @@
                   <button
                     v-if="(selectedProvider.models || []).length > 1"
                     type="button"
-                    class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition hover:bg-gray-100 hover:text-gray-700"
+                    class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-blue-100 bg-white text-blue-700 transition hover:bg-blue-50 hover:text-blue-900"
                     @click="removeModel(model)"
                   >
                     <Trash2 class="h-4 w-4" />
@@ -203,7 +203,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
         <Cpu class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">还没有可用的供应商配置</div>
@@ -223,8 +223,8 @@
               type="button"
               class="rounded-lg border px-4 py-3 text-left transition"
               :class="providerDraft.provider_type === option.value
-                ? 'border-blue-700 bg-blue-700 text-white'
-                : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'"
+                ? 'border-blue-800 bg-blue-800 text-white'
+                : 'border-blue-100 bg-white text-gray-700 hover:bg-blue-50/40'"
               @click="selectProviderType(option.value)"
             >
               <div class="text-sm font-medium">{{ option.label }}</div>

--- a/opendataagent/web/src/views/settings/RuntimeSettingsView.vue
+++ b/opendataagent/web/src/views/settings/RuntimeSettingsView.vue
@@ -42,7 +42,7 @@
           </div>
         </section>
 
-        <section class="border-t border-gray-200 pt-8">
+        <section class="border-t border-blue-100 pt-8">
           <div class="text-xl font-semibold tracking-tight text-gray-900">Skill 目录</div>
           <div class="mt-2 text-sm leading-relaxed text-gray-500">
             托管 Skill 与内置 Skill 的本地目录。

--- a/opendataagent/web/src/views/skills/SkillAdminView.vue
+++ b/opendataagent/web/src/views/skills/SkillAdminView.vue
@@ -6,6 +6,10 @@
     :stats="skillStats"
   >
     <template #actions>
+      <button type="button" class="oda-btn-primary" @click="openImportDialog">
+        <Upload class="h-4 w-4" />
+        导入 Skill
+      </button>
       <button type="button" class="oda-btn-secondary" :disabled="syncLoading" @click="triggerSync">
         <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': syncLoading }" />
         {{ syncLoading ? '刷新中' : '刷新目录' }}
@@ -24,15 +28,15 @@
           <span class="oda-chip">{{ filteredDocuments.length }}</span>
         </div>
 
-        <div class="mt-5 flex flex-wrap gap-2">
+        <div class="mt-5 flex flex-wrap gap-1.5">
           <button
             v-for="option in sourceOptions"
             :key="option.value"
             type="button"
-            class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition"
+            class="inline-flex min-h-9 items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition"
             :class="selectedSource === option.value
-              ? 'border-blue-700 bg-blue-700 text-white'
-              : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'"
+              ? 'bg-blue-800 text-white shadow-sm'
+              : 'bg-transparent text-gray-600 hover:bg-blue-50 hover:text-gray-900'"
             @click="selectedSource = option.value"
           >
             <span>{{ option.label }}</span>
@@ -72,8 +76,8 @@
                 type="button"
                 class="w-full rounded-lg border p-3 text-left transition"
                 :class="row.id === selectedDocumentId
-                  ? 'border-blue-700 bg-blue-700 text-white shadow-sm'
-                  : 'border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50'"
+                  ? 'border-blue-800 bg-blue-800 text-white shadow-sm'
+                  : 'border-blue-100 bg-white hover:border-blue-200 hover:bg-blue-50/40'"
                 @click="loadDocument(row.id)"
               >
                 <div class="flex items-start justify-between gap-3">
@@ -135,7 +139,7 @@
 
     <template v-if="detail">
       <section v-loading="detailLoading" class="oda-card p-5">
-        <div class="flex flex-col gap-5 border-b border-gray-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">{{ displayName(detail) }}</div>
             <div class="mt-2 text-sm leading-relaxed text-gray-600">
@@ -179,19 +183,19 @@
         </div>
 
         <div class="mt-5 grid gap-4 lg:grid-cols-3">
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">最近更新</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ formatTime(detail.updated_at) }}</div>
             <div class="mt-1 text-sm text-gray-500">
               {{ detail.last_change_summary || '最近一次更新未填写说明' }}
             </div>
           </div>
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">变更来源</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail.last_change_source || '-' }}</div>
             <div class="mt-1 text-sm text-gray-500">用于标记最近一次版本是如何产生的。</div>
           </div>
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">文件类型</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail.content_type }}</div>
             <div class="mt-1 text-sm text-gray-500">正文内容会直接同步到当前托管 Skill。</div>
@@ -209,7 +213,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-gray-200 bg-white">
+        <div class="mt-5 rounded-lg border border-blue-100 bg-white">
           <TextCodeEditor
             v-model="editorContent"
             :placeholder="detail.content_type === 'json' ? '请输入 JSON 内容' : '请输入文件内容'"
@@ -218,7 +222,7 @@
       </section>
 
       <section class="oda-card p-5">
-        <div class="flex flex-col gap-2 border-b border-gray-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex flex-col gap-2 border-b border-blue-100 pb-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <div class="oda-section-title">版本历史</div>
             <div class="mt-1 text-sm text-gray-500">保留每次保存记录，方便回看或回滚。</div>
@@ -264,7 +268,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-gray-500">
         <FileCode2 class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">先从左侧选择一个 Skill</div>
@@ -311,27 +315,61 @@
         </div>
 
         <div v-if="compareResult" class="grid gap-4 xl:grid-cols-2">
-          <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <div class="rounded-lg border border-blue-100 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.left_label }}</div>
             <TextCodeEditor :model-value="compareResult.left_content" read-only />
           </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <div class="rounded-lg border border-blue-100 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.right_label }}</div>
             <TextCodeEditor :model-value="compareResult.right_content" read-only />
           </div>
         </div>
 
-        <div v-if="compareResult" class="rounded-lg border border-gray-200 bg-white p-4">
+        <div v-if="compareResult" class="rounded-lg border border-blue-100 bg-white p-4">
           <div class="mb-3 text-sm font-semibold text-gray-900">Unified Diff</div>
           <TextCodeEditor :model-value="compareResult.diff_text" read-only />
         </div>
       </div>
     </el-dialog>
+
+    <el-dialog v-model="importDialogVisible" title="导入 Skill 包" width="560px">
+      <div class="space-y-5">
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700">文件夹名称</label>
+          <input
+            v-model="importForm.folder"
+            class="oda-input"
+            type="text"
+            placeholder="可选，不填则从文件名或压缩包目录推断"
+          >
+        </div>
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700">上传文件</label>
+          <input
+            ref="fileInputRef"
+            class="block w-full rounded-lg border border-dashed border-gray-300 bg-blue-50/40 px-4 py-4 text-sm text-gray-600"
+            type="file"
+            accept=".zip,.md,.markdown,text/markdown,application/zip"
+            @change="handleImportFileChange"
+          >
+          <div class="mt-2 text-sm text-gray-500">{{ importForm.file?.name || '请选择 zip 包或 markdown 文件' }}</div>
+        </div>
+      </div>
+      <template #footer>
+        <div class="flex justify-end gap-3">
+          <button type="button" class="oda-btn-secondary" @click="importDialogVisible = false">取消</button>
+          <button type="button" class="oda-btn-primary" :disabled="importing" @click="submitImport">
+            <Upload class="h-4 w-4" />
+            {{ importing ? '导入中' : '导入' }}
+          </button>
+        </div>
+      </template>
+    </el-dialog>
   </ProductPageShell>
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import dayjs from 'dayjs'
 import {
@@ -340,10 +378,12 @@ import {
   RefreshCw,
   RotateCcw,
   Save,
-  Trash2
+  Trash2,
+  Upload
 } from 'lucide-vue-next'
 import ProductPageShell from '@/components/ProductPageShell.vue'
 import { dataagentApi } from '@/api/dataagent'
+import { marketApi } from '@/api/market'
 import TextCodeEditor from '@/components/TextCodeEditor.vue'
 
 const listLoading = ref(false)
@@ -351,6 +391,7 @@ const detailLoading = ref(false)
 const saveLoading = ref(false)
 const syncLoading = ref(false)
 const compareLoading = ref(false)
+const importing = ref(false)
 const runtimeUpdatingId = ref('')
 
 const searchKeyword = ref('')
@@ -361,6 +402,12 @@ const detail = ref(null)
 const editorContent = ref('')
 const changeSummary = ref('')
 const syncResult = ref(null)
+const importDialogVisible = ref(false)
+const fileInputRef = ref(null)
+const importForm = reactive({
+  folder: '',
+  file: null
+})
 const settings = ref({
   skills_root_dir: ''
 })
@@ -403,12 +450,15 @@ const sourceOptions = computed(() => {
     managed: documents.value.filter((item) => item.source === 'managed').length,
     other: documents.value.filter((item) => item.source !== 'bundled' && item.source !== 'managed').length
   }
-  return [
+  const options = [
     { value: 'all', label: '全部', count: counts.all },
     { value: 'bundled', label: '内置', count: counts.bundled },
-    { value: 'managed', label: '本地导入', count: counts.managed },
-    { value: 'other', label: '其他', count: counts.other }
+    { value: 'managed', label: '本地导入', count: counts.managed }
   ]
+  if (counts.other > 0) {
+    options.push({ value: 'other', label: '其他', count: counts.other })
+  }
+  return options
 })
 
 const editorDirty = computed(() => !!detail.value && editorContent.value !== (detail.value.current_content || ''))
@@ -597,6 +647,43 @@ const confirmRollback = async (version) => {
   changeSummary.value = ''
   await loadDocuments()
   ElMessage.success(`已回滚到 V${version.version_no}`)
+}
+
+const openImportDialog = () => {
+  importForm.folder = ''
+  importForm.file = null
+  if (fileInputRef.value) {
+    fileInputRef.value.value = ''
+  }
+  importDialogVisible.value = true
+}
+
+const handleImportFileChange = (event) => {
+  importForm.file = event?.target?.files?.[0] || null
+}
+
+const submitImport = async () => {
+  if (!importForm.file) {
+    ElMessage.error('请先选择要导入的文件')
+    return
+  }
+  const formData = new FormData()
+  formData.append('file', importForm.file)
+  if (String(importForm.folder || '').trim()) {
+    formData.append('folder', String(importForm.folder).trim())
+  }
+
+  importing.value = true
+  try {
+    const item = await marketApi.importPackage(formData)
+    importDialogVisible.value = false
+    ElMessage.success(`已导入 ${item.name || item.folder}`)
+    await loadDocuments()
+  } catch (error) {
+    ElMessage.error(error.message || '导入 Skill 失败')
+  } finally {
+    importing.value = false
+  }
 }
 
 const triggerSync = async () => {

--- a/opendataagent/web/src/views/skills/SkillDetailView.vue
+++ b/opendataagent/web/src/views/skills/SkillDetailView.vue
@@ -25,9 +25,9 @@
 
     <template #sidebar>
       <section class="oda-card p-5">
-        <div v-if="skillItem" class="border-b border-gray-200 pb-5">
+        <div v-if="skillItem" class="border-b border-blue-100 pb-5">
           <div class="flex items-start gap-3">
-            <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+            <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-800">
               <component :is="iconForItem(skillItem)" class="h-5 w-5" />
             </div>
             <div class="min-w-0">
@@ -66,7 +66,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-gray-200 bg-gray-50/70 p-3">
+        <div class="mt-5 rounded-lg border border-blue-100 bg-blue-50/40 p-3">
           <div class="mb-3 flex items-center gap-2 text-sm font-medium text-gray-700">
             <FolderTree class="h-4 w-4 text-gray-400" />
             <span>{{ folder }}</span>
@@ -82,7 +82,7 @@
             />
           </div>
 
-          <div v-else class="rounded-md border border-dashed border-gray-200 bg-white px-3 py-5 text-center text-sm text-gray-500">
+          <div v-else class="rounded-md border border-dashed border-blue-100 bg-white px-3 py-5 text-center text-sm text-gray-500">
             当前 Skill 还没有可展示的文件。
           </div>
         </div>
@@ -91,7 +91,7 @@
 
     <template v-if="skillItem">
       <section class="oda-card p-6">
-        <div class="flex flex-col gap-5 border-b border-gray-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">
               {{ detail ? displayName(detail) : skillItem.name }}
@@ -110,7 +110,7 @@
           </div>
 
           <div class="flex flex-wrap gap-3">
-            <div v-if="primaryDocument" class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5">
+            <div v-if="primaryDocument" class="flex items-center gap-3 rounded-lg border border-blue-100 bg-blue-50/40 px-4 py-2.5">
               <span class="text-sm font-medium text-gray-600">启用 Skill</span>
               <el-switch
                 :model-value="skillEnabled"
@@ -148,17 +148,17 @@
         </div>
 
         <div class="mt-5 grid gap-4 lg:grid-cols-3">
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">Skill 文件夹</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ folder }}</div>
             <div class="mt-1 text-sm text-gray-500">{{ filteredDocuments.length }} 个文件</div>
           </div>
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">最近更新</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail ? formatTime(detail.updated_at) : '-' }}</div>
             <div class="mt-1 text-sm text-gray-500">{{ detail?.last_change_summary || '最近一次更新未填写说明' }}</div>
           </div>
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">文件状态</div>
             <div class="mt-2 text-sm font-medium text-gray-900">
               {{ detail?.editable === false ? '只读' : '可编辑' }}
@@ -178,7 +178,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-gray-200 bg-white">
+        <div class="mt-5 rounded-lg border border-blue-100 bg-white">
           <TextCodeEditor
             v-if="detail"
             v-model="editorContent"
@@ -192,7 +192,7 @@
       </section>
 
       <section v-if="detail" class="oda-card p-6">
-        <div class="flex flex-col gap-2 border-b border-gray-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex flex-col gap-2 border-b border-blue-100 pb-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <div class="oda-section-title">版本历史</div>
             <div class="mt-1 text-sm text-gray-500">查看当前文件的版本记录，并支持回滚。</div>
@@ -238,7 +238,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-gray-500">
         <FileCode2 class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">没有找到这个 Skill</div>
@@ -285,17 +285,17 @@
         </div>
 
         <div v-if="compareResult" class="grid gap-4 xl:grid-cols-2">
-          <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <div class="rounded-lg border border-blue-100 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.left_label }}</div>
             <TextCodeEditor :model-value="compareResult.left_content" read-only />
           </div>
-          <div class="rounded-lg border border-gray-200 bg-white p-4">
+          <div class="rounded-lg border border-blue-100 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.right_label }}</div>
             <TextCodeEditor :model-value="compareResult.right_content" read-only />
           </div>
         </div>
 
-        <div v-if="compareResult" class="rounded-lg border border-gray-200 bg-white p-4">
+        <div v-if="compareResult" class="rounded-lg border border-blue-100 bg-white p-4">
           <div class="mb-3 text-sm font-semibold text-gray-900">Unified Diff</div>
           <TextCodeEditor :model-value="compareResult.diff_text" read-only />
         </div>

--- a/opendataagent/web/src/views/skills/SkillFileTreeNode.vue
+++ b/opendataagent/web/src/views/skills/SkillFileTreeNode.vue
@@ -4,8 +4,8 @@
       type="button"
       class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition"
       :class="node.type === 'file' && node.documentId === selectedDocumentId
-        ? 'bg-blue-700 text-white'
-        : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'"
+        ? 'bg-blue-800 text-white'
+        : 'text-gray-600 hover:bg-blue-50/40 hover:text-gray-900'"
       :style="{ paddingLeft: `${12 + level * 16}px` }"
       @click="handleClick"
     >


### PR DESCRIPTION
## Summary
- Updates the OpenDataAgent desktop UI so Skills, model settings, and runtime settings use a consistent business-blue visual theme.
- Hides the MCP management item from the top navigation while keeping its route available for future re-enable.

## What Changed

- Sets Element Plus primary variables and shared `oda-*` component styles to deep business-blue tokens.
- Recolors Skill market/admin/detail, model settings, and runtime settings surfaces to blue borders, blue selected states, and blue-tinted empty/info states.
- Adds the Skill import action to the Skill management top action row and keeps refresh beside it.
- Removes the MCP management menu item from the top navigation.

## Validation
- [x] `npm --prefix opendataagent/web ci`
- [x] `nvm use && npm --prefix opendataagent/web run build`
- [x] Browser smoke via Vite + Playwright for `/skills`, `/models`, and `/settings`; local API proxy returned `ECONNREFUSED/500` because the backend was not running, but pages rendered and screenshots confirmed the business-blue layout.

## Risks
- Risk: visual-only Tailwind class changes could affect spacing or color contrast on less common viewport sizes.

## Rollback
- Rollback: revert this single commit to restore the previous OpenDataAgent navigation and color treatment.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updates not required for this UI-only change.
