### PR TITLE
[codex] Fix stale taskGroupId after Dolphin switch

### DIFF
--- a/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowPublishService.java
@@ -1052,7 +1052,7 @@ public class WorkflowPublishService {
             }
             Integer taskGroupId = readInt(taskObject, "taskGroupId");
             String taskGroupName = readText(taskObject, "taskGroupName");
-            if ((taskGroupId == null || taskGroupId <= 0) && StringUtils.hasText(taskGroupName)) {
+            if (shouldResolveTaskGroupByName(workflow, taskGroupId, taskGroupName)) {
                 needTaskGroupResolve = true;
             }
         }
@@ -1130,10 +1130,12 @@ public class WorkflowPublishService {
             }
             Integer taskGroupId = readInt(taskObject, "taskGroupId");
             String taskGroupName = readText(taskObject, "taskGroupName");
-            if ((taskGroupId == null || taskGroupId <= 0) && StringUtils.hasText(taskGroupName)) {
+            if (shouldResolveTaskGroupByName(workflow, taskGroupId, taskGroupName)) {
                 DolphinTaskGroupOption groupOption = taskGroupByName.get(taskGroupName.trim());
                 if (groupOption != null && groupOption.getId() != null && groupOption.getId() > 0) {
                     changed |= putInt(taskObject, "taskGroupId", groupOption.getId());
+                } else if (isFirstDeploy(workflow)) {
+                    changed |= removeField(taskObject, "taskGroupId");
                 }
             }
         }
@@ -1188,6 +1190,13 @@ public class WorkflowPublishService {
         return "task.datasourceId".equals(field) || "task.taskGroupId".equals(field);
     }
 
+    private boolean shouldResolveTaskGroupByName(DataWorkflow workflow, Integer taskGroupId, String taskGroupName) {
+        if (!StringUtils.hasText(taskGroupName)) {
+            return false;
+        }
+        return taskGroupId == null || taskGroupId <= 0 || isFirstDeploy(workflow);
+    }
+
     private ObjectNode ensureObject(ObjectNode root, String field) {
         if (root == null || !StringUtils.hasText(field)) {
             return objectMapper.createObjectNode();
@@ -1222,6 +1231,14 @@ public class WorkflowPublishService {
             return false;
         }
         node.put(field, value);
+        return true;
+    }
+
+    private boolean removeField(ObjectNode node, String field) {
+        if (node == null || !StringUtils.hasText(field) || !node.has(field)) {
+            return false;
+        }
+        node.remove(field);
         return true;
     }
 

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowService.java
@@ -1938,6 +1938,7 @@ public class WorkflowService {
         resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "processDefinition"));
         resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "workflowDefinition"));
         resetNestedScheduleRuntimeBinding(firstPresent(rootObject, "workflow"));
