### PR TITLE
feat: reorganize intelligent query navigation

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -78,6 +78,12 @@ const routes = [
         meta: { title: '智能问数' }
       },
       {
+        path: '/intelligent-query/skills/:folder',
+        name: 'IntelligentQuerySkillDetail',
+        component: () => import('@/views/intelligence/IntelligentQueryView.vue'),
+        meta: { title: 'Skill 详情' }
+      },
+      {
         path: '/nl2sql',
         redirect: (to) => ({ path: '/intelligent-query', query: to.query, hash: to.hash })
       },
@@ -85,17 +91,24 @@ const routes = [
         path: '/settings',
         name: 'Settings',
         component: () => import('@/views/settings/ConfigurationManagement.vue'),
-        meta: { title: '管理员' }
+        meta: { title: '设置' }
       },
       {
         path: '/settings/skills',
-        redirect: () => ({ path: '/settings', query: { tab: 'skills' } })
+        redirect: (to) => ({
+          path: '/intelligent-query',
+          query: {
+            ...to.query,
+            tab: 'skills'
+          }
+        })
       },
       {
         path: '/settings/skills/:folder',
-        name: 'SkillDetail',
-        component: () => import('@/views/settings/SkillDetailView.vue'),
-        meta: { title: 'Skill 详情' }
+        redirect: (to) => ({
+          path: `/intelligent-query/skills/${encodeURIComponent(String(to.params.folder || ''))}`,
+          query: to.query
+        })
       },
       {
         path: '/playground',

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -55,7 +55,7 @@ const menuItems = computed(() => {
     { index: '/inspection', label: '数据质量', icon: Warning },
     { index: '/integration', label: '数据集成', icon: Link },
     { index: '/intelligent-query', label: '智能问数', icon: ChatDotRound },
-    { index: '/settings', label: '管理员', icon: Setting }
+    { index: '/settings', label: '设置', icon: Setting }
   ]
   if (!isDemoMode) {
     return items

--- a/frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -1,25 +1,141 @@
 <template>
   <div class="intelligent-query-view">
-    <NL2SqlChat />
+    <aside class="intelligent-query-sidebar">
+      <el-menu
+        :default-active="activeMenu"
+        class="intelligent-query-menu"
+        @select="handleMenuSelect"
+      >
+        <el-menu-item index="chat">
+          <el-icon><ChatDotRound /></el-icon>
+          <span>智能问数</span>
+        </el-menu-item>
+        <el-menu-item index="skills">
+          <el-icon><Collection /></el-icon>
+          <span>Skills</span>
+        </el-menu-item>
+        <el-menu-item index="models">
+          <el-icon><Cpu /></el-icon>
+          <span>模型管理</span>
+        </el-menu-item>
+      </el-menu>
+    </aside>
+
+    <main class="intelligent-query-content" :class="{ 'is-chat': activeMenu === 'chat' }">
+      <SkillDetailView v-if="isSkillDetailRoute" />
+      <SkillStudio v-else-if="activeTab === 'skills'" />
+      <DataAgentConfig v-else-if="activeTab === 'models'" />
+      <NL2SqlChat v-else />
+    </main>
   </div>
 </template>
 
 <script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ChatDotRound, Collection, Cpu } from '@element-plus/icons-vue'
 import NL2SqlChat from './NL2SqlChat.vue'
+import SkillStudio from '../settings/SkillStudio.vue'
+import DataAgentConfig from '../settings/DataAgentConfig.vue'
+import SkillDetailView from '../settings/SkillDetailView.vue'
+
+const route = useRoute()
+const router = useRouter()
+const validTabs = new Set(['chat', 'skills', 'models'])
+
+const isSkillDetailRoute = computed(() => (
+  route.name === 'IntelligentQuerySkillDetail' || route.path.startsWith('/intelligent-query/skills/')
+))
+
+const activeTab = computed(() => {
+  if (isSkillDetailRoute.value) {
+    return 'skills'
+  }
+  const tab = String(route.query.tab || 'chat')
+  return validTabs.has(tab) ? tab : 'chat'
+})
+
+const activeMenu = computed(() => activeTab.value)
+
+const handleMenuSelect = (index) => {
+  const tab = validTabs.has(index) ? index : 'chat'
+  if (tab === activeTab.value && !isSkillDetailRoute.value) {
+    return
+  }
+
+  router.replace({
+    path: '/intelligent-query',
+    query: tab === 'chat' ? {} : { tab }
+  })
+}
 </script>
 
 <style scoped>
 .intelligent-query-view {
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 208px minmax(0, 1fr);
+  background: #f4f7fb;
+  overflow: hidden;
+}
+
+.intelligent-query-sidebar {
+  min-width: 0;
+  border-right: 1px solid #dbe3ef;
+  background: #ffffff;
+  overflow: hidden;
+}
+
+.intelligent-query-menu {
+  height: 100%;
+  border-right: none;
+  padding: 12px 0;
+}
+
+.intelligent-query-menu :deep(.el-menu-item) {
+  height: 44px;
+  line-height: 44px;
+}
+
+.intelligent-query-content {
+  min-width: 0;
+  min-height: 0;
   height: 100%;
   padding: 16px;
-  background:
-    radial-gradient(circle at top right, rgba(102, 126, 234, 0.12), transparent 28%),
-    linear-gradient(180deg, #f4f7fb 0%, #edf2f8 100%);
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+.intelligent-query-content.is-chat {
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {
   .intelligent-query-view {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .intelligent-query-sidebar {
+    border-right: none;
+    border-bottom: 1px solid #dbe3ef;
+  }
+
+  .intelligent-query-menu {
+    display: flex;
+    height: auto;
+    padding: 6px;
+    overflow-x: auto;
+  }
+
+  .intelligent-query-menu :deep(.el-menu-item) {
+    flex: 0 0 auto;
+    height: 38px;
+    line-height: 38px;
+  }
+
+  .intelligent-query-content {
     padding: 12px;
   }
 }

--- a/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerReplace = vi.hoisted(() => vi.fn())
+const routeState = vi.hoisted(() => ({
+  path: '/intelligent-query',
+  name: 'IntelligentQuery',
+  query: {},
+  params: {}
+}))
+
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: routerReplace
+  })
+}))
+
+import IntelligentQueryView from '../IntelligentQueryView.vue'
+
+const stubs = {
+  NL2SqlChat: { template: '<div data-test="nl2sql-chat">智能问数聊天</div>' },
+  SkillStudio: { template: '<div data-test="skill-studio">Skills 内容</div>' },
+  DataAgentConfig: { template: '<div data-test="dataagent-config">模型管理内容</div>' },
+  SkillDetailView: { template: '<div data-test="skill-detail">Skill 详情</div>' },
+  'el-menu': {
+    props: ['defaultActive'],
+    emits: ['select'],
+    template: '<nav class="el-menu-stub" :data-active="defaultActive"><slot /></nav>'
+  },
+  'el-menu-item': {
+    props: ['index'],
+    template: '<button class="el-menu-item-stub" :data-index="index"><slot /></button>'
+  },
+  'el-icon': { template: '<span><slot /></span>' }
+}
+
+const mountView = (route = {}) => {
+  routeState.path = route.path || '/intelligent-query'
+  routeState.name = route.name || 'IntelligentQuery'
+  routeState.query = route.query || {}
+  routeState.params = route.params || {}
+  return mount(IntelligentQueryView, {
+    global: { stubs }
+  })
+}
+
+describe('IntelligentQueryView', () => {
+  beforeEach(() => {
+    routerReplace.mockReset()
+  })
+
+  it('renders the original chat workbench by default', () => {
+    const wrapper = mountView()
+
+    expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="skill-studio"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="dataagent-config"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('chat')
+  })
+
+  it('renders Skills from the tab query and updates the query from menu selection', async () => {
+    const wrapper = mountView({ query: { tab: 'skills' } })
+
+    expect(wrapper.find('[data-test="skill-studio"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('skills')
+
+    await wrapper.vm.handleMenuSelect('models')
+    expect(routerReplace).toHaveBeenCalledWith({
+      path: '/intelligent-query',
+      query: { tab: 'models' }
+    })
+  })
+
+  it('renders model management from the tab query', () => {
+    const wrapper = mountView({ query: { tab: 'models' } })
+
+    expect(wrapper.find('[data-test="dataagent-config"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('models')
+  })
+
+  it('keeps Skills selected when rendering the skill detail route', () => {
+    const wrapper = mountView({
+      path: '/intelligent-query/skills/marketing-insights',
+      name: 'IntelligentQuerySkillDetail',
+      params: { folder: 'marketing-insights' }
+    })
+
+    expect(wrapper.find('[data-test="skill-detail"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="skill-studio"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('skills')
+  })
+})

--- a/frontend/src/views/settings/ConfigurationManagement.vue
+++ b/frontend/src/views/settings/ConfigurationManagement.vue
@@ -12,12 +12,6 @@
         <el-tab-pane label="MinIO 环境" name="minio" lazy>
           <MinioConfigManagement />
         </el-tab-pane>
-        <el-tab-pane label="模型服务" name="dataagent" lazy>
-          <DataAgentConfig />
-        </el-tab-pane>
-        <el-tab-pane label="Skill 列表" name="skills" lazy>
-          <SkillStudio />
-        </el-tab-pane>
       </el-tabs>
     </el-card>
   </div>
@@ -28,21 +22,42 @@ import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import DolphinConfig from './DolphinConfig.vue'
 import MinioConfigManagement from './MinioConfigManagement.vue'
-import DataAgentConfig from './DataAgentConfig.vue'
-import SkillStudio from './SkillStudio.vue'
 
 const route = useRoute()
 const router = useRouter()
-const availableTabs = new Set(['dolphin', 'minio', 'dataagent', 'skills'])
+const availableTabs = new Set(['dolphin', 'minio'])
+const legacyTabMap = {
+  dataagent: 'models',
+  skills: 'skills'
+}
 const activeTab = ref(availableTabs.has(route.query.tab) ? route.query.tab : 'dolphin')
+
+const redirectLegacyTab = (tab) => {
+  const targetTab = legacyTabMap[tab]
+  if (!targetTab) {
+    return false
+  }
+  router.replace({
+    path: '/intelligent-query',
+    query: {
+      ...route.query,
+      tab: targetTab
+    }
+  })
+  return true
+}
 
 watch(
   () => route.query.tab,
   (tab) => {
+    if (redirectLegacyTab(tab)) {
+      return
+    }
     if (availableTabs.has(tab)) {
       activeTab.value = tab
     }
-  }
+  },
+  { immediate: true }
 )
 
 watch(activeTab, (tab) => {

--- a/frontend/src/views/settings/SkillDetailView.vue
+++ b/frontend/src/views/settings/SkillDetailView.vue
@@ -300,7 +300,7 @@ const notifyError = (error, fallbackMessage) => {
 
 const goBack = () => {
   router.push({
-    path: '/settings',
+    path: '/intelligent-query',
     query: { tab: 'skills' }
   })
 }

--- a/frontend/src/views/settings/SkillStudio.vue
+++ b/frontend/src/views/settings/SkillStudio.vue
@@ -169,7 +169,7 @@ const loadDocuments = async () => {
 const openSkillDetail = (folder) => {
   if (!folder) return
   router.push({
-    name: 'SkillDetail',
+    name: 'IntelligentQuerySkillDetail',
     params: { folder }
   })
 }

--- a/frontend/src/views/settings/__tests__/ConfigurationManagement.spec.js
+++ b/frontend/src/views/settings/__tests__/ConfigurationManagement.spec.js
@@ -1,0 +1,71 @@
+import { shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerReplace = vi.hoisted(() => vi.fn())
+const routeState = vi.hoisted(() => ({
+  path: '/settings',
+  query: {}
+}))
+
+vi.mock('vue-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: routerReplace
+  })
+}))
+
+import ConfigurationManagement from '../ConfigurationManagement.vue'
+
+const stubs = {
+  DolphinConfig: { template: '<div>Dolphin 配置内容</div>' },
+  MinioConfigManagement: { template: '<div>MinIO 环境内容</div>' },
+  'el-card': { template: '<section><slot /></section>' },
+  'el-tabs': {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<div><slot /></div>'
+  },
+  'el-tab-pane': {
+    props: ['label', 'name'],
+    template: '<div class="tab-pane-stub">{{ label }}<slot /></div>'
+  }
+}
+
+const mountView = (query = {}) => {
+  routeState.query = query
+  return shallowMount(ConfigurationManagement, {
+    global: { stubs }
+  })
+}
+
+describe('ConfigurationManagement', () => {
+  beforeEach(() => {
+    routerReplace.mockReset()
+    routeState.query = {}
+  })
+
+  it('keeps only infrastructure configuration tabs under settings', () => {
+    const wrapper = mountView()
+
+    expect(wrapper.text()).toContain('Dolphin 配置')
+    expect(wrapper.text()).toContain('MinIO 环境')
+    expect(wrapper.text()).not.toContain('模型服务')
+    expect(wrapper.text()).not.toContain('Skill 列表')
+  })
+
+  it('redirects legacy Skill and model query tabs to intelligent query', () => {
+    mountView({ tab: 'skills' })
+    expect(routerReplace).toHaveBeenCalledWith({
+      path: '/intelligent-query',
+      query: { tab: 'skills' }
+    })
+
+    routerReplace.mockReset()
+    mountView({ tab: 'dataagent' })
+    expect(routerReplace).toHaveBeenCalledWith({
+      path: '/intelligent-query',
+      query: { tab: 'models' }
+    })
+  })
+})

--- a/frontend/src/views/settings/__tests__/SkillDetailView.spec.js
+++ b/frontend/src/views/settings/__tests__/SkillDetailView.spec.js
@@ -284,7 +284,7 @@ describe('SkillDetailView', () => {
     expect(apiMocks.uninstallSkill).toHaveBeenCalledWith('marketing-insights')
     expect(messageMocks.success).toHaveBeenCalledWith('Skill「marketing-insights」已卸载')
     expect(routerPush).toHaveBeenCalledWith({
-      path: '/settings',
+      path: '/intelligent-query',
       query: { tab: 'skills' }
     })
   })

--- a/frontend/src/views/settings/__tests__/SkillStudio.spec.js
+++ b/frontend/src/views/settings/__tests__/SkillStudio.spec.js
@@ -169,7 +169,7 @@ describe('SkillStudio', () => {
 
     wrapper.vm.openSkillDetail('marketing-insights')
     expect(routerPush).toHaveBeenCalledWith({
-      name: 'SkillDetail',
+      name: 'IntelligentQuerySkillDetail',
       params: { folder: 'marketing-insights' }
     })
   })

--- a/frontend/src/views/settings/components/SchemaBackupManager.vue
+++ b/frontend/src/views/settings/components/SchemaBackupManager.vue
@@ -94,7 +94,7 @@
           <el-select v-model="configForm.minioConfigId" placeholder="请选择 MinIO 环境" :loading="minioLoading">
             <el-option v-for="item in minioOptions" :key="item.id" :label="item.configName" :value="item.id" />
           </el-select>
-          <div class="tip">在“管理员 / 配置管理 / MinIO 环境”中维护</div>
+          <div class="tip">在“设置 / 配置管理 / MinIO 环境”中维护</div>
         </el-form-item>
 
         <el-form-item label="Bucket" prop="minioBucket">


### PR DESCRIPTION
## Summary
- Rename the top-level admin menu to Settings while keeping the `/settings` route.
- Move Skills and model management into a new left-menu layout under Intelligent Query.
- Rehome Skill detail pages under `/intelligent-query/skills/:folder` with legacy settings routes redirected.

## Changes
- Added an Element Plus vertical menu shell to `IntelligentQueryView` for chat, Skills, and model management content.
- Simplified Settings to Dolphin and MinIO configuration tabs only, with legacy query redirects for moved tabs.
- Updated Skill list/detail navigation and related tests for the new route ownership.

## Validation
- `npm --prefix frontend test -- IntelligentQueryView ConfigurationManagement SkillStudio SkillDetailView` passed: 4 files, 18 tests.
- `npm --prefix frontend run build` passed with existing Sass deprecation/chunk-size warnings.
- `git diff --check` passed.

## Risk
Low to medium: this is frontend route/layout work; the main risk is stale deep links, covered by redirects from the old settings Skill routes.

## Rollback
Revert commit `f468138` to restore the prior Settings tabs and Intelligent Query single-page layout.
