### PR TITLE
fix: surface opendataagent model stream failures

### DIFF
--- a/opendataagent/server/internal/app/app.go
+++ b/opendataagent/server/internal/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -417,6 +418,8 @@ func (a *App) runTask(taskID string) {
 	a.mu.Unlock()
 	defer a.clearTaskCancel(taskID)
 
+	log.Printf("agent task started task_id=%s topic_id=%s provider=%s model=%s", task.TaskID, task.TopicID, task.ProviderID, task.ModelName)
+
 	modelFactory, _, err := agentcfg.CreateModelFactoryFromSettings(
 		settings,
 		task.ProviderID,
@@ -424,6 +427,7 @@ func (a *App) runTask(taskID string) {
 		runtime.NewMockModelFactory(activeSkills, activeMcps),
 	)
 	if err != nil {
+		log.Printf("agent task model setup failed task_id=%s provider=%s model=%s error=%v", task.TaskID, task.ProviderID, task.ModelName, err)
 		a.finishTaskError(taskID, err, runtime.TaskResult{})
 		return
 	}
@@ -440,16 +444,20 @@ func (a *App) runTask(taskID string) {
 	})
 	if err != nil {
 		if errors.Is(err, context.Canceled) || a.isTaskCancelled(taskID) {
+			log.Printf("agent task cancelled task_id=%s provider=%s model=%s", task.TaskID, task.ProviderID, task.ModelName)
 			a.finishTaskAsCancelled(taskID)
 			return
 		}
+		log.Printf("agent task failed task_id=%s provider=%s model=%s error=%v", task.TaskID, task.ProviderID, task.ModelName, err)
 		a.finishTaskError(taskID, err, result)
 		return
 	}
 	if a.isTaskCancelled(taskID) {
+		log.Printf("agent task cancelled task_id=%s provider=%s model=%s", task.TaskID, task.ProviderID, task.ModelName)
 		a.finishTaskAsCancelled(taskID)
 		return
 	}
+	log.Printf("agent task finished task_id=%s provider=%s model=%s final_len=%d blocks=%d", task.TaskID, task.ProviderID, task.ModelName, len(result.Final), len(result.Blocks))
 	a.finishTaskSuccess(taskID, result)
 }
 
@@ -547,12 +555,25 @@ func (a *App) finishTaskError(taskID string, runErr error, result runtime.TaskRe
 			}
 		}
 	}
+	if !a.hasErrorEventLocked(taskID) {
+		a.appendTaskEventLocked(taskID, models.TaskEvent{
+			Type: "error",
+			Payload: map[string]interface{}{
+				"message": runErr.Error(),
+			},
+		})
+	}
 	_ = a.saveLocked()
 }
 
 func (a *App) appendTaskEvent(taskID string, event models.TaskEvent) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.appendTaskEventLocked(taskID, event)
