### PR TITLE
feat: support Dolphin scheduler engine switching

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataTaskController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataTaskController.java
@@ -132,8 +132,9 @@ public class DataTaskController {
      * 获取 DolphinScheduler Web UI 配置
      */
     @GetMapping("/config/dolphin-webui")
-    public Result<Map<String, String>> getDolphinWebuiConfig() {
-        String webuiUrl = dolphinSchedulerService.getWebuiBaseUrl();
+    public Result<Map<String, String>> getDolphinWebuiConfig(
+            @RequestParam(required = false) Long dolphinConfigId) {
+        String webuiUrl = dolphinSchedulerService.getWebuiBaseUrl(dolphinConfigId);
         return Result.success(Collections.singletonMap("webuiUrl", webuiUrl));
     }
 

--- a/backend/src/main/java/com/onedata/portal/controller/DolphinConfigController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DolphinConfigController.java
@@ -4,9 +4,12 @@ import com.onedata.portal.annotation.RequireAuth;
 import com.onedata.portal.dto.Result;
 import com.onedata.portal.entity.DolphinConfig;
 import com.onedata.portal.service.DolphinConfigService;
+import com.onedata.portal.service.DolphinSchedulerService;
 import com.onedata.portal.service.dolphin.DolphinOpenApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/settings/dolphin")
@@ -15,6 +18,7 @@ public class DolphinConfigController {
 
     private final DolphinConfigService dolphinConfigService;
     private final DolphinOpenApiClient dolphinOpenApiClient;
+    private final DolphinSchedulerService dolphinSchedulerService;
 
     @GetMapping
     public Result<DolphinConfig> getConfig() {
@@ -26,6 +30,7 @@ public class DolphinConfigController {
     public Result<DolphinConfig> updateConfig(@RequestBody DolphinConfig config) {
         DolphinConfig updated = dolphinConfigService.updateConfig(config);
         // Clear project code dependency cache in apiClient if needed
+        dolphinSchedulerService.clearProjectCodeCache();
         return Result.success(updated);
     }
 
@@ -36,5 +41,53 @@ public class DolphinConfigController {
         // Pass the temporary config to the client method
         boolean success = dolphinOpenApiClient.testConnection(config);
         return Result.success(success);
+    }
+
+    @GetMapping("/configs")
+    public Result<List<DolphinConfig>> listConfigs(@RequestParam(required = false) Boolean activeOnly) {
+        return Result.success(dolphinConfigService.listAll(activeOnly));
+    }
+
+    @GetMapping("/configs/{id}")
+    public Result<DolphinConfig> getById(@PathVariable Long id) {
+        return Result.success(dolphinConfigService.getById(id));
+    }
+
+    @RequireAuth
+    @PostMapping("/configs")
+    public Result<DolphinConfig> create(@RequestBody DolphinConfig config) {
+        DolphinConfig created = dolphinConfigService.create(config);
+        dolphinSchedulerService.clearProjectCodeCache();
+        return Result.success(created);
+    }
+
+    @RequireAuth
+    @PutMapping("/configs/{id}")
+    public Result<DolphinConfig> update(@PathVariable Long id, @RequestBody DolphinConfig config) {
+        DolphinConfig updated = dolphinConfigService.update(id, config);
+        dolphinSchedulerService.clearProjectCodeCache();
+        return Result.success(updated);
+    }
+
+    @RequireAuth
+    @DeleteMapping("/configs/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        dolphinConfigService.delete(id);
+        dolphinSchedulerService.clearProjectCodeCache();
+        return Result.success();
+    }
+
+    @RequireAuth
+    @PostMapping("/configs/{id}/default")
+    public Result<Void> setDefault(@PathVariable Long id) {
+        dolphinConfigService.setDefault(id);
+        dolphinSchedulerService.clearProjectCodeCache();
+        return Result.success();
+    }
+
+    @RequireAuth
+    @PostMapping("/configs/{id}/test")
+    public Result<Boolean> testSavedConnection(@PathVariable Long id) {
+        return Result.success(dolphinSchedulerService.testConnection(id));
     }
 }

--- a/backend/src/main/java/com/onedata/portal/controller/DolphinDatasourceController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DolphinDatasourceController.java
@@ -28,14 +28,16 @@ public class DolphinDatasourceController {
     @GetMapping("/datasources")
     public Result<List<DolphinDatasourceOption>> listDatasources(
             @RequestParam(required = false) String type,
-            @RequestParam(required = false) String keyword) {
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long dolphinConfigId) {
         String filterType;
         if ("ALL".equalsIgnoreCase(type)) {
             filterType = null;
         } else {
             filterType = type;
         }
-        List<DolphinDatasourceOption> options = dataTaskService.listDatasourceOptions(filterType, keyword);
+        List<DolphinDatasourceOption> options =
+                dataTaskService.listDatasourceOptions(filterType, keyword, dolphinConfigId);
         return Result.success(options);
     }
 }

--- a/backend/src/main/java/com/onedata/portal/controller/DolphinMetaController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DolphinMetaController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,31 +27,34 @@ public class DolphinMetaController {
     private final DolphinSchedulerService dolphinSchedulerService;
 
     @GetMapping("/worker-groups")
-    public Result<List<String>> listWorkerGroups() {
-        return Result.success(dolphinSchedulerService.listWorkerGroups());
+    public Result<List<String>> listWorkerGroups(@RequestParam(required = false) Long dolphinConfigId) {
+        return Result.success(dolphinSchedulerService.listWorkerGroups(dolphinConfigId));
     }
 
     @GetMapping("/tenants")
-    public Result<List<String>> listTenants() {
-        return Result.success(dolphinSchedulerService.listTenants());
+    public Result<List<String>> listTenants(@RequestParam(required = false) Long dolphinConfigId) {
+        return Result.success(dolphinSchedulerService.listTenants(dolphinConfigId));
     }
 
     @GetMapping("/alert-groups")
-    public Result<List<DolphinAlertGroupOption>> listAlertGroups() {
-        return Result.success(dolphinSchedulerService.listAlertGroups());
+    public Result<List<DolphinAlertGroupOption>> listAlertGroups(
+            @RequestParam(required = false) Long dolphinConfigId) {
+        return Result.success(dolphinSchedulerService.listAlertGroups(dolphinConfigId));
     }
 
     @GetMapping("/environments")
-    public Result<List<DolphinEnvironmentOption>> listEnvironments() {
-        return Result.success(dolphinSchedulerService.listEnvironments());
+    public Result<List<DolphinEnvironmentOption>> listEnvironments(
+            @RequestParam(required = false) Long dolphinConfigId) {
+        return Result.success(dolphinSchedulerService.listEnvironments(dolphinConfigId));
     }
 
     @PostMapping("/schedules/preview")
-    public Result<List<String>> previewSchedule(@RequestBody SchedulePreviewRequest request) {
+    public Result<List<String>> previewSchedule(@RequestBody SchedulePreviewRequest request,
+            @RequestParam(required = false) Long dolphinConfigId) {
         if (request == null || !StringUtils.hasText(request.getSchedule())) {
             return Result.fail("schedule is required");
         }
-        return Result.success(dolphinSchedulerService.previewSchedule(request.getSchedule()));
+        return Result.success(dolphinSchedulerService.previewSchedule(request.getSchedule(), dolphinConfigId));
     }
 
     @Data
@@ -61,4 +65,3 @@ public class DolphinMetaController {
         private String schedule;
     }
 }
-

--- a/backend/src/main/java/com/onedata/portal/controller/DolphinTaskGroupController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DolphinTaskGroupController.java
@@ -26,8 +26,8 @@ public class DolphinTaskGroupController {
      */
     @GetMapping("/task-groups")
     public Result<List<DolphinTaskGroupOption>> listTaskGroups(
-            @RequestParam(required = false) String keyword) {
-        return Result.success(dolphinSchedulerService.listTaskGroups(keyword));
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long dolphinConfigId) {
+        return Result.success(dolphinSchedulerService.listTaskGroups(keyword, dolphinConfigId));
     }
 }
-

--- a/backend/src/main/java/com/onedata/portal/controller/WorkflowController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/WorkflowController.java
@@ -23,6 +23,7 @@ import com.onedata.portal.dto.workflow.WorkflowVersionRollbackRequest;
 import com.onedata.portal.dto.workflow.WorkflowVersionRollbackResponse;
 import com.onedata.portal.dto.workflow.WorkflowVersionDeleteResponse;
 import com.onedata.portal.dto.workflow.WorkflowScheduleRequest;
+import com.onedata.portal.dto.workflow.WorkflowSchedulerEngineRequest;
 import com.onedata.portal.dto.workflow.runtime.DolphinRuntimeWorkflowOption;
 import com.onedata.portal.entity.DataWorkflow;
 import com.onedata.portal.entity.WorkflowPublishRecord;
@@ -109,6 +110,12 @@ public class WorkflowController {
                                        @RequestBody WorkflowDefinitionRequest request) {
         DataWorkflow workflow = workflowService.updateWorkflow(id, request);
         return Result.success(workflow);
+    }
+
+    @PutMapping("/{id}/scheduler-engine")
+    public Result<DataWorkflow> switchSchedulerEngine(@PathVariable Long id,
+                                                      @RequestBody WorkflowSchedulerEngineRequest request) {
+        return Result.success(workflowService.switchSchedulerEngine(id, request));
     }
 
     @GetMapping("/{id}/export-json")

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowDefinitionRequest.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowDefinitionRequest.java
@@ -34,5 +34,7 @@ public class WorkflowDefinitionRequest {
 
     private String triggerSource = "manual";
 
+    private Long dolphinConfigId;
+
     private Long projectCode;
 }

--- a/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowSchedulerEngineRequest.java
+++ b/backend/src/main/java/com/onedata/portal/dto/workflow/WorkflowSchedulerEngineRequest.java
@@ -1,0 +1,14 @@
+package com.onedata.portal.dto.workflow;
+
+import lombok.Data;
+
+/**
+ * 工作流调度引擎切换请求
+ */
+@Data
+public class WorkflowSchedulerEngineRequest {
+
+    private Long dolphinConfigId;
+
+    private String operator;
+}

--- a/backend/src/main/java/com/onedata/portal/entity/DataWorkflow.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DataWorkflow.java
@@ -20,6 +20,8 @@ public class DataWorkflow {
     @TableId(type = IdType.AUTO)
     private Long id;
 
+    private Long dolphinConfigId;
+
     private Long workflowCode;
 
     private Long projectCode;

--- a/backend/src/main/java/com/onedata/portal/entity/DolphinConfig.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DolphinConfig.java
@@ -1,8 +1,11 @@
 package com.onedata.portal.entity;
 
 import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableLogic;
 import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -13,8 +16,11 @@ public class DolphinConfig {
     @TableId(type = IdType.AUTO)
     private Long id;
 
+    private String configName;
+
     private String url;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String token;
 
     private String projectName;
@@ -27,9 +33,18 @@ public class DolphinConfig {
 
     private String executionType;
 
+    private String description;
+
     private Boolean isActive;
 
+    private Integer isDefault;
+
+    @TableField(fill = com.baomidou.mybatisplus.annotation.FieldFill.INSERT)
     private LocalDateTime createdAt;
 
+    @TableField(fill = com.baomidou.mybatisplus.annotation.FieldFill.INSERT_UPDATE)
     private LocalDateTime updatedAt;
+
+    @TableLogic
+    private Integer deleted;
 }

--- a/backend/src/main/java/com/onedata/portal/entity/WorkflowPublishRecord.java
+++ b/backend/src/main/java/com/onedata/portal/entity/WorkflowPublishRecord.java
@@ -25,6 +25,8 @@ public class WorkflowPublishRecord {
 
     private String targetEngine;
 
+    private Long dolphinConfigId;
+
     private String operation;
 
     private String status;

--- a/backend/src/main/java/com/onedata/portal/mapper/DolphinConfigMapper.java
+++ b/backend/src/main/java/com/onedata/portal/mapper/DolphinConfigMapper.java
@@ -3,7 +3,16 @@ package com.onedata.portal.mapper;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.onedata.portal.entity.DolphinConfig;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface DolphinConfigMapper extends BaseMapper<DolphinConfig> {
+
+    @Select("SELECT COUNT(1) FROM data_workflow "
+            + "WHERE dolphin_config_id = #{configId} "
+            + "AND workflow_code IS NOT NULL "
+            + "AND workflow_code > 0 "
+            + "AND (deleted IS NULL OR deleted = 0)")
+    Long countRuntimeBoundWorkflows(@Param("configId") Long configId);
 }

--- a/backend/src/main/java/com/onedata/portal/service/DataTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataTaskService.java
@@ -181,6 +181,10 @@ public class DataTaskService {
         return dolphinSchedulerService.listDatasources(type, keyword);
     }
 
+    public List<DolphinDatasourceOption> listDatasourceOptions(String type, String keyword, Long dolphinConfigId) {
+        return dolphinSchedulerService.listDatasources(type, keyword, dolphinConfigId);
+    }
+
     /**
      * 创建任务
      */

--- a/backend/src/main/java/com/onedata/portal/service/DolphinConfigService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinConfigService.java
@@ -1,12 +1,18 @@
 package com.onedata.portal.service;
 
-import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
 import com.onedata.portal.entity.DolphinConfig;
 import com.onedata.portal.mapper.DolphinConfigMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Service for managing DolphinScheduler configuration.
@@ -15,6 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DolphinConfigService {
+
+    private static final String DEFAULT_TENANT_CODE = "default";
+    private static final String DEFAULT_WORKER_GROUP = "default";
+    private static final String DEFAULT_EXECUTION_TYPE = "PARALLEL";
 
     private final DolphinConfigMapper dolphinConfigMapper;
 
@@ -33,13 +43,7 @@ public class DolphinConfigService {
         if (cachedConfig != null) {
             return cachedConfig;
         }
-
-        // Find the active config (assuming there's only one active or we take the
-        // latest)
-        DolphinConfig config = dolphinConfigMapper.selectOne(new LambdaQueryWrapper<DolphinConfig>()
-                .eq(DolphinConfig::getIsActive, true)
-                .orderByDesc(DolphinConfig::getId)
-                .last("LIMIT 1"));
+        DolphinConfig config = getDefaultConfig();
 
         if (config != null) {
             cachedConfig = config;
@@ -54,6 +58,109 @@ public class DolphinConfigService {
         return getActiveConfig();
     }
 
+    public List<DolphinConfig> listAll(Boolean activeOnly) {
+        QueryWrapper<DolphinConfig> wrapper = new QueryWrapper<>();
+        if (Boolean.TRUE.equals(activeOnly)) {
+            wrapper.eq("is_active", true);
+        }
+        wrapper.orderByDesc("is_default")
+                .orderByAsc("config_name")
+                .orderByAsc("id");
+        return dolphinConfigMapper.selectList(wrapper);
+    }
+
+    public DolphinConfig getById(Long id) {
+        return id == null ? null : dolphinConfigMapper.selectById(id);
+    }
+
+    public DolphinConfig getEnabledConfig(Long id) {
+        DolphinConfig config = id == null ? getDefaultConfig() : dolphinConfigMapper.selectById(id);
+        if (config == null) {
+            throw new IllegalArgumentException("Dolphin 环境不存在");
+        }
+        if (!Boolean.TRUE.equals(config.getIsActive())) {
+            throw new IllegalStateException("Dolphin 环境未启用: " + displayName(config));
+        }
+        return config;
+    }
+
+    public DolphinConfig getDefaultConfig() {
+        DolphinConfig config = dolphinConfigMapper.selectOne(new QueryWrapper<DolphinConfig>()
+                .eq("is_default", 1)
+                .eq("is_active", true)
+                .orderByDesc("id")
+                .last("LIMIT 1"));
+        if (config != null) {
+            return config;
+        }
+        return dolphinConfigMapper.selectOne(new QueryWrapper<DolphinConfig>()
+                .eq("is_active", true)
+                .orderByDesc("id")
+                .last("LIMIT 1"));
+    }
+
+    @Transactional
+    public DolphinConfig create(DolphinConfig config) {
+        normalize(config, true, null);
+        if (Integer.valueOf(1).equals(config.getIsDefault())) {
+            resetDefault(null);
+        }
+        dolphinConfigMapper.insert(config);
+        invalidateCache();
+        log.info("Created DolphinScheduler configuration: {}", config.getConfigName());
+        return config;
+    }
+
+    @Transactional
+    public DolphinConfig update(Long id, DolphinConfig config) {
+        DolphinConfig existing = dolphinConfigMapper.selectById(id);
+        if (existing == null) {
+            throw new IllegalArgumentException("Dolphin 环境不存在");
+        }
+        boolean runtimeBound = countRuntimeBoundWorkflows(id) > 0;
+        normalize(config, false, existing);
+        if (runtimeBound && runtimeIdentityChanged(existing, config)) {
+            throw new IllegalStateException("Dolphin 环境已被运行态工作流绑定，不能修改服务地址或项目名称");
+        }
+        config.setId(id);
+        if (Integer.valueOf(1).equals(config.getIsDefault())) {
+            resetDefault(id);
+        }
+        dolphinConfigMapper.updateById(config);
+        invalidateCache();
+        log.info("Updated DolphinScheduler configuration: {}({})", id, config.getConfigName());
+        return dolphinConfigMapper.selectById(id);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        DolphinConfig existing = dolphinConfigMapper.selectById(id);
+        if (existing == null) {
+            return;
+        }
+        if (countRuntimeBoundWorkflows(id) > 0) {
+            throw new IllegalStateException("Dolphin 环境已被运行态工作流绑定，不能删除");
+        }
+        dolphinConfigMapper.deleteById(id);
+        invalidateCache();
+        log.info("Deleted DolphinScheduler configuration: {}({})", id, displayName(existing));
+    }
+
+    @Transactional
+    public void setDefault(Long id) {
+        DolphinConfig existing = dolphinConfigMapper.selectById(id);
+        if (existing == null) {
+            throw new IllegalArgumentException("Dolphin 环境不存在");
+        }
+        if (!Boolean.TRUE.equals(existing.getIsActive())) {
+            throw new IllegalStateException("停用的 Dolphin 环境不能设为默认");
+        }
+        resetDefault(id);
+        existing.setIsDefault(1);
+        dolphinConfigMapper.updateById(existing);
+        invalidateCache();
+    }
+
     /**
      * Update the DolphinScheduler configuration.
      * Implementation: Update the existing active record or insert a new one if none
@@ -62,26 +169,120 @@ public class DolphinConfigService {
      */
     @Transactional
     public DolphinConfig updateConfig(DolphinConfig newConfig) {
-        DolphinConfig current = getActiveConfig();
+        DolphinConfig current = getDefaultConfig();
 
         if (current == null) {
-            newConfig.setIsActive(true);
-            dolphinConfigMapper.insert(newConfig);
-            current = newConfig;
+            newConfig.setIsDefault(1);
+            current = create(newConfig);
         } else {
-            current.setUrl(newConfig.getUrl());
-            current.setToken(newConfig.getToken());
-            current.setProjectName(newConfig.getProjectName());
-            current.setProjectCode(newConfig.getProjectCode());
-            current.setTenantCode(newConfig.getTenantCode());
-            current.setWorkerGroup(newConfig.getWorkerGroup());
-            current.setExecutionType(newConfig.getExecutionType());
-            dolphinConfigMapper.updateById(current);
+            newConfig.setConfigName(StringUtils.hasText(newConfig.getConfigName())
+                    ? newConfig.getConfigName()
+                    : current.getConfigName());
+            newConfig.setDescription(newConfig.getDescription());
+            newConfig.setIsDefault(1);
+            current = update(current.getId(), newConfig);
         }
 
         // Update cache
         cachedConfig = current;
         log.info("Updated DolphinScheduler configuration");
         return current;
+    }
+
+    private void normalize(DolphinConfig config, boolean requireToken, DolphinConfig existing) {
+        if (config == null) {
+            throw new IllegalArgumentException("Dolphin 配置不能为空");
+        }
+        if (!StringUtils.hasText(config.getConfigName())) {
+            config.setConfigName(existing != null && StringUtils.hasText(existing.getConfigName())
+                    ? existing.getConfigName()
+                    : "Dolphin");
+        } else {
+            config.setConfigName(config.getConfigName().trim());
+        }
+        if (!StringUtils.hasText(config.getUrl())) {
+            throw new IllegalArgumentException("Dolphin 服务地址不能为空");
+        }
+        config.setUrl(trimTrailingSlash(config.getUrl()));
+        if (!StringUtils.hasText(config.getToken())) {
+            if (existing != null && StringUtils.hasText(existing.getToken())) {
+                config.setToken(existing.getToken());
+            } else if (requireToken) {
+                throw new IllegalArgumentException("Dolphin 访问令牌不能为空");
+            }
+        } else {
+            config.setToken(config.getToken().trim());
+        }
+        if (!StringUtils.hasText(config.getProjectName())) {
+            throw new IllegalArgumentException("Dolphin 项目名称不能为空");
+        }
+        config.setProjectName(config.getProjectName().trim());
+        if (StringUtils.hasText(config.getProjectCode())) {
+            config.setProjectCode(config.getProjectCode().trim());
+        } else if (existing != null) {
+            config.setProjectCode(existing.getProjectCode());
+        }
+        config.setTenantCode(defaultText(config.getTenantCode(), DEFAULT_TENANT_CODE));
+        config.setWorkerGroup(defaultText(config.getWorkerGroup(), DEFAULT_WORKER_GROUP));
+        config.setExecutionType(defaultText(config.getExecutionType(), DEFAULT_EXECUTION_TYPE).toUpperCase(Locale.ROOT));
+        if (config.getIsActive() == null) {
+            config.setIsActive(existing == null ? Boolean.TRUE : existing.getIsActive());
+        }
+        if (config.getIsDefault() == null) {
+            config.setIsDefault(existing == null ? 0 : existing.getIsDefault());
+        } else {
+            config.setIsDefault(config.getIsDefault() == 1 ? 1 : 0);
+        }
+        if (StringUtils.hasText(config.getDescription())) {
+            config.setDescription(config.getDescription().trim());
+        }
+        if (config.getDeleted() == null) {
+            config.setDeleted(existing == null ? 0 : existing.getDeleted());
+        }
+    }
+
+    private long countRuntimeBoundWorkflows(Long id) {
+        Long count = dolphinConfigMapper.countRuntimeBoundWorkflows(id);
+        return count == null ? 0L : count;
+    }
+
+    private boolean runtimeIdentityChanged(DolphinConfig existing, DolphinConfig next) {
+        return !Objects.equals(trimTrailingSlash(existing.getUrl()), trimTrailingSlash(next.getUrl()))
+                || !Objects.equals(existing.getProjectName(), next.getProjectName());
+    }
+
+    private void resetDefault(Long excludeId) {
+        UpdateWrapper<DolphinConfig> wrapper = new UpdateWrapper<DolphinConfig>()
+                .set("is_default", 0);
+        if (excludeId != null) {
+            wrapper.ne("id", excludeId);
+        }
+        dolphinConfigMapper.update(null, wrapper);
+    }
+
+    private void invalidateCache() {
+        cachedConfig = null;
+    }
+
+    private String defaultText(String value, String defaultValue) {
+        return StringUtils.hasText(value) ? value.trim() : defaultValue;
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        String normalized = value.trim();
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private String displayName(DolphinConfig config) {
+        if (config == null) {
+            return "-";
+        }
+        return StringUtils.hasText(config.getConfigName()) ? config.getConfigName() : String.valueOf(config.getId());
     }
 }

--- a/backend/src/main/java/com/onedata/portal/service/DolphinRuntimeDefinitionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinRuntimeDefinitionService.java
@@ -80,6 +80,15 @@ public class DolphinRuntimeDefinitionService {
         return result;
     }
 
+    public DolphinRuntimeWorkflowPage listRuntimeWorkflows(Long dolphinConfigId,
+            Long projectCode,
+            Integer pageNum,
+            Integer pageSize,
+            String keyword) {
+        return dolphinSchedulerService.withConfig(dolphinConfigId,
+                () -> listRuntimeWorkflows(projectCode, pageNum, pageSize, keyword));
+    }
+
     public RuntimeWorkflowDefinition loadRuntimeDefinition(Long projectCode, Long workflowCode) {
         if (workflowCode == null || workflowCode <= 0) {
             throw new IllegalArgumentException("workflowCode 不能为空");
@@ -149,6 +158,11 @@ public class DolphinRuntimeDefinitionService {
         return result;
     }
 
+    public RuntimeWorkflowDefinition loadRuntimeDefinition(Long dolphinConfigId, Long projectCode, Long workflowCode) {
+        return dolphinSchedulerService.withConfig(dolphinConfigId,
+                () -> loadRuntimeDefinition(projectCode, workflowCode));
+    }
+
     /**
      * 通过 Dolphin 导出 JSON 获取运行态定义（导出主路）。
      */
@@ -212,6 +226,13 @@ public class DolphinRuntimeDefinitionService {
         result.setExplicitEdges(explicitEdges);
         result.setRawDefinitionJson(toJson(exported));
         return result;
+    }
+
+    public RuntimeWorkflowDefinition loadRuntimeDefinitionFromExport(Long dolphinConfigId,
+            Long projectCode,
+            Long workflowCode) {
+        return dolphinSchedulerService.withConfig(dolphinConfigId,
+                () -> loadRuntimeDefinitionFromExport(projectCode, workflowCode));
     }
 
     /**

--- a/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
@@ -918,7 +918,9 @@ public class DolphinSchedulerService {
     }
 
     public String getWebuiBaseUrl(Long dolphinConfigId) {
-        return this.<String>withConfig(dolphinConfigId, this::getWebuiBaseUrl);
+        return withConfig(dolphinConfigId, () -> {
+            return getWebuiBaseUrl();
+        });
     }
 
     public String getDefaultTenantCode() {
@@ -1247,7 +1249,9 @@ public class DolphinSchedulerService {
     }
 
     public List<String> listWorkerGroups(Long dolphinConfigId) {
-        return this.<List<String>>withConfig(dolphinConfigId, this::listWorkerGroups);
+        return withConfig(dolphinConfigId, () -> {
+            return listWorkerGroups();
+        });
     }
 
     /**
@@ -1263,7 +1267,9 @@ public class DolphinSchedulerService {
     }
 
     public List<String> listTenants(Long dolphinConfigId) {
-        return this.<List<String>>withConfig(dolphinConfigId, this::listTenants);
+        return withConfig(dolphinConfigId, () -> {
+            return listTenants();
+        });
     }
 
     /**
@@ -1279,7 +1285,9 @@ public class DolphinSchedulerService {
     }
 
     public List<DolphinAlertGroupOption> listAlertGroups(Long dolphinConfigId) {
-        return this.<List<DolphinAlertGroupOption>>withConfig(dolphinConfigId, this::listAlertGroups);
+        return withConfig(dolphinConfigId, () -> {
+            return listAlertGroups();
+        });
     }
 
     /**
@@ -1295,7 +1303,9 @@ public class DolphinSchedulerService {
     }
 
     public List<DolphinEnvironmentOption> listEnvironments(Long dolphinConfigId) {
-        return this.<List<DolphinEnvironmentOption>>withConfig(dolphinConfigId, this::listEnvironments);
+        return withConfig(dolphinConfigId, () -> {
+            return listEnvironments();
+        });
     }
 
     /**

--- a/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Client wrapper around the DolphinScheduler OpenAPI.
@@ -49,8 +51,10 @@ public class DolphinSchedulerService {
     private final DolphinOpenApiClient openApiClient;
     private final AtomicLong taskCodeSequence = new AtomicLong(System.currentTimeMillis());
 
-    // Cache for project code to avoid repeated API calls
-    private volatile Long cachedProjectCode;
+    // Cache for project code to avoid repeated API calls. Key is Dolphin config id,
+    // with -1 reserved for legacy/default config calls before an id is persisted.
+    private final Map<Long, Long> cachedProjectCodeByConfigId = new ConcurrentHashMap<>();
+    private final ThreadLocal<DolphinConfig> scopedConfig = new ThreadLocal<>();
 
     public DolphinSchedulerService(DolphinConfigService dolphinConfigService,
             ObjectMapper objectMapper,
@@ -61,11 +65,43 @@ public class DolphinSchedulerService {
     }
 
     private DolphinConfig getConfig() {
-        DolphinConfig config = dolphinConfigService.getActiveConfig();
+        DolphinConfig config = scopedConfig.get();
+        if (config == null) {
+            config = dolphinConfigService.getActiveConfig();
+        }
         if (config == null) {
             throw new IllegalStateException("DolphinScheduler configuration is missing");
         }
         return config;
+    }
+
+    public DolphinConfig getConfig(Long dolphinConfigId) {
+        return dolphinConfigId == null ? getConfig() : dolphinConfigService.getEnabledConfig(dolphinConfigId);
+    }
+
+    public <T> T withConfig(Long dolphinConfigId, Supplier<T> supplier) {
+        if (dolphinConfigId == null) {
+            return supplier.get();
+        }
+        DolphinConfig config = dolphinConfigService.getEnabledConfig(dolphinConfigId);
+        DolphinConfig previous = scopedConfig.get();
+        scopedConfig.set(config);
+        try {
+            return openApiClient.withConfig(config, supplier);
+        } finally {
+            if (previous == null) {
+                scopedConfig.remove();
+            } else {
+                scopedConfig.set(previous);
+            }
+        }
+    }
+
+    public void withConfig(Long dolphinConfigId, Runnable runnable) {
+        withConfig(dolphinConfigId, () -> {
+            runnable.run();
+            return null;
+        });
     }
 
     /**
@@ -80,31 +116,33 @@ public class DolphinSchedulerService {
      * Query project code with option to force refresh the cache.
      */
     public Long getProjectCode(boolean forceRefresh) {
-        if (!forceRefresh && cachedProjectCode != null) {
-            return cachedProjectCode;
+        DolphinConfig activeConfig = getConfig();
+        Long cacheKey = configCacheKey(activeConfig);
+        if (!forceRefresh && cachedProjectCodeByConfigId.containsKey(cacheKey)) {
+            return cachedProjectCodeByConfigId.get(cacheKey);
         }
 
         synchronized (this) {
-            if (!forceRefresh && cachedProjectCode != null) {
-                return cachedProjectCode;
+            if (!forceRefresh && cachedProjectCodeByConfigId.containsKey(cacheKey)) {
+                return cachedProjectCodeByConfigId.get(cacheKey);
             }
 
-            String projectName = getConfig().getProjectName();
+            String projectName = activeConfig.getProjectName();
             try {
                 DolphinProject project = openApiClient.getProject(projectName);
                 if (project != null) {
-                    cachedProjectCode = project.getCode();
-                    log.info("Queried project code for {}: {}", projectName, cachedProjectCode);
-                    return cachedProjectCode;
+                    cachedProjectCodeByConfigId.put(cacheKey, project.getCode());
+                    log.info("Queried project code for {}: {}", projectName, project.getCode());
+                    return project.getCode();
                 } else {
                     log.info("Project {} not found. Attempting to create it...", projectName);
                     try {
                         Long newCode = openApiClient.createProject(projectName,
                                 "Auto-created by OpenDataWorks");
                         if (newCode != null && newCode > 0) {
-                            cachedProjectCode = newCode;
-                            log.info("Created project {}: {}", projectName, cachedProjectCode);
-                            return cachedProjectCode;
+                            cachedProjectCodeByConfigId.put(cacheKey, newCode);
+                            log.info("Created project {}: {}", projectName, newCode);
+                            return newCode;
                         }
                     } catch (Exception ex) {
                         log.error("Failed to auto-create project {}", projectName, ex);
@@ -124,8 +162,21 @@ public class DolphinSchedulerService {
      * Clear the cached project code. Use this when DolphinScheduler is reset.
      */
     public void clearProjectCodeCache() {
-        cachedProjectCode = null;
+        cachedProjectCodeByConfigId.clear();
         log.info("Cleared project code cache");
+    }
+
+    public Long getProjectCode(Long dolphinConfigId, boolean forceRefresh) {
+        return withConfig(dolphinConfigId, () -> getProjectCode(forceRefresh));
+    }
+
+    public boolean testConnection(Long dolphinConfigId) {
+        DolphinConfig config = dolphinConfigService.getEnabledConfig(dolphinConfigId);
+        return openApiClient.testConnection(config);
+    }
+
+    private Long configCacheKey(DolphinConfig config) {
+        return config != null && config.getId() != null ? config.getId() : -1L;
     }
 
     /**
@@ -171,6 +222,24 @@ public class DolphinSchedulerService {
         }
     }
 
+    public long syncWorkflow(Long dolphinConfigId,
+            long workflowCode,
+            String workflowName,
+            String workflowDescription,
+            List<Map<String, Object>> tasks,
+            List<TaskRelationPayload> relations,
+            List<TaskLocationPayload> locations,
+            String globalParams) {
+        return withConfig(dolphinConfigId, () -> syncWorkflow(
+                workflowCode,
+                workflowName,
+                workflowDescription,
+                tasks,
+                relations,
+                locations,
+                globalParams));
+    }
+
     /**
      * Update workflow release state (ONLINE/OFFLINE).
      */
@@ -181,6 +250,10 @@ public class DolphinSchedulerService {
 
         openApiClient.releaseProcessDefinition(projectCode, workflowCode, releaseState);
         log.info("Updated Dolphin workflow {} release state to {}", workflowCode, releaseState);
+    }
+
+    public void setWorkflowReleaseState(Long dolphinConfigId, long workflowCode, String releaseState) {
+        withConfig(dolphinConfigId, () -> setWorkflowReleaseState(workflowCode, releaseState));
     }
 
     /**
@@ -212,6 +285,28 @@ public class DolphinSchedulerService {
                 environmentCode);
         log.info("Created Dolphin schedule for workflow {} -> {}", workflowCode, scheduleId);
         return scheduleId;
+    }
+
+    public Long createWorkflowSchedule(Long dolphinConfigId,
+            long workflowCode,
+            String scheduleJson,
+            String warningType,
+            String failureStrategy,
+            Long warningGroupId,
+            String processInstancePriority,
+            String workerGroup,
+            String tenantCode,
+            Long environmentCode) {
+        return withConfig(dolphinConfigId, () -> createWorkflowSchedule(
+                workflowCode,
+                scheduleJson,
+                warningType,
+                failureStrategy,
+                warningGroupId,
+                processInstancePriority,
+                workerGroup,
+                tenantCode,
+                environmentCode));
     }
 
     /**
@@ -246,6 +341,30 @@ public class DolphinSchedulerService {
         log.info("Updated Dolphin schedule {} for workflow {}", scheduleId, workflowCode);
     }
 
+    public void updateWorkflowSchedule(Long dolphinConfigId,
+            long scheduleId,
+            long workflowCode,
+            String scheduleJson,
+            String warningType,
+            String failureStrategy,
+            Long warningGroupId,
+            String processInstancePriority,
+            String workerGroup,
+            String tenantCode,
+            Long environmentCode) {
+        withConfig(dolphinConfigId, () -> updateWorkflowSchedule(
+                scheduleId,
+                workflowCode,
+                scheduleJson,
+                warningType,
+                failureStrategy,
+                warningGroupId,
+                processInstancePriority,
+                workerGroup,
+                tenantCode,
+                environmentCode));
+    }
+
     /**
      * Online a DolphinScheduler schedule.
      */
@@ -258,6 +377,10 @@ public class DolphinSchedulerService {
         log.info("Onlined Dolphin schedule {}", scheduleId);
     }
 
+    public void onlineWorkflowSchedule(Long dolphinConfigId, long scheduleId) {
+        withConfig(dolphinConfigId, () -> onlineWorkflowSchedule(scheduleId));
+    }
+
     /**
      * Offline a DolphinScheduler schedule.
      */
@@ -268,6 +391,10 @@ public class DolphinSchedulerService {
         }
         openApiClient.offlineSchedule(projectCode, scheduleId);
         log.info("Offlined Dolphin schedule {}", scheduleId);
+    }
+
+    public void offlineWorkflowSchedule(Long dolphinConfigId, long scheduleId) {
+        withConfig(dolphinConfigId, () -> offlineWorkflowSchedule(scheduleId));
     }
 
     /**
@@ -304,6 +431,10 @@ public class DolphinSchedulerService {
             log.debug("Failed to query workflow schedule {}: {}", workflowCode, e.getMessage());
             return null;
         }
+    }
+
+    public DolphinSchedule getWorkflowSchedule(Long dolphinConfigId, long workflowCode) {
+        return withConfig(dolphinConfigId, () -> getWorkflowSchedule(workflowCode));
     }
 
     private DolphinSchedule parseScheduleFromDefinitionNode(JsonNode definition) {
@@ -420,6 +551,10 @@ public class DolphinSchedulerService {
         }
     }
 
+    public boolean checkWorkflowExists(Long dolphinConfigId, long workflowCode) {
+        return withConfig(dolphinConfigId, () -> checkWorkflowExists(workflowCode));
+    }
+
     /**
      * Start workflow instance via DolphinScheduler OpenAPI.
      */
@@ -447,6 +582,14 @@ public class DolphinSchedulerService {
         String executionId = instanceId != null ? String.valueOf(instanceId) : "exec-" + System.currentTimeMillis();
         log.info("Started workflow instance for definition {} -> {}", workflowCode, executionId);
         return executionId;
+    }
+
+    public String startProcessInstance(Long dolphinConfigId,
+            Long workflowCode,
+            String projectName,
+            String workflowName) {
+        return withConfig(dolphinConfigId,
+                () -> startProcessInstance(workflowCode, projectName, workflowName));
     }
 
     /**
@@ -510,6 +653,12 @@ public class DolphinSchedulerService {
         return triggerId;
     }
 
+    public String backfillProcessInstance(Long dolphinConfigId,
+            Long workflowCode,
+            WorkflowBackfillRequest request) {
+        return withConfig(dolphinConfigId, () -> backfillProcessInstance(workflowCode, request));
+    }
+
     private String buildComplementScheduleTime(WorkflowBackfillRequest request) {
         Map<String, String> payload = new HashMap<>();
         String mode = StringUtils.hasText(request.getMode()) ? request.getMode() : "range";
@@ -555,6 +704,10 @@ public class DolphinSchedulerService {
         log.info("Deleted DolphinScheduler workflow {}", workflowCode);
     }
 
+    public void deleteWorkflow(Long dolphinConfigId, Long workflowCode) {
+        withConfig(dolphinConfigId, () -> deleteWorkflow(workflowCode));
+    }
+
     /**
      * Get workflow instance status via DolphinScheduler OpenAPI.
      */
@@ -581,6 +734,10 @@ public class DolphinSchedulerService {
             log.warn("Invalid instance ID format: {}", instanceId);
             return null;
         }
+    }
+
+    public JsonNode getWorkflowInstanceStatus(Long dolphinConfigId, Long workflowCode, String instanceId) {
+        return withConfig(dolphinConfigId, () -> getWorkflowInstanceStatus(workflowCode, instanceId));
     }
 
     /**
@@ -625,6 +782,10 @@ public class DolphinSchedulerService {
                     .build());
         }
         return result;
+    }
+
+    public List<WorkflowInstanceSummary> listWorkflowInstances(Long dolphinConfigId, Long workflowCode, int limit) {
+        return withConfig(dolphinConfigId, () -> listWorkflowInstances(workflowCode, limit));
     }
 
     private List<DolphinProcessInstance> collectWorkflowInstances(Long projectCode,
@@ -711,6 +872,10 @@ public class DolphinSchedulerService {
                 baseUrl, projectCode, workflowCode);
     }
 
+    public String getWorkflowDefinitionUrl(Long dolphinConfigId, Long workflowCode) {
+        return withConfig(dolphinConfigId, () -> getWorkflowDefinitionUrl(workflowCode));
+    }
+
     /**
      * Generate DolphinScheduler Web UI URL for task instances.
      */
@@ -736,6 +901,10 @@ public class DolphinSchedulerService {
         return builder.build(true).toUriString();
     }
 
+    public String getTaskDefinitionUrl(Long dolphinConfigId, Long taskCode) {
+        return withConfig(dolphinConfigId, () -> getTaskDefinitionUrl(taskCode));
+    }
+
     /**
      * Return the configured DolphinScheduler Web UI base URL without trailing
      * slashes.
@@ -746,6 +915,10 @@ public class DolphinSchedulerService {
             return null;
         }
         return url.replaceAll("/+$", "");
+    }
+
+    public String getWebuiBaseUrl(Long dolphinConfigId) {
+        return this.<String>withConfig(dolphinConfigId, this::getWebuiBaseUrl);
     }
 
     public String getDefaultTenantCode() {
@@ -999,6 +1172,10 @@ public class DolphinSchedulerService {
         }
     }
 
+    public List<DolphinDatasourceOption> listDatasources(String type, String keyword, Long dolphinConfigId) {
+        return withConfig(dolphinConfigId, () -> listDatasources(type, keyword));
+    }
+
     /**
      * Retrieve task group options from DolphinScheduler OpenAPI.
      */
@@ -1049,6 +1226,10 @@ public class DolphinSchedulerService {
         }
     }
 
+    public List<DolphinTaskGroupOption> listTaskGroups(String keyword, Long dolphinConfigId) {
+        return withConfig(dolphinConfigId, () -> listTaskGroups(keyword));
+    }
+
     /**
      * Retrieve worker group list from DolphinScheduler (project scoped).
      */
@@ -1065,6 +1246,10 @@ public class DolphinSchedulerService {
         }
     }
 
+    public List<String> listWorkerGroups(Long dolphinConfigId) {
+        return this.<List<String>>withConfig(dolphinConfigId, this::listWorkerGroups);
+    }
+
     /**
      * Retrieve tenant code list from DolphinScheduler.
      */
@@ -1075,6 +1260,10 @@ public class DolphinSchedulerService {
             log.warn("Failed to load tenants from DolphinScheduler: {}", ex.getMessage());
             return Collections.emptyList();
         }
+    }
+
+    public List<String> listTenants(Long dolphinConfigId) {
+        return this.<List<String>>withConfig(dolphinConfigId, this::listTenants);
     }
 
     /**
@@ -1089,6 +1278,10 @@ public class DolphinSchedulerService {
         }
     }
 
+    public List<DolphinAlertGroupOption> listAlertGroups(Long dolphinConfigId) {
+        return this.<List<DolphinAlertGroupOption>>withConfig(dolphinConfigId, this::listAlertGroups);
+    }
+
     /**
      * Retrieve environment list from DolphinScheduler.
      */
@@ -1099,6 +1292,10 @@ public class DolphinSchedulerService {
             log.warn("Failed to load environments from DolphinScheduler: {}", ex.getMessage());
             return Collections.emptyList();
         }
+    }
+
+    public List<DolphinEnvironmentOption> listEnvironments(Long dolphinConfigId) {
+        return this.<List<DolphinEnvironmentOption>>withConfig(dolphinConfigId, this::listEnvironments);
     }
 
     /**
@@ -1115,6 +1312,10 @@ public class DolphinSchedulerService {
             log.warn("Failed to preview schedule from DolphinScheduler: {}", ex.getMessage());
             return Collections.emptyList();
         }
+    }
+
+    public List<String> previewSchedule(String scheduleJson, Long dolphinConfigId) {
+        return withConfig(dolphinConfigId, () -> previewSchedule(scheduleJson));
     }
 
     private Long parseDuration(String value) {

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowDeployService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowDeployService.java
@@ -49,7 +49,10 @@ public class WorkflowDeployService {
     @Transactional
     public DeploymentResult deploy(DataWorkflow workflow) {
         // Ensure project exists (force refresh/create)
-        Long actualProjectCode = dolphinSchedulerService.getProjectCode(true);
+        Long dolphinConfigId = workflow.getDolphinConfigId();
+        Long actualProjectCode = dolphinConfigId == null
+                ? dolphinSchedulerService.getProjectCode(true)
+                : dolphinSchedulerService.getProjectCode(dolphinConfigId, true);
 
         List<WorkflowTaskRelation> bindings = workflowTaskRelationMapper.selectList(
                 Wrappers.<WorkflowTaskRelation>lambdaQuery()
@@ -215,25 +218,41 @@ public class WorkflowDeployService {
         boolean existingWorkflow = workflowCode > 0;
         if (existingWorkflow) {
             // Check if the workflow definition actually exists in DolphinScheduler
-            boolean workflowExists = dolphinSchedulerService.checkWorkflowExists(workflowCode);
+            boolean workflowExists = dolphinConfigId == null
+                    ? dolphinSchedulerService.checkWorkflowExists(workflowCode)
+                    : dolphinSchedulerService.checkWorkflowExists(dolphinConfigId, workflowCode);
             if (!workflowExists) {
                 log.warn("Workflow {} no longer exists in DolphinScheduler, creating new definition", workflowCode);
                 existingWorkflow = false;
                 workflowCode = 0L; // Reset to 0 to force creation
             } else {
                 log.info("Workflow {} already exists, switch OFFLINE before redeploy", workflowCode);
-                dolphinSchedulerService.setWorkflowReleaseState(workflowCode, "OFFLINE");
+                if (dolphinConfigId == null) {
+                    dolphinSchedulerService.setWorkflowReleaseState(workflowCode, "OFFLINE");
+                } else {
+                    dolphinSchedulerService.setWorkflowReleaseState(dolphinConfigId, workflowCode, "OFFLINE");
+                }
             }
         }
 
-        long deployedCode = dolphinSchedulerService.syncWorkflow(
-                workflowCode,
-                workflow.getWorkflowName(),
-                workflow.getDescription(),
-                definitions,
-                relationPayloads,
-                locationPayloads,
-                workflow.getGlobalParams());
+        long deployedCode = dolphinConfigId == null
+                ? dolphinSchedulerService.syncWorkflow(
+                        workflowCode,
+                        workflow.getWorkflowName(),
+                        workflow.getDescription(),
+                        definitions,
+                        relationPayloads,
+                        locationPayloads,
+                        workflow.getGlobalParams())
+                : dolphinSchedulerService.syncWorkflow(
+                        dolphinConfigId,
+                        workflowCode,
+                        workflow.getWorkflowName(),
+                        workflow.getDescription(),
+                        definitions,
+                        relationPayloads,
+                        locationPayloads,
+                        workflow.getGlobalParams());
 
         updateTaskProcessCode(orderedTasks, deployedCode);
 

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
@@ -119,9 +119,7 @@ public class WorkflowPublishService {
                 : "system";
         RuntimeWorkflowDefinition runtimeDefinition = null;
         if (workflow.getWorkflowCode() != null && workflow.getWorkflowCode() > 0) {
-            runtimeDefinition = runtimeDefinitionService.loadRuntimeDefinitionFromExport(
-                    workflow.getProjectCode(),
-                    workflow.getWorkflowCode());
+            runtimeDefinition = loadRuntimeDefinitionFromExport(workflow);
         }
 
         WorkflowPublishRepairResponse response = new WorkflowPublishRepairResponse();
@@ -165,6 +163,7 @@ public class WorkflowPublishService {
         record.setVersionId(version.getId());
         record.setOperation(operation);
         record.setTargetEngine("dolphin");
+        record.setDolphinConfigId(workflow.getDolphinConfigId());
         record.setStatus("pending");
         record.setOperator(request.getOperator());
         publishRecordMapper.insert(record);
@@ -226,9 +225,7 @@ public class WorkflowPublishService {
             response.getWarnings().add(warning);
         } else {
             try {
-                runtimeDefinition = runtimeDefinitionService.loadRuntimeDefinitionFromExport(
-                        workflow.getProjectCode(),
-                        workflow.getWorkflowCode());
+                runtimeDefinition = loadRuntimeDefinitionFromExport(workflow);
             } catch (Exception ex) {
                 if (isRuntimeWorkflowMissing(ex.getMessage())) {
                     RuntimeSyncIssue warning = RuntimeSyncIssue.warning(
@@ -338,7 +335,9 @@ public class WorkflowPublishService {
             runtimeTask.setSql(task.getTaskSql());
             runtimeTask.setDatasourceName(task.getDatasourceName());
             runtimeTask.setDatasourceType(task.getDatasourceType());
-            runtimeTask.setFlag(normalizeDolphinFlag(task.getDolphinFlag()));
+            if (StringUtils.hasText(task.getDolphinFlag())) {
+                runtimeTask.setFlag(normalizeDolphinFlag(task.getDolphinFlag()));
+            }
             DefinitionTaskMetadata metadata = runtimeTask.getTaskCode() != null
                     ? definitionTaskMetadataByCode.get(runtimeTask.getTaskCode())
                     : null;
@@ -365,6 +364,18 @@ public class WorkflowPublishService {
         }
         definition.setTasks(tasks);
         return definition;
+    }
+
+    private RuntimeWorkflowDefinition loadRuntimeDefinitionFromExport(DataWorkflow workflow) {
+        if (workflow.getDolphinConfigId() == null) {
+            return runtimeDefinitionService.loadRuntimeDefinitionFromExport(
+                    workflow.getProjectCode(),
+                    workflow.getWorkflowCode());
+        }
+        return runtimeDefinitionService.loadRuntimeDefinitionFromExport(
+                workflow.getDolphinConfigId(),
+                workflow.getProjectCode(),
+                workflow.getWorkflowCode());
     }
 
     private RuntimeWorkflowSchedule buildPlatformSchedule(DataWorkflow workflow) {
@@ -1041,7 +1052,9 @@ public class WorkflowPublishService {
         Map<String, DolphinDatasourceOption> datasourceByName;
         Map<Long, DolphinDatasourceOption> datasourceById;
         try {
-            List<DolphinDatasourceOption> datasourceOptions = dolphinSchedulerService.listDatasources(null, null);
+            List<DolphinDatasourceOption> datasourceOptions = workflow.getDolphinConfigId() == null
+                    ? dolphinSchedulerService.listDatasources(null, null)
+                    : dolphinSchedulerService.listDatasources(null, null, workflow.getDolphinConfigId());
             datasourceByName = new LinkedHashMap<>();
             datasourceById = new LinkedHashMap<>();
             if (!CollectionUtils.isEmpty(datasourceOptions)) {
@@ -1065,7 +1078,10 @@ public class WorkflowPublishService {
 
         Map<String, DolphinTaskGroupOption> taskGroupByName;
         try {
-            taskGroupByName = dolphinSchedulerService.listTaskGroups(null)
+            List<DolphinTaskGroupOption> taskGroupOptions = workflow.getDolphinConfigId() == null
+                    ? dolphinSchedulerService.listTaskGroups(null)
+                    : dolphinSchedulerService.listTaskGroups(null, workflow.getDolphinConfigId());
+            taskGroupByName = taskGroupOptions
                     .stream()
                     .filter(Objects::nonNull)
                     .filter(item -> StringUtils.hasText(item.getName()) && item.getId() != null && item.getId() > 0)
@@ -1417,10 +1433,10 @@ public class WorkflowPublishService {
         }
         try {
             if ("online".equals(record.getOperation())) {
-                dolphinSchedulerService.setWorkflowReleaseState(workflow.getWorkflowCode(), "ONLINE");
+                setWorkflowReleaseState(workflow, "ONLINE");
                 tryAutoOnlineSchedule(workflow);
             } else if ("offline".equals(record.getOperation())) {
-                dolphinSchedulerService.setWorkflowReleaseState(workflow.getWorkflowCode(), "OFFLINE");
+                setWorkflowReleaseState(workflow, "OFFLINE");
                 tryAutoOfflineSchedule(workflow);
             } else {
                 log.debug("No Dolphin action for operation {}", record.getOperation());
@@ -1430,11 +1446,43 @@ public class WorkflowPublishService {
         }
     }
 
+    private void setWorkflowReleaseState(DataWorkflow workflow, String releaseState) {
+        if (workflow.getDolphinConfigId() == null) {
+            dolphinSchedulerService.setWorkflowReleaseState(workflow.getWorkflowCode(), releaseState);
+        } else {
+            dolphinSchedulerService.setWorkflowReleaseState(
+                    workflow.getDolphinConfigId(), workflow.getWorkflowCode(), releaseState);
+        }
+    }
+
+    private DolphinSchedule getWorkflowSchedule(DataWorkflow workflow) {
+        if (workflow.getDolphinConfigId() == null) {
+            return dolphinSchedulerService.getWorkflowSchedule(workflow.getWorkflowCode());
+        }
+        return dolphinSchedulerService.getWorkflowSchedule(workflow.getDolphinConfigId(), workflow.getWorkflowCode());
+    }
+
+    private void onlineWorkflowSchedule(DataWorkflow workflow, Long scheduleId) {
+        if (workflow.getDolphinConfigId() == null) {
+            dolphinSchedulerService.onlineWorkflowSchedule(scheduleId);
+        } else {
+            dolphinSchedulerService.onlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
+        }
+    }
+
+    private void offlineWorkflowSchedule(DataWorkflow workflow, Long scheduleId) {
+        if (workflow.getDolphinConfigId() == null) {
+            dolphinSchedulerService.offlineWorkflowSchedule(scheduleId);
+        } else {
+            dolphinSchedulerService.offlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
+        }
+    }
+
     private void tryAutoOnlineSchedule(DataWorkflow workflow) {
         if (!Boolean.TRUE.equals(workflow.getScheduleAutoOnline())) {
             return;
         }
-        DolphinSchedule schedule = dolphinSchedulerService.getWorkflowSchedule(workflow.getWorkflowCode());
+        DolphinSchedule schedule = getWorkflowSchedule(workflow);
         if (schedule != null && schedule.getId() != null && schedule.getId() > 0) {
             workflow.setDolphinScheduleId(schedule.getId());
             if (StringUtils.hasText(schedule.getReleaseState())) {
@@ -1458,7 +1506,7 @@ public class WorkflowPublishService {
         }
 
         try {
-            dolphinSchedulerService.onlineWorkflowSchedule(scheduleId);
+            onlineWorkflowSchedule(workflow, scheduleId);
             workflow.setScheduleState("ONLINE");
         } catch (Exception ex) {
             log.warn("Failed to online schedule {} for workflow {}: {}",
@@ -1467,7 +1515,7 @@ public class WorkflowPublishService {
     }
 
     private void tryAutoOfflineSchedule(DataWorkflow workflow) {
-        DolphinSchedule schedule = dolphinSchedulerService.getWorkflowSchedule(workflow.getWorkflowCode());
+        DolphinSchedule schedule = getWorkflowSchedule(workflow);
         if (schedule != null && schedule.getId() != null && schedule.getId() > 0) {
             workflow.setDolphinScheduleId(schedule.getId());
             if (StringUtils.hasText(schedule.getReleaseState())) {
@@ -1481,7 +1529,7 @@ public class WorkflowPublishService {
             return;
         }
         try {
-            dolphinSchedulerService.offlineWorkflowSchedule(scheduleId);
+            offlineWorkflowSchedule(workflow, scheduleId);
         } catch (Exception ex) {
             log.warn("Failed to offline schedule {} for workflow {}: {}",
                     scheduleId, workflow.getWorkflowCode(), ex.getMessage());
@@ -1524,6 +1572,7 @@ public class WorkflowPublishService {
         if (result.getProjectCode() != null) {
             workflow.setProjectCode(result.getProjectCode());
         }
+        record.setDolphinConfigId(workflow.getDolphinConfigId());
         applyWorkflowStatus(workflow, record);
         record.setStatus("success");
         record.setEngineWorkflowCode(result.getWorkflowCode());

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowRuntimeSyncService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowRuntimeSyncService.java
@@ -265,7 +265,8 @@ public class WorkflowRuntimeSyncService {
         response.setProjectCode(workflow.getProjectCode());
         response.setWorkflowCode(workflow.getWorkflowCode());
 
-        PreviewContext context = buildPreviewContext(workflow.getProjectCode(), workflow.getWorkflowCode(), false);
+        PreviewContext context = buildPreviewContext(
+                workflow.getDolphinConfigId(), workflow.getProjectCode(), workflow.getWorkflowCode(), false);
         response.setWarnings(context.getWarnings());
         response.setErrors(context.getErrors());
         response.setDiffSummary(context.getDiffSummary());
@@ -319,6 +320,13 @@ public class WorkflowRuntimeSyncService {
     }
 
     private PreviewContext buildPreviewContext(Long projectCode, Long workflowCode, boolean strictDefinitionError) {
+        return buildPreviewContext(null, projectCode, workflowCode, strictDefinitionError);
+    }
+
+    private PreviewContext buildPreviewContext(Long dolphinConfigId,
+            Long projectCode,
+            Long workflowCode,
+            boolean strictDefinitionError) {
         PreviewContext context = new PreviewContext();
         context.setProjectCode(projectCode);
         context.setWorkflowCode(workflowCode);
@@ -332,7 +340,9 @@ public class WorkflowRuntimeSyncService {
 
         RuntimeWorkflowDefinition definition;
         try {
-            definition = runtimeDefinitionService.loadRuntimeDefinitionFromExport(projectCode, workflowCode);
+            definition = dolphinConfigId == null
+                    ? runtimeDefinitionService.loadRuntimeDefinitionFromExport(projectCode, workflowCode)
+                    : runtimeDefinitionService.loadRuntimeDefinitionFromExport(dolphinConfigId, projectCode, workflowCode);
         } catch (Exception ex) {
             context.getErrors().add(RuntimeSyncIssue.error(
                     resolveDefinitionErrorCode(ex.getMessage(), strictDefinitionError),
@@ -362,7 +372,9 @@ public class WorkflowRuntimeSyncService {
             return context;
         }
 
-        Map<Long, DolphinDatasourceOption> datasourceById = dolphinSchedulerService.listDatasources(null, null)
+        Map<Long, DolphinDatasourceOption> datasourceById = (dolphinConfigId == null
+                ? dolphinSchedulerService.listDatasources(null, null)
+                : dolphinSchedulerService.listDatasources(null, null, dolphinConfigId))
                 .stream()
                 .filter(option -> option != null && option.getId() != null)
                 .collect(Collectors.toMap(DolphinDatasourceOption::getId, option -> option, (left, right) -> left));

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowScheduleService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowScheduleService.java
@@ -128,6 +128,7 @@ public class WorkflowScheduleService {
         boolean newSchedule = scheduleId == null || scheduleId <= 0;
         if (newSchedule) {
             scheduleId = dolphinSchedulerService.createWorkflowSchedule(
+                    workflow.getDolphinConfigId(),
                     workflow.getWorkflowCode(),
                     scheduleJson,
                     warningType,
@@ -146,6 +147,7 @@ public class WorkflowScheduleService {
             }
         } else {
             dolphinSchedulerService.updateWorkflowSchedule(
+                    workflow.getDolphinConfigId(),
                     scheduleId,
                     workflow.getWorkflowCode(),
                     scheduleJson,
@@ -176,10 +178,10 @@ public class WorkflowScheduleService {
         // Apply enable/disable if provided
         if (request.getEnabled() != null) {
             if (Boolean.TRUE.equals(request.getEnabled())) {
-                dolphinSchedulerService.onlineWorkflowSchedule(scheduleId);
+                dolphinSchedulerService.onlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
                 workflow.setScheduleState("ONLINE");
             } else {
-                dolphinSchedulerService.offlineWorkflowSchedule(scheduleId);
+                dolphinSchedulerService.offlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
                 workflow.setScheduleState("OFFLINE");
             }
         }
@@ -198,7 +200,7 @@ public class WorkflowScheduleService {
         if (!"online".equalsIgnoreCase(workflow.getStatus())) {
             throw new IllegalStateException("工作流未上线，无法启用定时调度");
         }
-        dolphinSchedulerService.onlineWorkflowSchedule(scheduleId);
+        dolphinSchedulerService.onlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
         workflow.setScheduleState("ONLINE");
         dataWorkflowMapper.updateById(workflow);
         return workflow;
@@ -211,7 +213,7 @@ public class WorkflowScheduleService {
         if (scheduleId == null || scheduleId <= 0) {
             throw new IllegalStateException("尚未创建调度配置");
         }
-        dolphinSchedulerService.offlineWorkflowSchedule(scheduleId);
+        dolphinSchedulerService.offlineWorkflowSchedule(workflow.getDolphinConfigId(), scheduleId);
         workflow.setScheduleState("OFFLINE");
         dataWorkflowMapper.updateById(workflow);
         return workflow;

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
@@ -15,11 +15,13 @@ import com.onedata.portal.dto.workflow.WorkflowDetailResponse;
 import com.onedata.portal.dto.workflow.WorkflowInstanceSummary;
 import com.onedata.portal.dto.workflow.WorkflowBackfillRequest;
 import com.onedata.portal.dto.workflow.WorkflowQueryRequest;
+import com.onedata.portal.dto.workflow.WorkflowSchedulerEngineRequest;
 import com.onedata.portal.dto.workflow.WorkflowTaskBinding;
 import com.onedata.portal.dto.workflow.WorkflowTopologyResult;
 import com.onedata.portal.entity.DataLineage;
 import com.onedata.portal.entity.DataTask;
 import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.DolphinConfig;
 import com.onedata.portal.entity.TableTaskRelation;
 import com.onedata.portal.entity.TaskExecutionLog;
 import com.onedata.portal.entity.WorkflowInstanceCache;
@@ -101,6 +103,7 @@ public class WorkflowService {
     private final TableTaskRelationMapper tableTaskRelationMapper;
     private final TaskExecutionLogMapper taskExecutionLogMapper;
     private final WorkflowTopologyService workflowTopologyService;
+    private final DolphinConfigService dolphinConfigService;
 
     public Page<DataWorkflow> list(WorkflowQueryRequest request) {
         LambdaQueryWrapper<DataWorkflow> wrapper = Wrappers.lambdaQuery();
@@ -179,7 +182,7 @@ public class WorkflowService {
         }
         try {
             List<WorkflowInstanceSummary> realtimeSummaries = dolphinSchedulerService
-                    .listWorkflowInstances(workflow.getWorkflowCode(), limit);
+                    .listWorkflowInstances(workflow.getDolphinConfigId(), workflow.getWorkflowCode(), limit);
             workflowInstanceCacheService.replaceCache(workflow, realtimeSummaries);
             return mapSummariesToCaches(workflow.getId(), realtimeSummaries);
         } catch (Exception ex) {
@@ -221,6 +224,7 @@ public class WorkflowService {
         workflow.setTaskGroupName(request.getTaskGroupName());
         workflow.setStatus("draft");
         workflow.setPublishStatus("never");
+        workflow.setDolphinConfigId(resolveDolphinConfigId(request.getDolphinConfigId()));
         workflow.setProjectCode(resolveProjectCode(request.getProjectCode()));
         workflow.setCreatedBy(request.getOperator());
         workflow.setUpdatedBy(request.getOperator());
@@ -260,6 +264,7 @@ public class WorkflowService {
         TaskExecutionLog executionLog = createWorkflowExecutionLog(workflowId, "manual");
         try {
             String executionId = dolphinSchedulerService.startProcessInstance(
+                    workflow.getDolphinConfigId(),
                     workflowCode,
                     null,
                     workflow.getWorkflowName());
@@ -293,7 +298,8 @@ public class WorkflowService {
         }
         TaskExecutionLog executionLog = createWorkflowExecutionLog(workflowId, "manual");
         try {
-            String triggerId = dolphinSchedulerService.backfillProcessInstance(workflowCode, request);
+            String triggerId = dolphinSchedulerService.backfillProcessInstance(
+                    workflow.getDolphinConfigId(), workflowCode, request);
             if (executionLog != null) {
                 executionLog.setExecutionId(triggerId);
                 executionLog.setStatus("running");
@@ -362,6 +368,9 @@ public class WorkflowService {
         workflow.setTaskGroupName(request.getTaskGroupName());
         workflow.setUpdatedBy(request.getOperator());
         workflow.setUpdatedAt(LocalDateTime.now());
+        if (workflow.getDolphinConfigId() == null) {
+            workflow.setDolphinConfigId(resolveDolphinConfigId(request.getDolphinConfigId()));
+        }
         if (workflow.getProjectCode() == null || workflow.getProjectCode() == 0) {
             workflow.setProjectCode(resolveProjectCode(request.getProjectCode()));
         }
@@ -399,6 +408,7 @@ public class WorkflowService {
         request.setDescription(workflow.getDescription());
         request.setTaskGroupName(workflow.getTaskGroupName());
         request.setGlobalParams(workflow.getGlobalParams());
+        request.setDolphinConfigId(workflow.getDolphinConfigId());
         request.setProjectCode(workflow.getProjectCode());
         request.setTasks(buildTaskBindingsFromRelations(relations));
         request.setOperator(resolveWorkflowOperator(workflow, operator));
@@ -431,6 +441,47 @@ public class WorkflowService {
             workflow.setUpdatedBy(operator.trim());
         }
         workflow.setUpdatedAt(LocalDateTime.now());
+        dataWorkflowMapper.updateById(workflow);
+        return workflow;
+    }
+
+    @Transactional
+    public DataWorkflow switchSchedulerEngine(Long workflowId, WorkflowSchedulerEngineRequest request) {
+        if (workflowId == null) {
+            throw new IllegalArgumentException("workflowId 不能为空");
+        }
+        if (request == null || request.getDolphinConfigId() == null || request.getDolphinConfigId() <= 0) {
+            throw new IllegalArgumentException("dolphinConfigId 不能为空");
+        }
+        DataWorkflow workflow = dataWorkflowMapper.selectById(workflowId);
+        if (workflow == null) {
+            throw new IllegalArgumentException("Workflow not found: " + workflowId);
+        }
+        Long targetConfigId = request.getDolphinConfigId();
+        DolphinConfig targetConfig = dolphinConfigService.getEnabledConfig(targetConfigId);
+        if (!dolphinSchedulerService.testConnection(targetConfigId)) {
+            throw new IllegalStateException("目标 Dolphin 环境连接失败: " + targetConfig.getConfigName());
+        }
+        Long targetProjectCode = dolphinSchedulerService.getProjectCode(targetConfigId, true);
+        if (targetProjectCode == null || targetProjectCode <= 0) {
+            throw new IllegalStateException("目标 Dolphin 项目不可用: " + targetConfig.getProjectName());
+        }
+
+        workflow.setDolphinConfigId(targetConfigId);
+        workflow.setWorkflowCode(null);
+        workflow.setProjectCode(targetProjectCode);
+        workflow.setDolphinScheduleId(null);
+        workflow.setScheduleState("OFFLINE");
+        workflow.setStatus("offline");
+        workflow.setPublishStatus("never");
+        workflow.setLastPublishedVersionId(null);
+        workflow.setRuntimeSyncStatus(null);
+        workflow.setRuntimeSyncMessage(null);
+        workflow.setRuntimeSyncHash(null);
+        workflow.setRuntimeSyncAt(null);
+        workflow.setUpdatedBy(StringUtils.hasText(request.getOperator()) ? request.getOperator().trim() : "system");
+        workflow.setUpdatedAt(LocalDateTime.now());
+        workflow.setDefinitionJson(refreshDefinitionRuntimeIds(workflow.getDefinitionJson(), targetConfigId));
         dataWorkflowMapper.updateById(workflow);
         return workflow;
     }
@@ -563,7 +614,8 @@ public class WorkflowService {
         Map<String, Object> definition = buildPlatformDefinitionDocument(workflow, taskBindings, topology);
         return mergeAndNormalizeDefinitionJson(definition,
                 workflow != null ? workflow.getDefinitionJson() : null,
-                incomingDefinitionJson);
+                incomingDefinitionJson,
+                workflow != null ? workflow.getDolphinConfigId() : null);
     }
 
     private boolean isMeaningfulDefinitionJson(String definitionJson) {
@@ -613,7 +665,8 @@ public class WorkflowService {
 
     private String mergeAndNormalizeDefinitionJson(Map<String, Object> generatedDefinition,
             String persistedDefinitionJson,
-            String incomingDefinitionJson) {
+            String incomingDefinitionJson,
+            Long dolphinConfigId) {
         try {
             ObjectNode generatedNode = objectMapper.valueToTree(generatedDefinition);
             if (generatedNode == null || generatedNode.isNull() || generatedNode.isMissingNode()) {
@@ -621,7 +674,7 @@ public class WorkflowService {
             }
             applyDefinitionMetadataSeed(generatedNode, persistedDefinitionJson);
             applyDefinitionMetadataSeed(generatedNode, incomingDefinitionJson);
-            enrichDefinitionMetadataFromCatalog(generatedNode);
+            enrichDefinitionMetadataFromCatalog(generatedNode, dolphinConfigId);
             return objectMapper.writeValueAsString(generatedNode);
         } catch (Exception ex) {
             return toJson(generatedDefinition);
@@ -629,6 +682,10 @@ public class WorkflowService {
     }
 
     private void enrichDefinitionMetadataFromCatalog(ObjectNode rootNode) {
+        enrichDefinitionMetadataFromCatalog(rootNode, null);
+    }
+
+    private void enrichDefinitionMetadataFromCatalog(ObjectNode rootNode, Long dolphinConfigId) {
         if (rootNode == null || rootNode.isNull() || rootNode.isMissingNode()) {
             return;
         }
@@ -671,10 +728,10 @@ public class WorkflowService {
         }
 
         DatasourceCatalog datasourceCatalog = needDatasourceResolve
-                ? loadDatasourceCatalog()
+                ? loadDatasourceCatalog(dolphinConfigId)
                 : DatasourceCatalog.empty();
         Map<String, DolphinTaskGroupOption> taskGroupByName = needTaskGroupResolve
-                ? loadTaskGroupCatalogByName()
+                ? loadTaskGroupCatalogByName(dolphinConfigId)
                 : Collections.emptyMap();
 
         for (JsonNode taskNode : (ArrayNode) taskListNode) {
@@ -713,8 +770,14 @@ public class WorkflowService {
     }
 
     private DatasourceCatalog loadDatasourceCatalog() {
+        return loadDatasourceCatalog(null);
+    }
+
+    private DatasourceCatalog loadDatasourceCatalog(Long dolphinConfigId) {
         try {
-            List<DolphinDatasourceOption> options = dolphinSchedulerService.listDatasources(null, null);
+            List<DolphinDatasourceOption> options = dolphinConfigId == null
+                    ? dolphinSchedulerService.listDatasources(null, null)
+                    : dolphinSchedulerService.listDatasources(null, null, dolphinConfigId);
             if (CollectionUtils.isEmpty(options)) {
                 return DatasourceCatalog.empty();
             }
@@ -763,8 +826,14 @@ public class WorkflowService {
     }
 
     private Map<String, DolphinTaskGroupOption> loadTaskGroupCatalogByName() {
+        return loadTaskGroupCatalogByName(null);
+    }
+
+    private Map<String, DolphinTaskGroupOption> loadTaskGroupCatalogByName(Long dolphinConfigId) {
         try {
-            List<DolphinTaskGroupOption> options = dolphinSchedulerService.listTaskGroups(null);
+            List<DolphinTaskGroupOption> options = dolphinConfigId == null
+                    ? dolphinSchedulerService.listTaskGroups(null)
+                    : dolphinSchedulerService.listTaskGroups(null, dolphinConfigId);
             if (CollectionUtils.isEmpty(options)) {
                 return Collections.emptyMap();
             }
@@ -1796,6 +1865,32 @@ public class WorkflowService {
         return null;
     }
 
+    private Long resolveDolphinConfigId(Long requestDolphinConfigId) {
+        if (requestDolphinConfigId != null && requestDolphinConfigId > 0) {
+            return dolphinConfigService.getEnabledConfig(requestDolphinConfigId).getId();
+        }
+        DolphinConfig config = dolphinConfigService.getDefaultConfig();
+        return config != null ? config.getId() : null;
+    }
+
+    private String refreshDefinitionRuntimeIds(String definitionJson, Long dolphinConfigId) {
+        if (!StringUtils.hasText(definitionJson)) {
+            return definitionJson;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(definitionJson);
+            if (!(root instanceof ObjectNode)) {
+                return definitionJson;
+            }
+            enrichDefinitionMetadataFromCatalog((ObjectNode) root, dolphinConfigId);
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception ex) {
+            log.warn("Failed to refresh workflow definition metadata for Dolphin config {}: {}",
+                    dolphinConfigId, ex.getMessage());
+            return definitionJson;
+        }
+    }
+
     private void attachLatestInstanceInfo(List<DataWorkflow> workflows) {
         if (CollectionUtils.isEmpty(workflows)) {
             return;
@@ -1809,7 +1904,7 @@ public class WorkflowService {
             if (workflow.getWorkflowCode() != null && workflow.getWorkflowCode() > 0) {
                 try {
                     List<WorkflowInstanceSummary> summaries = dolphinSchedulerService
-                            .listWorkflowInstances(workflow.getWorkflowCode(), 1);
+                            .listWorkflowInstances(workflow.getDolphinConfigId(), workflow.getWorkflowCode(), 1);
                     realtimeLoaded = true;
                     if (!summaries.isEmpty()) {
                         latest = mapSummaryToCache(workflow.getId(), summaries.get(0));

--- a/backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java
+++ b/backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Direct client for DolphinScheduler OpenAPI.
@@ -45,6 +46,7 @@ public class DolphinOpenApiClient {
     // Cache the WebClient instance to avoid recreating it for every request
     // Key: url + token
     private final Map<String, WebClient> webClientCache = new ConcurrentHashMap<>();
+    private final ThreadLocal<DolphinConfig> scopedConfig = new ThreadLocal<>();
 
     public DolphinOpenApiClient(DolphinConfigService dolphinConfigService,
             ObjectMapper objectMapper,
@@ -55,11 +57,37 @@ public class DolphinOpenApiClient {
     }
 
     private WebClient getWebClient() {
-        DolphinConfig config = dolphinConfigService.getActiveConfig();
+        DolphinConfig config = resolveConfig();
         if (config == null || !StringUtils.hasText(config.getUrl())) {
             throw new IllegalStateException("DolphinScheduler configuration is missing or URL is empty");
         }
         return getWebClient(config);
+    }
+
+    public <T> T withConfig(DolphinConfig config, Supplier<T> supplier) {
+        DolphinConfig previous = scopedConfig.get();
+        scopedConfig.set(config);
+        try {
+            return supplier.get();
+        } finally {
+            if (previous == null) {
+                scopedConfig.remove();
+            } else {
+                scopedConfig.set(previous);
+            }
+        }
+    }
+
+    public void withConfig(DolphinConfig config, Runnable runnable) {
+        withConfig(config, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    private DolphinConfig resolveConfig() {
+        DolphinConfig config = scopedConfig.get();
+        return config != null ? config : dolphinConfigService.getActiveConfig();
     }
 
     private WebClient getWebClient(DolphinConfig config) {
@@ -796,7 +824,7 @@ public class DolphinOpenApiClient {
             formData.add("failureStrategy", StringUtils.hasText(failureStrategy) ? failureStrategy : "CONTINUE");
             formData.add("warningGroupId", String.valueOf(warningGroupId != null ? warningGroupId : 0L));
 
-            DolphinConfig config = dolphinConfigService.getActiveConfig();
+            DolphinConfig config = resolveConfig();
             String resolvedTenantCode = StringUtils.hasText(tenantCode) ? tenantCode.trim()
                     : (config != null && StringUtils.hasText(config.getTenantCode()) ? config.getTenantCode()
                             : "default");
@@ -866,7 +894,7 @@ public class DolphinOpenApiClient {
             formData.add("failureStrategy", StringUtils.hasText(failureStrategy) ? failureStrategy : "CONTINUE");
             formData.add("warningGroupId", String.valueOf(warningGroupId != null ? warningGroupId : 0L));
 
-            DolphinConfig config = dolphinConfigService.getActiveConfig();
+            DolphinConfig config = resolveConfig();
             String resolvedTenantCode = StringUtils.hasText(tenantCode) ? tenantCode.trim()
                     : (config != null && StringUtils.hasText(config.getTenantCode()) ? config.getTenantCode()
                             : "default");

--- a/backend/src/main/resources/db/migration/V43__add_multi_dolphin_config.sql
+++ b/backend/src/main/resources/db/migration/V43__add_multi_dolphin_config.sql
@@ -1,0 +1,47 @@
+ALTER TABLE `dolphin_config`
+    ADD COLUMN `config_name` VARCHAR(100) DEFAULT NULL COMMENT 'Dolphin 环境名称' AFTER `id`,
+    ADD COLUMN `description` TEXT DEFAULT NULL COMMENT '环境说明' AFTER `execution_type`,
+    ADD COLUMN `is_default` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否默认环境' AFTER `is_active`,
+    ADD COLUMN `deleted` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '逻辑删除标记' AFTER `updated_at`;
+
+UPDATE `dolphin_config`
+SET `config_name` = COALESCE(NULLIF(`config_name`, ''), CONCAT('Dolphin-', `id`)),
+    `deleted` = 0
+WHERE `config_name` IS NULL OR `config_name` = '' OR `deleted` IS NULL;
+
+SET @default_dolphin_config_id := (
+    SELECT `id`
+    FROM (
+        SELECT `id`
+        FROM `dolphin_config`
+        WHERE `deleted` = 0 AND `is_active` = 1
+        ORDER BY `id` DESC
+        LIMIT 1
+    ) active_config
+);
+
+UPDATE `dolphin_config`
+SET `is_default` = CASE WHEN `id` = @default_dolphin_config_id THEN 1 ELSE 0 END
+WHERE `deleted` = 0;
+
+ALTER TABLE `data_workflow`
+    ADD COLUMN `dolphin_config_id` BIGINT DEFAULT NULL COMMENT '绑定的 Dolphin 环境ID' AFTER `id`;
+
+ALTER TABLE `workflow_publish_record`
+    ADD COLUMN `dolphin_config_id` BIGINT DEFAULT NULL COMMENT '发布目标 Dolphin 环境ID' AFTER `target_engine`;
+
+UPDATE `data_workflow`
+SET `dolphin_config_id` = @default_dolphin_config_id
+WHERE `dolphin_config_id` IS NULL AND @default_dolphin_config_id IS NOT NULL;
+
+UPDATE `workflow_publish_record`
+SET `dolphin_config_id` = @default_dolphin_config_id
+WHERE `dolphin_config_id` IS NULL
+  AND (`target_engine` IS NULL OR LOWER(`target_engine`) = 'dolphin')
+  AND @default_dolphin_config_id IS NOT NULL;
+
+CREATE INDEX `idx_data_workflow_dolphin_config`
+    ON `data_workflow` (`dolphin_config_id`, `workflow_code`);
+
+CREATE INDEX `idx_publish_record_dolphin_config`
+    ON `workflow_publish_record` (`dolphin_config_id`, `created_at`);

--- a/backend/src/test/java/com/onedata/portal/service/DolphinConfigServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DolphinConfigServiceTest.java
@@ -1,0 +1,90 @@
+package com.onedata.portal.service;
+
+import com.onedata.portal.entity.DolphinConfig;
+import com.onedata.portal.mapper.DolphinConfigMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DolphinConfigServiceTest {
+
+    @Mock
+    private DolphinConfigMapper dolphinConfigMapper;
+
+    @Test
+    void createShouldNormalizeDefaultsAndInsertNamedConfig() {
+        DolphinConfigService service = new DolphinConfigService(dolphinConfigMapper);
+        DolphinConfig config = new DolphinConfig();
+        config.setConfigName(" New Dolphin ");
+        config.setUrl("http://new-ds/dolphinscheduler/");
+        config.setToken("token");
+        config.setProjectName("new_project");
+        config.setTenantCode(null);
+        config.setWorkerGroup(null);
+        config.setExecutionType(null);
+        config.setIsActive(null);
+        config.setIsDefault(1);
+
+        service.create(config);
+
+        ArgumentCaptor<DolphinConfig> captor = ArgumentCaptor.forClass(DolphinConfig.class);
+        verify(dolphinConfigMapper).insert(captor.capture());
+        DolphinConfig saved = captor.getValue();
+        assertEquals("New Dolphin", saved.getConfigName());
+        assertEquals("http://new-ds/dolphinscheduler", saved.getUrl());
+        assertEquals("default", saved.getTenantCode());
+        assertEquals("default", saved.getWorkerGroup());
+        assertEquals("PARALLEL", saved.getExecutionType());
+        assertEquals(Boolean.TRUE, saved.getIsActive());
+        assertEquals(Integer.valueOf(1), saved.getIsDefault());
+    }
+
+    @Test
+    void getEnabledConfigShouldRejectInactiveConfig() {
+        DolphinConfigService service = new DolphinConfigService(dolphinConfigMapper);
+        DolphinConfig inactive = new DolphinConfig();
+        inactive.setId(2L);
+        inactive.setConfigName("stopped");
+        inactive.setIsActive(false);
+        when(dolphinConfigMapper.selectById(2L)).thenReturn(inactive);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.getEnabledConfig(2L));
+        assertEquals("Dolphin 环境未启用: stopped", ex.getMessage());
+    }
+
+    @Test
+    void deleteShouldRejectRuntimeBoundConfig() {
+        DolphinConfigService service = new DolphinConfigService(dolphinConfigMapper);
+        when(dolphinConfigMapper.selectById(3L)).thenReturn(activeConfig(3L));
+        when(dolphinConfigMapper.countRuntimeBoundWorkflows(3L)).thenReturn(1L);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.delete(3L));
+        assertEquals("Dolphin 环境已被运行态工作流绑定，不能删除", ex.getMessage());
+    }
+
+    private DolphinConfig activeConfig(Long id) {
+        DolphinConfig config = new DolphinConfig();
+        config.setId(id);
+        config.setConfigName("active");
+        config.setUrl("http://ds/dolphinscheduler");
+        config.setToken("token");
+        config.setProjectName("opendataworks");
+        config.setTenantCode("default");
+        config.setWorkerGroup("default");
+        config.setExecutionType("PARALLEL");
+        config.setIsActive(true);
+        config.setIsDefault(0);
+        return config;
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
@@ -1,0 +1,129 @@
+package com.onedata.portal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.workflow.WorkflowSchedulerEngineRequest;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.DolphinConfig;
+import com.onedata.portal.mapper.DataLineageMapper;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.DataWorkflowMapper;
+import com.onedata.portal.mapper.TableTaskRelationMapper;
+import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import com.onedata.portal.mapper.WorkflowInstanceCacheMapper;
+import com.onedata.portal.mapper.WorkflowPublishRecordMapper;
+import com.onedata.portal.mapper.WorkflowTaskRelationMapper;
+import com.onedata.portal.mapper.WorkflowVersionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowSchedulerEngineSwitchTest {
+
+    @Mock
+    private DataWorkflowMapper dataWorkflowMapper;
+    @Mock
+    private WorkflowTaskRelationMapper workflowTaskRelationMapper;
+    @Mock
+    private WorkflowPublishRecordMapper workflowPublishRecordMapper;
+    @Mock
+    private WorkflowVersionService workflowVersionService;
+    @Mock
+    private WorkflowVersionMapper workflowVersionMapper;
+    @Mock
+    private WorkflowInstanceCacheMapper workflowInstanceCacheMapper;
+    @Mock
+    private DolphinSchedulerService dolphinSchedulerService;
+    @Mock
+    private DataTaskMapper dataTaskMapper;
+    @Mock
+    private DataLineageMapper dataLineageMapper;
+    @Mock
+    private TableTaskRelationMapper tableTaskRelationMapper;
+    @Mock
+    private TaskExecutionLogMapper taskExecutionLogMapper;
+    @Mock
+    private WorkflowTopologyService workflowTopologyService;
+    @Mock
+    private DolphinConfigService dolphinConfigService;
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        WorkflowInstanceCacheService cacheService = new WorkflowInstanceCacheService(workflowInstanceCacheMapper);
+        workflowService = new WorkflowService(
+                dataWorkflowMapper,
+                workflowTaskRelationMapper,
+                workflowPublishRecordMapper,
+                workflowVersionService,
+                workflowVersionMapper,
+                cacheService,
+                new ObjectMapper(),
+                dolphinSchedulerService,
+                dataTaskMapper,
+                dataLineageMapper,
+                tableTaskRelationMapper,
+                taskExecutionLogMapper,
+                workflowTopologyService,
+                dolphinConfigService);
+    }
+
+    @Test
+    void switchSchedulerEngineShouldResetRuntimeBindingAndKeepPlatformDefinition() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(1L);
+        workflow.setDolphinConfigId(1L);
+        workflow.setWorkflowCode(5001L);
+        workflow.setProjectCode(11L);
+        workflow.setWorkflowName("wf_order");
+        workflow.setStatus("online");
+        workflow.setPublishStatus("published");
+        workflow.setLastPublishedVersionId(88L);
+        workflow.setCurrentVersionId(99L);
+        workflow.setDefinitionJson("{\"taskDefinitionList\":[]}");
+        workflow.setDolphinScheduleId(900L);
+        workflow.setScheduleState("ONLINE");
+        workflow.setScheduleCron("0 0 1 * * ? *");
+
+        DolphinConfig target = new DolphinConfig();
+        target.setId(2L);
+        target.setConfigName("new-dolphin");
+        target.setIsActive(true);
+        target.setProjectName("new_project");
+
+        WorkflowSchedulerEngineRequest request = new WorkflowSchedulerEngineRequest();
+        request.setDolphinConfigId(2L);
+        request.setOperator("tester");
+
+        when(dataWorkflowMapper.selectById(1L)).thenReturn(workflow);
+        when(dolphinConfigService.getEnabledConfig(2L)).thenReturn(target);
+        when(dolphinSchedulerService.testConnection(2L)).thenReturn(true);
+        when(dolphinSchedulerService.getProjectCode(2L, true)).thenReturn(22L);
+
+        DataWorkflow result = workflowService.switchSchedulerEngine(1L, request);
+
+        assertEquals(Long.valueOf(2L), result.getDolphinConfigId());
+        assertNull(result.getWorkflowCode());
+        assertEquals(Long.valueOf(22L), result.getProjectCode());
+        assertNull(result.getDolphinScheduleId());
+        assertEquals("OFFLINE", result.getScheduleState());
+        assertEquals("offline", result.getStatus());
+        assertEquals("never", result.getPublishStatus());
+        assertNull(result.getLastPublishedVersionId());
+        assertEquals(Long.valueOf(99L), result.getCurrentVersionId());
+        assertEquals("0 0 1 * * ? *", result.getScheduleCron());
+
+        ArgumentCaptor<DataWorkflow> captor = ArgumentCaptor.forClass(DataWorkflow.class);
+        verify(dataWorkflowMapper).updateById(captor.capture());
+        assertEquals(Long.valueOf(2L), captor.getValue().getDolphinConfigId());
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowServiceMetadataPersistenceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowServiceMetadataPersistenceTest.java
@@ -92,6 +92,9 @@ class WorkflowServiceMetadataPersistenceTest {
     @Mock
     private WorkflowTopologyService workflowTopologyService;
 
+    @Mock
+    private DolphinConfigService dolphinConfigService;
+
     private ObjectMapper objectMapper;
     private WorkflowService service;
 
@@ -111,7 +114,8 @@ class WorkflowServiceMetadataPersistenceTest {
                 dataLineageMapper,
                 tableTaskRelationMapper,
                 taskExecutionLogMapper,
-                workflowTopologyService);
+                workflowTopologyService,
+                dolphinConfigService);
     }
 
     @Test

--- a/docs/design/2026-04-28-dolphin-engine-switch-design.md
+++ b/docs/design/2026-04-28-dolphin-engine-switch-design.md
@@ -1,0 +1,59 @@
+# Dolphin Engine Switch Design
+
+**Date:** 2026-04-28
+**Goal:** 支持管理员维护多个 DolphinScheduler 环境，并允许已发布工作流切换目标 Dolphin 后重新发布。
+**Tech Stack:** Java 8 + Spring Boot 2.7 backend, MySQL + Flyway, Vue 3 + Element Plus frontend
+
+## Current State
+
+- DolphinScheduler 配置存储在单表 `dolphin_config`，服务层通过 `getActiveConfig()` 读取一个全局配置。
+- 工作流只保存 `workflow_code`、`project_code`、`dolphin_schedule_id`，没有记录这些运行态字段属于哪个 Dolphin 环境。
+- 发布预检、发布、上线、下线、执行、补数、调度和 WebUI 跳转都默认使用当前全局 Dolphin 配置。
+- 如果发布后把全局 Dolphin 地址改为新集群，平台仍拿旧集群的 `workflow_code` 到新集群读取运行态定义，容易出现“找不到运行态工作流”。
+
+## Solution
+
+- 将 Dolphin 配置从单全局配置升级为多环境配置：
+  - `dolphin_config` 增加环境名称、说明、默认标记和逻辑删除字段。
+  - `is_active` 继续表示启停状态。
+  - 默认环境用于兼容未绑定工作流和旧接口。
+- 在工作流与发布记录上保存 `dolphin_config_id`：
+  - 工作流所有运行态调用都优先使用自身绑定的 Dolphin 环境。
+  - 发布记录写入当次目标环境，保证审计可追溯。
+- 工作流详情提供“切换调度引擎”操作：
+  - 目标 Dolphin 必须启用且连接测试通过。
+  - 切换后清空旧运行态绑定，下一次发布在新 Dolphin 新建运行态工作流。
+  - 平台保留工作流任务、版本、调度表达式等定义，不自动修改旧 Dolphin。
+- Dolphin 客户端支持按配置显式调用：
+  - `DolphinSchedulerService` 增加以 `dolphinConfigId` 为参数的重载。
+  - 项目编码缓存按配置隔离，避免切换后复用旧项目编码。
+  - 元数据目录、发布预检、修复元数据等路径使用工作流绑定配置。
+
+## Interfaces
+
+- 保留旧接口：
+  - `GET /v1/settings/dolphin` 返回默认 Dolphin 配置。
+  - `PUT /v1/settings/dolphin` 更新默认 Dolphin 配置。
+  - `POST /v1/settings/dolphin/test` 测试传入配置。
+- 新增接口：
+  - `GET /v1/settings/dolphin/configs`
+  - `GET /v1/settings/dolphin/configs/{id}`
+  - `POST /v1/settings/dolphin/configs`
+  - `PUT /v1/settings/dolphin/configs/{id}`
+  - `DELETE /v1/settings/dolphin/configs/{id}`
+  - `POST /v1/settings/dolphin/configs/{id}/default`
+  - `POST /v1/settings/dolphin/configs/{id}/test`
+  - `PUT /v1/workflows/{id}/scheduler-engine`
+- Dolphin 元数据接口新增可选 `dolphinConfigId` 查询参数，旧调用不带参数时继续使用默认环境。
+
+## Tradeoffs
+
+- 采用“新建绑定”而不是按名称自动匹配，是为了避免跨集群误绑定已有生产工作流。
+- 切换时不自动下线或删除旧 Dolphin 工作流，避免平台在不确定旧集群权限和业务影响时做破坏性动作。
+- 本轮不抽象 Dinky 或通用调度引擎，只把现有 Dolphin 集成升级为多环境绑定，降低改动范围。
+
+## Verification
+
+- 后端单测覆盖 Dolphin 多配置管理、工作流切换字段重置、发布记录环境追溯、发布/执行/调度调用使用绑定环境。
+- 前端测试覆盖配置管理 UI、工作流切换弹窗和切换后发布预检首次部署提示。
+- 环境可用时用两个 Dolphin 配置做本地 smoke：A 发布成功，切换 B，B 首次发布成功，旧 A 不被自动修改。

--- a/docs/plans/2026-04-28-dolphin-engine-switch-plan.md
+++ b/docs/plans/2026-04-28-dolphin-engine-switch-plan.md
@@ -1,0 +1,57 @@
+# Dolphin Engine Switch Plan
+
+> Design: [2026-04-28-dolphin-engine-switch-design.md](../design/2026-04-28-dolphin-engine-switch-design.md)
+
+**Goal:** 支持多个 DolphinScheduler 环境，并允许工作流切换绑定环境后重新发布。
+**Tech Stack:** Java 8 + Spring Boot 2.7, MyBatis-Plus, Flyway, Vue 3 + Element Plus
+
+## Task 1: Schema And Config Management
+
+**Files:**
+- `backend/src/main/resources/db/migration/V43__add_multi_dolphin_config.sql`
+- `backend/src/main/java/com/onedata/portal/entity/DolphinConfig.java`
+- `backend/src/main/java/com/onedata/portal/service/DolphinConfigService.java`
+- `backend/src/main/java/com/onedata/portal/controller/DolphinConfigController.java`
+
+**Steps:**
+1. Add migration fields for named Dolphin configs and workflow/publish bindings.
+2. Add service CRUD, default selection, enabled lookup and connection-tested switching helpers.
+3. Keep legacy default-config endpoints compatible.
+
+## Task 2: Workflow Binding And Runtime Calls
+
+**Files:**
+- `backend/src/main/java/com/onedata/portal/entity/DataWorkflow.java`
+- `backend/src/main/java/com/onedata/portal/entity/WorkflowPublishRecord.java`
+- `backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java`
+- `backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java`
+- `backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java`
+- `backend/src/main/java/com/onedata/portal/service/WorkflowDeployService.java`
+- `backend/src/main/java/com/onedata/portal/service/WorkflowScheduleService.java`
+- `backend/src/main/java/com/onedata/portal/service/WorkflowService.java`
+
+**Steps:**
+1. Add explicit `dolphinConfigId` routing through Dolphin service and client methods.
+2. Make workflow publish, online, offline, execute, backfill, schedule and instance sync use the workflow binding.
+3. Add switch endpoint behavior that clears old runtime identifiers and preserves platform definition.
+
+## Task 3: Frontend Management And Switch UI
+
+**Files:**
+- `frontend/src/api/settings.js`
+- `frontend/src/api/workflow.js`
+- `frontend/src/api/task.js`
+- `frontend/src/views/settings/DolphinConfig.vue`
+- `frontend/src/views/workflows/WorkflowDetail.vue`
+- `frontend/src/views/tasks/TaskEditDrawer.vue`
+
+**Steps:**
+1. Replace single Dolphin config form with multi-environment table and dialog.
+2. Add scheduler engine display and switch dialog to workflow detail.
+3. Pass workflow-bound `dolphinConfigId` into Dolphin option APIs.
+
+## Verification
+
+- Run focused backend tests for `DolphinConfigService`, `WorkflowPublishService`, `WorkflowService`, `WorkflowScheduleService`, and `DolphinSchedulerService`.
+- Run frontend unit tests for touched settings/workflow helpers where present.
+- If a two-Dolphin local environment is unavailable, report that full cross-Dolphin smoke remains unrun.

--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -27,6 +27,58 @@ export const settingsApi = {
         })
     },
 
+    listDolphinConfigs(params = {}) {
+        return request({
+            url: '/v1/settings/dolphin/configs',
+            method: 'get',
+            params
+        })
+    },
+
+    getDolphinConfigById(id) {
+        return request({
+            url: `/v1/settings/dolphin/configs/${id}`,
+            method: 'get'
+        })
+    },
+
+    createDolphinConfig(data) {
+        return request({
+            url: '/v1/settings/dolphin/configs',
+            method: 'post',
+            data
+        })
+    },
+
+    updateDolphinConfigById(id, data) {
+        return request({
+            url: `/v1/settings/dolphin/configs/${id}`,
+            method: 'put',
+            data
+        })
+    },
+
+    deleteDolphinConfig(id) {
+        return request({
+            url: `/v1/settings/dolphin/configs/${id}`,
+            method: 'delete'
+        })
+    },
+
+    setDefaultDolphinConfig(id) {
+        return request({
+            url: `/v1/settings/dolphin/configs/${id}/default`,
+            method: 'post'
+        })
+    },
+
+    testSavedDolphinConnection(id) {
+        return request({
+            url: `/v1/settings/dolphin/configs/${id}/test`,
+            method: 'post'
+        })
+    },
+
     listMinioConfigs(params = {}) {
         return request({
             url: '/v1/settings/minio',

--- a/frontend/src/api/task.js
+++ b/frontend/src/api/task.js
@@ -42,8 +42,8 @@ export const taskApi = {
   },
 
   // 获取 DolphinScheduler WebUI 配置
-  getDolphinWebuiConfig() {
-    return request.get('/v1/tasks/config/dolphin-webui')
+  getDolphinWebuiConfig(params = {}) {
+    return request.get('/v1/tasks/config/dolphin-webui', { params })
   },
 
   // 获取任务血缘关系
@@ -74,28 +74,28 @@ export const taskApi = {
   },
 
   // 获取 Dolphin worker group 列表（项目级）
-  fetchWorkerGroups() {
-    return request.get('/v1/dolphin/worker-groups')
+  fetchWorkerGroups(params = {}) {
+    return request.get('/v1/dolphin/worker-groups', { params })
   },
 
   // 获取 Dolphin tenant 列表
-  fetchTenants() {
-    return request.get('/v1/dolphin/tenants')
+  fetchTenants(params = {}) {
+    return request.get('/v1/dolphin/tenants', { params })
   },
 
   // 获取 Dolphin 告警组列表
-  fetchAlertGroups() {
-    return request.get('/v1/dolphin/alert-groups')
+  fetchAlertGroups(params = {}) {
+    return request.get('/v1/dolphin/alert-groups', { params })
   },
 
   // 获取 Dolphin 环境列表
-  fetchEnvironments() {
-    return request.get('/v1/dolphin/environments')
+  fetchEnvironments(params = {}) {
+    return request.get('/v1/dolphin/environments', { params })
   },
 
   // 预览调度未来触发时间
-  previewSchedule(payload) {
-    return request.post('/v1/dolphin/schedules/preview', payload)
+  previewSchedule(payload, params = {}) {
+    return request.post('/v1/dolphin/schedules/preview', payload, { params })
   },
 
 }

--- a/frontend/src/api/workflow.js
+++ b/frontend/src/api/workflow.js
@@ -29,6 +29,10 @@ export const workflowApi = {
     return request.put(`/v1/workflows/${id}`, data)
   },
 
+  switchSchedulerEngine(id, payload) {
+    return request.put(`/v1/workflows/${id}/scheduler-engine`, payload)
+  },
+
   exportJson(id) {
     return request.get(`/v1/workflows/${id}/export-json`)
   },

--- a/frontend/src/views/settings/DolphinConfig.vue
+++ b/frontend/src/views/settings/DolphinConfig.vue
@@ -1,72 +1,151 @@
 <template>
   <div class="dolphin-config">
-    <!-- Header removed for tab integration -->
-
-    <el-card class="config-card">
+    <el-card class="config-card" shadow="never">
       <template #header>
         <div class="card-header">
-          <span>基础配置</span>
-          <div class="actions">
-            <el-button type="primary" :loading="testing" @click="handleTestConnection">测试连接</el-button>
-            <el-button type="success" :loading="saving" @click="handleSave">保存配置</el-button>
-          </div>
+          <span>Dolphin 环境管理</span>
+          <el-button type="primary" @click="openCreate">新增环境</el-button>
         </div>
       </template>
 
-      <el-form ref="formRef" :model="form" :rules="rules" label-width="120px" status-icon v-loading="loading">
+      <el-table v-loading="loading" :data="configs" border style="width: 100%">
+        <el-table-column prop="configName" label="环境名称" min-width="150" show-overflow-tooltip />
+        <el-table-column prop="url" label="服务地址" min-width="240" show-overflow-tooltip />
+        <el-table-column prop="projectName" label="项目名称" min-width="140" show-overflow-tooltip />
+        <el-table-column prop="projectCode" label="项目编码" min-width="120">
+          <template #default="{ row }">
+            <span>{{ row.projectCode || '-' }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="租户/Worker" min-width="170" show-overflow-tooltip>
+          <template #default="{ row }">
+            {{ row.tenantCode || 'default' }} / {{ row.workerGroup || 'default' }}
+          </template>
+        </el-table-column>
+        <el-table-column label="状态" min-width="90">
+          <template #default="{ row }">
+            <el-tag size="small" :type="row.isActive ? 'success' : 'info'">
+              {{ row.isActive ? '启用' : '停用' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="默认" min-width="90">
+          <template #default="{ row }">
+            <el-tag size="small" :type="row.isDefault === 1 ? 'warning' : 'info'">
+              {{ row.isDefault === 1 ? '默认' : '否' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="description" label="说明" min-width="200" show-overflow-tooltip>
+          <template #default="{ row }">
+            <span>{{ row.description || '-' }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="330" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" @click="openEdit(row)">编辑</el-button>
+            <el-button link type="primary" :loading="testingId === row.id" @click="testSaved(row)">测试</el-button>
+            <el-button link type="warning" :disabled="row.isDefault === 1 || !row.isActive" @click="setDefault(row)">
+              设为默认
+            </el-button>
+            <el-button link :type="row.isActive ? 'warning' : 'success'" @click="toggleActive(row)">
+              {{ row.isActive ? '停用' : '启用' }}
+            </el-button>
+            <el-button link type="danger" @click="removeConfig(row)">删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
+    <el-dialog
+      v-model="dialogVisible"
+      :title="isEdit ? '编辑 Dolphin 环境' : '新增 Dolphin 环境'"
+      width="660px"
+      :close-on-click-modal="false"
+    >
+      <el-form ref="formRef" :model="form" :rules="rules" label-width="120px" status-icon>
+        <el-form-item label="环境名称" prop="configName">
+          <el-input v-model="form.configName" placeholder="例如：生产 Dolphin / 新 Dolphin" />
+        </el-form-item>
+
         <el-form-item label="服务地址" prop="url">
           <el-input v-model="form.url" placeholder="http://localhost:12345/dolphinscheduler" />
-          <div class="form-tip">DolphinScheduler API 服务地址</div>
         </el-form-item>
 
         <el-form-item label="访问令牌" prop="token">
-          <el-input v-model="form.token" type="password" show-password placeholder="请输入访问令牌" />
-          <div class="form-tip">用于 API 认证的 Token</div>
+          <el-input
+            v-model="form.token"
+            type="password"
+            show-password
+            :placeholder="isEdit ? '留空表示不修改 Token' : '请输入访问令牌'"
+          />
         </el-form-item>
 
         <el-form-item label="项目名称" prop="projectName">
           <el-input v-model="form.projectName" placeholder="默认为 opendataworks" />
         </el-form-item>
-        
+
         <el-form-item label="项目编码" prop="projectCode">
-          <el-input v-model="form.projectCode" disabled placeholder="自动获取" />
-          <div class="form-tip">系统自动获取，无需手动填写</div>
+          <el-input v-model="form.projectCode" disabled placeholder="测试连接或发布时自动获取" />
         </el-form-item>
 
         <el-form-item label="租户编码" prop="tenantCode">
           <el-input v-model="form.tenantCode" placeholder="default" />
         </el-form-item>
-          
+
         <el-form-item label="Worker 分组" prop="workerGroup">
           <el-input v-model="form.workerGroup" placeholder="default" />
         </el-form-item>
+
+        <el-form-item label="执行模式" prop="executionType">
+          <el-select v-model="form.executionType" style="width: 100%">
+            <el-option label="PARALLEL" value="PARALLEL" />
+            <el-option label="SERIAL_WAIT" value="SERIAL_WAIT" />
+            <el-option label="SERIAL_DISCARD" value="SERIAL_DISCARD" />
+            <el-option label="SERIAL_PRIORITY" value="SERIAL_PRIORITY" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item label="默认环境" prop="isDefault">
+          <el-switch v-model="form.isDefault" :active-value="1" :inactive-value="0" />
+        </el-form-item>
+
+        <el-form-item label="状态" prop="isActive">
+          <el-switch v-model="form.isActive" active-text="启用" inactive-text="停用" />
+        </el-form-item>
+
+        <el-form-item label="说明" prop="description">
+          <el-input v-model="form.description" type="textarea" :rows="3" placeholder="可选" />
+        </el-form-item>
       </el-form>
-      
-      <el-alert
-        title="配置说明"
-        type="info"
-        :closable="false"
-        show-icon
-        class="mt-4"
-      >
-        <p>配置修改后即时生效。请确保服务地址和令牌正确，否则可能导致任务调度失败。</p>
-      </el-alert>
-    </el-card>
+
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button :loading="testingForm" @click="testFormConnection">测试连接</el-button>
+        <el-button type="primary" :loading="saving" @click="saveConfig">保存</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
-import { ElMessage } from 'element-plus'
+import { computed, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { settingsApi } from '@/api/settings'
 
 const loading = ref(false)
 const saving = ref(false)
-const testing = ref(false)
+const testingId = ref(null)
+const testingForm = ref(false)
+const configs = ref([])
+
+const dialogVisible = ref(false)
+const isEdit = ref(false)
+const currentId = ref(null)
 const formRef = ref(null)
 
 const form = reactive({
-  id: null,
+  configName: '',
   url: '',
   token: '',
   projectName: 'opendataworks',
@@ -74,102 +153,228 @@ const form = reactive({
   tenantCode: 'default',
   workerGroup: 'default',
   executionType: 'PARALLEL',
-  isActive: true
+  isActive: true,
+  isDefault: 0,
+  description: ''
 })
 
-const rules = {
+const tokenRule = computed(() => ({
+  validator: (_, value, callback) => {
+    if (!isEdit.value && !value) {
+      callback(new Error('请输入访问令牌'))
+      return
+    }
+    callback()
+  },
+  trigger: 'blur'
+}))
+
+const rules = computed(() => ({
+  configName: [{ required: true, message: '请输入环境名称', trigger: 'blur' }],
   url: [{ required: true, message: '请输入服务地址', trigger: 'blur' }],
-  token: [{ required: true, message: '请输入访问令牌', trigger: 'blur' }],
+  token: [tokenRule.value],
   projectName: [{ required: true, message: '请输入项目名称', trigger: 'blur' }]
+}))
+
+const resetForm = () => {
+  form.configName = ''
+  form.url = ''
+  form.token = ''
+  form.projectName = 'opendataworks'
+  form.projectCode = ''
+  form.tenantCode = 'default'
+  form.workerGroup = 'default'
+  form.executionType = 'PARALLEL'
+  form.isActive = true
+  form.isDefault = 0
+  form.description = ''
 }
 
-async function loadConfig() {
+const loadConfigs = async () => {
   loading.value = true
   try {
-    const data = await settingsApi.getDolphinConfig()
-    if (data) {
-      Object.assign(form, data)
-    }
+    const list = await settingsApi.listDolphinConfigs()
+    configs.value = Array.isArray(list) ? list : []
   } catch (error) {
-    console.error('Failed to load config', error)
+    console.error('加载 Dolphin 配置失败:', error)
+    ElMessage.error('加载 Dolphin 配置失败: ' + (error.message || '未知错误'))
   } finally {
     loading.value = false
   }
 }
 
-async function handleTestConnection() {
-  if (!form.url || !form.token) {
-    ElMessage.warning('请先填写服务地址和令牌')
+const openCreate = () => {
+  resetForm()
+  isEdit.value = false
+  currentId.value = null
+  dialogVisible.value = true
+}
+
+const openEdit = row => {
+  resetForm()
+  isEdit.value = true
+  currentId.value = row.id
+  form.configName = row.configName || ''
+  form.url = row.url || ''
+  form.token = ''
+  form.projectName = row.projectName || 'opendataworks'
+  form.projectCode = row.projectCode || ''
+  form.tenantCode = row.tenantCode || 'default'
+  form.workerGroup = row.workerGroup || 'default'
+  form.executionType = row.executionType || 'PARALLEL'
+  form.isActive = row.isActive !== false
+  form.isDefault = row.isDefault === 1 ? 1 : 0
+  form.description = row.description || ''
+  dialogVisible.value = true
+}
+
+const buildPayload = () => ({
+  configName: form.configName,
+  url: form.url,
+  token: form.token || null,
+  projectName: form.projectName,
+  projectCode: form.projectCode || null,
+  tenantCode: form.tenantCode || 'default',
+  workerGroup: form.workerGroup || 'default',
+  executionType: form.executionType || 'PARALLEL',
+  isActive: form.isActive,
+  isDefault: form.isDefault,
+  description: form.description || null
+})
+
+const saveConfig = async () => {
+  if (!formRef.value) return
+  try {
+    await formRef.value.validate()
+  } catch {
     return
   }
-  
-  testing.value = true
+
+  saving.value = true
   try {
-    const success = await settingsApi.testDolphinConnection(form)
+    const payload = buildPayload()
+    if (isEdit.value && currentId.value) {
+      await settingsApi.updateDolphinConfigById(currentId.value, payload)
+      ElMessage.success('Dolphin 环境已更新')
+    } else {
+      payload.token = form.token
+      await settingsApi.createDolphinConfig(payload)
+      ElMessage.success('Dolphin 环境已创建')
+    }
+    dialogVisible.value = false
+    await loadConfigs()
+  } catch (error) {
+    console.error('保存 Dolphin 配置失败:', error)
+    ElMessage.error('保存 Dolphin 配置失败: ' + (error.message || '未知错误'))
+  } finally {
+    saving.value = false
+  }
+}
+
+const testFormConnection = async () => {
+  if (!form.url || (!isEdit.value && !form.token)) {
+    ElMessage.warning('请先填写服务地址和访问令牌')
+    return
+  }
+  testingForm.value = true
+  try {
+    const success = isEdit.value && currentId.value && !form.token
+      ? await settingsApi.testSavedDolphinConnection(currentId.value)
+      : await settingsApi.testDolphinConnection(buildPayload())
     if (success) {
       ElMessage.success('连接成功')
     } else {
       ElMessage.error('连接失败，请检查配置')
     }
   } catch (error) {
-    console.error(error)
-    ElMessage.error('连接测试出错')
+    console.error('测试 Dolphin 连接失败:', error)
+    ElMessage.error('连接测试出错: ' + (error.message || '未知错误'))
   } finally {
-    testing.value = false
+    testingForm.value = false
   }
 }
 
-async function handleSave() {
-  if (!formRef.value) return
-  await formRef.value.validate()
-  
-  saving.value = true
+const testSaved = async row => {
+  testingId.value = row.id
   try {
-    const updated = await settingsApi.updateDolphinConfig(form)
-    Object.assign(form, updated)
-    ElMessage.success('保存成功')
+    const success = await settingsApi.testSavedDolphinConnection(row.id)
+    if (success) {
+      ElMessage.success('连接成功')
+    } else {
+      ElMessage.error('连接失败，请检查配置')
+    }
   } catch (error) {
-    console.error(error)
+    console.error('测试 Dolphin 环境失败:', error)
+    ElMessage.error('连接测试出错: ' + (error.message || '未知错误'))
   } finally {
-    saving.value = false
+    testingId.value = null
   }
 }
 
-onMounted(() => {
-  loadConfig()
-})
+const setDefault = async row => {
+  try {
+    await settingsApi.setDefaultDolphinConfig(row.id)
+    ElMessage.success('已设为默认 Dolphin 环境')
+    await loadConfigs()
+  } catch (error) {
+    console.error('设置默认 Dolphin 环境失败:', error)
+    ElMessage.error('设置默认失败: ' + (error.message || '未知错误'))
+  }
+}
+
+const toggleActive = async row => {
+  const payload = {
+    ...row,
+    token: null,
+    isActive: !row.isActive
+  }
+  try {
+    await settingsApi.updateDolphinConfigById(row.id, payload)
+    ElMessage.success(payload.isActive ? 'Dolphin 环境已启用' : 'Dolphin 环境已停用')
+    await loadConfigs()
+  } catch (error) {
+    console.error('更新 Dolphin 环境状态失败:', error)
+    ElMessage.error('状态更新失败: ' + (error.message || '未知错误'))
+  }
+}
+
+const removeConfig = async row => {
+  try {
+    await ElMessageBox.confirm(`确认删除 Dolphin 环境「${row.configName || row.id}」吗？已绑定运行态的环境不能删除。`, '删除确认', {
+      type: 'warning',
+      confirmButtonText: '确认删除',
+      cancelButtonText: '取消'
+    })
+  } catch {
+    return
+  }
+
+  try {
+    await settingsApi.deleteDolphinConfig(row.id)
+    ElMessage.success('已删除 Dolphin 环境')
+    await loadConfigs()
+  } catch (error) {
+    console.error('删除 Dolphin 环境失败:', error)
+    ElMessage.error('删除失败: ' + (error.message || '未知错误'))
+  }
+}
+
+loadConfigs()
 </script>
 
 <style scoped>
 .dolphin-config {
-  /* padding removed */
   max-width: 1200px;
   margin: 0 auto;
 }
 
 .config-card {
-  max-width: 800px;
+  width: 100%;
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-
-.actions {
-  display: flex;
-  gap: 10px;
-}
-
-.form-tip {
-  font-size: 12px;
-  color: #909399;
-  line-height: 1.5;
-  margin-top: 4px;
-}
-
-.mt-4 {
-  margin-top: 24px;
 }
 </style>

--- a/frontend/src/views/tasks/TaskEditDrawer.vue
+++ b/frontend/src/views/tasks/TaskEditDrawer.vue
@@ -350,6 +350,13 @@ const SqlEditor = defineAsyncComponent({
   suspensible: false
 })
 
+const props = defineProps({
+  dolphinConfigId: {
+    type: Number,
+    default: null
+  }
+})
+
 const emit = defineEmits(['saved', 'success', 'close'])
 
 const route = useRoute()
@@ -366,6 +373,7 @@ const taskNameChecking = ref(false)
 const originalTaskName = ref('')
 const workflowOptions = ref([])
 const isWriteTask = ref(false)
+const contextDolphinConfigId = ref(null)
 
 const datasourceOptions = ref([])
 const tableOptions = ref([])
@@ -407,7 +415,8 @@ const fetchWorkflowOptions = async () => {
 
 const fetchDatasourceOptions = async () => {
   try {
-    const res = await taskApi.fetchDatasources()
+    const params = effectiveDolphinConfigId.value ? { dolphinConfigId: effectiveDolphinConfigId.value } : {}
+    const res = await taskApi.fetchDatasources(params)
     datasourceOptions.value = res || []
     syncSqlDatasourceType()
   } catch (error) {
@@ -768,14 +777,36 @@ const goToMetadataSync = () => {
   })
 }
 
+const activeWorkflowDolphinConfigId = computed(() => {
+  const workflowId = Number(form.task.workflowId)
+  if (!Number.isFinite(workflowId)) {
+    return null
+  }
+  const workflow = workflowOptions.value.find(item => Number(item?.id) === workflowId)
+  return workflow?.dolphinConfigId || null
+})
+
+const effectiveDolphinConfigId = computed(() => (
+  props.dolphinConfigId
+  || contextDolphinConfigId.value
+  || activeWorkflowDolphinConfigId.value
+  || null
+))
+
 const open = async (id = null, initialData = {}) => {
   visible.value = true
   loading.value = false
   isEdit.value = !!id
+  contextDolphinConfigId.value = initialData.dolphinConfigId || null
 
   resetForm()
-  await Promise.all([fetchDatasourceOptions(), fetchWorkflowOptions()])
   lockedWorkflowId.value = null
+  if (initialData.workflowId) {
+    form.task.workflowId = initialData.workflowId
+    lockedWorkflowId.value = initialData.workflowId
+  }
+  await fetchWorkflowOptions()
+  await fetchDatasourceOptions()
 
   if (id) {
     try {
@@ -799,11 +830,6 @@ const open = async (id = null, initialData = {}) => {
     if (initialData.taskSql) form.task.taskSql = initialData.taskSql
     if (initialData.taskName) form.task.taskName = initialData.taskName
     if (initialData.taskDesc) form.task.taskDesc = initialData.taskDesc
-
-    if (initialData.workflowId) {
-      form.task.workflowId = initialData.workflowId
-      lockedWorkflowId.value = initialData.workflowId
-    }
 
     if (initialData.relation && initialData.tableId) {
       const tableId = Number(initialData.tableId)
@@ -1021,6 +1047,13 @@ watch(
     scheduleSqlAnalyze()
   }
 )
+
+watch(effectiveDolphinConfigId, async (nextId, prevId) => {
+  if (!visible.value || nextId === prevId) {
+    return
+  }
+  await fetchDatasourceOptions()
+})
 
 onBeforeUnmount(() => {
   cancelPendingAnalyze()

--- a/frontend/src/views/tasks/TaskTable.vue
+++ b/frontend/src/views/tasks/TaskTable.vue
@@ -174,7 +174,7 @@
       style="margin-top: 20px; justify-content: flex-end"
     />
 
-    <TaskEditDrawer ref="drawerRef" @success="handleDrawerSuccess" />
+    <TaskEditDrawer ref="drawerRef" :dolphin-config-id="dolphinConfigId" @success="handleDrawerSuccess" />
   </div>
 </template>
 
@@ -215,6 +215,10 @@ const props = defineProps({
   hideDeleteAction: {
     type: Boolean,
     default: false
+  },
+  dolphinConfigId: {
+    type: Number,
+    default: null
   }
 })
 
@@ -340,7 +344,7 @@ const parseNumericFilter = (value) => {
 
 const loadDolphinConfig = async () => {
   try {
-    const config = await taskApi.getDolphinWebuiConfig()
+    const config = await taskApi.getDolphinWebuiConfig(buildDolphinConfigParams())
     if (config?.webuiUrl) {
       dolphinWebuiUrl.value = config.webuiUrl.replace(/\/+$/, '')
     } else {
@@ -350,6 +354,12 @@ const loadDolphinConfig = async () => {
     console.error('加载 DolphinScheduler 配置失败:', error)
     dolphinWebuiUrl.value = ''
   }
+}
+
+const buildDolphinConfigParams = () => {
+  return props.dolphinConfigId
+    ? { dolphinConfigId: props.dolphinConfigId }
+    : {}
 }
 
 const loadWorkflowOptions = async () => {
@@ -392,6 +402,9 @@ const openCreateDrawer = () => {
   if (workflowId) {
     initialData.workflowId = workflowId
   }
+  if (props.dolphinConfigId) {
+    initialData.dolphinConfigId = props.dolphinConfigId
+  }
   drawerRef.value?.open(null, initialData)
 }
 
@@ -400,7 +413,7 @@ const openEditDrawer = (row) => {
     showDemoReadonlyMessage('编辑任务')
     return
   }
-  drawerRef.value?.open(row.id)
+  drawerRef.value?.open(row.id, props.dolphinConfigId ? { dolphinConfigId: props.dolphinConfigId } : {})
 }
 
 const handleDrawerSuccess = () => {
@@ -523,6 +536,10 @@ onMounted(async () => {
 
 watch(() => props.workflowId, () => {
   loadData()
+})
+
+watch(() => props.dolphinConfigId, () => {
+  loadDolphinConfig()
 })
 
 watch(() => props.externalData, (newData) => {

--- a/frontend/src/views/workflows/WorkflowDetail.vue
+++ b/frontend/src/views/workflows/WorkflowDetail.vue
@@ -123,7 +123,15 @@
                 <el-button size="small" @click="cancelEditName">取消</el-button>
               </div>
             </el-descriptions-item>
-            <el-descriptions-item label="项目">{{ workflow?.workflow?.projectCode }}</el-descriptions-item>
+            <el-descriptions-item label="项目">{{ workflow?.workflow?.projectCode || '-' }}</el-descriptions-item>
+            <el-descriptions-item label="调度引擎">
+              <div class="scheduler-engine-cell">
+                <el-tag size="small" :type="currentDolphinConfig?.isActive === false ? 'info' : 'success'">
+                  {{ currentDolphinConfigName }}
+                </el-tag>
+                <el-button link type="primary" @click="openSchedulerSwitchDialog">切换</el-button>
+              </div>
+            </el-descriptions-item>
             <el-descriptions-item label="默认任务组">
               <div v-if="!isEditingTaskGroup" class="editable-field" @click="startEditTaskGroup">
                 <span>{{ workflow?.workflow?.taskGroupName || '-' }}</span>
@@ -195,6 +203,7 @@
               v-if="workflow?.workflow?.id" 
               :workflow-id="workflow.workflow.id"
               :workflow-task-ids="workflowTaskIds"
+              :dolphin-config-id="currentDolphinConfigId"
               @update="loadWorkflowDetail"
             />
           </div>
@@ -756,6 +765,50 @@
       <el-empty v-else description="该版本暂无发布记录" />
     </el-dialog>
 
+    <el-dialog
+      v-model="schedulerSwitchDialogVisible"
+      title="切换调度引擎"
+      width="560px"
+      :close-on-click-modal="false"
+    >
+      <el-alert
+        title="旧 Dolphin 不会自动下线或删除，目标 Dolphin 需要重新发布后生成新的运行态工作流。"
+        type="warning"
+        show-icon
+        :closable="false"
+        class="scheduler-switch-alert"
+      />
+      <el-form label-width="110px" class="scheduler-switch-form">
+        <el-form-item label="当前环境">
+          <span>{{ currentDolphinConfigName }}</span>
+        </el-form-item>
+        <el-form-item label="目标环境" required>
+          <el-select
+            v-model="schedulerSwitchForm.dolphinConfigId"
+            placeholder="请选择 Dolphin 环境"
+            filterable
+            :loading="dolphinConfigsLoading"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="item in dolphinConfigs"
+              :key="item.id"
+              :label="formatDolphinConfigOption(item)"
+              :value="item.id"
+              :disabled="!item.isActive"
+            />
+          </el-select>
+        </el-form-item>
+      </el-form>
+
+      <template #footer>
+        <el-button @click="schedulerSwitchDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="schedulerSwitchSaving" @click="switchSchedulerEngine">
+          确认切换
+        </el-button>
+      </template>
+    </el-dialog>
+
     <WorkflowBackfillDialog
       v-model="backfillDialogVisible"
       :workflow="backfillTarget"
@@ -771,6 +824,7 @@ import { useRouter } from 'vue-router'
 import { ArrowLeft, Link, Delete, Edit, Plus, Close } from '@element-plus/icons-vue'
 import { workflowApi } from '@/api/workflow'
 import { taskApi } from '@/api/task'
+import { settingsApi } from '@/api/settings'
 import dayjs from 'dayjs'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import WorkflowTaskManager from './WorkflowTaskManager.vue'
@@ -791,6 +845,8 @@ const loading = ref(false)
 const workflow = ref(null)
 const activeTab = ref('tasks')
 const dolphinWebuiUrl = ref('')
+const dolphinConfigs = ref([])
+const dolphinConfigsLoading = ref(false)
 const pendingApprovalFlags = reactive({})
 const actionLoading = reactive({})
 const backfillDialogVisible = ref(false)
@@ -807,6 +863,40 @@ const deleteLoadingVersionId = ref(null)
 const versionPublishRecordDialogVisible = ref(false)
 const activeVersionPublishRecords = ref([])
 const activeVersionForRecords = ref(null)
+const schedulerSwitchDialogVisible = ref(false)
+const schedulerSwitchSaving = ref(false)
+const schedulerSwitchForm = reactive({
+  dolphinConfigId: null
+})
+
+const defaultDolphinConfig = computed(() => {
+  return dolphinConfigs.value.find(item => item?.isDefault === 1) || null
+})
+
+const currentDolphinConfigId = computed(() => {
+  const boundId = workflow.value?.workflow?.dolphinConfigId
+  if (boundId) {
+    return boundId
+  }
+  return defaultDolphinConfig.value?.id || null
+})
+
+const currentDolphinConfig = computed(() => {
+  const id = currentDolphinConfigId.value
+  if (!id) {
+    return null
+  }
+  return dolphinConfigs.value.find(item => item?.id === id) || null
+})
+
+const currentDolphinConfigName = computed(() => {
+  const config = currentDolphinConfig.value
+  if (!config) {
+    return currentDolphinConfigId.value ? `Dolphin #${currentDolphinConfigId.value}` : '默认 Dolphin'
+  }
+  const suffix = config.isDefault === 1 ? '（默认）' : ''
+  return `${config.configName || `Dolphin #${config.id}`}${suffix}`
+})
 
 // Schedule states
 const scheduleFormRef = ref(null)
@@ -941,17 +1031,24 @@ const scheduleRules = {
   ]
 }
 
-const loadScheduleOptions = async () => {
-  if (scheduleOptionsLoaded.value) {
+const buildDolphinConfigParams = () => {
+  return currentDolphinConfigId.value
+    ? { dolphinConfigId: currentDolphinConfigId.value }
+    : {}
+}
+
+const loadScheduleOptions = async (force = false) => {
+  if (scheduleOptionsLoaded.value && !force) {
     return
   }
   scheduleOptionsLoading.value = true
   try {
+    const params = buildDolphinConfigParams()
     const [workerGroups, tenants, alertGroups, environments] = await Promise.all([
-      taskApi.fetchWorkerGroups().catch(() => []),
-      taskApi.fetchTenants().catch(() => []),
-      taskApi.fetchAlertGroups().catch(() => []),
-      taskApi.fetchEnvironments().catch(() => [])
+      taskApi.fetchWorkerGroups(params).catch(() => []),
+      taskApi.fetchTenants(params).catch(() => []),
+      taskApi.fetchAlertGroups(params).catch(() => []),
+      taskApi.fetchEnvironments(params).catch(() => [])
     ])
     workerGroupOptions.value = workerGroups || []
     tenantOptions.value = tenants || []
@@ -995,7 +1092,7 @@ const previewScheduleTimes = async () => {
       crontab: scheduleForm.scheduleCron,
       timezoneId: scheduleForm.scheduleTimezone
     })
-    const res = await taskApi.previewSchedule({ schedule })
+    const res = await taskApi.previewSchedule({ schedule }, buildDolphinConfigParams())
     schedulePreviewList.value = Array.isArray(res) ? res : []
   } catch (error) {
     console.error('预览调度时间失败', error)
@@ -1239,7 +1336,7 @@ const loadTaskGroupOptions = async () => {
   }
   taskGroupsLoading.value = true
   try {
-    const res = await taskApi.fetchTaskGroups()
+    const res = await taskApi.fetchTaskGroups(buildDolphinConfigParams())
     taskGroupOptions.value = res || []
   } catch (error) {
     console.error('加载任务组失败', error)
@@ -1433,10 +1530,103 @@ const syncPendingFlag = (workflowId, records) => {
 
 const loadDolphinConfig = async () => {
   try {
-    const config = await taskApi.getDolphinWebuiConfig()
+    const config = await taskApi.getDolphinWebuiConfig(buildDolphinConfigParams())
     dolphinWebuiUrl.value = config?.webuiUrl || ''
   } catch (error) {
     console.warn('加载 Dolphin 配置失败', error)
+  }
+}
+
+const loadDolphinConfigs = async () => {
+  dolphinConfigsLoading.value = true
+  try {
+    const list = await settingsApi.listDolphinConfigs()
+    dolphinConfigs.value = Array.isArray(list) ? list : []
+  } catch (error) {
+    console.warn('加载 Dolphin 环境列表失败', error)
+  } finally {
+    dolphinConfigsLoading.value = false
+  }
+}
+
+const formatDolphinConfigOption = (item) => {
+  if (!item) {
+    return '-'
+  }
+  const parts = [item.configName || `Dolphin #${item.id}`]
+  if (item.isDefault === 1) {
+    parts.push('默认')
+  }
+  if (!item.isActive) {
+    parts.push('停用')
+  }
+  return parts.join(' / ')
+}
+
+const openSchedulerSwitchDialog = async () => {
+  if (!workflow.value?.workflow?.id) {
+    return
+  }
+  if (!dolphinConfigs.value.length) {
+    await loadDolphinConfigs()
+  }
+  schedulerSwitchForm.dolphinConfigId = currentDolphinConfigId.value
+  schedulerSwitchDialogVisible.value = true
+}
+
+const switchSchedulerEngine = async () => {
+  const wf = workflow.value?.workflow
+  if (!wf?.id) {
+    return
+  }
+  const targetId = schedulerSwitchForm.dolphinConfigId
+  if (!targetId) {
+    ElMessage.warning('请选择目标 Dolphin 环境')
+    return
+  }
+  if (targetId === currentDolphinConfigId.value) {
+    ElMessage.warning('目标环境与当前绑定环境一致')
+    return
+  }
+
+  const target = dolphinConfigs.value.find(item => item.id === targetId)
+  if (target && !target.isActive) {
+    ElMessage.warning('目标 Dolphin 环境未启用')
+    return
+  }
+
+  try {
+    await ElMessageBox.confirm(
+      `确认切换到「${target?.configName || targetId}」吗？切换后旧 Dolphin 不会自动下线，当前工作流需要重新发布到目标 Dolphin。`,
+      '确认切换调度引擎',
+      {
+        type: 'warning',
+        confirmButtonText: '确认切换',
+        cancelButtonText: '取消'
+      }
+    )
+  } catch {
+    return
+  }
+
+  schedulerSwitchSaving.value = true
+  try {
+    await workflowApi.switchSchedulerEngine(wf.id, {
+      dolphinConfigId: targetId,
+      operator: 'portal-ui'
+    })
+    schedulerSwitchDialogVisible.value = false
+    scheduleOptionsLoaded.value = false
+    taskGroupOptions.value = []
+    ElMessage.success('调度引擎已切换，请重新发布工作流')
+    await loadWorkflowDetail()
+    await loadDolphinConfigs()
+    await loadDolphinConfig()
+  } catch (error) {
+    console.error('切换调度引擎失败', error)
+    ElMessage.error(getErrorMessage(error))
+  } finally {
+    schedulerSwitchSaving.value = false
   }
 }
 
@@ -2338,9 +2528,21 @@ const openDolphinInstance = (instance) => {
   window.open(url, '_blank')
 }
 
-onMounted(() => {
-  loadWorkflowDetail()
-  loadDolphinConfig()
+watch(currentDolphinConfigId, async (nextId, prevId) => {
+  if (nextId === prevId) {
+    return
+  }
+  dolphinWebuiUrl.value = ''
+  scheduleOptionsLoaded.value = false
+  taskGroupOptions.value = []
+  if (workflow.value?.workflow?.id) {
+    await loadDolphinConfig()
+  }
+})
+
+onMounted(async () => {
+  await Promise.all([loadDolphinConfigs(), loadWorkflowDetail()])
+  await loadDolphinConfig()
 })
 </script>
 
@@ -2373,6 +2575,21 @@ onMounted(() => {
   align-items: flex-start;
   gap: 4px;
   width: 100%;
+}
+
+.scheduler-engine-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.scheduler-switch-alert {
+  margin-bottom: 16px;
+}
+
+.scheduler-switch-form {
+  margin-top: 4px;
 }
 
 .change-toolbar {

--- a/frontend/src/views/workflows/WorkflowList.vue
+++ b/frontend/src/views/workflows/WorkflowList.vue
@@ -272,6 +272,7 @@ const statusOptions = [
 ]
 
 const dolphinWebuiUrl = ref('')
+const dolphinWebuiUrlByConfigId = reactive({})
 const pendingApprovalFlags = reactive({})
 const createDrawerVisible = ref(false)
 const editingWorkflowId = ref(null)
@@ -291,6 +292,7 @@ const loadWorkflows = async () => {
     })
     workflows.value = res.records || []
     pagination.total = res.total || 0
+    prefetchDolphinWebuiUrls(workflows.value)
   } catch (error) {
     console.error('加载工作流失败', error)
     ElMessage.error('加载工作流失败')
@@ -381,18 +383,20 @@ const syncPendingFlag = (workflowId, records) => {
 }
 
 const canJumpToDolphin = (workflow) => {
+  const webuiUrl = resolveDolphinWebuiUrl(workflow)
   return Boolean(
-    dolphinWebuiUrl.value
+    webuiUrl
     && workflow?.workflowCode
     && workflow?.projectCode
   )
 }
 
 const buildDolphinWorkflowUrl = (workflow) => {
-  if (!dolphinWebuiUrl.value || !workflow?.projectCode || !workflow?.workflowCode) {
+  const webuiUrl = resolveDolphinWebuiUrl(workflow)
+  if (!webuiUrl || !workflow?.projectCode || !workflow?.workflowCode) {
     return ''
   }
-  const base = dolphinWebuiUrl.value.replace(/\/+$/, '')
+  const base = webuiUrl.replace(/\/+$/, '')
   return `${base}/ui/projects/${workflow.projectCode}/workflow/definitions/${workflow.workflowCode}`
 }
 
@@ -407,10 +411,11 @@ const openDolphin = (workflow) => {
 
 
 const buildRowInstanceUrl = (row) => {
-  if (!row || !dolphinWebuiUrl.value || !row.projectCode || !row.workflowCode || !row.latestInstanceId) {
+  const webuiUrl = resolveDolphinWebuiUrl(row)
+  if (!row || !webuiUrl || !row.projectCode || !row.workflowCode || !row.latestInstanceId) {
     return ''
   }
-  const base = dolphinWebuiUrl.value.replace(/\/+$/, '')
+  const base = webuiUrl.replace(/\/+$/, '')
   return `${base}/ui/projects/${row.projectCode}/workflow/instances/${row.latestInstanceId}?code=${row.workflowCode}`
 }
 
@@ -872,6 +877,33 @@ const loadDolphinConfig = async () => {
   } catch (error) {
     console.warn('加载 Dolphin 配置失败', error)
   }
+}
+
+const resolveDolphinWebuiUrl = (workflow) => {
+  const configId = workflow?.dolphinConfigId
+  if (configId && dolphinWebuiUrlByConfigId[configId]) {
+    return dolphinWebuiUrlByConfigId[configId]
+  }
+  return dolphinWebuiUrl.value
+}
+
+const prefetchDolphinWebuiUrls = async (rows) => {
+  const ids = Array.from(new Set((rows || [])
+    .map(row => row?.dolphinConfigId)
+    .filter(Boolean)))
+    .filter(id => !dolphinWebuiUrlByConfigId[id])
+  if (!ids.length) {
+    return
+  }
+  await Promise.all(ids.map(async (id) => {
+    try {
+      const config = await taskApi.getDolphinWebuiConfig({ dolphinConfigId: id })
+      dolphinWebuiUrlByConfigId[id] = config?.webuiUrl || ''
+    } catch (error) {
+      console.warn(`加载 Dolphin WebUI 地址失败: ${id}`, error)
+      dolphinWebuiUrlByConfigId[id] = ''
+    }
+  }))
 }
 
 onMounted(() => {

--- a/frontend/src/views/workflows/WorkflowTaskManager.vue
+++ b/frontend/src/views/workflows/WorkflowTaskManager.vue
@@ -78,6 +78,7 @@
           <TaskTable
             ref="rightTableRef"
             :workflow-id="workflowId"
+            :dolphin-config-id="dolphinConfigId"
             :additional-data="newlyAddedTasks"
             :show-toolbar="true"
             :embedded="true"
@@ -107,6 +108,10 @@ const props = defineProps({
   workflowTaskIds: {
     type: Array,
     default: () => []
+  },
+  dolphinConfigId: {
+    type: Number,
+    default: null
   }
 })
 


### PR DESCRIPTION
## Summary
- Add multi-environment DolphinScheduler configuration management while preserving the legacy default config endpoint.
- Bind workflows and publish records to a Dolphin config, and add a workflow detail action to switch the bound scheduler engine.
- Reset runtime binding fields on scheduler-engine switch so the next publish creates a fresh runtime workflow in the target Dolphin environment; the old Dolphin workflow is not modified.

## Changes
- Added Flyway migration `V43__add_multi_dolphin_config.sql` for Dolphin config metadata, workflow binding, and publish-record traceability.
- Extended Dolphin service/client calls to accept an explicit `dolphinConfigId`, including publish, deploy, schedule, run, backfill, sync, metadata dropdowns, and WebUI URL paths.
- Reworked the admin Dolphin settings tab into a multi-environment table with create/edit/delete/default/test/toggle actions.
- Added workflow detail scheduler-engine display and switch dialog, plus `dolphinConfigId` propagation through task editing, schedule options, and Dolphin WebUI jumps.
- Added targeted backend regression tests for config management and scheduler-engine switching.

## Validation
- `git diff --check origin/main..HEAD` passed.
- `/usr/local/bin/mvn -U -pl backend -am -DfailIfNoTests=false -Dtest=DolphinConfigServiceTest,WorkflowSchedulerEngineSwitchTest,WorkflowPublishServiceTest,WorkflowDeployServiceTest,WorkflowServiceMetadataPersistenceTest test` passed: 35 tests, 0 failures.
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test` passed: 15 files, 87 tests.
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build` passed.

## Risk / Rollback
- Risk: switching to a target Dolphin whose datasource/task-group names do not match the platform definition will require metadata repair before publish.
- Rollback: revert this PR and roll back migration `V43` before relying on per-workflow Dolphin bindings.

## Follow-up
- Run a real integration smoke with Dolphin A -> switch to Dolphin B -> publish to B, and verify the old Dolphin workflow remains unchanged. A same-address/two-project smoke can be used if two Dolphin deployments are unavailable.