### PR TITLE
[codex] Add DataAgent model call diagnostics

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -9,10 +9,10 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
+from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
 from core.skill_discovery import prepare_enabled_skills_project_cwd, resolve_builtin_skill_root_dir
 
@@ -413,13 +413,4 @@ def _clip_text(text: str, max_chars: int) -> str:
 
 
 def _safe_base_url(raw_url: str | None) -> str:
-    text = str(raw_url or "").strip()
-    if not text:
-        return ""
-    try:
-        parsed = urlparse(text)
-        if parsed.scheme and parsed.netloc:
-            return f"{parsed.scheme}://{parsed.netloc}"
-    except Exception:
-        pass
-    return text[:200]
+    return _safe_base_url_for_log(raw_url)

--- a/dataagent/dataagent-backend/core/provider_runtime.py
+++ b/dataagent/dataagent-backend/core/provider_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse, urlunparse
+
 
 def normalize_provider_id(raw: str | None, base_url: str | None = None) -> str:
     value = str(raw or "").strip().lower()
@@ -13,6 +15,25 @@ def normalize_provider_id(raw: str | None, base_url: str | None = None) -> str:
     if base:
         return "anthropic_compatible"
     return "anthropic"
+
+
+def safe_base_url_for_log(raw_url: str | None) -> str:
+    text = str(raw_url or "").strip()
+    if not text:
+        return ""
+    try:
+        parsed = urlparse(text)
+        if parsed.scheme and parsed.netloc:
+            host = parsed.hostname or ""
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+            netloc = host
+            if parsed.port is not None:
+                netloc = f"{netloc}:{parsed.port}"
+            return urlunparse((parsed.scheme, netloc, parsed.path or "", "", "", ""))
+    except Exception:
+        pass
+    return text.split("?", 1)[0].split("#", 1)[0][:200]
 
 
 def build_provider_env(provider_id: str, *, api_key: str, auth_token: str, base_url: str) -> dict[str, str]:

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -19,7 +19,11 @@ import anyio
 
 from config import get_settings, update_settings
 from core.claude_cli import resolve_claude_cli_path
-from core.provider_runtime import build_provider_env, normalize_provider_id as normalize_runtime_provider_id
+from core.provider_runtime import (
+    build_provider_env,
+    normalize_provider_id as normalize_runtime_provider_id,
+    safe_base_url_for_log,
+)
 from core.skill_admin_store import get_skill_admin_store
 from core.skill_discovery import (
     resolve_agent_project_cwd,
@@ -596,6 +600,17 @@ async def _run_model_detection(
     )
     runtime_env = dict(os.environ)
     runtime_env.update(provider_env)
+    cli_path = resolve_claude_cli_path(get_settings())
+    logger.info(
+        "model_detection.start provider=%s model=%s base_url=%s supports_partial_messages=%s auth_token_set=%s api_key_set=%s cli_path_set=%s",
+        provider_id,
+        model,
+        safe_base_url_for_log(base_url),
+        supports_partial_messages,
+        bool(str(auth_token or "").strip()),
+        bool(str(api_key or "").strip()),
+        bool(cli_path),
+    )
     options_kwargs = dict(
         system_prompt="你是模型服务连通性检测程序。只需用最短文本回答检测请求。",
         model=model,
@@ -613,7 +628,6 @@ async def _run_model_detection(
             str(line or "").rstrip(),
         ),
     )
-    cli_path = resolve_claude_cli_path(get_settings())
     if cli_path:
         options_kwargs["cli_path"] = cli_path
     options = ClaudeAgentOptions(**options_kwargs)

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -859,7 +859,7 @@ async def execute_task_stream(
     timeout_seconds = max(10, int(params.timeout_seconds or cfg.agent_timeout_seconds))
 
     logger.info(
-        "task.start task_id=%s topic_id=%s provider=%s model=%s cwd=%s setting_sources=%s allowed_tools=%s mcp_servers=%s max_turns=%s partial=%s base_url=%s",
+        "task.start task_id=%s topic_id=%s provider=%s model=%s cwd=%s setting_sources=%s allowed_tools=%s mcp_servers=%s max_turns=%s partial=%s base_url=%s env_base_url=%s auth_token_set=%s api_key_set=%s",
         params.task_id,
         params.topic_id,
         provider_id,
@@ -870,7 +870,10 @@ async def execute_task_stream(
         ",".join(sorted(mcp_servers.keys())) if mcp_servers else "(none)",
         max_turns,
         supports_partial_messages,
+        _safe_base_url(runtime_target.get("base_url")),
         _safe_base_url(env_payload.get("ANTHROPIC_BASE_URL")),
+        bool(str(runtime_target.get("auth_token") or "").strip()),
+        bool(str(runtime_target.get("api_key") or "").strip()),
     )
 
     async def _cancelled() -> bool:

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -66,6 +66,18 @@ def test_build_runtime_env_defaults_query_limit_to_backend_max(monkeypatch):
     assert runtime_env["DATAAGENT_RESULT_PREVIEW_ROWS"] == "20"
 
 
+def test_safe_base_url_preserves_path_without_query_or_fragment():
+    actual = agent_runtime._safe_base_url("http://relay.example.internal/maas?token=secret#frag")
+
+    assert actual == "http://relay.example.internal/maas"
+
+
+def test_safe_base_url_drops_userinfo_from_log_value():
+    actual = agent_runtime._safe_base_url("https://user:pass@relay.example.internal/maas/v1/messages")
+
+    assert actual == "https://relay.example.internal/maas/v1/messages"
+
+
 def test_settings_defaults_query_result_limit_to_backend_max(monkeypatch):
     monkeypatch.delenv("QUERY_RESULT_LIMIT", raising=False)
 

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -229,6 +230,42 @@ def test_execute_task_stream_converts_claude_events_to_magic_records(monkeypatch
         ("content", "END"),
     ]
     assert chunks[-1]["content"] == "最终回答"
+
+
+def test_execute_task_stream_logs_safe_runtime_base_url_and_preserves_env(monkeypatch, tmp_path: Path, caplog):
+    base_url = "http://relay.example.internal/maas"
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            ResultMessage("success", session_id="sdk-session-log"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": "anthropic_compatible",
+            "model": model,
+            "api_key": "",
+            "auth_token": "relay-token",
+            "base_url": base_url,
+            "supports_partial_messages": False,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    caplog.set_level(logging.INFO, logger="core.task_executor")
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    assert ClaudeAgentOptions.last_kwargs["env"]["ANTHROPIC_BASE_URL"] == base_url
+    assert "base_url=http://relay.example.internal/maas" in caplog.text
+    assert "env_base_url=http://relay.example.internal/maas" in caplog.text
+    assert "auth_token_set=True" in caplog.text
+    assert "api_key_set=False" in caplog.text
 
 
 def test_execute_task_stream_buffers_partial_text_until_turn_end(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Preserve URL paths such as `/maas` in safe DataAgent model-call logs while stripping query, fragment, and userinfo.
- Add model detection startup diagnostics with provider, model, safe base URL, partial-message mode, credential presence, and CLI path presence.
- Expand task startup diagnostics with configured and SDK env base URLs plus credential presence flags.

## Validation
- `dataagent/dataagent-backend/.venv-py313/bin/pytest dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py -q` -> 24 passed, 1 existing Pydantic deprecation warning.
- `git diff --check` -> passed.

## Risk and rollback
Risk is limited to additional INFO-level diagnostics and safe URL formatting for logs; runtime provider selection and model validation are unchanged. Roll back by reverting commit `f928420` if the extra diagnostics are too noisy.