### PR TITLE
style: unify OpenDataAgent business blue

### DIFF
--- a/opendataagent/web/src/App.vue
+++ b/opendataagent/web/src/App.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex h-screen min-w-0 flex-col overflow-hidden bg-[#f6f8fc] text-slate-900">
-    <header class="shrink-0 overflow-hidden border-b border-blue-100 bg-white">
+  <div class="flex h-screen min-w-0 flex-col overflow-hidden bg-[#f7f9fc] text-slate-900">
+    <header class="shrink-0 overflow-hidden border-b border-slate-200 bg-white">
       <div class="px-4 sm:px-5 lg:px-6">
         <div class="flex min-h-[76px] min-w-0 flex-wrap items-center gap-4 py-3 lg:flex-nowrap">
           <div class="flex min-w-[210px] shrink-0 items-center gap-3">
             <button
               type="button"
-              class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-800 text-white shadow-sm shadow-blue-950/10"
+              class="flex h-10 w-10 items-center justify-center rounded-lg bg-[#2f5f9f] text-white shadow-sm shadow-slate-950/10"
               @click="navigateTo('/chat')"
             >
               <Bot class="h-[18px] w-[18px]" />
@@ -14,7 +14,7 @@
 
             <div class="min-w-0">
               <button type="button" class="text-left" @click="navigateTo('/chat')">
-                <div class="text-[18px] font-semibold tracking-tight text-blue-950">OpenDataAgent</div>
+                <div class="text-[18px] font-semibold tracking-tight text-slate-900">OpenDataAgent</div>
               </button>
             </div>
           </div>
@@ -109,17 +109,17 @@ const navigateTo = async (target) => {
 }
 
 .oda-top-menu:deep(.el-menu-item:hover) {
-  color: #1e40af;
+  color: #2f5f9f;
   background: transparent;
 }
 
 .oda-top-menu:deep(.el-menu-item.is-active) {
   background: transparent;
-  color: #1e40af;
+  color: #2f5f9f;
 }
 
 .oda-top-menu:deep(.el-menu-item.is-active svg) {
-  color: #1e40af;
+  color: #2f5f9f;
 }
 
 .oda-top-menu:deep(.el-menu-item svg) {
@@ -132,7 +132,7 @@ const navigateTo = async (target) => {
 .oda-top-menu:deep(.el-menu-item.is-active::after) {
   height: 3px;
   border-radius: 999px;
-  background-color: #1d4ed8;
+  background-color: #2f5f9f;
 }
 
 @media (max-width: 768px) {

--- a/opendataagent/web/src/components/MetricTrendChart.vue
+++ b/opendataagent/web/src/components/MetricTrendChart.vue
@@ -98,7 +98,7 @@ const buildOption = () => ({
     borderWidth: 0,
     backgroundColor: '#244f86',
     textStyle: {
-      color: '#f9fafb',
+      color: '#f8fafc',
       fontSize: 12
     },
     formatter(params) {
@@ -119,7 +119,7 @@ const buildOption = () => ({
       show: false
     },
     axisLabel: {
-      color: '#6b7280',
+      color: '#667085',
       fontSize: 11
     },
     data: normalizedData.value.map((item) => item?.[props.xKey] ?? '')
@@ -134,13 +134,13 @@ const buildOption = () => ({
       show: false
     },
     axisLabel: {
-      color: '#6b7280',
+      color: '#667085',
       fontSize: 11,
       formatter: (value) => formatValue(value)
     },
     splitLine: {
       lineStyle: {
-        color: '#f3f4f6'
+        color: '#edf3fa'
       }
     }
   },

--- a/opendataagent/web/src/components/MetricTrendChart.vue
+++ b/opendataagent/web/src/components/MetricTrendChart.vue
@@ -58,7 +58,7 @@ const props = defineProps({
   },
   color: {
     type: String,
-    default: '#2563eb'
+    default: '#2f5f9f'
   },
   area: {
     type: Boolean,
@@ -96,7 +96,7 @@ const buildOption = () => ({
   tooltip: {
     trigger: 'axis',
     borderWidth: 0,
-    backgroundColor: '#1d4ed8',
+    backgroundColor: '#244f86',
     textStyle: {
       color: '#f9fafb',
       fontSize: 12

--- a/opendataagent/web/src/components/TextCodeEditor.vue
+++ b/opendataagent/web/src/components/TextCodeEditor.vue
@@ -69,7 +69,7 @@ const createEditor = () => {
           },
           '.cm-activeLineGutter': {
             backgroundColor: '#eff6ff',
-            color: '#1d4ed8'
+            color: '#2f5f9f'
           },
           '.cm-activeLine': {
             backgroundColor: '#f8fafc'

--- a/opendataagent/web/src/styles.css
+++ b/opendataagent/web/src/styles.css
@@ -4,17 +4,18 @@
   --font-sans: Inter, "SF Pro Text", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-@layer base {
-  :root {
-    --el-color-primary: #2f5f9f;
-    --el-color-primary-light-3: #4f7fba;
-    --el-color-primary-light-5: #7fa4ce;
-    --el-color-primary-light-7: #b7cbe2;
-    --el-color-primary-light-8: #d1deed;
-    --el-color-primary-light-9: #e8eff7;
-    --el-color-primary-dark-2: #244f86;
-  }
+html:root {
+  --el-color-primary-rgb: 47, 95, 159;
+  --el-color-primary: #2f5f9f;
+  --el-color-primary-light-3: #4f7fba;
+  --el-color-primary-light-5: #667085;
+  --el-color-primary-light-7: #98a8ba;
+  --el-color-primary-light-8: #c8d5e5;
+  --el-color-primary-light-9: #edf3fa;
+  --el-color-primary-dark-2: #244f86;
+}
 
+@layer base {
   html {
     font-family: var(--font-sans);
     background: #f6f8fc;
@@ -47,7 +48,7 @@
   }
 
   .oda-kicker {
-    @apply text-xs font-semibold uppercase tracking-[0.16em] text-[#2f5f9f];
+    @apply text-xs font-semibold uppercase tracking-[0.16em] text-slate-500;
   }
 
   .oda-title {
@@ -75,7 +76,7 @@
   }
 
   .oda-btn-primary {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-[#2f5f9f] px-4 text-[15px] font-medium text-white shadow-sm shadow-slate-950/10 transition hover:bg-[#244f86] disabled:cursor-not-allowed disabled:bg-[#9bb7d6];
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-[#2f5f9f] px-4 text-[15px] font-medium text-white shadow-sm shadow-slate-950/10 transition hover:bg-[#244f86] disabled:cursor-not-allowed disabled:bg-[#98a8ba];
   }
 
   .oda-btn-secondary {

--- a/opendataagent/web/src/styles.css
+++ b/opendataagent/web/src/styles.css
@@ -6,13 +6,13 @@
 
 @layer base {
   :root {
-    --el-color-primary: #1e40af;
-    --el-color-primary-light-3: #2563eb;
-    --el-color-primary-light-5: #3b82f6;
-    --el-color-primary-light-7: #93c5fd;
-    --el-color-primary-light-8: #bfdbfe;
-    --el-color-primary-light-9: #dbeafe;
-    --el-color-primary-dark-2: #1e3a8a;
+    --el-color-primary: #2f5f9f;
+    --el-color-primary-light-3: #4f7fba;
+    --el-color-primary-light-5: #7fa4ce;
+    --el-color-primary-light-7: #b7cbe2;
+    --el-color-primary-light-8: #d1deed;
+    --el-color-primary-light-9: #e8eff7;
+    --el-color-primary-dark-2: #244f86;
   }
 
   html {
@@ -33,21 +33,21 @@
   }
 
   * {
-    border-color: #dbe4f0;
+    border-color: #d8e0eb;
   }
 }
 
 @layer components {
   .oda-card {
-    @apply rounded-lg border border-blue-100 bg-white shadow-sm shadow-blue-950/5;
+    @apply rounded-lg border border-slate-200 bg-white shadow-sm shadow-slate-950/5;
   }
 
   .oda-card-muted {
-    @apply rounded-lg border border-blue-100 bg-blue-50/40 shadow-sm shadow-blue-950/5;
+    @apply rounded-lg border border-slate-200 bg-slate-50/70 shadow-sm shadow-slate-950/5;
   }
 
   .oda-kicker {
-    @apply text-xs font-semibold uppercase tracking-[0.16em] text-blue-700;
+    @apply text-xs font-semibold uppercase tracking-[0.16em] text-[#2f5f9f];
   }
 
   .oda-title {
@@ -67,19 +67,19 @@
   }
 
   .oda-input {
-    @apply h-11 w-full rounded-lg border border-blue-100 bg-white px-4 text-[15px] text-slate-900 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700/10;
+    @apply h-11 w-full rounded-lg border border-slate-200 bg-white px-4 text-[15px] text-slate-900 placeholder:text-slate-400 focus:border-[#2f5f9f] focus:outline-none focus:ring-2 focus:ring-[#2f5f9f]/10;
   }
 
   .oda-textarea {
-    @apply w-full rounded-lg border border-blue-100 bg-white px-4 py-3 text-[15px] leading-relaxed text-slate-900 placeholder:text-slate-400 focus:border-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700/10;
+    @apply w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-[15px] leading-relaxed text-slate-900 placeholder:text-slate-400 focus:border-[#2f5f9f] focus:outline-none focus:ring-2 focus:ring-[#2f5f9f]/10;
   }
 
   .oda-btn-primary {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-blue-800 px-4 text-[15px] font-medium text-white shadow-sm shadow-blue-950/10 transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300;
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-[#2f5f9f] px-4 text-[15px] font-medium text-white shadow-sm shadow-slate-950/10 transition hover:bg-[#244f86] disabled:cursor-not-allowed disabled:bg-[#9bb7d6];
   }
 
   .oda-btn-secondary {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-blue-100 bg-white px-4 text-[15px] font-medium text-blue-900 transition hover:border-blue-200 hover:bg-blue-50 disabled:cursor-not-allowed disabled:text-slate-400;
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 text-[15px] font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-400;
   }
 
   .oda-btn-danger {
@@ -87,11 +87,11 @@
   }
 
   .oda-chip {
-    @apply inline-flex items-center rounded-md bg-blue-50 px-2.5 py-1 text-[13px] font-medium text-blue-800;
+    @apply inline-flex items-center rounded-md bg-slate-100 px-2.5 py-1 text-[13px] font-medium text-slate-600;
   }
 
   .oda-chip-success {
-    @apply inline-flex items-center rounded-md bg-blue-100 px-2.5 py-1 text-[13px] font-medium text-blue-900;
+    @apply inline-flex items-center rounded-md bg-emerald-50 px-2.5 py-1 text-[13px] font-medium text-emerald-700;
   }
 
   .oda-chip-warning {
@@ -103,7 +103,7 @@
   }
 
   .oda-icon-button {
-    @apply inline-flex h-9 w-9 items-center justify-center rounded-md border border-blue-100 bg-white text-blue-700 transition hover:bg-blue-50 hover:text-blue-900;
+    @apply inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-800;
   }
 
   .oda-prose {
@@ -120,7 +120,7 @@
   }
 
   .oda-prose a {
-    @apply text-blue-700 underline underline-offset-2;
+    @apply text-[#2f5f9f] underline underline-offset-2;
   }
 
   .oda-prose code {

--- a/opendataagent/web/src/views/chat/AgentChatView.vue
+++ b/opendataagent/web/src/views/chat/AgentChatView.vue
@@ -1197,15 +1197,15 @@ onBeforeUnmount(() => {
   --sidebar-bg: #ffffff;
   --sidebar-border: #e5e7eb;
   --sidebar-text: #111827;
-  --sidebar-text-muted: #6b7280;
-  --surface: #f9fafb;
+  --sidebar-text-muted: #667085;
+  --surface: #f8fafc;
   --surface-muted: #ffffff;
-  --surface-soft: #f3f4f6;
+  --surface-soft: #f1f5f9;
   --line: #e5e7eb;
   --line-soft: #eef2f7;
   --text: #111827;
-  --text-muted: #6b7280;
-  --text-soft: #9ca3af;
+  --text-muted: #667085;
+  --text-soft: #98a8ba;
   --accent: #2f5f9f;
   --accent-soft: rgba(47, 95, 159, 0.08);
   --primary: #2f5f9f;
@@ -1260,8 +1260,8 @@ onBeforeUnmount(() => {
   height: 26px;
   padding: 0 9px;
   border-radius: 6px;
-  background: #f3f4f6;
-  color: #4b5563;
+  background: #f1f5f9;
+  color: #64748b;
   font-size: 14px;
   font-weight: 600;
 }
@@ -1463,12 +1463,12 @@ onBeforeUnmount(() => {
 }
 
 .query-main-meta-item {
-  color: #4b5563;
+  color: var(--text-muted);
   font-size: 14px;
 }
 
 .query-main-meta-dot {
-  color: #d1d5db;
+  color: #cbd5e1;
   font-size: 14px;
 }
 
@@ -1478,8 +1478,8 @@ onBeforeUnmount(() => {
   height: 26px;
   padding: 0 10px;
   border-radius: 6px;
-  background: #f3f4f6;
-  color: #4b5563;
+  background: #f1f5f9;
+  color: #64748b;
   font-size: 13px;
 }
 
@@ -1525,8 +1525,8 @@ onBeforeUnmount(() => {
   justify-content: center;
   padding: 0 14px;
   border-radius: 8px;
-  background: #edf3fa;
-  color: #2f5f9f;
+  background: #f1f5f9;
+  color: #475569;
   font-size: 15px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -1567,10 +1567,10 @@ onBeforeUnmount(() => {
 }
 
 .query-suggestion:hover {
-  border-color: #c8d5e5;
-  background: #f2f6fb;
+  border-color: #cbd5e1;
+  background: #f8fafc;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(47, 95, 159, 0.08);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
 .query-message-row {
@@ -1648,7 +1648,7 @@ onBeforeUnmount(() => {
   height: 7px;
   border-radius: 999px;
   background: var(--accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 3px rgba(47, 95, 159, 0.12);
   animation: query-process-pulse 1.4s ease-in-out infinite;
 }
 
@@ -1931,8 +1931,8 @@ onBeforeUnmount(() => {
 .query-main-text :deep(code) {
   padding: 2px 6px;
   border-radius: 6px;
-  background: #edf3fa;
-  color: #2f5f9f;
+  background: #f1f5f9;
+  color: #334155;
   font-size: 15px;
 }
 
@@ -1940,8 +1940,8 @@ onBeforeUnmount(() => {
   margin: 12px 0;
   padding: 14px 16px;
   border-radius: 16px;
-  background: #1c2647;
-  color: #e6ebff;
+  background: #111827;
+  color: #e5e7eb;
   overflow-x: auto;
   font-size: 15px;
   line-height: 1.65;
@@ -1957,8 +1957,8 @@ onBeforeUnmount(() => {
 .query-main-text :deep(blockquote) {
   margin: 10px 0;
   padding: 8px 14px;
-  border-left: 3px solid var(--accent);
-  background: rgba(37, 99, 235, 0.06);
+  border-left: 3px solid #cbd5e1;
+  background: #f8fafc;
   color: var(--text-muted);
 }
 
@@ -1986,7 +1986,7 @@ onBeforeUnmount(() => {
 }
 
 .query-main-text :deep(th) {
-  background: #f3f8fc;
+  background: #f8fafc;
   font-weight: 700;
 }
 
@@ -2017,7 +2017,7 @@ onBeforeUnmount(() => {
 }
 
 .query-citation-chip:hover {
-  border-color: rgba(37, 99, 235, 0.28);
+  border-color: rgba(47, 95, 159, 0.28);
   color: var(--accent);
 }
 
@@ -2081,20 +2081,20 @@ onBeforeUnmount(() => {
 }
 
 .query-btn-sm:hover {
-  border-color: rgba(102, 126, 234, 0.28);
-  background: #f7f9ff;
+  border-color: rgba(47, 95, 159, 0.28);
+  background: #edf3fa;
 }
 
 .query-btn-primary {
-  border-color: rgba(102, 126, 234, 0.35);
+  border-color: rgba(47, 95, 159, 0.35);
   color: var(--accent);
 }
 
 .query-sql-code {
   margin: 0;
   padding: 15px 16px;
-  background: #1c2647;
-  color: #e6ebff;
+  background: #111827;
+  color: #e5e7eb;
   overflow-x: auto;
   font-size: 13px;
   line-height: 1.65;
@@ -2249,8 +2249,8 @@ onBeforeUnmount(() => {
 }
 
 .query-composer:focus-within {
-  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.08);
-  border-color: rgba(37, 99, 235, 0.2);
+  box-shadow: 0 8px 24px rgba(47, 95, 159, 0.08);
+  border-color: rgba(47, 95, 159, 0.2);
 }
 
 .query-composer-top {
@@ -2299,9 +2299,9 @@ onBeforeUnmount(() => {
   min-width: 0;
   height: 40px;
   padding: 0 40px 0 14px;
-  border: 1px solid rgba(37, 99, 235, 0.16);
+  border: 1px solid rgba(47, 95, 159, 0.16);
   border-radius: 10px;
-  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
   color: #0f172a;
   font-size: 14px;
   font-weight: 600;
@@ -2311,12 +2311,12 @@ onBeforeUnmount(() => {
 }
 
 .query-select:hover {
-  border-color: rgba(37, 99, 235, 0.28);
+  border-color: rgba(47, 95, 159, 0.28);
 }
 
 .query-select:focus {
-  border-color: rgba(37, 99, 235, 0.46);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.08);
+  border-color: rgba(47, 95, 159, 0.46);
+  box-shadow: 0 0 0 3px rgba(47, 95, 159, 0.08);
 }
 
 .query-select:disabled {

--- a/opendataagent/web/src/views/chat/AgentChatView.vue
+++ b/opendataagent/web/src/views/chat/AgentChatView.vue
@@ -1206,9 +1206,9 @@ onBeforeUnmount(() => {
   --text: #111827;
   --text-muted: #6b7280;
   --text-soft: #9ca3af;
-  --accent: #2563eb;
-  --accent-soft: rgba(37, 99, 235, 0.08);
-  --primary: #2563eb;
+  --accent: #2f5f9f;
+  --accent-soft: rgba(47, 95, 159, 0.08);
+  --primary: #2f5f9f;
   --content-max-width: min(60%, 980px);
   height: 100%;
   min-height: 0;
@@ -1290,7 +1290,7 @@ onBeforeUnmount(() => {
 }
 
 .query-btn-new:hover {
-  background: #1d4ed8;
+  background: #244f86;
   transform: translateY(-1px);
 }
 
@@ -1484,8 +1484,8 @@ onBeforeUnmount(() => {
 }
 
 .query-main-pill--active {
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: #edf3fa;
+  color: #2f5f9f;
 }
 
 .query-config-empty {
@@ -1525,8 +1525,8 @@ onBeforeUnmount(() => {
   justify-content: center;
   padding: 0 14px;
   border-radius: 8px;
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: #edf3fa;
+  color: #2f5f9f;
   font-size: 15px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -1567,10 +1567,10 @@ onBeforeUnmount(() => {
 }
 
 .query-suggestion:hover {
-  border-color: #bfdbfe;
-  background: #eff6ff;
+  border-color: #c8d5e5;
+  background: #f2f6fb;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.08);
+  box-shadow: 0 4px 12px rgba(47, 95, 159, 0.08);
 }
 
 .query-message-row {
@@ -1586,7 +1586,7 @@ onBeforeUnmount(() => {
   max-width: 72%;
   padding: 14px 18px;
   border-radius: 12px 12px 4px 12px;
-  background: #2563eb;
+  background: #2f5f9f;
   color: #ffffff;
   font-size: 16px;
   line-height: 1.75;
@@ -1931,8 +1931,8 @@ onBeforeUnmount(() => {
 .query-main-text :deep(code) {
   padding: 2px 6px;
   border-radius: 6px;
-  background: #eff6ff;
-  color: #1d4ed8;
+  background: #edf3fa;
+  color: #2f5f9f;
   font-size: 15px;
 }
 
@@ -2412,7 +2412,7 @@ onBeforeUnmount(() => {
 }
 
 .query-btn-send:not(:disabled):hover {
-  background: #1d4ed8;
+  background: #244f86;
 }
 
 .query-btn-cancel {

--- a/opendataagent/web/src/views/chat/ToolOutputRenderer.vue
+++ b/opendataagent/web/src/views/chat/ToolOutputRenderer.vue
@@ -841,11 +841,11 @@ onBeforeUnmount(() => {
 }
 
 .shell-trace-summary-status.is-running {
-  color: #6b7280;
+  color: #667085;
 }
 
 .shell-trace-summary-status.is-success {
-  color: #6b7280;
+  color: #667085;
 }
 
 .shell-trace-summary-status.is-failed {

--- a/opendataagent/web/src/views/market/SkillMarketView.vue
+++ b/opendataagent/web/src/views/market/SkillMarketView.vue
@@ -13,8 +13,8 @@
             type="button"
             class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition"
             :class="filters.source === option.value
-              ? 'border-blue-800 bg-blue-800 text-white'
-              : 'border-blue-100 bg-white text-blue-900 hover:bg-blue-50/40'"
+              ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white'
+              : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50/70'"
             @click="setSourceFilter(option.value)"
           >
             <span>{{ option.label }}</span>
@@ -53,7 +53,7 @@
         <article
           v-for="item in installedItems"
           :key="item.id"
-          class="oda-card cursor-pointer p-5 transition hover:border-blue-200"
+          class="oda-card cursor-pointer p-5 transition hover:border-slate-300"
           tabindex="0"
           @click="openSkillDetail(item)"
           @keydown.enter.prevent="openSkillDetail(item)"
@@ -61,7 +61,7 @@
         >
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-3">
-              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-800">
+              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-slate-100 text-slate-700">
                 <component :is="iconForItem(item)" class="h-5 w-5" />
               </div>
               <div class="min-w-0">
@@ -98,7 +98,7 @@
         <article
           v-for="item in availableItems"
           :key="item.id"
-          class="oda-card cursor-pointer p-5 transition hover:border-blue-200"
+          class="oda-card cursor-pointer p-5 transition hover:border-slate-300"
           tabindex="0"
           @click="openSkillDetail(item)"
           @keydown.enter.prevent="openSkillDetail(item)"
@@ -106,7 +106,7 @@
         >
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-3">
-              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+              <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-slate-100 text-slate-600">
                 <component :is="iconForItem(item)" class="h-5 w-5" />
               </div>
               <div class="min-w-0">
@@ -144,7 +144,7 @@
     </section>
 
     <section v-if="!loading && !items.length" class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-slate-100 text-slate-600">
         <PackageSearch class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">还没有可展示的 Skill</div>
@@ -168,7 +168,7 @@
           <label class="mb-2 block text-sm font-medium text-gray-700">上传文件</label>
           <input
             ref="fileInputRef"
-            class="block w-full rounded-lg border border-dashed border-blue-200 bg-blue-50/40 px-4 py-4 text-sm text-blue-900"
+            class="block w-full rounded-lg border border-dashed border-slate-300 bg-slate-50/70 px-4 py-4 text-sm text-slate-700"
             type="file"
             accept=".zip,.md,.markdown,text/markdown,application/zip"
             @change="handleImportFileChange"

--- a/opendataagent/web/src/views/mcps/McpManagerView.vue
+++ b/opendataagent/web/src/views/mcps/McpManagerView.vue
@@ -13,7 +13,7 @@
             type="button"
             class="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition"
             :class="activeFilter === option.value
-              ? 'border-blue-700 bg-blue-700 text-white'
+              ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white'
               : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'"
             @click="activeFilter = option.value"
           >
@@ -129,12 +129,12 @@
               type="button"
               class="rounded-lg border px-4 py-3 text-left transition"
               :class="draft.connection_type === 'process'
-                ? 'border-blue-700 bg-blue-700 text-white'
+                ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white'
                 : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'"
               @click="draft.connection_type = 'process'"
             >
               <div class="text-sm font-medium">本地进程</div>
-              <div class="mt-1 text-xs" :class="draft.connection_type === 'process' ? 'text-blue-100' : 'text-gray-500'">
+              <div class="mt-1 text-xs" :class="draft.connection_type === 'process' ? 'text-slate-100' : 'text-gray-500'">
                 适合 CLI、脚本和受控命令
               </div>
             </button>
@@ -142,12 +142,12 @@
               type="button"
               class="rounded-lg border px-4 py-3 text-left transition"
               :class="draft.connection_type === 'remote'
-                ? 'border-blue-700 bg-blue-700 text-white'
+                ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white'
                 : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'"
               @click="draft.connection_type = 'remote'"
             >
               <div class="text-sm font-medium">远程服务</div>
-              <div class="mt-1 text-xs" :class="draft.connection_type === 'remote' ? 'text-blue-100' : 'text-gray-500'">
+              <div class="mt-1 text-xs" :class="draft.connection_type === 'remote' ? 'text-slate-100' : 'text-gray-500'">
                 适合已有网关或 HTTP MCP 服务
               </div>
             </button>

--- a/opendataagent/web/src/views/settings/AgentSettingsView.vue
+++ b/opendataagent/web/src/views/settings/AgentSettingsView.vue
@@ -19,19 +19,19 @@
           </div>
         </div>
 
-        <div class="mt-5 overflow-hidden rounded-lg border border-blue-100 bg-white">
-          <div class="grid grid-cols-[minmax(0,1fr)_84px_84px] gap-3 border-b border-blue-100 bg-blue-50/40 px-4 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
+        <div class="mt-5 overflow-hidden rounded-lg border border-slate-200 bg-white">
+          <div class="grid grid-cols-[minmax(0,1fr)_84px_84px] gap-3 border-b border-slate-200 bg-slate-50/70 px-4 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
             <span>供应商</span>
             <span class="text-center">启用</span>
             <span class="text-center">默认</span>
           </div>
 
-          <div class="divide-y divide-blue-100">
+          <div class="divide-y divide-slate-200">
             <div
               v-for="provider in orderedProviders"
               :key="provider.provider_id"
               class="grid grid-cols-[minmax(0,1fr)_84px_84px] items-center gap-3 px-4 py-3 transition"
-              :class="provider.provider_id === inspectedProviderId ? 'bg-blue-50/60' : 'bg-white'"
+              :class="provider.provider_id === inspectedProviderId ? 'bg-slate-100' : 'bg-white'"
             >
               <button
                 type="button"
@@ -44,7 +44,7 @@
                   </div>
                   <span
                     v-if="provider.provider_id === inspectedProviderId"
-                    class="rounded-md bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-800"
+                    class="rounded-md bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-700"
                   >
                     当前
                   </span>
@@ -73,7 +73,7 @@
 
     <template v-if="selectedProvider">
       <form class="oda-card p-6" @submit.prevent>
-        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-slate-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">
               {{ selectedProvider.display_name || selectedProvider.provider_id }}
@@ -99,7 +99,7 @@
           </div>
         </div>
 
-        <div v-if="selectedProvider.provider_id !== 'mock'" class="mt-5 border-t border-blue-100 pt-5">
+        <div v-if="selectedProvider.provider_id !== 'mock'" class="mt-5 border-t border-slate-200 pt-5">
           <div class="text-base font-semibold text-gray-900">Base URL</div>
           <div class="mt-2 text-sm leading-relaxed text-gray-500">
             当前供应商的模型请求地址。
@@ -130,11 +130,11 @@
           </div>
         </div>
 
-        <div v-else class="mt-5 border-t border-blue-100 pt-5 text-sm leading-relaxed text-gray-600">
+        <div v-else class="mt-5 border-t border-slate-200 pt-5 text-sm leading-relaxed text-gray-600">
           Mock Runtime 仅用于本地调试，不需要配置 Base URL 或 API Token。
         </div>
 
-        <div class="mt-5 border-t border-blue-100 pt-5">
+        <div class="mt-5 border-t border-slate-200 pt-5">
           <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div class="min-w-0">
               <div class="text-base font-semibold text-gray-900">模型</div>
@@ -149,14 +149,14 @@
           </div>
 
           <div class="mt-4">
-            <div class="grid grid-cols-[minmax(0,1fr)_112px_112px_auto] gap-3 border-b border-blue-100 px-1 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
+            <div class="grid grid-cols-[minmax(0,1fr)_112px_112px_auto] gap-3 border-b border-slate-200 px-1 py-3 text-xs font-medium uppercase tracking-[0.08em] text-gray-500">
               <span>模型名称</span>
               <span class="text-center">是否启用</span>
               <span class="text-center">是否默认</span>
               <span class="text-right">操作</span>
             </div>
 
-            <div v-if="(selectedProvider.models || []).length" class="divide-y divide-blue-100">
+            <div v-if="(selectedProvider.models || []).length" class="divide-y divide-slate-200">
               <div
                 v-for="model in selectedProvider.models || []"
                 :key="model.name"
@@ -185,7 +185,7 @@
                   <button
                     v-if="(selectedProvider.models || []).length > 1"
                     type="button"
-                    class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-blue-100 bg-white text-blue-700 transition hover:bg-blue-50 hover:text-blue-900"
+                    class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:bg-slate-50 hover:text-slate-700"
                     @click="removeModel(model)"
                   >
                     <Trash2 class="h-4 w-4" />
@@ -203,7 +203,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-blue-700">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-slate-100 text-slate-600">
         <Cpu class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">还没有可用的供应商配置</div>
@@ -223,12 +223,12 @@
               type="button"
               class="rounded-lg border px-4 py-3 text-left transition"
               :class="providerDraft.provider_type === option.value
-                ? 'border-blue-800 bg-blue-800 text-white'
-                : 'border-blue-100 bg-white text-gray-700 hover:bg-blue-50/40'"
+                ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white'
+                : 'border-slate-200 bg-white text-gray-700 hover:bg-slate-50/70'"
               @click="selectProviderType(option.value)"
             >
               <div class="text-sm font-medium">{{ option.label }}</div>
-              <div class="mt-1 text-xs" :class="providerDraft.provider_type === option.value ? 'text-blue-100' : 'text-gray-500'">
+              <div class="mt-1 text-xs" :class="providerDraft.provider_type === option.value ? 'text-slate-100' : 'text-gray-500'">
                 {{ option.hint }}
               </div>
             </button>

--- a/opendataagent/web/src/views/settings/RuntimeSettingsView.vue
+++ b/opendataagent/web/src/views/settings/RuntimeSettingsView.vue
@@ -42,7 +42,7 @@
           </div>
         </section>
 
-        <section class="border-t border-blue-100 pt-8">
+        <section class="border-t border-slate-200 pt-8">
           <div class="text-xl font-semibold tracking-tight text-gray-900">Skill 目录</div>
           <div class="mt-2 text-sm leading-relaxed text-gray-500">
             托管 Skill 与内置 Skill 的本地目录。

--- a/opendataagent/web/src/views/skills/SkillAdminView.vue
+++ b/opendataagent/web/src/views/skills/SkillAdminView.vue
@@ -35,12 +35,12 @@
             type="button"
             class="inline-flex min-h-9 items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition"
             :class="selectedSource === option.value
-              ? 'bg-blue-800 text-white shadow-sm'
-              : 'bg-transparent text-gray-600 hover:bg-blue-50 hover:text-gray-900'"
+              ? 'bg-[#2f5f9f] text-white shadow-sm'
+              : 'bg-transparent text-gray-600 hover:bg-slate-50 hover:text-gray-900'"
             @click="selectedSource = option.value"
           >
             <span>{{ option.label }}</span>
-            <span class="text-xs" :class="selectedSource === option.value ? 'text-blue-100' : 'text-gray-400'">
+            <span class="text-xs" :class="selectedSource === option.value ? 'text-slate-100' : 'text-gray-400'">
               {{ option.count }}
             </span>
           </button>
@@ -76,8 +76,8 @@
                 type="button"
                 class="w-full rounded-lg border p-3 text-left transition"
                 :class="row.id === selectedDocumentId
-                  ? 'border-blue-800 bg-blue-800 text-white shadow-sm'
-                  : 'border-blue-100 bg-white hover:border-blue-200 hover:bg-blue-50/40'"
+                  ? 'border-[#2f5f9f] bg-[#2f5f9f] text-white shadow-sm'
+                  : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/70'"
                 @click="loadDocument(row.id)"
               >
                 <div class="flex items-start justify-between gap-3">
@@ -139,7 +139,7 @@
 
     <template v-if="detail">
       <section v-loading="detailLoading" class="oda-card p-5">
-        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-slate-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">{{ displayName(detail) }}</div>
             <div class="mt-2 text-sm leading-relaxed text-gray-600">
@@ -183,19 +183,19 @@
         </div>
 
         <div class="mt-5 grid gap-4 lg:grid-cols-3">
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">最近更新</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ formatTime(detail.updated_at) }}</div>
             <div class="mt-1 text-sm text-gray-500">
               {{ detail.last_change_summary || '最近一次更新未填写说明' }}
             </div>
           </div>
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">变更来源</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail.last_change_source || '-' }}</div>
             <div class="mt-1 text-sm text-gray-500">用于标记最近一次版本是如何产生的。</div>
           </div>
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">文件类型</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail.content_type }}</div>
             <div class="mt-1 text-sm text-gray-500">正文内容会直接同步到当前托管 Skill。</div>
@@ -213,7 +213,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-blue-100 bg-white">
+        <div class="mt-5 rounded-lg border border-slate-200 bg-white">
           <TextCodeEditor
             v-model="editorContent"
             :placeholder="detail.content_type === 'json' ? '请输入 JSON 内容' : '请输入文件内容'"
@@ -222,7 +222,7 @@
       </section>
 
       <section class="oda-card p-5">
-        <div class="flex flex-col gap-2 border-b border-blue-100 pb-5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex flex-col gap-2 border-b border-slate-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <div class="oda-section-title">版本历史</div>
             <div class="mt-1 text-sm text-gray-500">保留每次保存记录，方便回看或回滚。</div>
@@ -268,7 +268,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-slate-100 text-gray-500">
         <FileCode2 class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">先从左侧选择一个 Skill</div>
@@ -315,17 +315,17 @@
         </div>
 
         <div v-if="compareResult" class="grid gap-4 xl:grid-cols-2">
-          <div class="rounded-lg border border-blue-100 bg-white p-4">
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.left_label }}</div>
             <TextCodeEditor :model-value="compareResult.left_content" read-only />
           </div>
-          <div class="rounded-lg border border-blue-100 bg-white p-4">
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.right_label }}</div>
             <TextCodeEditor :model-value="compareResult.right_content" read-only />
           </div>
         </div>
 
-        <div v-if="compareResult" class="rounded-lg border border-blue-100 bg-white p-4">
+        <div v-if="compareResult" class="rounded-lg border border-slate-200 bg-white p-4">
           <div class="mb-3 text-sm font-semibold text-gray-900">Unified Diff</div>
           <TextCodeEditor :model-value="compareResult.diff_text" read-only />
         </div>
@@ -347,7 +347,7 @@
           <label class="mb-2 block text-sm font-medium text-gray-700">上传文件</label>
           <input
             ref="fileInputRef"
-            class="block w-full rounded-lg border border-dashed border-gray-300 bg-blue-50/40 px-4 py-4 text-sm text-gray-600"
+            class="block w-full rounded-lg border border-dashed border-gray-300 bg-slate-50/70 px-4 py-4 text-sm text-gray-600"
             type="file"
             accept=".zip,.md,.markdown,text/markdown,application/zip"
             @change="handleImportFileChange"

--- a/opendataagent/web/src/views/skills/SkillDetailView.vue
+++ b/opendataagent/web/src/views/skills/SkillDetailView.vue
@@ -25,9 +25,9 @@
 
     <template #sidebar>
       <section class="oda-card p-5">
-        <div v-if="skillItem" class="border-b border-blue-100 pb-5">
+        <div v-if="skillItem" class="border-b border-slate-200 pb-5">
           <div class="flex items-start gap-3">
-            <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-blue-50 text-blue-800">
+            <div class="flex h-11 w-11 items-center justify-center rounded-lg bg-slate-100 text-slate-700">
               <component :is="iconForItem(skillItem)" class="h-5 w-5" />
             </div>
             <div class="min-w-0">
@@ -66,7 +66,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-blue-100 bg-blue-50/40 p-3">
+        <div class="mt-5 rounded-lg border border-slate-200 bg-slate-50/70 p-3">
           <div class="mb-3 flex items-center gap-2 text-sm font-medium text-gray-700">
             <FolderTree class="h-4 w-4 text-gray-400" />
             <span>{{ folder }}</span>
@@ -82,7 +82,7 @@
             />
           </div>
 
-          <div v-else class="rounded-md border border-dashed border-blue-100 bg-white px-3 py-5 text-center text-sm text-gray-500">
+          <div v-else class="rounded-md border border-dashed border-slate-200 bg-white px-3 py-5 text-center text-sm text-gray-500">
             当前 Skill 还没有可展示的文件。
           </div>
         </div>
@@ -91,7 +91,7 @@
 
     <template v-if="skillItem">
       <section class="oda-card p-6">
-        <div class="flex flex-col gap-5 border-b border-blue-100 pb-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="flex flex-col gap-5 border-b border-slate-200 pb-5 xl:flex-row xl:items-start xl:justify-between">
           <div class="min-w-0">
             <div class="text-xl font-semibold tracking-tight text-gray-900">
               {{ detail ? displayName(detail) : skillItem.name }}
@@ -110,7 +110,7 @@
           </div>
 
           <div class="flex flex-wrap gap-3">
-            <div v-if="primaryDocument" class="flex items-center gap-3 rounded-lg border border-blue-100 bg-blue-50/40 px-4 py-2.5">
+            <div v-if="primaryDocument" class="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50/70 px-4 py-2.5">
               <span class="text-sm font-medium text-gray-600">启用 Skill</span>
               <el-switch
                 :model-value="skillEnabled"
@@ -148,17 +148,17 @@
         </div>
 
         <div class="mt-5 grid gap-4 lg:grid-cols-3">
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">Skill 文件夹</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ folder }}</div>
             <div class="mt-1 text-sm text-gray-500">{{ filteredDocuments.length }} 个文件</div>
           </div>
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">最近更新</div>
             <div class="mt-2 text-sm font-medium text-gray-900">{{ detail ? formatTime(detail.updated_at) : '-' }}</div>
             <div class="mt-1 text-sm text-gray-500">{{ detail?.last_change_summary || '最近一次更新未填写说明' }}</div>
           </div>
-          <div class="rounded-lg border border-blue-100 bg-blue-50/40 p-4">
+          <div class="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
             <div class="text-xs font-semibold uppercase tracking-[0.08em] text-gray-400">文件状态</div>
             <div class="mt-2 text-sm font-medium text-gray-900">
               {{ detail?.editable === false ? '只读' : '可编辑' }}
@@ -178,7 +178,7 @@
           >
         </div>
 
-        <div class="mt-5 rounded-lg border border-blue-100 bg-white">
+        <div class="mt-5 rounded-lg border border-slate-200 bg-white">
           <TextCodeEditor
             v-if="detail"
             v-model="editorContent"
@@ -192,7 +192,7 @@
       </section>
 
       <section v-if="detail" class="oda-card p-6">
-        <div class="flex flex-col gap-2 border-b border-blue-100 pb-5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex flex-col gap-2 border-b border-slate-200 pb-5 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <div class="oda-section-title">版本历史</div>
             <div class="mt-1 text-sm text-gray-500">查看当前文件的版本记录，并支持回滚。</div>
@@ -238,7 +238,7 @@
     </template>
 
     <section v-else class="oda-card p-10 text-center">
-      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-blue-50 text-gray-500">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-lg bg-slate-100 text-gray-500">
         <FileCode2 class="h-6 w-6" />
       </div>
       <div class="mt-4 text-lg font-semibold text-gray-900">没有找到这个 Skill</div>
@@ -285,17 +285,17 @@
         </div>
 
         <div v-if="compareResult" class="grid gap-4 xl:grid-cols-2">
-          <div class="rounded-lg border border-blue-100 bg-white p-4">
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.left_label }}</div>
             <TextCodeEditor :model-value="compareResult.left_content" read-only />
           </div>
-          <div class="rounded-lg border border-blue-100 bg-white p-4">
+          <div class="rounded-lg border border-slate-200 bg-white p-4">
             <div class="mb-3 text-sm font-semibold text-gray-900">{{ compareResult.right_label }}</div>
             <TextCodeEditor :model-value="compareResult.right_content" read-only />
           </div>
         </div>
 
-        <div v-if="compareResult" class="rounded-lg border border-blue-100 bg-white p-4">
+        <div v-if="compareResult" class="rounded-lg border border-slate-200 bg-white p-4">
           <div class="mb-3 text-sm font-semibold text-gray-900">Unified Diff</div>
           <TextCodeEditor :model-value="compareResult.diff_text" read-only />
         </div>

--- a/opendataagent/web/src/views/skills/SkillFileTreeNode.vue
+++ b/opendataagent/web/src/views/skills/SkillFileTreeNode.vue
@@ -4,8 +4,8 @@
       type="button"
       class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition"
       :class="node.type === 'file' && node.documentId === selectedDocumentId
-        ? 'bg-blue-800 text-white'
-        : 'text-gray-600 hover:bg-blue-50/40 hover:text-gray-900'"
+        ? 'bg-[#2f5f9f] text-white'
+        : 'text-gray-600 hover:bg-slate-50/70 hover:text-gray-900'"
       :style="{ paddingLeft: `${12 + level * 16}px` }"
       @click="handleClick"
     >


### PR DESCRIPTION
## Summary
- Unifies OpenDataAgent around the requested business blue `#2f5f9f` while keeping non-interactive surfaces neutral.
- Keeps blue reserved for primary actions, active navigation, focused inputs, and chart/interactive feedback.
- Preserves the previous top-nav no-scroll layout behavior and chart visibility safeguards.

## What Changed
- Overrides Element Plus primary color tokens with `html:root` so component focus and active states use `#2f5f9f` instead of the default bright blue.
- Replaces remaining bright-blue and purple-blue accent remnants with `#2f5f9f` derivatives or neutral slate/gray surfaces.
- Normalizes active chips, skill/source filters, settings tabs, file-tree selection, editor selection, and chat composer focus states.
- Keeps metric chart defaults away from white/near-white colors and aligns the default series color with the business-blue palette.

## Validation
- [x] `rg -n "blue-|#409eff|#1d4ed8|#2563eb|#1e40af|#365f8d|#27496d|#374151|37, 99, 235|102, 126, 234|59, 130, 246|64, 158, 255|#f7f9ff|#1c2647|#e6ebff" opendataagent/web/src -S` returned no matches.
- [x] Browser smoke via Playwright/Chromium on `/chat`, `/skills`, `/models`, and `/settings` at `1440x900` and `390x844`.
- [x] Browser assertions confirmed `--el-color-primary = #2f5f9f`, no page/nav overflow, active nav color `rgb(47, 95, 159)`, and chart/canvas/svg presence on chat.
- [x] `npm --prefix opendataagent/web run build` passed after `nvm use`; Vite emitted only the existing large chunk warning.

## Risks
- Risk is limited to OpenDataAgent web styling; the main regression area is visual contrast or state-color consistency across less-used controls.

## Rollback
- Revert this PR to restore the current post-navigation-fix OpenDataAgent palette.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updates not required for this scoped UI style change.
