### PR TITLE
[codex] Fix Dolphin engine switch publish export

### DIFF
--- a/backend/src/main/java/com/onedata/portal/service/WorkflowDeployService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowDeployService.java
@@ -214,7 +214,7 @@ public class WorkflowDeployService {
                     offsetInLevel));
         }
 
-        long workflowCode = workflow.getWorkflowCode() == null ? 0L : workflow.getWorkflowCode();
+        long workflowCode = isFirstDeploy(workflow) ? 0L : workflow.getWorkflowCode();
         boolean existingWorkflow = workflowCode > 0;
         if (existingWorkflow) {
             // Check if the workflow definition actually exists in DolphinScheduler
@@ -388,6 +388,13 @@ public class WorkflowDeployService {
             throw new IllegalStateException("检测到任务缺少 Dolphin 元数据，请先保存/修复后再发布: "
                     + String.join(", ", invalidTasks));
         }
+    }
+
+    private boolean isFirstDeploy(DataWorkflow workflow) {
+        if (workflow == null || workflow.getWorkflowCode() == null || workflow.getWorkflowCode() <= 0) {
+            return true;
+        }
+        return "never".equalsIgnoreCase(normalizeText(workflow.getPublishStatus()));
     }
 
     private List<DataTask> resolveUpstreamTasks(DataTask task,

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
@@ -204,7 +204,8 @@ public class WorkflowPublishService {
         WorkflowPublishPreviewResponse response = new WorkflowPublishPreviewResponse();
         response.setWorkflowId(workflow.getId());
         response.setProjectCode(workflow.getProjectCode());
-        response.setWorkflowCode(workflow.getWorkflowCode());
+        boolean firstDeploy = isFirstDeploy(workflow);
+        response.setWorkflowCode(firstDeploy ? null : workflow.getWorkflowCode());
 
         RuntimeWorkflowDefinition platformDefinition = buildPlatformDefinition(workflow);
         if (CollectionUtils.isEmpty(platformDefinition.getTasks())) {
@@ -217,7 +218,7 @@ public class WorkflowPublishService {
         }
 
         RuntimeWorkflowDefinition runtimeDefinition = null;
-        if (workflow.getWorkflowCode() == null || workflow.getWorkflowCode() <= 0) {
+        if (firstDeploy) {
             RuntimeSyncIssue warning = RuntimeSyncIssue.warning(
                     PUBLISH_FIRST_DEPLOY,
                     "Dolphin 侧尚无 workflowCode，当前发布将执行首次部署");
@@ -280,7 +281,7 @@ public class WorkflowPublishService {
     private RuntimeWorkflowDefinition buildPlatformDefinition(DataWorkflow workflow) {
         RuntimeWorkflowDefinition definition = new RuntimeWorkflowDefinition();
         definition.setProjectCode(workflow.getProjectCode());
-        definition.setWorkflowCode(workflow.getWorkflowCode());
+        definition.setWorkflowCode(isFirstDeploy(workflow) ? null : workflow.getWorkflowCode());
         definition.setWorkflowName(workflow.getWorkflowName());
         definition.setDescription(workflow.getDescription());
         definition.setReleaseState(mapWorkflowReleaseState(workflow.getStatus()));
@@ -376,6 +377,13 @@ public class WorkflowPublishService {
                 workflow.getDolphinConfigId(),
                 workflow.getProjectCode(),
                 workflow.getWorkflowCode());
+    }
+
+    private boolean isFirstDeploy(DataWorkflow workflow) {
+        if (workflow == null || workflow.getWorkflowCode() == null || workflow.getWorkflowCode() <= 0) {
+            return true;
+        }
+        return "never".equalsIgnoreCase(normalizeText(workflow.getPublishStatus()));
     }
 
     private RuntimeWorkflowSchedule buildPlatformSchedule(DataWorkflow workflow) {

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
@@ -467,6 +467,9 @@ public class WorkflowService {
             throw new IllegalStateException("目标 Dolphin 项目不可用: " + targetConfig.getProjectName());
         }
 
+        String operator = StringUtils.hasText(request.getOperator()) ? request.getOperator().trim() : "system";
+        LocalDateTime updatedAt = LocalDateTime.now();
+
         workflow.setDolphinConfigId(targetConfigId);
         workflow.setWorkflowCode(null);
         workflow.setProjectCode(targetProjectCode);
@@ -479,10 +482,29 @@ public class WorkflowService {
         workflow.setRuntimeSyncMessage(null);
         workflow.setRuntimeSyncHash(null);
         workflow.setRuntimeSyncAt(null);
-        workflow.setUpdatedBy(StringUtils.hasText(request.getOperator()) ? request.getOperator().trim() : "system");
-        workflow.setUpdatedAt(LocalDateTime.now());
-        workflow.setDefinitionJson(refreshDefinitionRuntimeIds(workflow.getDefinitionJson(), targetConfigId));
-        dataWorkflowMapper.updateById(workflow);
+        workflow.setUpdatedBy(operator);
+        workflow.setUpdatedAt(updatedAt);
+        workflow.setDefinitionJson(refreshDefinitionRuntimeIds(
+                workflow.getDefinitionJson(),
+                targetConfigId,
+                targetProjectCode));
+        dataWorkflowMapper.update(null, Wrappers.<DataWorkflow>lambdaUpdate()
+                .eq(DataWorkflow::getId, workflowId)
+                .set(DataWorkflow::getDolphinConfigId, targetConfigId)
+                .set(DataWorkflow::getWorkflowCode, null)
+                .set(DataWorkflow::getProjectCode, targetProjectCode)
+                .set(DataWorkflow::getDolphinScheduleId, null)
+                .set(DataWorkflow::getScheduleState, "OFFLINE")
+                .set(DataWorkflow::getStatus, "offline")
+                .set(DataWorkflow::getPublishStatus, "never")
+                .set(DataWorkflow::getLastPublishedVersionId, null)
+                .set(DataWorkflow::getRuntimeSyncStatus, null)
+                .set(DataWorkflow::getRuntimeSyncMessage, null)
+                .set(DataWorkflow::getRuntimeSyncHash, null)
+                .set(DataWorkflow::getRuntimeSyncAt, null)
+                .set(DataWorkflow::getDefinitionJson, workflow.getDefinitionJson())
+                .set(DataWorkflow::getUpdatedBy, operator)
+                .set(DataWorkflow::getUpdatedAt, updatedAt));
         return workflow;
     }
 
@@ -1873,7 +1895,7 @@ public class WorkflowService {
         return config != null ? config.getId() : null;
     }
 
-    private String refreshDefinitionRuntimeIds(String definitionJson, Long dolphinConfigId) {
+    private String refreshDefinitionRuntimeIds(String definitionJson, Long dolphinConfigId, Long projectCode) {
         if (!StringUtils.hasText(definitionJson)) {
             return definitionJson;
         }
@@ -1882,13 +1904,74 @@ public class WorkflowService {
             if (!(root instanceof ObjectNode)) {
                 return definitionJson;
             }
-            enrichDefinitionMetadataFromCatalog((ObjectNode) root, dolphinConfigId);
+            ObjectNode rootObject = (ObjectNode) root;
+            resetDefinitionRuntimeBinding(rootObject, projectCode);
+            enrichDefinitionMetadataFromCatalog(rootObject, dolphinConfigId);
             return objectMapper.writeValueAsString(root);
         } catch (Exception ex) {
             log.warn("Failed to refresh workflow definition metadata for Dolphin config {}: {}",
                     dolphinConfigId, ex.getMessage());
             return definitionJson;
         }
+    }
+
+    private void resetDefinitionRuntimeBinding(ObjectNode rootObject, Long projectCode) {
+        if (rootObject == null) {
+            return;
+        }
+        resetWorkflowDefinitionNode(firstPresent(rootObject, "processDefinition"), projectCode);
+        resetWorkflowDefinitionNode(firstPresent(rootObject, "workflowDefinition"), projectCode);
+        resetWorkflowDefinitionNode(firstPresent(rootObject, "workflow"), projectCode);
+
+        JsonNode metaNode = rootObject.get("xPlatformWorkflowMeta");
+        if (metaNode instanceof ObjectNode) {
+            ObjectNode metaObject = (ObjectNode) metaNode;
+            metaObject.remove("workflowCode");
+            if (projectCode != null && projectCode > 0) {
+                metaObject.put("projectCode", projectCode);
+            } else {
+                metaObject.remove("projectCode");
+            }
+        }
+
+        resetScheduleRuntimeBinding(rootObject.get("schedule"));
+        resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "processDefinition"));
+        resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "workflowDefinition"));
+        resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "workflow"));
+    }
+
+    private void resetWorkflowDefinitionNode(JsonNode node, Long projectCode) {
+        if (!(node instanceof ObjectNode)) {
+            return;
+        }
+        ObjectNode object = (ObjectNode) node;
+        object.remove("code");
+        object.remove("workflowCode");
+        object.remove("processDefinitionCode");
+        if (projectCode != null && projectCode > 0) {
+            object.put("projectCode", projectCode);
+        } else {
+            object.remove("projectCode");
+        }
+    }
+
+    private void resetNestedScheduleRuntimeBinding(JsonNode definitionNode) {
+        if (!(definitionNode instanceof ObjectNode)) {
+            return;
+        }
+        resetScheduleRuntimeBinding(definitionNode.get("schedule"));
+    }
+
+    private void resetScheduleRuntimeBinding(JsonNode scheduleNode) {
+        if (!(scheduleNode instanceof ObjectNode)) {
+            return;
+        }
+        ObjectNode scheduleObject = (ObjectNode) scheduleNode;
+        scheduleObject.remove("id");
+        scheduleObject.remove("scheduleId");
+        scheduleObject.remove("dolphinScheduleId");
+        scheduleObject.put("scheduleState", "OFFLINE");
+        scheduleObject.put("releaseState", "OFFLINE");
     }
 
     private void attachLatestInstanceInfo(List<DataWorkflow> workflows) {

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowDeployServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowDeployServiceTest.java
@@ -236,6 +236,77 @@ class WorkflowDeployServiceTest {
         verify(dolphinSchedulerService, never()).listTaskGroups(any());
     }
 
+    @Test
+    void deployShouldIgnoreStaleWorkflowCodeWhenWorkflowWasResetForFirstDeploy() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(1L);
+        workflow.setWorkflowName("wf_switched");
+        workflow.setProjectCode(22L);
+        workflow.setWorkflowCode(5001L);
+        workflow.setPublishStatus("never");
+        workflow.setDescription("switched workflow");
+        workflow.setGlobalParams("[]");
+
+        WorkflowTaskRelation relation = new WorkflowTaskRelation();
+        relation.setWorkflowId(1L);
+        relation.setTaskId(10L);
+        when(workflowTaskRelationMapper.selectList(any())).thenReturn(Collections.singletonList(relation));
+
+        DataTask task = new DataTask();
+        task.setId(10L);
+        task.setTaskName("task_shell");
+        task.setTaskDesc("desc");
+        task.setTaskSql("select 1");
+        task.setEngine("dolphin");
+        task.setDolphinNodeType("SHELL");
+        task.setDolphinTaskCode(1001L);
+        task.setDolphinTaskVersion(1);
+        task.setPriority(5);
+        task.setRetryTimes(1);
+        task.setRetryInterval(1);
+        task.setTimeoutSeconds(60);
+        when(dataTaskMapper.selectBatchIds(anyList())).thenReturn(Collections.singletonList(task));
+        when(tableTaskRelationMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        when(dolphinSchedulerService.buildShellScript(anyString())).thenReturn("echo ok");
+        when(dolphinSchedulerService.buildTaskDefinition(anyLong(), anyInt(), anyString(), anyString(), anyString(),
+                anyString(), anyInt(), anyInt(), anyInt(), anyString(), any(), any(), any(), any(), any()))
+                .thenReturn(Collections.singletonMap("ok", true));
+        when(dolphinSchedulerService.buildRelation(anyLong(), anyInt(), anyLong(), anyInt()))
+                .thenAnswer(invocation -> dolphinRelation(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1),
+                        invocation.getArgument(2),
+                        invocation.getArgument(3)));
+        when(dolphinSchedulerService.buildLocation(anyLong(), anyInt(), anyInt()))
+                .thenAnswer(invocation -> dolphinLocation(invocation.getArgument(0)));
+        when(dolphinSchedulerService.getProjectCode(true)).thenReturn(22L);
+        when(dolphinSchedulerService.syncWorkflow(
+                anyLong(),
+                anyString(),
+                anyString(),
+                anyList(),
+                anyList(),
+                anyList(),
+                any()))
+                .thenReturn(90002L);
+
+        WorkflowDeployService.DeploymentResult result = service.deploy(workflow);
+
+        assertEquals(90002L, result.getWorkflowCode());
+        ArgumentCaptor<Long> workflowCodeCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(dolphinSchedulerService).syncWorkflow(
+                workflowCodeCaptor.capture(),
+                eq("wf_switched"),
+                eq("switched workflow"),
+                anyList(),
+                anyList(),
+                anyList(),
+                eq("[]"));
+        assertEquals(Long.valueOf(0L), workflowCodeCaptor.getValue());
+        verify(dolphinSchedulerService, never()).checkWorkflowExists(anyLong());
+    }
+
     private DolphinSchedulerService.TaskRelationPayload dolphinRelation(long preCode,
             int preVersion,
             long postCode,

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowPublishServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowPublishServiceTest.java
@@ -191,6 +191,24 @@ class WorkflowPublishServiceTest {
     }
 
     @Test
+    void previewPublishShouldTreatNeverPublishedWorkflowAsFirstDeployEvenWithStaleWorkflowCode() {
+        DataWorkflow workflow = workflow(1L, 5001L, 101L);
+        workflow.setPublishStatus("never");
+        mockPreviewInputs(workflow);
+
+        when(dataWorkflowMapper.selectById(1L)).thenReturn(workflow);
+
+        WorkflowPublishPreviewResponse preview = service.previewPublish(1L);
+
+        assertTrue(Boolean.TRUE.equals(preview.getCanPublish()));
+        assertTrue(preview.getWarnings().stream()
+                .anyMatch(issue -> "PUBLISH_FIRST_DEPLOY".equals(issue.getCode())));
+        verify(runtimeDefinitionService, never()).loadRuntimeDefinitionFromExport(any(Long.class), any(Long.class));
+        verify(runtimeDefinitionService, never()).loadRuntimeDefinitionFromExport(
+                any(Long.class), any(Long.class), any(Long.class));
+    }
+
+    @Test
     void publishOnlineShouldUseLastPublishedVersionWhenRequestVersionAbsent() {
         DataWorkflow workflow = workflow(1L, 90001L, 101L);
         workflow.setLastPublishedVersionId(88L);

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
@@ -1,5 +1,9 @@
 package com.onedata.portal.service;
 
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.dto.workflow.WorkflowSchedulerEngineRequest;
 import com.onedata.portal.entity.DataWorkflow;
@@ -13,6 +17,7 @@ import com.onedata.portal.mapper.WorkflowInstanceCacheMapper;
 import com.onedata.portal.mapper.WorkflowPublishRecordMapper;
 import com.onedata.portal.mapper.WorkflowTaskRelationMapper;
 import com.onedata.portal.mapper.WorkflowVersionMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,11 +27,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WorkflowSchedulerEngineSwitchTest {
+
+    static {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new MybatisConfiguration(), "");
+        TableInfoHelper.initTableInfo(assistant, DataWorkflow.class);
+    }
 
     @Mock
     private DataWorkflowMapper dataWorkflowMapper;
@@ -78,7 +92,7 @@ class WorkflowSchedulerEngineSwitchTest {
     }
 
     @Test
-    void switchSchedulerEngineShouldResetRuntimeBindingAndKeepPlatformDefinition() {
+    void switchSchedulerEngineShouldResetRuntimeBindingAndKeepPlatformDefinition() throws Exception {
         DataWorkflow workflow = new DataWorkflow();
         workflow.setId(1L);
         workflow.setDolphinConfigId(1L);
@@ -89,7 +103,11 @@ class WorkflowSchedulerEngineSwitchTest {
         workflow.setPublishStatus("published");
         workflow.setLastPublishedVersionId(88L);
         workflow.setCurrentVersionId(99L);
-        workflow.setDefinitionJson("{\"taskDefinitionList\":[]}");
+        workflow.setDefinitionJson("{\"processDefinition\":{\"code\":5001,\"workflowCode\":5001,\"projectCode\":11,"
+                + "\"name\":\"wf_order\"},\"taskDefinitionList\":[],"
+                + "\"schedule\":{\"id\":900,\"scheduleId\":900,\"dolphinScheduleId\":900,"
+                + "\"crontab\":\"0 0 1 * * ? *\",\"scheduleState\":\"ONLINE\"},"
+                + "\"xPlatformWorkflowMeta\":{\"workflowCode\":5001,\"projectCode\":11}}");
         workflow.setDolphinScheduleId(900L);
         workflow.setScheduleState("ONLINE");
         workflow.setScheduleCron("0 0 1 * * ? *");
@@ -122,8 +140,27 @@ class WorkflowSchedulerEngineSwitchTest {
         assertEquals(Long.valueOf(99L), result.getCurrentVersionId());
         assertEquals("0 0 1 * * ? *", result.getScheduleCron());
 
-        ArgumentCaptor<DataWorkflow> captor = ArgumentCaptor.forClass(DataWorkflow.class);
-        verify(dataWorkflowMapper).updateById(captor.capture());
-        assertEquals(Long.valueOf(2L), captor.getValue().getDolphinConfigId());
+        ArgumentCaptor<LambdaUpdateWrapper<DataWorkflow>> wrapperCaptor =
+                ArgumentCaptor.forClass(LambdaUpdateWrapper.class);
+        verify(dataWorkflowMapper).update(eq(null), wrapperCaptor.capture());
+        verify(dataWorkflowMapper, never()).updateById(org.mockito.ArgumentMatchers.any());
+
+        String sqlSet = wrapperCaptor.getValue().getSqlSet();
+        assertTrue(sqlSet.contains("workflow_code"), sqlSet);
+        assertTrue(sqlSet.contains("dolphin_schedule_id"), sqlSet);
+        assertTrue(sqlSet.contains("last_published_version_id"), sqlSet);
+
+        JsonNode root = new ObjectMapper().readTree(result.getDefinitionJson());
+        JsonNode processDefinition = root.path("processDefinition");
+        assertFalse(processDefinition.has("code"));
+        assertFalse(processDefinition.has("workflowCode"));
+        assertFalse(processDefinition.has("processDefinitionCode"));
+        assertEquals(22L, processDefinition.path("projectCode").asLong());
+        assertFalse(root.path("xPlatformWorkflowMeta").has("workflowCode"));
+        assertEquals(22L, root.path("xPlatformWorkflowMeta").path("projectCode").asLong());
+        assertFalse(root.path("schedule").has("id"));
+        assertFalse(root.path("schedule").has("scheduleId"));
+        assertFalse(root.path("schedule").has("dolphinScheduleId"));
+        assertEquals("OFFLINE", root.path("schedule").path("scheduleState").asText());
     }
 }


### PR DESCRIPTION
## Summary
- Fix scheduler-engine switch cleanup so stale Dolphin workflow and schedule identifiers are explicitly cleared in persistence.
- Reset runtime identifiers inside workflow definition JSON while preserving platform schedule settings and refreshing target-environment metadata.
- Treat `publishStatus=never` workflows as first deploys during publish preview and deploy, even if old workflow codes remain in historical data.

## Root Cause
MyBatis-Plus `updateById` skipped null fields during scheduler-engine switch, so old `workflowCode` and schedule bindings could remain in the database. The next publish preview combined the new target `projectCode` with the stale workflow code and failed on Dolphin batch export.

## Validation
- `mvn -pl backend-agent-api install -DskipTests`
- `cd backend && mvn test -Dtest=WorkflowSchedulerEngineSwitchTest,WorkflowPublishServiceTest,WorkflowDeployServiceTest`

## Risk
Low: the change is scoped to Dolphin switch cleanup and first-deploy guards, with regression coverage for switch, preview, and deploy behavior.

## Rollback
Revert commit `7cbaa93` to restore the previous scheduler-engine switch and publish behavior.