+	_ = a.saveLocked()
+}
+
+func (a *App) appendTaskEventLocked(taskID string, event models.TaskEvent) {
 	task, ok := a.state.Tasks[taskID]
 	if !ok {
 		return
@@ -564,8 +585,16 @@ func (a *App) appendTaskEvent(taskID string, event models.TaskEvent) {
 	event.MessageID = task.AssistantMessageID
 	event.CreatedAt = util.Now()
 	a.state.TaskEvents[taskID] = append(a.state.TaskEvents[taskID], event)
-	_ = a.saveLocked()
 	a.broadcastLocked(taskID, event)
+}
+
+func (a *App) hasErrorEventLocked(taskID string) bool {
+	for _, event := range a.state.TaskEvents[taskID] {
+		if event.Type == "error" {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) GetTask(taskID string) (models.Task, error) {

--- a/opendataagent/server/internal/app/app_test.go
+++ b/opendataagent/server/internal/app/app_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"opendataagent/server/internal/models"
+	"opendataagent/server/internal/runtime"
+)
+
+type memoryStore struct {
+	state models.StateSnapshot
+}
+
+func (s *memoryStore) Load() (models.StateSnapshot, error) {
+	return s.state, nil
+}
+
+func (s *memoryStore) Save(state models.StateSnapshot) error {
+	s.state = state
+	return nil
+}
+
+func (s *memoryStore) Close() error {
+	return nil
+}
+
+func TestFinishTaskErrorBroadcastsRuntimeErrorEvent(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	taskID := "task-1"
+	topicID := "topic-1"
+	messageID := "assistant-1"
+	core := &App{
+		store:       &memoryStore{},
+		subscribers: map[string]map[chan models.TaskEvent]struct{}{},
+		taskCancels: map[string]context.CancelFunc{},
+		state: models.StateSnapshot{
+			Topics: map[string]*models.Topic{
+				topicID: {
+					TopicID:           topicID,
+					CurrentTaskID:     taskID,
+					CurrentTaskStatus: "running",
+					Messages: []models.Message{
+						{
+							MessageID:  messageID,
+							TopicID:    topicID,
+							SenderType: "assistant",
+							Status:     "running",
+							TaskID:     taskID,
+							CreatedAt:  now,
+							UpdatedAt:  now,
+						},
+					},
+				},
+			},
+			Tasks: map[string]*models.Task{
+				taskID: {
+					TaskID:             taskID,
+					TopicID:            topicID,
+					AssistantMessageID: messageID,
+					TaskStatus:         "running",
+					CreatedAt:          now,
+					UpdatedAt:          now,
+				},
+			},
+			TaskEvents: map[string][]models.TaskEvent{},
+		},
+	}
+
+	events, unsubscribe := core.Subscribe(taskID)
+	defer unsubscribe()
+
+	core.finishTaskError(taskID, errors.New("gateway stream failed"), runtime.TaskResult{})
+
+	select {
+	case event := <-events:
+		if event.Type != "error" {
+			t.Fatalf("expected error event, got %#v", event)
+		}
+		if got := event.Payload["message"]; got != "gateway stream failed" {
+			t.Fatalf("unexpected error message payload: %#v", event.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for error event")
+	}
+}

--- a/opendataagent/server/internal/runtime/runtime.go
+++ b/opendataagent/server/internal/runtime/runtime.go
@@ -72,12 +72,38 @@ func Run(ctx context.Context, input RunInput, emit EventEmitter) (TaskResult, er
 		return TaskResult{}, err
 	}
 
+	var streamErr error
 	for streamEvent := range stream {
+		if streamEvent.Type == sdkapi.EventError && streamErr == nil {
+			streamErr = errors.New(defaultString(fmt.Sprint(streamEvent.Output), "runtime error"))
+		}
 		for _, taskEvent := range convertStreamEvent(streamEvent) {
 			emitEvent(taskEvent)
 		}
 	}
-	return collector.Result(), nil
+	result := collector.Result()
+	if streamErr != nil {
+		return result, streamErr
+	}
+	if isEmptyTaskResult(result) {
+		return result, errors.New("model returned empty response")
+	}
+	return result, nil
+}
+
+func isEmptyTaskResult(result TaskResult) bool {
+	if strings.TrimSpace(result.Final) != "" {
+		return false
+	}
+	for _, block := range result.Blocks {
+		if strings.TrimSpace(block.Text) != "" {
+			return false
+		}
+		if block.Tool != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func buildOptions(input RunInput) sdkapi.Options {
@@ -548,14 +574,14 @@ func sanitizeSkillName(value string) string {
 }
 
 type collector struct {
-	blocks     []*models.MessageBlock
-	blockIndex map[string]*models.MessageBlock
-	toolInput  map[string]string
-	toolBlocks map[string]string
+	blocks      []*models.MessageBlock
+	blockIndex  map[string]*models.MessageBlock
+	toolInput   map[string]string
+	toolBlocks  map[string]string
 	textParsers map[string]*textStreamParser
-	usage      map[string]interface{}
-	mainText   strings.Builder
-	messageSeq int
+	usage       map[string]interface{}
+	mainText    strings.Builder
+	messageSeq  int
 }
 
 type textStreamParser struct {
@@ -566,11 +592,11 @@ type textStreamParser struct {
 
 func newCollector() *collector {
 	return &collector{
-		blockIndex: map[string]*models.MessageBlock{},
-		toolInput:  map[string]string{},
-		toolBlocks: map[string]string{},
+		blockIndex:  map[string]*models.MessageBlock{},
+		toolInput:   map[string]string{},
+		toolBlocks:  map[string]string{},
 		textParsers: map[string]*textStreamParser{},
-		usage:      map[string]interface{}{},
+		usage:       map[string]interface{}{},
 	}
 }
 

--- a/opendataagent/server/internal/runtime/runtime_test.go
+++ b/opendataagent/server/internal/runtime/runtime_test.go
@@ -1,9 +1,13 @@
 package runtime
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	sdkapi "github.com/stellarlinkco/agentsdk-go/pkg/api"
+	sdkmodel "github.com/stellarlinkco/agentsdk-go/pkg/model"
 
 	"opendataagent/server/internal/agent"
 	"opendataagent/server/internal/models"
@@ -11,6 +15,67 @@ import (
 
 func intPtr(value int) *int {
 	return &value
+}
+
+type failingStreamModel struct {
+	err error
+}
+
+func (m failingStreamModel) Complete(context.Context, sdkmodel.Request) (*sdkmodel.Response, error) {
+	return nil, m.err
+}
+
+func (m failingStreamModel) CompleteStream(context.Context, sdkmodel.Request, sdkmodel.StreamHandler) error {
+	return m.err
+}
+
+type emptyStreamModel struct{}
+
+func (m emptyStreamModel) Complete(context.Context, sdkmodel.Request) (*sdkmodel.Response, error) {
+	return &sdkmodel.Response{Message: sdkmodel.Message{Role: "assistant"}}, nil
+}
+
+func (m emptyStreamModel) CompleteStream(_ context.Context, _ sdkmodel.Request, cb sdkmodel.StreamHandler) error {
+	return cb(sdkmodel.StreamResult{
+		Final: true,
+		Response: &sdkmodel.Response{
+			Message: sdkmodel.Message{Role: "assistant"},
+		},
+	})
+}
+
+func TestRunReturnsErrorWhenStreamReportsModelError(t *testing.T) {
+	t.Setenv("ODA_DISABLE_AGENT_TOOLS", "1")
+
+	result, err := Run(context.Background(), RunInput{
+		Prompt:      "hello",
+		SessionID:   "stream-error",
+		ProjectRoot: t.TempDir(),
+		ModelFactory: sdkapi.ModelFactoryFunc(func(context.Context) (sdkmodel.Model, error) {
+			return failingStreamModel{err: errors.New("gateway stream failed")}, nil
+		}),
+	}, nil)
+
+	if err == nil || !strings.Contains(err.Error(), "gateway stream failed") {
+		t.Fatalf("expected stream error, got result=%#v err=%v", result, err)
+	}
+}
+
+func TestRunReturnsErrorWhenModelProducesNoContent(t *testing.T) {
+	t.Setenv("ODA_DISABLE_AGENT_TOOLS", "1")
+
+	result, err := Run(context.Background(), RunInput{
+		Prompt:      "hello",
+		SessionID:   "empty-response",
+		ProjectRoot: t.TempDir(),
+		ModelFactory: sdkapi.ModelFactoryFunc(func(context.Context) (sdkmodel.Model, error) {
+			return emptyStreamModel{}, nil
+		}),
+	}, nil)
+
+	if err == nil || !strings.Contains(err.Error(), "model returned empty response") {
+		t.Fatalf("expected empty response error, got result=%#v err=%v", result, err)
+	}
 }
 
 func TestCollectorPreservesMarkdownLineBreaksInTextDeltas(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix opendataagent chat runs that silently finish with no assistant output when an Anthropic-compatible gateway reports a stream error or empty model response.
- Treat runtime stream errors and empty model output as explicit task failures, then surface the failure through task events, persisted task state, and server logs.

## What Changed

### Behavior Changes
- Converts SDK `error` stream events into `runtime.Run` errors instead of returning a successful empty result.
- Fails empty model responses with `model returned empty response`, preventing blank successful assistant messages.
- Broadcasts a task `error` event when task execution fails so the chat UI can render the error immediately.
- Adds task lifecycle logs for start, setup failure, runtime failure, cancellation, and success without logging tokens or request secrets.

### Key Files
- `opendataagent/server/internal/runtime/runtime.go`: promotes stream errors and empty results to runtime failures.
- `opendataagent/server/internal/app/app.go`: logs task lifecycle and emits persisted/broadcast task error events.
- `opendataagent/server/internal/runtime/runtime_test.go`: covers stream error and empty response regressions.
- `opendataagent/server/internal/app/app_test.go`: covers error event broadcast on task failure.


## Validation
- Command: `cd opendataagent/server && /Users/guoruping/.goenv/versions/1.24.13/bin/go test ./...`
  Result: pass; all opendataagent server packages completed successfully.

## Risks
- Main regression risk: providers that intentionally return empty text with only metadata will now be marked as failed; current chat flow expects visible text/tool output, so this is the safer behavior for the reported symptom.

## Rollback
- Fast rollback path: revert commit `6df8069` to restore the previous silent-success behavior.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updates not required for this backend-only runtime error handling fix.
