### PR TITLE
[codex] fix readonly SQL validation for aggregate queries

### DIFF
--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
@@ -6,7 +6,9 @@ import com.onedata.portal.agentapi.dto.AgentReadQueryResponse;
 import lombok.RequiredArgsConstructor;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.select.Select;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -14,6 +16,8 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -23,8 +27,9 @@ public class BackendAgentQueryService implements AgentQueryService {
     private static final int MAX_LIMIT = 1000;
     private static final int DEFAULT_TIMEOUT_SECONDS = 30;
     private static final int MAX_TIMEOUT_SECONDS = 120;
-    private static final Set<String> READ_ONLY_PREFIXES = new LinkedHashSet<>(
-            Arrays.asList("SELECT", "WITH", "SHOW", "DESC", "DESCRIBE", "EXPLAIN")
+    private static final Pattern LEADING_KEYWORD_PATTERN = Pattern.compile("^\\s*([a-zA-Z]+)");
+    private static final Set<String> READ_ONLY_FALLBACK_KEYWORDS = new LinkedHashSet<>(
+            Arrays.asList("SHOW", "DESC", "DESCRIBE", "EXPLAIN")
     );
 
     private final AgentMetadataService agentMetadataService;
@@ -80,17 +85,33 @@ public class BackendAgentQueryService implements AgentQueryService {
             throw new IllegalArgumentException("仅支持单条只读 SQL");
         }
 
-        String sqlType = detectSqlType(sql);
-        if (!READ_ONLY_PREFIXES.contains(sqlType)) {
+        Statement statement = statements.getStatements().get(0);
+        if (!isReadOnlyStatement(statement, sql)) {
             throw new IllegalArgumentException("仅支持只读 SQL");
         }
     }
 
-    private String detectSqlType(String sql) {
-        String text = String.valueOf(sql == null ? "" : sql).trim();
-        int whitespace = text.indexOf(' ');
-        String head = whitespace < 0 ? text : text.substring(0, whitespace);
-        return head.toUpperCase(Locale.ROOT);
+    private boolean isReadOnlyStatement(Statement statement, String sql) {
+        if (statement instanceof Select) {
+            return true;
+        }
+
+        String statementType = statement == null ? "" : statement.getClass().getSimpleName();
+        if (statementType.startsWith("Show")
+                || "DescribeStatement".equals(statementType)
+                || "ExplainStatement".equals(statementType)) {
+            return true;
+        }
+
+        return READ_ONLY_FALLBACK_KEYWORDS.contains(detectLeadingKeyword(sql));
+    }
+
+    private String detectLeadingKeyword(String sql) {
+        if (!StringUtils.hasText(sql)) {
+            return "";
+        }
+        Matcher matcher = LEADING_KEYWORD_PATTERN.matcher(sql);
+        return matcher.find() ? matcher.group(1).toUpperCase(Locale.ROOT) : "";
     }
 
     private int normalizeLimit(Integer limit) {

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
@@ -66,31 +66,75 @@ class BackendAgentQueryServiceTest {
     }
 
     @Test
-    void readQueryRejectsMutatingSql() {
-        AgentReadQueryRequest request = new AgentReadQueryRequest();
-        request.setDatabase("opendataworks");
-        request.setSql("INSERT INTO demo VALUES (1)");
+    void readQueryAcceptsSelectWithLeadingComment() {
+        String sql = "/* publish trend */\n"
+                + "SELECT\n"
+                + "  DATE(created_at) AS publish_date,\n"
+                + "  SUM(publish_count) AS total_publish_count\n"
+                + "FROM opendataworks.workflow_publish_record\n"
+                + "GROUP BY DATE(created_at)";
 
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> backendAgentQueryService.readQuery(request)
-        );
+        assertReadQueryAccepted(sql);
+    }
 
-        assertEquals("仅支持只读 SQL", exception.getMessage());
+    @Test
+    void readQueryAcceptsSelectWhenCommentContainsMutatingKeywords() {
+        String sql = "/* example only: update demo set name = 'x'; "
+                + "delete from demo; drop table demo; alter table demo add column name varchar(64); */\n"
+                + "SELECT * FROM demo LIMIT 10";
+
+        assertReadQueryAccepted(sql);
+    }
+
+    @Test
+    void readQueryAcceptsMultilineAggregateSelect() {
+        String sql = "SELECT\n"
+                + "  DATE(created_at) AS publish_date,\n"
+                + "  SUM(publish_count) AS total_publish_count\n"
+                + "FROM opendataworks.workflow_publish_record\n"
+                + "GROUP BY DATE(created_at)\n"
+                + "ORDER BY publish_date";
+
+        assertReadQueryAccepted(sql);
+    }
+
+    @Test
+    void readQueryAcceptsShowSql() {
+        assertReadQueryAccepted("SHOW TABLES");
+    }
+
+    @Test
+    void readQueryAcceptsDescribeAndExplainSql() {
+        assertReadQueryAccepted("DESCRIBE demo");
+        assertReadQueryAccepted("EXPLAIN SELECT * FROM demo");
+    }
+
+    @Test
+    void readQueryAcceptsCrudSelectAndRejectsMutatingCrudSql() {
+        assertReadQueryAccepted("SELECT * FROM demo LIMIT 10");
+        assertReadQueryRejected("INSERT INTO demo VALUES (1)", "仅支持只读 SQL");
+        assertReadQueryRejected("UPDATE demo SET name = 'updated' WHERE id = 1", "仅支持只读 SQL");
+        assertReadQueryRejected("DELETE FROM demo WHERE id = 1", "仅支持只读 SQL");
+    }
+
+    @Test
+    void readQueryRejectsMutatingSqlWithLeadingComment() {
+        assertReadQueryRejected("/* cleanup */\nDELETE FROM demo WHERE id = 1", "仅支持只读 SQL");
+    }
+
+    @Test
+    void readQueryRejectsTruncateSql() {
+        assertReadQueryRejected("TRUNCATE TABLE demo", "仅支持只读 SQL");
+    }
+
+    @Test
+    void readQueryRejectsAlterSql() {
+        assertReadQueryRejected("ALTER TABLE demo ADD COLUMN name VARCHAR(64)", "仅支持只读 SQL");
     }
 
     @Test
     void readQueryRejectsMultipleStatements() {
-        AgentReadQueryRequest request = new AgentReadQueryRequest();
-        request.setDatabase("opendataworks");
-        request.setSql("SELECT 1; SELECT 2");
-
-        IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> backendAgentQueryService.readQuery(request)
-        );
-
-        assertEquals("仅支持单条只读 SQL", exception.getMessage());
+        assertReadQueryRejected("SELECT 1; SELECT 2", "仅支持单条只读 SQL");
     }
 
     @Test
@@ -111,5 +155,35 @@ class BackendAgentQueryServiceTest {
         backendAgentQueryService.readQuery(request);
 
         verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, "SELECT 1", 1000, 120);
+    }
+
+    private void assertReadQueryAccepted(String sql) {
+        AgentReadQueryRequest request = new AgentReadQueryRequest();
+        request.setDatabase("opendataworks");
+        request.setSql(sql);
+
+        AgentDatasourceResolution datasource = new AgentDatasourceResolution();
+        datasource.setDatabase("opendataworks");
+        datasource.setEngine("mysql");
+        when(agentMetadataService.resolveDatasource("opendataworks", null)).thenReturn(datasource);
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), eq(sql), eq(200), eq(30)))
+                .thenReturn(new AgentJdbcExecutor.QueryExecutionResult());
+
+        backendAgentQueryService.readQuery(request);
+
+        verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, sql, 200, 30);
+    }
+
+    private void assertReadQueryRejected(String sql, String expectedMessage) {
+        AgentReadQueryRequest request = new AgentReadQueryRequest();
+        request.setDatabase("opendataworks");
+        request.setSql(sql);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> backendAgentQueryService.readQuery(request)
+        );
+
+        assertEquals(expectedMessage, exception.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- Fix backend agent read-only SQL validation so multiline aggregate SELECT queries are accepted.
- Use parsed JSqlParser statement types as the primary read-only decision and keep leading-keyword matching only as a fallback for SHOW/DESC/DESCRIBE/EXPLAIN.
- Expand coverage for comments, CRUD, SHOW/DESCRIBE/EXPLAIN, TRUNCATE, ALTER, and multiple-statement rejection.

## Root Cause
The previous validation detected SQL type from the raw leading text. Queries with multiline formatting or leading comments could be misclassified before execution even when the actual statement was a read-only SELECT.

## Validation
- `mvn -pl backend -am -Dtest=BackendAgentQueryServiceTest -DfailIfNoTests=false test`
- Result: 12 tests run, 0 failures, 0 errors.

## Notes
- No public API changes.
- Full intelligent-query end-to-end smoke was not run; this PR validates the backend query validation layer directly.