### PR TITLE
[codex] Unify agent query limits and SQL validation

### DIFF
--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
@@ -23,11 +23,18 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class BackendAgentQueryService implements AgentQueryService {
 
-    private static final int DEFAULT_LIMIT = 200;
-    private static final int MAX_LIMIT = 1000;
+    private static final int DEFAULT_LIMIT = 1000;
+    private static final int MAX_LIMIT = 10000;
     private static final int DEFAULT_TIMEOUT_SECONDS = 30;
     private static final int MAX_TIMEOUT_SECONDS = 120;
     private static final Pattern LEADING_KEYWORD_PATTERN = Pattern.compile("^\\s*([a-zA-Z]+)");
+    private static final Pattern MUTATING_FALLBACK_KEYWORD_PATTERN = Pattern.compile(
+            "(^|[^a-zA-Z0-9_])(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|REPLACE|MERGE|CALL|GRANT|REVOKE)([^a-zA-Z0-9_]|$)",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Set<String> READ_ONLY_PARSE_FALLBACK_KEYWORDS = new LinkedHashSet<>(
+            Arrays.asList("SELECT", "WITH", "SHOW", "DESC", "DESCRIBE", "EXPLAIN")
+    );
     private static final Set<String> READ_ONLY_FALLBACK_KEYWORDS = new LinkedHashSet<>(
             Arrays.asList("SHOW", "DESC", "DESCRIBE", "EXPLAIN")
     );
@@ -76,7 +83,8 @@ public class BackendAgentQueryService implements AgentQueryService {
         try {
             statements = CCJSqlParserUtil.parseStatements(sql);
         } catch (JSQLParserException e) {
-            throw new IllegalArgumentException("SQL 解析失败，仅支持单条只读 SQL");
+            validateReadOnlySqlWithLexicalFallback(sql);
+            return;
         }
         if (statements == null || statements.getStatements() == null || statements.getStatements().isEmpty()) {
             throw new IllegalArgumentException("SQL 不能为空");
@@ -104,6 +112,138 @@ public class BackendAgentQueryService implements AgentQueryService {
         }
 
         return READ_ONLY_FALLBACK_KEYWORDS.contains(detectLeadingKeyword(sql));
+    }
+
+    private void validateReadOnlySqlWithLexicalFallback(String sql) {
+        String normalizedSql = maskCommentsAndQuotedText(sql);
+        if (!isSingleStatement(normalizedSql)) {
+            throw new IllegalArgumentException("仅支持单条只读 SQL");
+        }
+        if (!READ_ONLY_PARSE_FALLBACK_KEYWORDS.contains(detectLeadingKeyword(normalizedSql))) {
+            throw new IllegalArgumentException("仅支持只读 SQL");
+        }
+        if (MUTATING_FALLBACK_KEYWORD_PATTERN.matcher(normalizedSql).find()) {
+            throw new IllegalArgumentException("仅支持只读 SQL");
+        }
+    }
+
+    private boolean isSingleStatement(String normalizedSql) {
+        boolean seenTerminator = false;
+        for (int i = 0; i < normalizedSql.length(); i++) {
+            char current = normalizedSql.charAt(i);
+            if (current == ';') {
+                if (seenTerminator) {
+                    return false;
+                }
+                seenTerminator = true;
+                continue;
+            }
+            if (seenTerminator && !Character.isWhitespace(current)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String maskCommentsAndQuotedText(String sql) {
+        StringBuilder result = new StringBuilder(sql.length());
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+        boolean inBacktick = false;
+        boolean inLineComment = false;
+        boolean inBlockComment = false;
+
+        for (int i = 0; i < sql.length(); i++) {
+            char current = sql.charAt(i);
+            char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
+
+            if (inLineComment) {
+                result.append(isLineBreak(current) ? current : ' ');
+                if (isLineBreak(current)) {
+                    inLineComment = false;
+                }
+                continue;
+            }
+            if (inBlockComment) {
+                if (current == '*' && next == '/') {
+                    result.append(' ');
+                    result.append(' ');
+                    i++;
+                    inBlockComment = false;
+                } else {
+                    result.append(isLineBreak(current) ? current : ' ');
+                }
+                continue;
+            }
+            if (inSingleQuote) {
+                result.append(isLineBreak(current) ? current : ' ');
+                if (current == '\\' && next != '\0') {
+                    result.append(isLineBreak(next) ? next : ' ');
+                    i++;
+                } else if (current == '\'' && next == '\'') {
+                    result.append(' ');
+                    i++;
+                } else if (current == '\'') {
+                    inSingleQuote = false;
+                }
+                continue;
+            }
+            if (inDoubleQuote) {
+                result.append(isLineBreak(current) ? current : ' ');
+                if (current == '\\' && next != '\0') {
+                    result.append(isLineBreak(next) ? next : ' ');
+                    i++;
+                } else if (current == '"' && next == '"') {
+                    result.append(' ');
+                    i++;
+                } else if (current == '"') {
+                    inDoubleQuote = false;
+                }
+                continue;
+            }
+            if (inBacktick) {
+                result.append(isLineBreak(current) ? current : ' ');
+                if (current == '`' && next == '`') {
+                    result.append(' ');
+                    i++;
+                } else if (current == '`') {
+                    inBacktick = false;
+                }
+                continue;
+            }
+
+            if (current == '-' && next == '-') {
+                result.append(' ');
+                result.append(' ');
+                i++;
+                inLineComment = true;
+            } else if (current == '#') {
+                result.append(' ');
+                inLineComment = true;
+            } else if (current == '/' && next == '*') {
+                result.append(' ');
+                result.append(' ');
+                i++;
+                inBlockComment = true;
+            } else if (current == '\'') {
+                result.append(' ');
+                inSingleQuote = true;
+            } else if (current == '"') {
+                result.append(' ');
+                inDoubleQuote = true;
+            } else if (current == '`') {
+                result.append(' ');
+                inBacktick = true;
+            } else {
+                result.append(current);
+            }
+        }
+
+        return result.toString();
+    }
+
+    private boolean isLineBreak(char value) {
+        return value == '\n' || value == '\r';
     }
 
     private String detectLeadingKeyword(String sql) {

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
@@ -99,6 +99,66 @@ class BackendAgentQueryServiceTest {
     }
 
     @Test
+    void readQueryAcceptsDorisSelectWithNestedNotInAndChineseAliases() {
+        String sql = "SELECT\n"
+                + "  c.cmp_name AS 组件英文名,\n"
+                + "  c.cn_cmp_name AS 组件中文名,\n"
+                + "  c.env_name AS 环境,\n"
+                + "  c.system_level AS 分级保障,\n"
+                + "  c.component_type AS 组件类型\n"
+                + "FROM public.dim_tech_public_env_cmp_df c\n"
+                + "WHERE c.ds = (\n"
+                + "  SELECT MAX(ds)\n"
+                + "  FROM public.dim_tech_public_env_cmp_df\n"
+                + "  WHERE ds <= '2026-05-08'\n"
+                + ")\n"
+                + "AND c.component_type != 'DB'\n"
+                + "AND c.env_name = 'PROD'\n"
+                + "AND c.cmp_name NOT IN (\n"
+                + "  SELECT DISTINCT cmp_name\n"
+                + "  FROM public.dim_tech_public_env_cmp_df\n"
+                + "  WHERE ds = (\n"
+                + "    SELECT MAX(ds)\n"
+                + "    FROM public.dim_tech_public_env_cmp_df\n"
+                + "    WHERE ds <= '2026-04-08'\n"
+                + "  )\n"
+                + "  AND component_type != 'DB'\n"
+                + "  AND env_name = 'PROD'\n"
+                + ")\n"
+                + "ORDER BY c.cmp_name\n"
+                + "LIMIT 500;";
+
+        assertReadQueryAccepted(sql);
+    }
+
+    @Test
+    void readQueryAcceptsDorisSelectWithChineseAliasAndMutatingWordsInMaskedText() {
+        String sql = "/* example only: update demo set name = 'x'; delete from demo; */\n"
+                + "SELECT c.cmp_name AS 组件英文名\n"
+                + "FROM public.dim_tech_public_env_cmp_df c\n"
+                + "WHERE c.remark = 'drop table demo; update demo set name = ''x'''\n"
+                + "LIMIT 10;";
+
+        assertReadQueryAccepted(sql);
+    }
+
+    @Test
+    void readQueryRejectsMultipleStatementsWhenParserFallbackHandlesDorisAlias() {
+        assertReadQueryRejected(
+                "SELECT c.cmp_name AS 组件英文名 FROM public.dim_tech_public_env_cmp_df c; SELECT 2",
+                "仅支持单条只读 SQL"
+        );
+    }
+
+    @Test
+    void readQueryRejectsMutatingSqlWhenParserFallbackHandlesDorisAlias() {
+        assertReadQueryRejected(
+                "SELECT c.cmp_name AS 组件英文名 FROM public.dim_tech_public_env_cmp_df c DELETE FROM demo",
+                "仅支持只读 SQL"
+        );
+    }
+
+    @Test
     void readQueryAcceptsShowSql() {
         assertReadQueryAccepted("SHOW TABLES");
     }
@@ -142,19 +202,19 @@ class BackendAgentQueryServiceTest {
         AgentReadQueryRequest request = new AgentReadQueryRequest();
         request.setDatabase("opendataworks");
         request.setSql("SELECT 1");
-        request.setLimit(5000);
+        request.setLimit(20000);
         request.setTimeoutSeconds(500);
 
         AgentDatasourceResolution datasource = new AgentDatasourceResolution();
         datasource.setDatabase("opendataworks");
         datasource.setEngine("mysql");
         when(agentMetadataService.resolveDatasource("opendataworks", null)).thenReturn(datasource);
-        when(agentJdbcExecutor.executeReadOnlyQuery(any(), eq("SELECT 1"), eq(1000), eq(120)))
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), eq("SELECT 1"), eq(10000), eq(120)))
                 .thenReturn(new AgentJdbcExecutor.QueryExecutionResult());
 
         backendAgentQueryService.readQuery(request);
 
-        verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, "SELECT 1", 1000, 120);
+        verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, "SELECT 1", 10000, 120);
     }
 
     private void assertReadQueryAccepted(String sql) {
@@ -166,12 +226,12 @@ class BackendAgentQueryServiceTest {
         datasource.setDatabase("opendataworks");
         datasource.setEngine("mysql");
         when(agentMetadataService.resolveDatasource("opendataworks", null)).thenReturn(datasource);
-        when(agentJdbcExecutor.executeReadOnlyQuery(any(), eq(sql), eq(200), eq(30)))
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), eq(sql), eq(1000), eq(30)))
                 .thenReturn(new AgentJdbcExecutor.QueryExecutionResult());
 
         backendAgentQueryService.readQuery(request);
 
-        verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, sql, 200, 30);
+        verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, sql, 1000, 30);
     }
 
     private void assertReadQueryRejected(String sql, String expectedMessage) {

--- a/dataagent/.claude/skills/dataagent-nl2sql/scripts/run_sql.py
+++ b/dataagent/.claude/skills/dataagent-nl2sql/scripts/run_sql.py
@@ -61,13 +61,13 @@ def main():
     parser.add_argument("--database", required=True)
     parser.add_argument("--engine", default="")
     parser.add_argument("--sql", required=True)
-    parser.add_argument("--limit", type=int, default=env_int("DATAAGENT_QUERY_LIMIT", 100))
+    parser.add_argument("--limit", type=int, default=env_int("DATAAGENT_QUERY_LIMIT", 1000))
     args = parser.parse_args()
 
     database = str(args.database or "").strip()
     preferred_engine = str(args.engine or "").strip().lower() or None
     sql = str(args.sql or "").strip()
-    limit = max(1, int(args.limit or 100))
+    limit = max(1, int(args.limit if args.limit is not None else 1000))
 
     try:
         ensure_read_only(sql)

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
     max_few_shot_examples: int = 5
     max_schema_tables: int = 10
     max_business_rules: int = 5
-    query_result_limit: int = 100
+    query_result_limit: int = 1000
 
     class Config:
         env_file = ".env"

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -204,8 +204,8 @@ def _build_runtime_env(
     original_question = str(getattr(params, "question", "") or "").strip()
     runtime_env.update(
         {
-            "DATAAGENT_QUERY_LIMIT": str(int(cfg.query_result_limit or 100)),
-            "DATAAGENT_RESULT_PREVIEW_ROWS": str(min(20, int(cfg.query_result_limit or 100))),
+            "DATAAGENT_QUERY_LIMIT": str(int(cfg.query_result_limit or 1000)),
+            "DATAAGENT_RESULT_PREVIEW_ROWS": str(min(20, int(cfg.query_result_limit or 1000))),
             "DATAAGENT_SQL_READ_TIMEOUT_SECONDS": str(sql_read_timeout),
             "DATAAGENT_ORIGINAL_QUESTION": original_question,
             "DATAAGENT_PYTHON_BIN": str(python_bin),

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -10,6 +10,7 @@ if str(BACKEND_ROOT) not in sys.path:
 
 from core import agent_runtime
 from core.claude_cli import resolve_claude_cli_path
+from config import Settings
 
 
 def test_build_runtime_env_does_not_expose_direct_db_connection_settings(monkeypatch):
@@ -50,6 +51,25 @@ def test_build_runtime_env_does_not_expose_direct_db_connection_settings(monkeyp
     assert "ODW_MYSQL_PASSWORD" not in runtime_env
     assert "ODW_MYSQL_DATABASE" not in runtime_env
     assert "DATAAGENT_SQL_WRITE_TIMEOUT_SECONDS" not in runtime_env
+
+
+def test_build_runtime_env_defaults_query_limit_to_backend_max(monkeypatch):
+    monkeypatch.setattr(agent_runtime, "resolve_builtin_skill_root_dir", lambda: Path("/tmp/skill-root"))
+
+    runtime_env = agent_runtime._build_runtime_env(
+        SimpleNamespace(query_result_limit=0),
+        {},
+        SimpleNamespace(question="", sql_read_timeout_seconds=0),
+    )
+
+    assert runtime_env["DATAAGENT_QUERY_LIMIT"] == "1000"
+    assert runtime_env["DATAAGENT_RESULT_PREVIEW_ROWS"] == "20"
+
+
+def test_settings_defaults_query_result_limit_to_backend_max(monkeypatch):
+    monkeypatch.delenv("QUERY_RESULT_LIMIT", raising=False)
+
+    assert Settings(_env_file=None).query_result_limit == 1000
 
 
 def test_resolve_claude_cli_path_prefers_configured_value(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
+++ b/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
@@ -285,7 +285,7 @@ def test_run_sql_script_delegates_to_query_cli(monkeypatch):
         "database": "opendataworks",
         "sql": "SELECT 1",
         "preferred_engine": "mysql",
-        "limit": 100,
+        "limit": 1000,
         "timeout_seconds": 45,
     }
     assert payload["result"]["kind"] == "sql_execution"
@@ -373,7 +373,7 @@ def test_run_sql_script_allows_lineage_sql_with_explicit_fallback(monkeypatch):
 
     assert captured["database"] == "opendataworks"
     assert "data_lineage" in captured["sql"]
-    assert captured["limit"] == 100
+    assert captured["limit"] == 1000
     assert payload["result"]["kind"] == "sql_execution"
     assert payload["result"]["rows"] == [{"lineage_type": "upstream"}]
 

--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -72,7 +72,7 @@ class QueryReadonlyInput(BaseModel):
     database: str = Field(..., description="数据库名")
     sql: str = Field(..., min_length=1, description="单条只读 SQL")
     preferred_engine: Literal["mysql", "doris"] | None = Field(default=None, description="期望引擎，可选")
-    limit: int = Field(default=200, ge=1, le=1000, description="结果返回上限")
+    limit: int = Field(default=1000, ge=1, le=10000, description="结果返回上限")
     timeout_seconds: int = Field(default=30, ge=1, le=120, description="单次查询超时秒数")
 
 

--- a/dataagent/portal-mcp/tests/test_app.py
+++ b/dataagent/portal-mcp/tests/test_app.py
@@ -196,7 +196,7 @@ async def test_mcp_tools_are_exposed_and_parameter_mapping_is_preserved():
             "database": "dw",
             "sql": "SELECT 1",
             "preferred_engine": "doris",
-            "limit": 50,
+            "limit": 5000,
             "timeout_seconds": 15,
         },
     )
@@ -206,8 +206,33 @@ async def test_mcp_tools_are_exposed_and_parameter_mapping_is_preserved():
             "database": "dw",
             "sql": "SELECT 1",
             "preferredEngine": "doris",
-            "limit": 50,
+            "limit": 5000,
             "timeoutSeconds": 15,
+        },
+    )
+    assert result.structuredContent["kind"] == "query_result"
+
+
+@pytest.mark.anyio
+async def test_query_readonly_forwards_default_limit():
+    backend = FakeBackendClient()
+
+    result, _ = await _call_mcp_tool(
+        create_app(settings=_settings(), backend_client=backend),
+        tool_name="portal_query_readonly",
+        arguments={
+            "database": "dw",
+            "sql": "SELECT 1",
+        },
+    )
+
+    assert backend.calls[-1] == (
+        "query_readonly",
+        {
+            "database": "dw",
+            "sql": "SELECT 1",
+            "limit": 1000,
+            "timeoutSeconds": 30,
         },
     )
     assert result.structuredContent["kind"] == "query_result"

--- a/docs/design/2026-03-20-portal-mcp-design.md
+++ b/docs/design/2026-03-20-portal-mcp-design.md
@@ -59,7 +59,7 @@
 - `database` 必填
 - `sql` 必填
 - `preferredEngine` 可选
-- `limit` 可选，默认 `200`，最大 `1000`
+- `limit` 可选，默认 `1000`，最大 `10000`
 - `timeoutSeconds` 可选，默认 `30`，最大 `120`
 
 服务端约束：

--- a/docs/design/2026-05-11-agent-query-default-limit-design.md
+++ b/docs/design/2026-05-11-agent-query-default-limit-design.md
@@ -1,0 +1,48 @@
+# Agent Query Default Limit Design
+
+## Current State
+
+Agent read-only SQL has multiple default row limits:
+
+- `dataagent/.claude/skills/dataagent-nl2sql/scripts/run_sql.py` defaults `--limit` to `DATAAGENT_QUERY_LIMIT` or `100`.
+- `dataagent/dataagent-backend/config.py` defaults `query_result_limit` to `100`, and `core/agent_runtime.py` falls back to `100`.
+- `backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java` defaults omitted API `limit` to `200`.
+- `dataagent/portal-mcp/portal_mcp/app.py` defaults MCP `portal_query_readonly.limit` to `200`.
+- The Java backend clamps query limits to a maximum of `10000`.
+
+This causes different default row counts depending on whether the same read-only query is executed through `run_sql.py`, portal MCP, or the backend API directly.
+
+## Problem
+
+The default result size should be predictable for DataAgent read-only SQL execution. The current `100` vs `200` split makes troubleshooting and result interpretation harder, especially when SQL already includes an explicit `LIMIT 500` but the outer tool default truncates the displayed rows earlier.
+
+## Scope
+
+In scope:
+
+- Set the default DataAgent read-only query row limit to `1000`.
+- Keep explicit `--limit`, `DATAAGENT_QUERY_LIMIT`, and request `limit` overrides.
+- Raise the Java backend and portal MCP maximum limit to `10000`.
+- Update the portal MCP query schema default to match the backend and script path.
+- Update existing design documentation that describes the backend query contract.
+
+Out of scope:
+
+- Changing SQL text generation rules or injecting SQL `LIMIT`.
+- Changing task event pagination defaults.
+- Changing query timeout behavior.
+
+## Solution
+
+Use `1000` as the single default and `10000` as the explicit maximum for the agent read-only SQL result cap:
+
+- `run_sql.py`: default `--limit` to `DATAAGENT_QUERY_LIMIT` or `1000`.
+- DataAgent runtime settings: default `query_result_limit` and runtime fallback to `1000`.
+- Backend agent query service: default omitted `limit` to `1000`, clamp explicit requests above `10000`.
+- Portal MCP query input: default omitted `limit` to `1000`, allow explicit requests up to `10000`.
+
+The returned `has_more` behavior remains unchanged: the JDBC executor reads up to the effective cap and reports whether additional rows were available.
+
+## Tradeoffs
+
+Defaulting to `1000` can return larger payloads than before, but avoids surprising truncation for common analytic queries. Allowing explicit requests up to `10000` gives analysts a larger bounded escape hatch while keeping the default moderate. Callers that need smaller outputs can still pass an explicit lower `limit`.

--- a/docs/plans/2026-05-11-agent-query-default-limit-plan.md
+++ b/docs/plans/2026-05-11-agent-query-default-limit-plan.md
@@ -1,0 +1,37 @@
+# Agent Query Default Limit Plan
+
+## Touched Areas
+
+- Backend agent query service default limit and tests.
+- DataAgent runtime config, runtime environment fallback, and script tests.
+- Portal MCP query input default and tests.
+- Existing design documentation for the backend query contract.
+
+## Tasks
+
+1. Update tests first:
+   - Backend `BackendAgentQueryServiceTest` should expect default `limit=1000`.
+   - DataAgent `test_metadata_cli_bridge.py` should expect `run_sql.py` to pass `limit=1000` when no override is provided.
+   - DataAgent runtime tests should cover the config fallback default of `1000`.
+   - Portal MCP tests should cover omitted `limit` forwarding as `1000` and explicit limits above `1000`.
+2. Run targeted tests and confirm they fail on the current defaults.
+3. Update implementation defaults:
+   - `BackendAgentQueryService.DEFAULT_LIMIT`.
+   - `config.Settings.query_result_limit`.
+   - `agent_runtime._build_runtime_env()` fallback.
+   - `run_sql.py` parser default.
+   - `QueryReadonlyInput.limit`.
+   - Backend and portal MCP maximum limit from `1000` to `10000`.
+4. Update contract documentation to default `1000`, maximum `10000`.
+5. Run targeted verification:
+   - `mvn -Dtest=BackendAgentQueryServiceTest test`
+   - Relevant DataAgent pytest tests for runtime env and `run_sql.py`
+   - Relevant portal MCP pytest tests for query input forwarding
+
+## Rollout
+
+This changes the default row cap and also allows explicit agent read-query limits up to `10000`. Existing callers with explicit limits at or below `1000` keep their current behavior.
+
+## Backout
+
+Revert the default values and tests to the previous split defaults if larger default responses cause operational issues.


### PR DESCRIPTION
## Summary

- Add a backend read-only SQL validation fallback so Doris SELECT statements with unquoted Chinese aliases are not rejected by JSqlParser before execution.
- Unify DataAgent read-query defaults at 1000 rows across run_sql.py, backend agent API, runtime env, and portal MCP.
- Raise the explicit agent read-query maximum to 10000 rows while keeping the default at 1000.
- Add design and plan docs for the query-limit contract.

## Validation

- mvn -Dtest=BackendAgentQueryServiceTest test
- ./.venv-py313/bin/python -m pytest tests/test_metadata_cli_bridge.py::test_run_sql_script_delegates_to_query_cli tests/test_metadata_cli_bridge.py::test_run_sql_script_allows_lineage_sql_with_explicit_fallback tests/test_agent_runtime.py::test_build_runtime_env_does_not_expose_direct_db_connection_settings tests/test_agent_runtime.py::test_build_runtime_env_defaults_query_limit_to_backend_max tests/test_agent_runtime.py::test_settings_defaults_query_result_limit_to_backend_max
- ../dataagent-backend/.venv-py313/bin/python -m pytest tests/test_app.py::test_mcp_tools_are_exposed_and_parameter_mapping_is_preserved tests/test_app.py::test_query_readonly_forwards_default_limit
- git diff --check