+        resetTaskGroupRuntimeBinding(rootObject.get("taskDefinitionList"));
     }
 
     private void resetWorkflowDefinitionNode(JsonNode node, Long projectCode) {
@@ -1972,6 +1973,17 @@ public class WorkflowService {
         scheduleObject.remove("dolphinScheduleId");
         scheduleObject.put("scheduleState", "OFFLINE");
         scheduleObject.put("releaseState", "OFFLINE");
+    }
+
+    private void resetTaskGroupRuntimeBinding(JsonNode taskListNode) {
+        if (!(taskListNode instanceof ArrayNode)) {
+            return;
+        }
+        for (JsonNode taskNode : (ArrayNode) taskListNode) {
+            if (taskNode instanceof ObjectNode) {
+                ((ObjectNode) taskNode).remove("taskGroupId");
+            }
+        }
     }
 
     private void attachLatestInstanceInfo(List<DataWorkflow> workflows) {

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowPublishServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowPublishServiceTest.java
@@ -857,6 +857,34 @@ class WorkflowPublishServiceTest {
     }
 
     @Test
+    void repairPublishMetadataShouldOverwriteStaleTaskGroupIdFromTargetCatalog() {
+        WorkflowPublishService publishService = buildPreviewServiceWithRealDiff();
+        DataWorkflow workflow = workflow(1L, null, 101L);
+        workflow.setDolphinConfigId(2L);
+        workflow.setPublishStatus("never");
+        workflow.setDefinitionJson("{\"taskDefinitionList\":[{\"taskCode\":10001,\"taskGroupId\":12,"
+                + "\"taskGroupName\":\"tg_a\",\"taskParams\":{}}]}");
+        when(dataWorkflowMapper.selectById(1L)).thenReturn(workflow);
+        when(dolphinSchedulerService.listDatasources(null, null, 2L))
+                .thenReturn(Collections.emptyList());
+
+        DolphinTaskGroupOption groupOption = new DolphinTaskGroupOption();
+        groupOption.setId(71);
+        groupOption.setName("tg_a");
+        when(dolphinSchedulerService.listTaskGroups(null, 2L))
+                .thenReturn(Collections.singletonList(groupOption));
+
+        WorkflowPublishRepairRequest request = new WorkflowPublishRepairRequest();
+        request.setOperator("tester");
+        WorkflowPublishRepairResponse response = publishService.repairPublishMetadata(1L, request);
+
+        assertTrue(Boolean.TRUE.equals(response.getRepaired()));
+        assertTrue(workflow.getDefinitionJson().contains("\"taskGroupId\":71"));
+        verify(dataWorkflowMapper, times(1)).updateById(any(DataWorkflow.class));
+        verify(workflowService, times(1)).normalizeAndPersistMetadata(1L, "tester");
+    }
+
+    @Test
     void repairPublishMetadataShouldOverwriteWrongDatasourceTypeFromCatalog() {
         WorkflowPublishService publishService = buildPreviewServiceWithRealDiff();
         DataWorkflow workflow = workflow(1L, null, 101L);

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowSchedulerEngineSwitchTest.java
@@ -5,6 +5,7 @@ import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.DolphinTaskGroupOption;
 import com.onedata.portal.dto.workflow.WorkflowSchedulerEngineRequest;
 import com.onedata.portal.entity.DataWorkflow;
 import com.onedata.portal.entity.DolphinConfig;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -104,7 +107,9 @@ class WorkflowSchedulerEngineSwitchTest {
         workflow.setLastPublishedVersionId(88L);
         workflow.setCurrentVersionId(99L);
         workflow.setDefinitionJson("{\"processDefinition\":{\"code\":5001,\"workflowCode\":5001,\"projectCode\":11,"
-                + "\"name\":\"wf_order\"},\"taskDefinitionList\":[],"
+                + "\"name\":\"wf_order\",\"taskGroupName\":\"tg_default\"},"
+                + "\"taskDefinitionList\":[{\"taskCode\":1001,\"taskGroupId\":12,"
+                + "\"taskGroupName\":\"tg_default\",\"taskParams\":{}}],"
                 + "\"schedule\":{\"id\":900,\"scheduleId\":900,\"dolphinScheduleId\":900,"
                 + "\"crontab\":\"0 0 1 * * ? *\",\"scheduleState\":\"ONLINE\"},"
                 + "\"xPlatformWorkflowMeta\":{\"workflowCode\":5001,\"projectCode\":11}}");
@@ -126,6 +131,11 @@ class WorkflowSchedulerEngineSwitchTest {
         when(dolphinConfigService.getEnabledConfig(2L)).thenReturn(target);
         when(dolphinSchedulerService.testConnection(2L)).thenReturn(true);
         when(dolphinSchedulerService.getProjectCode(2L, true)).thenReturn(22L);
+        DolphinTaskGroupOption targetGroup = new DolphinTaskGroupOption();
+        targetGroup.setId(71);
+        targetGroup.setName("tg_default");
+        when(dolphinSchedulerService.listTaskGroups(null, 2L))
+                .thenReturn(Collections.singletonList(targetGroup));
 
         DataWorkflow result = workflowService.switchSchedulerEngine(1L, request);
 
@@ -162,5 +172,6 @@ class WorkflowSchedulerEngineSwitchTest {
         assertFalse(root.path("schedule").has("scheduleId"));
         assertFalse(root.path("schedule").has("dolphinScheduleId"));
         assertEquals("OFFLINE", root.path("schedule").path("scheduleState").asText());
+        assertEquals(71, root.path("taskDefinitionList").get(0).path("taskGroupId").asInt());
     }
 }


### PR DESCRIPTION
## Summary
- Clear task-level `taskGroupId` when switching a workflow to a different Dolphin environment, then remap it from the target environment by `taskGroupName`.
- Make publish metadata repair overwrite stale positive `taskGroupId` values for first-deploy workflows instead of treating them as valid.
- Add regression coverage for switch-time remapping and repair-time remapping.

## Root Cause
The previous switch fix cleared workflow and schedule runtime IDs, but `taskGroupId` was still considered valid whenever it was a positive number. Since Dolphin task group IDs are environment-specific, a positive value from the old cluster could survive and be sent to the new cluster.

## Validation
- `cd backend && mvn test -Dtest=WorkflowSchedulerEngineSwitchTest,WorkflowPublishServiceTest,WorkflowDeployServiceTest`

## Risk
Low: behavior is scoped to first-deploy/scheduler-switch flows and only remaps task group IDs when a task group name is available.

## Rollback
Revert commit `b75a557` to restore the previous task group ID handling.