### PR TITLE
[codex] Fix CSV export encoding and escaping

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataTableController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataTableController.java
@@ -935,7 +935,7 @@ public class DataTableController {
                 case "csv":
                 default:
                     data = dataExportService.exportToCsv(clusterId, database, actualTableName, limit);
-                    contentType = "text/csv";
+                    contentType = "text/csv;charset=UTF-8";
                     fileExtension = "csv";
                     break;
             }

--- a/backend/src/main/java/com/onedata/portal/service/DataExportService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataExportService.java
@@ -28,6 +28,8 @@ public class DataExportService {
     private final DorisConnectionService dorisConnectionService;
     private final ObjectMapper objectMapper;
 
+    private static final String UTF8_BOM = "\uFEFF";
+    private static final String CSV_LINE_SEPARATOR = "\r\n";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -38,24 +40,24 @@ public class DataExportService {
         List<Map<String, Object>> data = dorisConnectionService.previewTableData(clusterId, database, tableName, limit);
 
         if (data.isEmpty()) {
-            return new byte[0];
+            return UTF8_BOM.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         }
 
-        StringBuilder csv = new StringBuilder();
+        StringBuilder csv = new StringBuilder(UTF8_BOM);
 
         // 写入表头
         List<String> columns = new ArrayList<>(data.get(0).keySet());
         csv.append(String.join(",", columns.stream()
                 .map(this::escapeCsvValue)
                 .toArray(String[]::new)))
-           .append("\n");
+           .append(CSV_LINE_SEPARATOR);
 
         // 写入数据行
         for (Map<String, Object> row : data) {
             csv.append(String.join(",", columns.stream()
                     .map(col -> escapeCsvValue(formatValue(row.get(col))))
                     .toArray(String[]::new)))
-               .append("\n");
+               .append(CSV_LINE_SEPARATOR);
         }
 
         return csv.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8);
@@ -133,12 +135,23 @@ public class DataExportService {
             return "";
         }
 
-        // 如果包含逗号、引号或换行符，需要用引号包围并转义引号
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+        if (value.contains(",")
+                || value.contains("\"")
+                || value.contains("\n")
+                || value.contains("\r")
+                || startsWithSpreadsheetFormulaPrefix(value)) {
             return "\"" + value.replace("\"", "\"\"") + "\"";
         }
 
         return value;
+    }
+
+    private boolean startsWithSpreadsheetFormulaPrefix(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        char first = value.charAt(0);
+        return first == '=' || first == '+' || first == '-' || first == '@';
     }
 
     /**

--- a/backend/src/test/java/com/onedata/portal/service/DataExportServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DataExportServiceTest.java
@@ -1,0 +1,49 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DataExportServiceTest {
+
+    private DorisConnectionService dorisConnectionService;
+    private DataExportService service;
+
+    @BeforeEach
+    void setUp() {
+        dorisConnectionService = mock(DorisConnectionService.class);
+        service = new DataExportService(dorisConnectionService, new ObjectMapper());
+    }
+
+    @Test
+    void exportToCsvAddsUtf8BomAndEscapesValuesThatWouldBreakColumns() {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("名称", "张三");
+        row.put("备注,字段", "含逗号,双引号\"和\r\n换行");
+        row.put("公式", "=1+1");
+
+        when(dorisConnectionService.previewTableData(1L, "db1", "t_user", 100))
+                .thenReturn(Arrays.asList(row));
+
+        byte[] bytes = service.exportToCsv(1L, "db1", "t_user", 100);
+
+        assertTrue(bytes.length >= 3);
+        assertEquals((byte) 0xEF, bytes[0]);
+        assertEquals((byte) 0xBB, bytes[1]);
+        assertEquals((byte) 0xBF, bytes[2]);
+
+        String csv = new String(bytes, StandardCharsets.UTF_8);
+        assertEquals("\uFEFF名称,\"备注,字段\",公式\r\n"
+                + "张三,\"含逗号,双引号\"\"和\r\n换行\",\"=1+1\"\r\n", csv);
+    }
+}

--- a/frontend/src/views/datastudio/DataStudioNew.vue
+++ b/frontend/src/views/datastudio/DataStudioNew.vue
@@ -1184,6 +1184,7 @@ import TaskEditDrawer from '@/views/tasks/TaskEditDrawer.vue'
 import { isDemoMode, showDemoReadonlyMessage } from '@/demo/runtime'
 import { copyText } from '@/utils/clipboard'
 import { loadEcharts } from '@/utils/loadEcharts'
+import { buildCsvContent } from './csvExport'
 
 const SqlEditor = defineAsyncComponent({
   loader: () => import('@/components/SqlEditor.vue'),
@@ -3637,11 +3638,7 @@ const exportResult = (tabId, resultIndex = 0) => {
   const rows = set?.rows || state.queryResult.rows || []
   if (!rows.length || !columns.length) return
 
-  const header = columns.join(',')
-  const body = rows
-    .map((row) => columns.map((col) => formatCsvValue(row?.[col])).join(','))
-    .join('\n')
-  const blob = new Blob([`${header}\n${body}`], { type: 'text/csv;charset=utf-8;' })
+  const blob = new Blob([buildCsvContent(columns, rows)], { type: 'text/csv;charset=utf-8;' })
   const link = document.createElement('a')
   link.href = URL.createObjectURL(blob)
   link.download = `export_${Date.now()}.csv`
@@ -3774,12 +3771,6 @@ const handleCreateSuccess = async (result) => {
   }
 }
 
-
-const formatCsvValue = (value) => {
-  if (value === null || value === undefined) return ''
-  const str = String(value)
-  return str.includes(',') ? `"${str}"` : str
-}
 
 const getPaginatedRows = (tabId) => {
   const state = tabStates[tabId]

--- a/frontend/src/views/datastudio/__tests__/csvExport.spec.js
+++ b/frontend/src/views/datastudio/__tests__/csvExport.spec.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { buildCsvContent } from '../csvExport'
+
+describe('csvExport', () => {
+  it('adds a UTF-8 BOM and escapes headers and values that would break columns', () => {
+    const csv = buildCsvContent(
+      ['名称', '备注,字段', '公式'],
+      [
+        {
+          名称: '张三',
+          '备注,字段': '含逗号,双引号"和\r\n换行',
+          公式: '=1+1'
+        }
+      ]
+    )
+
+    expect(csv).toBe(
+      '\uFEFF名称,"备注,字段",公式\r\n' +
+        '张三,"含逗号,双引号""和\r\n换行","=1+1"\r\n'
+    )
+  })
+})

--- a/frontend/src/views/datastudio/csvExport.js
+++ b/frontend/src/views/datastudio/csvExport.js
@@ -1,0 +1,27 @@
+const UTF8_BOM = '\uFEFF'
+const CSV_LINE_SEPARATOR = '\r\n'
+
+const startsWithSpreadsheetFormulaPrefix = (value) => /^[=+\-@]/.test(value)
+
+export const formatCsvValue = (value) => {
+  if (value === null || value === undefined) return ''
+  const str = String(value)
+  if (
+    str.includes(',') ||
+    str.includes('"') ||
+    str.includes('\n') ||
+    str.includes('\r') ||
+    startsWithSpreadsheetFormulaPrefix(str)
+  ) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export const buildCsvContent = (columns = [], rows = []) => {
+  const header = columns.map((col) => formatCsvValue(col)).join(',')
+  const body = rows
+    .map((row) => columns.map((col) => formatCsvValue(row?.[col])).join(','))
+    .join(CSV_LINE_SEPARATOR)
+  return `${UTF8_BOM}${header}${CSV_LINE_SEPARATOR}${body ? `${body}${CSV_LINE_SEPARATOR}` : ''}`
+}


### PR DESCRIPTION
## Summary
- add UTF-8 BOM and charset metadata for backend CSV downloads to avoid garbled Chinese text in spreadsheet apps
- use CRLF row separators and quote CSV fields containing commas, quotes, CR/LF, or spreadsheet formula prefixes
- share the same CSV escaping behavior for DataStudio local query-result exports

## Root Cause
CSV exports were UTF-8 without a BOM and had incomplete escaping in the frontend path, so Excel-style consumers could mis-detect encoding and split fields incorrectly when values contained delimiters, quotes, or line breaks.

## Validation
- `mvn -pl backend -am -Dtest=DataExportServiceTest -DfailIfNoTests=false test`
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/views/datastudio/__tests__/csvExport.spec.js`

## Risk and Rollback
Risk is limited to CSV export byte formatting and response metadata. Roll back commit `f3c6d48` if downstream consumers require the previous no-BOM LF-only output.