### PR TITLE
feat: DataAgent eval modules & metadata sync guidance

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataTableController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataTableController.java
@@ -1064,6 +1064,49 @@ public class DataTableController {
     }
 
     /**
+     * 手动按库表名同步指定表的元数据，用于平台尚未有 tableId 的 Doris 表。
+     */
+    @PostMapping("/sync-metadata/database/{database}/table/{tableName}")
+    public Result<Map<String, Object>> syncTableMetadataByName(
+            @PathVariable String database,
+            @PathVariable String tableName,
+            @RequestParam(required = false) Long clusterId) {
+        if (clusterId == null) {
+            return Result.fail("请指定数据源");
+        }
+        DorisCluster cluster = dorisClusterService.getById(clusterId);
+        if (cluster == null) {
+            return Result.fail("未找到指定数据源: " + clusterId);
+        }
+
+        LocalDateTime startedAt = LocalDateTime.now();
+        DorisMetadataSyncService.SyncResult result;
+        try {
+            result = dorisMetadataSyncService.syncTable(clusterId, database, tableName);
+        } catch (Exception e) {
+            result = new DorisMetadataSyncService.SyncResult();
+            result.addError("表元数据同步失败: " + e.getMessage());
+        }
+
+        String scopeTarget = database + "." + tableName;
+        MetadataSyncHistory history = metadataSyncHistoryService.record(cluster, "manual", "table", scopeTarget, startedAt,
+                result);
+        Map<String, Object> response = buildSyncResponse(result, history);
+        DataTable syncedTable = dataTableService.getByDbAndTableName(clusterId, database, tableName);
+        response.put("database", database);
+        response.put("tableName", tableName);
+        response.put("tableId", syncedTable != null ? syncedTable.getId() : null);
+
+        if ("SUCCESS".equals(result.getStatus())) {
+            return Result.success(response, "表元数据同步成功");
+        }
+        if ("PARTIAL".equals(result.getStatus())) {
+            return Result.success(response, "表元数据同步完成，但存在部分错误");
+        }
+        return Result.success(response, "表元数据同步失败");
+    }
+
+    /**
      * 手动触发指定表的元数据同步
      */
     @PostMapping("/{id}/sync-metadata")

--- a/backend/src/main/java/com/onedata/portal/scheduled/DataSourceMetadataStatisticsSyncTask.java
+++ b/backend/src/main/java/com/onedata/portal/scheduled/DataSourceMetadataStatisticsSyncTask.java
@@ -1,0 +1,69 @@
+package com.onedata.portal.scheduled;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.mapper.DorisClusterMapper;
+import com.onedata.portal.service.DorisMetadataSyncService;
+import com.onedata.portal.service.MetadataSyncHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 元数据统计信息自动同步任务。
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataSourceMetadataStatisticsSyncTask {
+
+    private final DorisClusterMapper dorisClusterMapper;
+    private final DorisMetadataSyncService dorisMetadataSyncService;
+    private final MetadataSyncHistoryService metadataSyncHistoryService;
+
+    @Scheduled(fixedDelayString = "${metadata.statistics-sync.fixed-delay-ms:600000}")
+    public void scheduleStatisticsSync() {
+        List<DorisCluster> clusters = dorisClusterMapper.selectList(
+                new LambdaQueryWrapper<DorisCluster>()
+                        .eq(DorisCluster::getAutoSync, 1)
+                        .eq(DorisCluster::getStatus, "active")
+                        .orderByDesc(DorisCluster::getIsDefault)
+                        .orderByAsc(DorisCluster::getClusterName));
+
+        for (DorisCluster cluster : clusters) {
+            syncClusterStatistics(cluster);
+        }
+    }
+
+    private void syncClusterStatistics(DorisCluster cluster) {
+        if (cluster == null || cluster.getId() == null) {
+            return;
+        }
+
+        LocalDateTime startedAt = LocalDateTime.now();
+        DorisMetadataSyncService.SyncResult result = null;
+        try {
+            log.info("Auto metadata statistics sync triggered, datasource id={}, name={}",
+                    cluster.getId(), cluster.getClusterName());
+            result = dorisMetadataSyncService.syncAllStatistics(cluster.getId());
+            log.info("Auto metadata statistics sync finished, datasource id={}, name={}",
+                    cluster.getId(), cluster.getClusterName());
+        } catch (Exception e) {
+            result = new DorisMetadataSyncService.SyncResult();
+            result.addError("自动统计同步失败: " + e.getMessage());
+            log.error("Auto metadata statistics sync failed, datasource id={}, name={}",
+                    cluster.getId(), cluster.getClusterName(), e);
+        } finally {
+            try {
+                metadataSyncHistoryService.record(cluster, "auto", "all", "statistics", startedAt, result);
+            } catch (Exception historyEx) {
+                log.error("Failed to record auto metadata statistics sync history, datasource id={}, name={}",
+                        cluster.getId(), cluster.getClusterName(), historyEx);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java
@@ -497,13 +497,7 @@ public class DorisMetadataSyncService {
 
                     result.addTableDifference(diff);
                 } else {
-                    // 已存在表：自动同步统计信息 + 检查结构差异
-                    boolean statsSynced = syncTableStatistics(clusterId, dorisTable, localTable);
-                    if (statsSynced) {
-                        result.incrementStatisticsSynced();
-                    }
-
-                    // 比对结构差异
+                    // 已存在表：只比对结构差异，不在稽核路径写入统计信息。
                     TableDifference diff = compareTable(clusterId, database, tableName, dorisTable, localTable);
                     if (diff != null && (!diff.getChanges().isEmpty() || !diff.getFieldDifferences().isEmpty())) {
                         result.addTableDifference(diff);
@@ -527,77 +521,78 @@ public class DorisMetadataSyncService {
         return result;
     }
 
-    /**
-     * 自动同步表的统计信息（行数、数据量、更新时间等）
-     * 这些信息是安全的，可以自动同步，不需要人工确认
-     */
-    private boolean syncTableStatistics(Long clusterId, Map<String, Object> dorisTable, DataTable localTable) {
-        boolean updated = false;
+    private boolean applyTableStatistics(Long clusterId,
+            String database,
+            String tableName,
+            Map<String, Object> dorisTable,
+            DataTable localTable,
+            SyncResult result) {
+        Map<String, Object> tableChanges = new LinkedHashMap<>();
 
-        try {
-            // 优先使用 runtime stats（SHOW TABLE STATS / information_schema.table_stats）
-            DorisConnectionService.TableRuntimeStats runtimeStats = null;
-            if (StringUtils.hasText(localTable.getDbName())) {
-                runtimeStats = dorisConnectionService
-                        .getTableRuntimeStats(clusterId, localTable.getDbName(), localTable.getTableName())
-                        .orElse(null);
-            }
-
-            if (runtimeStats != null) {
-                if (runtimeStats.getRowCount() != null
-                        && !Objects.equals(runtimeStats.getRowCount(), localTable.getRowCount())) {
-                    localTable.setRowCount(runtimeStats.getRowCount());
-                    updated = true;
-                }
-
-                if (runtimeStats.getDataSize() != null
-                        && !Objects.equals(runtimeStats.getDataSize(), localTable.getStorageSize())) {
-                    localTable.setStorageSize(runtimeStats.getDataSize());
-                    updated = true;
-                }
-
-                Timestamp lastUpdate = runtimeStats.getLastUpdate();
-                if (lastUpdate != null) {
-                    LocalDateTime updateDateTime = lastUpdate.toLocalDateTime();
-                    if (!Objects.equals(updateDateTime, localTable.getDorisUpdateTime())) {
-                        localTable.setDorisUpdateTime(updateDateTime);
-                        updated = true;
-                    }
-                }
-            } else {
-                // 后备：使用 information_schema.tables 中的粗略统计
-                Long tableRows = (Long) dorisTable.get("tableRows");
-                if (tableRows != null && !Objects.equals(tableRows, localTable.getRowCount())) {
-                    localTable.setRowCount(tableRows);
-                    updated = true;
-                }
-
-                Long dataLength = (Long) dorisTable.get("dataLength");
-                if (dataLength != null && !Objects.equals(dataLength, localTable.getStorageSize())) {
-                    localTable.setStorageSize(dataLength);
-                    updated = true;
-                }
-
-                Timestamp updateTime = (Timestamp) dorisTable.get("updateTime");
-                if (updateTime != null) {
-                    LocalDateTime updateDateTime = updateTime.toLocalDateTime();
-                    if (!Objects.equals(updateDateTime, localTable.getDorisUpdateTime())) {
-                        localTable.setDorisUpdateTime(updateDateTime);
-                        updated = true;
-                    }
-                }
-            }
-
-            // 如果有更新，保存到数据库
-            if (updated) {
-                dataTableMapper.updateById(localTable);
-                log.debug("Auto-synced statistics for table: {}.{}", localTable.getDbName(), localTable.getTableName());
-            }
-        } catch (Exception e) {
-            log.warn("Failed to sync statistics for table {}.{}", localTable.getDbName(), localTable.getTableName(), e);
+        // 优先使用 runtime stats（SHOW TABLE STATS / information_schema.table_stats）
+        DorisConnectionService.TableRuntimeStats runtimeStats = null;
+        if (StringUtils.hasText(database)) {
+            runtimeStats = dorisConnectionService
+                    .getTableRuntimeStats(clusterId, database, tableName)
+                    .orElse(null);
         }
 
-        return updated;
+        if (runtimeStats != null) {
+            if (runtimeStats.getRowCount() != null
+                    && !Objects.equals(runtimeStats.getRowCount(), localTable.getRowCount())) {
+                addChangedValue(tableChanges, "rowCount", localTable.getRowCount(), runtimeStats.getRowCount());
+                localTable.setRowCount(runtimeStats.getRowCount());
+            }
+
+            if (runtimeStats.getDataSize() != null
+                    && !Objects.equals(runtimeStats.getDataSize(), localTable.getStorageSize())) {
+                addChangedValue(tableChanges, "storageSize", localTable.getStorageSize(), runtimeStats.getDataSize());
+                localTable.setStorageSize(runtimeStats.getDataSize());
+            }
+
+            Timestamp lastUpdate = runtimeStats.getLastUpdate();
+            if (lastUpdate != null) {
+                LocalDateTime updateDateTime = lastUpdate.toLocalDateTime();
+                if (!Objects.equals(updateDateTime, localTable.getDorisUpdateTime())) {
+                    addChangedValue(tableChanges, "dorisUpdateTime", localTable.getDorisUpdateTime(), updateDateTime);
+                    localTable.setDorisUpdateTime(updateDateTime);
+                }
+            }
+        } else {
+            // 后备：使用 information_schema.tables 中的粗略统计
+            Long tableRows = (Long) dorisTable.get("tableRows");
+            if (tableRows != null && !Objects.equals(tableRows, localTable.getRowCount())) {
+                addChangedValue(tableChanges, "rowCount", localTable.getRowCount(), tableRows);
+                localTable.setRowCount(tableRows);
+            }
+
+            Long dataLength = (Long) dorisTable.get("dataLength");
+            if (dataLength != null && !Objects.equals(dataLength, localTable.getStorageSize())) {
+                addChangedValue(tableChanges, "storageSize", localTable.getStorageSize(), dataLength);
+                localTable.setStorageSize(dataLength);
+            }
+
+            Timestamp updateTime = (Timestamp) dorisTable.get("updateTime");
+            if (updateTime != null) {
+                LocalDateTime updateDateTime = updateTime.toLocalDateTime();
+                if (!Objects.equals(updateDateTime, localTable.getDorisUpdateTime())) {
+                    addChangedValue(tableChanges, "dorisUpdateTime", localTable.getDorisUpdateTime(), updateDateTime);
+                    localTable.setDorisUpdateTime(updateDateTime);
+                }
+            }
+        }
+
+        if (tableChanges.isEmpty()) {
+            return false;
+        }
+
+        localTable.setSyncTime(LocalDateTime.now());
+        dataTableMapper.updateById(localTable);
+        result.addUpdatedTable();
+        result.addUpdatedTableDetail(database, tableName, "表统计信息更新", tableChanges);
+        recordStatisticsSnapshot(clusterId, database, tableName, localTable);
+        log.debug("Synced statistics for table: {}.{}", database, tableName);
+        return true;
     }
 
     /**
@@ -767,6 +762,122 @@ public class DorisMetadataSyncService {
         } catch (Exception e) {
             log.error("Failed to sync metadata", e);
             result.addError("同步元数据失败: " + e.getMessage());
+        }
+
+        return result;
+    }
+
+    /**
+     * 同步指定集群的表统计信息，不同步结构元数据。
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public SyncResult syncAllStatistics(Long clusterId) {
+        resolveCluster(clusterId);
+        SyncResult result = new SyncResult();
+        log.info("Starting metadata statistics sync for cluster: {}", clusterId);
+
+        try {
+            List<String> databases = dorisConnectionService.getAllDatabases(clusterId).stream()
+                    .filter(db -> !IGNORED_DATABASES.contains(db))
+                    .collect(Collectors.toList());
+
+            for (String database : databases) {
+                try {
+                    syncDatabaseStatisticsInternal(clusterId, database, result);
+                } catch (Exception e) {
+                    log.error("Failed to sync statistics for database: {}", database, e);
+                    result.addError("同步数据库统计 " + database + " 失败: " + e.getMessage());
+                }
+            }
+
+            log.info("Metadata statistics sync completed: {}", result);
+        } catch (Exception e) {
+            log.error("Failed to sync metadata statistics", e);
+            result.addError("同步元数据统计失败: " + e.getMessage());
+        }
+
+        return result;
+    }
+
+    /**
+     * 同步指定数据库的表统计信息，不同步结构元数据。
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public SyncResult syncDatabaseStatistics(Long clusterId, String database) {
+        resolveCluster(clusterId);
+        return syncDatabaseStatisticsInternal(clusterId, database, new SyncResult());
+    }
+
+    private SyncResult syncDatabaseStatisticsInternal(Long clusterId, String database, SyncResult result) {
+        if (result == null) {
+            result = new SyncResult();
+        }
+
+        log.info("Syncing metadata statistics for database: {}", database);
+        List<Map<String, Object>> dorisTables = dorisConnectionService.getTablesInDatabase(clusterId, database);
+        List<DataTable> localTables = dataTableMapper.selectList(
+                new LambdaQueryWrapper<DataTable>()
+                        .eq(DataTable::getDbName, database)
+                        .eq(DataTable::getClusterId, clusterId));
+
+        Map<String, DataTable> localTableMap = localTables.stream()
+                .collect(Collectors.toMap(DataTable::getTableName, t -> t));
+
+        for (Map<String, Object> dorisTable : dorisTables) {
+            String tableName = (String) dorisTable.get("tableName");
+            DataTable localTable = localTableMap.get(tableName);
+            if (localTable == null) {
+                continue;
+            }
+
+            try {
+                applyTableStatistics(clusterId, database, tableName, dorisTable, localTable, result);
+            } catch (Exception e) {
+                log.error("Failed to sync statistics for table {}.{}", database, tableName, e);
+                result.addError("同步表统计 " + database + "." + tableName + " 失败: " + e.getMessage());
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * 同步指定表的统计信息，不同步结构元数据。
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public SyncResult syncTableStatisticsOnly(Long clusterId, String database, String tableName) {
+        resolveCluster(clusterId);
+        SyncResult result = new SyncResult();
+        log.info("Syncing metadata statistics for table: {}.{}", database, tableName);
+
+        try {
+            List<Map<String, Object>> tables = dorisConnectionService.getTablesInDatabase(clusterId, database);
+            Map<String, Object> dorisTable = tables.stream()
+                    .filter(t -> tableName.equals(t.get("tableName")))
+                    .findFirst()
+                    .orElse(null);
+
+            if (dorisTable == null) {
+                result.addError("表 " + database + "." + tableName + " 在 Doris 中不存在");
+                return result;
+            }
+
+            DataTable localTable = dataTableMapper.selectOne(
+                    new LambdaQueryWrapper<DataTable>()
+                            .eq(DataTable::getDbName, database)
+                            .eq(DataTable::getTableName, tableName)
+                            .eq(DataTable::getClusterId, clusterId));
+
+            if (localTable == null) {
+                result.addError("表 " + database + "." + tableName + " 在平台中不存在");
+                return result;
+            }
+
+            applyTableStatistics(clusterId, database, tableName, dorisTable, localTable, result);
+            log.info("Table statistics sync completed: {}", result);
+        } catch (Exception e) {
+            log.error("Failed to sync table statistics {}.{}", database, tableName, e);
+            result.addError("同步表统计失败: " + e.getMessage());
         }
 
         return result;
@@ -1057,20 +1168,19 @@ public class DorisMetadataSyncService {
         String tableType = normalizeTableType((String) dorisTable.get("tableType"));
         boolean viewType = isViewType(tableType);
 
-        boolean updated = false;
-        boolean statisticsUpdated = false;
+        boolean tableMetadataUpdated = false;
         Map<String, Object> tableChanges = new LinkedHashMap<>();
 
         // 同步数据源
         if (!Objects.equals(localTable.getClusterId(), clusterId)) {
             addChangedValue(tableChanges, "clusterId", localTable.getClusterId(), clusterId);
             localTable.setClusterId(clusterId);
-            updated = true;
+            tableMetadataUpdated = true;
         }
         if (!Objects.equals(tableType, localTable.getTableType())) {
             addChangedValue(tableChanges, "tableType", localTable.getTableType(), tableType);
             localTable.setTableType(tableType);
-            updated = true;
+            tableMetadataUpdated = true;
         }
 
         // 之前因账号不可见被降级为 inactive 的表，在再次可见时自动恢复
@@ -1078,7 +1188,7 @@ public class DorisMetadataSyncService {
                 && Objects.equals(localTable.getIsSynced(), 0)) {
             addChangedValue(tableChanges, "status", localTable.getStatus(), "active");
             localTable.setStatus("active");
-            updated = true;
+            tableMetadataUpdated = true;
         }
 
         // 按表名前缀自动修正数据分层（ods_/dwd_/dim_/dws_/ads_）
@@ -1086,7 +1196,7 @@ public class DorisMetadataSyncService {
         if (StringUtils.hasText(inferredLayer) && !Objects.equals(inferredLayer, localTable.getLayer())) {
             addChangedValue(tableChanges, "layer", localTable.getLayer(), inferredLayer);
             localTable.setLayer(inferredLayer);
-            updated = true;
+            tableMetadataUpdated = true;
         }
 
         // 更新表注释
@@ -1094,7 +1204,7 @@ public class DorisMetadataSyncService {
         if (tableComment != null && !tableComment.equals(localTable.getTableComment())) {
             addChangedValue(tableChanges, "tableComment", localTable.getTableComment(), tableComment);
             localTable.setTableComment(tableComment);
-            updated = true;
+            tableMetadataUpdated = true;
         }
 
         if (isDoris && !viewType) {
@@ -1104,7 +1214,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(bucketNum, localTable.getBucketNum())) {
                     addChangedValue(tableChanges, "bucketNum", localTable.getBucketNum(), bucketNum);
                     localTable.setBucketNum(bucketNum);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1114,7 +1224,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(replicationNum, localTable.getReplicaNum())) {
                     addChangedValue(tableChanges, "replicationNum", localTable.getReplicaNum(), replicationNum);
                     localTable.setReplicaNum(replicationNum);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1124,7 +1234,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(partitionColumn, localTable.getPartitionColumn())) {
                     addChangedValue(tableChanges, "partitionColumn", localTable.getPartitionColumn(), partitionColumn);
                     localTable.setPartitionColumn(partitionColumn);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1134,7 +1244,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(distributionColumn, localTable.getDistributionColumn())) {
                     addChangedValue(tableChanges, "distributionColumn", localTable.getDistributionColumn(), distributionColumn);
                     localTable.setDistributionColumn(distributionColumn);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1144,7 +1254,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(keyColumns, localTable.getKeyColumns())) {
                     addChangedValue(tableChanges, "keyColumns", localTable.getKeyColumns(), keyColumns);
                     localTable.setKeyColumns(keyColumns);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1154,7 +1264,7 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(tableModel, localTable.getTableModel())) {
                     addChangedValue(tableChanges, "tableModel", localTable.getTableModel(), tableModel);
                     localTable.setTableModel(tableModel);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
 
@@ -1164,79 +1274,51 @@ public class DorisMetadataSyncService {
                 if (!Objects.equals(createTableSql, localTable.getDorisDdl())) {
                     addChangedValue(tableChanges, "dorisDdl", localTable.getDorisDdl(), createTableSql);
                     localTable.setDorisDdl(createTableSql);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             }
         } else {
             if (localTable.getBucketNum() != null) {
                 addChangedValue(tableChanges, "bucketNum", localTable.getBucketNum(), null);
                 localTable.setBucketNum(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             if (localTable.getReplicaNum() != null) {
                 addChangedValue(tableChanges, "replicationNum", localTable.getReplicaNum(), null);
                 localTable.setReplicaNum(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             if (StringUtils.hasText(localTable.getPartitionColumn())) {
                 addChangedValue(tableChanges, "partitionColumn", localTable.getPartitionColumn(), null);
                 localTable.setPartitionColumn(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             if (StringUtils.hasText(localTable.getDistributionColumn())) {
                 addChangedValue(tableChanges, "distributionColumn", localTable.getDistributionColumn(), null);
                 localTable.setDistributionColumn(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             if (StringUtils.hasText(localTable.getKeyColumns())) {
                 addChangedValue(tableChanges, "keyColumns", localTable.getKeyColumns(), null);
                 localTable.setKeyColumns(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             if (StringUtils.hasText(localTable.getTableModel())) {
                 addChangedValue(tableChanges, "tableModel", localTable.getTableModel(), null);
                 localTable.setTableModel(null);
-                updated = true;
+                tableMetadataUpdated = true;
             }
             String createTableSql = (String) tableCreateInfo.get("createTableSql");
             if (StringUtils.hasText(createTableSql)) {
                 if (!Objects.equals(createTableSql, localTable.getDorisDdl())) {
                     addChangedValue(tableChanges, "dorisDdl", localTable.getDorisDdl(), createTableSql);
                     localTable.setDorisDdl(createTableSql);
-                    updated = true;
+                    tableMetadataUpdated = true;
                 }
             } else if (StringUtils.hasText(localTable.getDorisDdl())) {
                 addChangedValue(tableChanges, "dorisDdl", localTable.getDorisDdl(), null);
                 localTable.setDorisDdl(null);
-                updated = true;
-            }
-        }
-
-        // 更新统计信息
-        Long tableRows = (Long) dorisTable.get("tableRows");
-        if (tableRows != null && !Objects.equals(tableRows, localTable.getRowCount())) {
-            addChangedValue(tableChanges, "rowCount", localTable.getRowCount(), tableRows);
-            localTable.setRowCount(tableRows);
-            updated = true;
-            statisticsUpdated = true;
-        }
-
-        Long dataLength = (Long) dorisTable.get("dataLength");
-        if (dataLength != null && !Objects.equals(dataLength, localTable.getStorageSize())) {
-            addChangedValue(tableChanges, "storageSize", localTable.getStorageSize(), dataLength);
-            localTable.setStorageSize(dataLength);
-            updated = true;
-            statisticsUpdated = true;
-        }
-
-        Timestamp updateTime = (Timestamp) dorisTable.get("updateTime");
-        if (updateTime != null) {
-            LocalDateTime updateDateTime = updateTime.toLocalDateTime();
-            if (!Objects.equals(updateDateTime, localTable.getDorisUpdateTime())) {
-                addChangedValue(tableChanges, "dorisUpdateTime", localTable.getDorisUpdateTime(), updateDateTime);
-                localTable.setDorisUpdateTime(updateDateTime);
-                updated = true;
-                statisticsUpdated = true;
+                tableMetadataUpdated = true;
             }
         }
 
@@ -1245,10 +1327,8 @@ public class DorisMetadataSyncService {
         if (!Objects.equals(synced, localTable.getIsSynced())) {
             addChangedValue(tableChanges, "isSynced", localTable.getIsSynced(), synced);
             localTable.setIsSynced(synced);
-            updated = true;
+            tableMetadataUpdated = true;
         }
-        localTable.setSyncTime(LocalDateTime.now());
-        updated = true;
 
         // 同步Doris创建时间（如果本地还没有记录）
         if (localTable.getDorisCreateTime() == null) {
@@ -1256,23 +1336,26 @@ public class DorisMetadataSyncService {
             if (createTime != null) {
                 addChangedValue(tableChanges, "dorisCreateTime", localTable.getDorisCreateTime(), createTime.toLocalDateTime());
                 localTable.setDorisCreateTime(createTime.toLocalDateTime());
-                updated = true;
+                tableMetadataUpdated = true;
             }
         }
 
-        if (updated) {
+        // 同步字段（增量更新）
+        FieldSyncChanges fieldChanges = syncTableFieldsIncremental(localTable.getId(), database, tableName, columns, result);
+
+        if (tableMetadataUpdated) {
+            localTable.setSyncTime(LocalDateTime.now());
             dataTableMapper.updateById(localTable);
             if (!tableChanges.isEmpty()) {
                 result.addUpdatedTable();
                 result.addUpdatedTableDetail(database, tableName, "表元数据更新", tableChanges);
             }
+        } else if (fieldChanges.hasChanges()) {
+            DataTable syncTimeUpdate = new DataTable();
+            syncTimeUpdate.setId(localTable.getId());
+            syncTimeUpdate.setSyncTime(LocalDateTime.now());
+            dataTableMapper.updateById(syncTimeUpdate);
         }
-        if (statisticsUpdated) {
-            recordStatisticsSnapshot(clusterId, database, tableName, localTable);
-        }
-
-        // 同步字段（增量更新）
-        syncTableFieldsIncremental(localTable.getId(), database, tableName, columns, result);
     }
 
     /**
@@ -1335,11 +1418,13 @@ public class DorisMetadataSyncService {
     /**
      * 同步表字段（增量更新，用于已存在的表）
      */
-    private void syncTableFieldsIncremental(Long tableId,
+    private FieldSyncChanges syncTableFieldsIncremental(Long tableId,
             String database,
             String tableName,
             List<Map<String, Object>> dorisColumns,
             SyncResult result) {
+        FieldSyncChanges changes = new FieldSyncChanges();
+
         // 获取本地已存在的字段
         List<DataField> localFields = dataFieldMapper.selectList(
                 new LambdaQueryWrapper<DataField>()
@@ -1370,6 +1455,7 @@ public class DorisMetadataSyncService {
                 newField.setFieldOrder((Integer) dorisColumn.get("ordinalPosition"));
 
                 dataFieldMapper.insert(newField);
+                changes.markCreated();
                 result.addNewField();
                 Map<String, Object> fieldChanges = new LinkedHashMap<>();
                 addChangedValue(fieldChanges, "type", null, newField.getFieldType());
@@ -1428,6 +1514,7 @@ public class DorisMetadataSyncService {
 
                 if (updated) {
                     dataFieldMapper.updateById(localField);
+                    changes.markUpdated();
                     result.addUpdatedField();
                     result.addUpdatedFieldDetail(database, tableName, fieldName, fieldChanges);
                 }
@@ -1439,10 +1526,35 @@ public class DorisMetadataSyncService {
             if (!dorisFieldNames.contains(localField.getFieldName())) {
                 // 逻辑删除
                 dataFieldMapper.deleteById(localField.getId());
+                changes.markDeleted();
                 result.addDeletedField();
                 result.addDeletedFieldDetail(database, tableName, localField.getFieldName());
                 log.info("Logically deleted field: {} from table {}", localField.getFieldName(), tableId);
             }
+        }
+
+        return changes;
+    }
+
+    private static class FieldSyncChanges {
+        private boolean created;
+        private boolean updated;
+        private boolean deleted;
+
+        private void markCreated() {
+            created = true;
+        }
+
+        private void markUpdated() {
+            updated = true;
+        }
+
+        private void markDeleted() {
+            deleted = true;
+        }
+
+        private boolean hasChanges() {
+            return created || updated || deleted;
         }
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -30,6 +30,10 @@ doris:
     session-charset: utf8mb4
     session-charset-fallback: utf8
 
+metadata:
+  statistics-sync:
+    fixed-delay-ms: 600000
+
 # MyBatis Plus 配置
 mybatis-plus:
   mapper-locations: classpath*:/mapper/**/*.xml

--- a/backend/src/test/java/com/onedata/portal/controller/DataTableControllerTest.java
+++ b/backend/src/test/java/com/onedata/portal/controller/DataTableControllerTest.java
@@ -1,0 +1,131 @@
+package com.onedata.portal.controller;
+
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.entity.MetadataSyncHistory;
+import com.onedata.portal.service.DataExportService;
+import com.onedata.portal.service.DataTableService;
+import com.onedata.portal.service.DorisClusterService;
+import com.onedata.portal.service.DorisConnectionService;
+import com.onedata.portal.service.DorisMetadataSyncService;
+import com.onedata.portal.service.DorisTableAccessService;
+import com.onedata.portal.service.MetadataSyncHistoryService;
+import com.onedata.portal.service.TableStatisticsCacheService;
+import com.onedata.portal.service.TableStatisticsHistoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class DataTableControllerTest {
+
+    @Mock
+    private DataTableService dataTableService;
+
+    @Mock
+    private DorisConnectionService dorisConnectionService;
+
+    @Mock
+    private TableStatisticsCacheService cacheService;
+
+    @Mock
+    private TableStatisticsHistoryService historyService;
+
+    @Mock
+    private DataExportService dataExportService;
+
+    @Mock
+    private DorisMetadataSyncService dorisMetadataSyncService;
+
+    @Mock
+    private DorisTableAccessService dorisTableAccessService;
+
+    @Mock
+    private DorisClusterService dorisClusterService;
+
+    @Mock
+    private MetadataSyncHistoryService metadataSyncHistoryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        DataTableController controller = new DataTableController(
+                dataTableService,
+                dorisConnectionService,
+                cacheService,
+                historyService,
+                dataExportService,
+                dorisMetadataSyncService,
+                dorisTableAccessService,
+                dorisClusterService,
+                metadataSyncHistoryService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void syncTableMetadataByNameReturnsSyncedTableId() throws Exception {
+        DorisCluster cluster = new DorisCluster();
+        cluster.setId(1L);
+        cluster.setClusterName("local-doris");
+        cluster.setSourceType("DORIS");
+
+        DorisMetadataSyncService.SyncResult syncResult = new DorisMetadataSyncService.SyncResult();
+        syncResult.addNewTable();
+
+        MetadataSyncHistory history = new MetadataSyncHistory();
+        history.setId(77L);
+
+        DataTable syncedTable = new DataTable();
+        syncedTable.setId(42L);
+        syncedTable.setClusterId(1L);
+        syncedTable.setDbName("dw");
+        syncedTable.setTableName("fact_orders");
+
+        when(dorisClusterService.getById(1L)).thenReturn(cluster);
+        when(dorisMetadataSyncService.syncTable(1L, "dw", "fact_orders")).thenReturn(syncResult);
+        when(metadataSyncHistoryService.record(eq(cluster), eq("manual"), eq("table"), eq("dw.fact_orders"),
+                any(LocalDateTime.class), eq(syncResult))).thenReturn(history);
+        when(dataTableService.getByDbAndTableName(1L, "dw", "fact_orders")).thenReturn(syncedTable);
+
+        mockMvc.perform(post("/v1/tables/sync-metadata/database/dw/table/fact_orders")
+                        .param("clusterId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("表元数据同步成功"))
+                .andExpect(jsonPath("$.data.success").value(true))
+                .andExpect(jsonPath("$.data.syncRunId").value(77))
+                .andExpect(jsonPath("$.data.database").value("dw"))
+                .andExpect(jsonPath("$.data.tableName").value("fact_orders"))
+                .andExpect(jsonPath("$.data.tableId").value(42));
+
+        verify(dorisMetadataSyncService).syncTable(1L, "dw", "fact_orders");
+        verify(metadataSyncHistoryService).record(eq(cluster), eq("manual"), eq("table"), eq("dw.fact_orders"),
+                any(LocalDateTime.class), eq(syncResult));
+    }
+
+    @Test
+    void syncTableMetadataByNameRequiresClusterId() throws Exception {
+        mockMvc.perform(post("/v1/tables/sync-metadata/database/dw/table/fact_orders"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(500))
+                .andExpect(jsonPath("$.message").value("请指定数据源"));
+
+        verifyNoInteractions(dorisMetadataSyncService);
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
@@ -1,11 +1,15 @@
 package com.onedata.portal.service;
 
+import com.onedata.portal.entity.DataField;
 import com.onedata.portal.entity.DataTable;
 import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.entity.TableStatisticsHistory;
 import com.onedata.portal.mapper.DataFieldMapper;
+import com.onedata.portal.mapper.DataLineageMapper;
 import com.onedata.portal.mapper.DataTableMapper;
 import com.onedata.portal.mapper.DorisClusterMapper;
 import com.onedata.portal.mapper.TableStatisticsHistoryMapper;
+import com.onedata.portal.mapper.TableTaskRelationMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,15 +18,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +53,12 @@ class DorisMetadataSyncServiceTest {
     private DataFieldMapper dataFieldMapper;
 
     @Mock
+    private TableTaskRelationMapper tableTaskRelationMapper;
+
+    @Mock
+    private DataLineageMapper dataLineageMapper;
+
+    @Mock
     private TableStatisticsHistoryMapper tableStatisticsHistoryMapper;
 
     @InjectMocks
@@ -52,10 +70,10 @@ class DorisMetadataSyncServiceTest {
         cluster.setId(1L);
         cluster.setSourceType("DORIS");
 
-        when(dorisClusterMapper.selectById(1L)).thenReturn(cluster);
-        when(dorisConnectionService.getTableCreateInfo(anyLong(), anyString(), anyString()))
+        lenient().when(dorisClusterMapper.selectById(1L)).thenReturn(cluster);
+        lenient().when(dorisConnectionService.getTableCreateInfo(anyLong(), anyString(), anyString()))
                 .thenReturn(Collections.emptyMap());
-        when(dorisConnectionService.getColumnsInTable(anyLong(), anyString(), anyString()))
+        lenient().when(dorisConnectionService.getColumnsInTable(anyLong(), anyString(), anyString()))
                 .thenReturn(Collections.emptyList());
     }
 
@@ -102,5 +120,220 @@ class DorisMetadataSyncServiceTest {
         ArgumentCaptor<DataTable> captor = ArgumentCaptor.forClass(DataTable.class);
         verify(dataTableMapper).updateById(captor.capture());
         assertEquals("ADS", captor.getValue().getLayer());
+    }
+
+    @Test
+    void syncDatabaseLeavesUnchangedExistingTableUntouched() {
+        DataTable existing = existingTable("dw", "fact_orders", "order facts");
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable("fact_orders", "order facts")));
+        when(dataTableMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(existing));
+        when(dataFieldMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        DorisMetadataSyncService.SyncResult result = service.syncDatabase(1L, "dw", null);
+
+        verify(dataTableMapper, never()).updateById(any(DataTable.class));
+        assertEquals(0, result.getUpdatedTables());
+    }
+
+    @Test
+    void syncDatabaseUpdatesTableCommentAndCountsUpdatedTable() {
+        DataTable existing = existingTable("dw", "fact_orders", "old comment");
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable("fact_orders", "new comment")));
+        when(dataTableMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(existing));
+        when(dataFieldMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        DorisMetadataSyncService.SyncResult result = service.syncDatabase(1L, "dw", null);
+
+        ArgumentCaptor<DataTable> captor = ArgumentCaptor.forClass(DataTable.class);
+        verify(dataTableMapper).updateById(captor.capture());
+        assertEquals("new comment", captor.getValue().getTableComment());
+        assertNotNull(captor.getValue().getSyncTime());
+        assertEquals(1, result.getUpdatedTables());
+    }
+
+    @Test
+    void syncDatabaseUpdatesChangedFieldsWithoutCountingTableUpdate() {
+        DataTable existing = existingTable("dw", "fact_orders", "order facts");
+        DataField localField = localField(100L, 10L, "amount", "DECIMAL(10,2)", "amount", 1);
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable("fact_orders", "order facts")));
+        when(dorisConnectionService.getColumnsInTable(1L, "dw", "fact_orders"))
+                .thenReturn(Collections.singletonList(dorisColumn(
+                        "amount", "DECIMAL(20,2)", "order amount", 2)));
+        when(dataTableMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(existing));
+        when(dataFieldMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(localField));
+
+        DorisMetadataSyncService.SyncResult result = service.syncDatabase(1L, "dw", null);
+
+        ArgumentCaptor<DataField> fieldCaptor = ArgumentCaptor.forClass(DataField.class);
+        verify(dataFieldMapper).updateById(fieldCaptor.capture());
+        assertEquals("DECIMAL(20,2)", fieldCaptor.getValue().getFieldType());
+        assertEquals("order amount", fieldCaptor.getValue().getFieldComment());
+        assertEquals(2, fieldCaptor.getValue().getFieldOrder());
+
+        ArgumentCaptor<DataTable> tableCaptor = ArgumentCaptor.forClass(DataTable.class);
+        verify(dataTableMapper).updateById(tableCaptor.capture());
+        assertEquals(10L, tableCaptor.getValue().getId());
+        assertNotNull(tableCaptor.getValue().getSyncTime());
+        assertEquals(0, result.getUpdatedTables());
+        assertEquals(1, result.getUpdatedFields());
+    }
+
+    @Test
+    void auditDatabaseDoesNotWriteTableStatistics() {
+        DataTable existing = existingTable("dw", "fact_orders", "order facts");
+        existing.setRowCount(1L);
+        existing.setStorageSize(2L);
+        existing.setDorisUpdateTime(LocalDateTime.of(2026, 5, 13, 10, 0));
+
+        Map<String, Object> dorisTable = dorisTable("fact_orders", "order facts");
+        dorisTable.put("tableRows", 9L);
+        dorisTable.put("dataLength", 20L);
+        dorisTable.put("updateTime", Timestamp.valueOf(LocalDateTime.of(2026, 5, 14, 10, 0)));
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable));
+        when(dataTableMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(existing));
+        when(dataFieldMapper.selectList(any())).thenReturn(Collections.emptyList());
+        lenient().when(dorisConnectionService.getTableRuntimeStats(eq(1L), eq("dw"), eq("fact_orders")))
+                .thenReturn(Optional.empty());
+
+        DorisMetadataSyncService.AuditResult result = service.auditDatabase(1L, "dw", null);
+
+        verify(dataTableMapper, never()).updateById(any(DataTable.class));
+        assertEquals(0, result.getStatisticsSynced());
+    }
+
+    @Test
+    void syncTableStatisticsOnlyUpdatesChangedStatsAndRecordsHistory() {
+        LocalDateTime updateTime = LocalDateTime.of(2026, 5, 14, 11, 0);
+        DataTable existing = existingTable("dw", "fact_orders", "order facts");
+        existing.setRowCount(1L);
+        existing.setStorageSize(2L);
+        existing.setDorisUpdateTime(LocalDateTime.of(2026, 5, 13, 11, 0));
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable("fact_orders", "order facts")));
+        when(dataTableMapper.selectOne(any())).thenReturn(existing);
+        when(dorisConnectionService.getTableRuntimeStats(eq(1L), eq("dw"), eq("fact_orders")))
+                .thenReturn(Optional.of(runtimeStats(9L, 20L, updateTime)));
+
+        DorisMetadataSyncService.SyncResult result = service.syncTableStatisticsOnly(1L, "dw", "fact_orders");
+
+        ArgumentCaptor<DataTable> tableCaptor = ArgumentCaptor.forClass(DataTable.class);
+        verify(dataTableMapper).updateById(tableCaptor.capture());
+        assertEquals(9L, tableCaptor.getValue().getRowCount());
+        assertEquals(20L, tableCaptor.getValue().getStorageSize());
+        assertEquals(updateTime, tableCaptor.getValue().getDorisUpdateTime());
+        assertNotNull(tableCaptor.getValue().getSyncTime());
+
+        ArgumentCaptor<TableStatisticsHistory> historyCaptor = ArgumentCaptor.forClass(TableStatisticsHistory.class);
+        verify(tableStatisticsHistoryMapper).insert(historyCaptor.capture());
+        assertEquals(10L, historyCaptor.getValue().getTableId());
+        assertEquals(1L, historyCaptor.getValue().getClusterId());
+        assertEquals("dw", historyCaptor.getValue().getDatabaseName());
+        assertEquals("fact_orders", historyCaptor.getValue().getTableName());
+        assertEquals(9L, historyCaptor.getValue().getRowCount());
+        assertEquals(20L, historyCaptor.getValue().getDataSize());
+        assertEquals(updateTime, historyCaptor.getValue().getTableLastUpdateTime());
+
+        assertEquals(1, result.getUpdatedTables());
+        verifyNoInteractions(dataFieldMapper);
+        verify(dorisConnectionService, never()).getTableCreateInfo(anyLong(), anyString(), anyString());
+        verify(dorisConnectionService, never()).getColumnsInTable(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    void syncTableStatisticsOnlySkipsUnchangedStats() {
+        LocalDateTime updateTime = LocalDateTime.of(2026, 5, 14, 11, 0);
+        DataTable existing = existingTable("dw", "fact_orders", "order facts");
+        existing.setRowCount(9L);
+        existing.setStorageSize(20L);
+        existing.setDorisUpdateTime(updateTime);
+
+        when(dorisConnectionService.getTablesInDatabase(1L, "dw"))
+                .thenReturn(Collections.singletonList(dorisTable("fact_orders", "order facts")));
+        when(dataTableMapper.selectOne(any())).thenReturn(existing);
+        when(dorisConnectionService.getTableRuntimeStats(eq(1L), eq("dw"), eq("fact_orders")))
+                .thenReturn(Optional.of(runtimeStats(9L, 20L, updateTime)));
+
+        DorisMetadataSyncService.SyncResult result = service.syncTableStatisticsOnly(1L, "dw", "fact_orders");
+
+        verify(dataTableMapper, never()).updateById(any(DataTable.class));
+        verify(tableStatisticsHistoryMapper, never()).insert(any(TableStatisticsHistory.class));
+        assertEquals(0, result.getUpdatedTables());
+        verifyNoInteractions(dataFieldMapper);
+        verify(dorisConnectionService, never()).getTableCreateInfo(anyLong(), anyString(), anyString());
+        verify(dorisConnectionService, never()).getColumnsInTable(anyLong(), anyString(), anyString());
+    }
+
+    private DataTable existingTable(String database, String tableName, String comment) {
+        DataTable table = new DataTable();
+        table.setId(10L);
+        table.setClusterId(1L);
+        table.setDbName(database);
+        table.setTableName(tableName);
+        table.setTableType("BASE TABLE");
+        table.setTableComment(comment);
+        table.setStatus("active");
+        table.setIsSynced(1);
+        table.setSyncTime(LocalDateTime.of(2026, 5, 13, 9, 0));
+        return table;
+    }
+
+    private Map<String, Object> dorisTable(String tableName, String comment) {
+        Map<String, Object> table = new HashMap<>();
+        table.put("tableName", tableName);
+        table.put("tableType", "BASE TABLE");
+        table.put("tableComment", comment);
+        return table;
+    }
+
+    private DataField localField(Long id,
+            Long tableId,
+            String fieldName,
+            String fieldType,
+            String fieldComment,
+            Integer fieldOrder) {
+        DataField field = new DataField();
+        field.setId(id);
+        field.setTableId(tableId);
+        field.setFieldName(fieldName);
+        field.setFieldType(fieldType);
+        field.setFieldComment(fieldComment);
+        field.setIsNullable(0);
+        field.setIsPrimary(0);
+        field.setFieldOrder(fieldOrder);
+        return field;
+    }
+
+    private Map<String, Object> dorisColumn(String columnName, String dataType, String columnComment, Integer ordinalPosition) {
+        Map<String, Object> column = new HashMap<>();
+        column.put("columnName", columnName);
+        column.put("dataType", dataType);
+        column.put("columnComment", columnComment);
+        column.put("isNullable", 0);
+        column.put("isPrimary", 0);
+        column.put("defaultValue", null);
+        column.put("ordinalPosition", ordinalPosition);
+        return column;
+    }
+
+    private DorisConnectionService.TableRuntimeStats runtimeStats(Long rowCount, Long dataSize, LocalDateTime lastUpdate) {
+        DorisConnectionService.TableRuntimeStats stats = new DorisConnectionService.TableRuntimeStats();
+        stats.setRowCount(rowCount);
+        stats.setDataSize(dataSize);
+        stats.setLastUpdate(Timestamp.valueOf(lastUpdate));
+        return stats;
     }
 }

--- a/docs/design/2026-05-14-metadata-sync-datastudio-workflow-guidance-design.md
+++ b/docs/design/2026-05-14-metadata-sync-datastudio-workflow-guidance-design.md
@@ -1,0 +1,68 @@
+# Metadata Sync, DataStudio, and Workflow Guidance Design
+
+**Date:** 2026-05-14
+**Goal:** 减少元数据同步对未变化表的写入，明确 DataStudio 中 Doris 存在但平台未同步表的状态，并在任务变更工作流后引导用户发布和上线。
+**Tech Stack:** Java 8 + Spring Boot 2.7 backend, Vue 3 + Vite + Element Plus frontend, MySQL/Flyway, Doris-compatible JDBC.
+
+## Current State
+
+- `DorisMetadataSyncService.syncAllMetadata` 会遍历数据源下所有库表；已存在表会调用 `syncExistingTable`，即使结构未变也会刷新 `syncTime` 并执行字段同步检查。
+- `auditAllMetadata` 当前也会同步统计信息，导致“只比对”接口存在写入行为。
+- 自动同步入口是 `DataSourceMetadataAutoSyncTask`，按 `doris_cluster.auto_sync + sync_cron` 触发全量结构同步并记录 `metadata_sync_history`。
+- DataStudio 左侧表树从 Doris 实时目录和平台 `data_table` 合并；Doris 有但平台没有的表可以出现在树上，但没有 `data_table.id`。
+- DataStudio 右侧编辑、删除、字段、血缘等操作依赖平台表 ID；当前未同步表的按钮状态和提示没有明确区分“未选择表”和“平台不存在该表”。
+- `TaskEditDrawer` 保存任务后只提示创建/更新成功；如果任务绑定了工作流，用户不会被提醒工作流定义已变化，需要发布到 Dolphin。
+- 工作流列表和详情页已有 `deploy` 与 `online` 操作，但发布成功后不会主动询问是否立即上线。
+
+## Design
+
+- 元数据结构同步改为“只落库变化部分”：
+  - 新表仍创建 `data_table` 和字段。
+  - 已存在表只在结构字段、注释、Doris DDL、表类型、分层、字段定义等真实变化时更新。
+  - 结构同步不再因为统计字段变化或 `syncTime` 单独变化而更新未变表。
+  - 平台有、Doris 无的表仍按现有引用保护策略删除或阻断删除。
+- 统计信息拆到独立定时任务：
+  - 新增统计同步方法，只同步行数、数据量、Doris 更新时间和统计快照。
+  - 新增 `DataSourceMetadataStatisticsSyncTask`，扫描启用自动同步且 active 的数据源，独立周期执行统计同步。
+  - 为避免额外数据库迁移，统计任务的历史记录继续写 `triggerType=auto`，`scopeType=all`，`scopeTarget=statistics`。
+- 稽核接口恢复“只比对不同步”语义：
+  - `auditAllMetadata` 和 `auditDatabase` 不再写统计字段。
+  - 统计变动由统计任务或后续手动统计同步覆盖。
+- DataStudio 未同步表状态显式化：
+  - 前端合并 Doris 表和平台表时，为 Doris 有但平台没有的表标记 `metadataMissing=true`。
+  - 左侧树在表名旁显示红色警示图标和 tooltip。
+  - 右侧顶部显示提示：“当前表在 Doris 中存在，平台中不存在”，并提供“立即同步”文字按钮。
+  - 点击立即同步先弹确认框，再调用按库表名同步的新后端接口；成功后强制刷新该库表列表、更新当前 tab 数据并解锁编辑/删除/字段/血缘操作。
+  - 对未同步表点击删除、编辑、字段编辑等操作时，提示“该表未同步到平台，需同步后才能操作”，不再提示“请先选择表”。
+- 任务保存后的工作流引导：
+  - 创建或更新任务时，只要保存后的任务绑定了工作流，就弹框提示“工作流有变化，请跳转到任务调度页面，将工作流发布到 Dolphin”。
+  - 用户确认后跳转到工作流详情页并携带轻量 query 标记；工作流详情页展示发布引导，不自动发布。
+  - 工作流 `deploy` 成功后，如果未进入审批且工作流尚未 online，弹框询问是否立即上线；确认后复用现有 `online` 发布接口。
+  - 工作流列表和详情页保持一致的发布成功后上线询问行为。
+
+## Interfaces
+
+- 新增后端接口：`POST /api/v1/tables/sync-metadata/database/{database}/table/{tableName}?clusterId=...`
+  - 用于没有平台表 ID 的 Doris 表按名称同步。
+  - 响应沿用现有同步响应字段，并追加 `database`、`tableName`、`tableId`。
+- 新增前端 API：`tableApi.syncTableMetadataByName(database, tableName, clusterId)`。
+- 新增或复用前端状态字段：
+  - `metadataMissing: boolean`
+  - `metadataStatus: 'missing' | 'synced'`
+  - `metadataSyncing: boolean` 放在 tab state，用于右侧提示按钮 loading。
+- 不新增数据库表。`metadata_sync_history` 枚举保持不变。
+
+## Risks and Tradeoffs
+
+- 结构同步不再用统计字段驱动表更新，短期内统计变化可能不会立刻显示在平台元数据中；独立统计任务会补齐这一点。
+- 统计任务如果频率过高会增加 Doris 查询压力；默认应保守，计划按 10 分钟固定延迟实现，并可通过 Spring 配置覆盖。
+- 按名称同步接口需要正确处理 URL 编码和特殊表名；前端必须使用 `encodeURIComponent`。
+- 发布成功后询问上线会改变工作流操作节奏，但只在用户主动发布成功后出现，不会自动上线。
+
+## Verification
+
+- 后端单测覆盖未变化表不更新、结构变化才更新、统计任务只更新统计字段、按名称同步返回 `tableId`、稽核不写库。
+- 前端单测或组件级测试覆盖未同步表标记、红色图标/提示、立即同步成功后刷新状态、未同步表删除提示。
+- 前端构建通过 `nvm use && npm --prefix frontend run build`。
+- 后端最小测试通过 Maven 指定测试类。
+- 若本地 Doris/MySQL/Dolphin 环境可用，补充一次 DataStudio 表同步 smoke 和一次工作流发布后上线询问 smoke；若不可用，报告未覆盖的外部运行态。

--- a/docs/plans/2026-05-14-metadata-sync-datastudio-workflow-guidance-plan.md
+++ b/docs/plans/2026-05-14-metadata-sync-datastudio-workflow-guidance-plan.md
@@ -1,0 +1,182 @@
+# Metadata Sync, DataStudio, and Workflow Guidance Implementation Plan
+
+> Design: [2026-05-14-metadata-sync-datastudio-workflow-guidance-design.md](../design/2026-05-14-metadata-sync-datastudio-workflow-guidance-design.md)
+
+**Goal:** 让元数据结构同步只落库真实差异，DataStudio 能识别并一键同步 Doris 有但平台无的表，并在任务绑定工作流后引导发布到 Dolphin 和上线。
+**Tech Stack:** Java 8 + Spring Boot 2.7, MyBatis-Plus, Vue 3 + Vite + Element Plus.
+
+## Task Checklist
+
+- [x] Task 1: Refactor metadata structure sync to skip unchanged existing tables.
+- [x] Task 2: Add separate metadata statistics sync path and scheduled task.
+- [x] Task 3: Add backend table-name metadata sync API for missing-platform tables.
+- [x] Task 4: Mark and render missing-platform Doris tables in DataStudio.
+- [x] Task 5: Add DataStudio one-click table sync and corrected operation guards.
+- [x] Task 6: Add task-save workflow publish guidance and post-deploy online prompt.
+- [x] Task 7: Run focused backend/frontend verification and record gaps.
+
+## Task 1: Structure Sync Only Applies Real Differences
+
+**Files:**
+- `backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java`
+- `backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java`
+
+**Steps:**
+1. Update `syncExistingTable` so existing tables are updated only when structural metadata changes.
+2. Remove row count, storage size, and Doris update time updates from existing-table structure sync.
+3. Do not set `syncTime` unless table metadata or fields changed.
+4. Change `syncTableFieldsIncremental` to return whether it created, updated, or deleted fields.
+5. If only fields changed, update the table `syncTime` without incrementing `updatedTables` unless table-level fields changed.
+6. Update `auditDatabase` so it does not call `syncTableStatistics`.
+7. Add tests:
+   - unchanged existing table does not call `dataTableMapper.updateById`
+   - table comment change updates table and increments `updatedTables`
+   - field type/comment/order change updates field counts
+   - audit does not write table statistics
+
+**Acceptance Criteria:**
+- A full structure sync can still scan all Doris tables, but unchanged existing tables produce no `data_table` update.
+- Existing table statistics no longer drive structure sync changes.
+
+## Task 2: Separate Statistics Sync Scheduled Task
+
+**Files:**
+- `backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java`
+- `backend/src/main/java/com/onedata/portal/scheduled/DataSourceMetadataStatisticsSyncTask.java`
+- `backend/src/main/resources/application.yml`
+- `backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java`
+
+**Steps:**
+1. Extract public statistics sync methods:
+   - `syncAllStatistics(Long clusterId)`
+   - `syncDatabaseStatistics(Long clusterId, String database)`
+   - `syncTableStatisticsOnly(Long clusterId, String database, String tableName)`
+2. These methods update only `rowCount`, `storageSize`, `dorisUpdateTime`, `syncTime`, and `table_statistics_history`.
+3. Implement `DataSourceMetadataStatisticsSyncTask` with `@Scheduled(fixedDelayString = "${metadata.statistics-sync.fixed-delay-ms:600000}")`.
+4. The task scans `DorisCluster` rows where `autoSync=1` and `status='active'`.
+5. Record history with `triggerType="auto"`, `scopeType="all"`, `scopeTarget="statistics"`.
+6. Add tests for statistics-only sync updating changed stats and skipping unchanged stats.
+
+**Acceptance Criteria:**
+- Structure sync and statistics sync can be reasoned about independently.
+- No database migration is required for the new scheduled task.
+
+## Task 3: Backend API to Sync a Missing Table by Name
+
+**Files:**
+- `backend/src/main/java/com/onedata/portal/controller/DataTableController.java`
+- `backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java`
+- `backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java`
+
+**Steps:**
+1. Add `POST /v1/tables/sync-metadata/database/{database}/table/{tableName}`.
+2. Require `clusterId`; validate the cluster exists.
+3. Call `dorisMetadataSyncService.syncTable(clusterId, database, tableName)`.
+4. After sync, query `data_table` by `clusterId + dbName + tableName` and add `tableId` to the response.
+5. Record sync history with `triggerType="manual"`, `scopeType="table"`, `scopeTarget="{database}.{tableName}"`.
+6. Keep the existing ID-based `POST /v1/tables/{id}/sync-metadata` API unchanged.
+
+**Acceptance Criteria:**
+- A Doris table without a platform ID can be synchronized without syncing the whole database.
+- The response gives the frontend enough data to reload and unlock the current tab.
+
+## Task 4: Mark Missing-Platform Doris Tables in DataStudio
+
+**Files:**
+- `frontend/src/views/datastudio/DataStudioNew.vue`
+- `frontend/src/views/datastudio/components/DataStudioRightPanel.vue`
+
+**Steps:**
+1. In `loadTables`, when a Doris table has no matching platform metadata row, add `metadataMissing: true`, `metadataStatus: 'missing'`, and `id: undefined`.
+2. When a matching metadata row exists, add `metadataMissing: false`, `metadataStatus: 'synced'`.
+3. Add helper `isPlatformMetadataMissing(table)`.
+4. In the left tree table node, render a red warning icon with tooltip for missing metadata.
+5. Provide the helper through `dataStudioCtx` for the right panel.
+
+**Acceptance Criteria:**
+- Users can see the missing-platform status before clicking the table.
+- Existing synced tables keep the current visual behavior.
+
+## Task 5: One-Click Table Sync and Correct Operation Guards
+
+**Files:**
+- `frontend/src/api/table.js`
+- `frontend/src/views/datastudio/DataStudioNew.vue`
+- `frontend/src/views/datastudio/components/DataStudioRightPanel.vue`
+
+**Steps:**
+1. Add `tableApi.syncTableMetadataByName(database, tableName, clusterId)`.
+2. Add `syncMissingTableMetadata(tabId)` in `DataStudioNew.vue`.
+3. Show a right-panel `el-alert` when `isPlatformMetadataMissing(state.table)` is true:
+   - text: `当前表在 Doris 中存在，平台中不存在。`
+   - action: link button `立即同步`
+4. On click, confirm with `ElMessageBox.confirm` before syncing.
+5. After success:
+   - force `loadTables(sourceId, dbName, true)`
+   - find the synced table in `tableStore`
+   - merge it into `state.table`
+   - set `state.dataLoaded=false`
+   - call `loadTabData(tabId)`
+6. Update `handleDeleteTable`, `startMetaEdit`, `startFieldsEdit`, `saveFieldsEdit`, `goCreateRelatedTask`, and `goLineage` to show the missing-platform message when the table lacks platform metadata.
+7. Disable edit/delete/field buttons in `DataStudioRightPanel` for missing-platform tables and show tooltip `请先同步到平台元数据后再操作`.
+
+**Acceptance Criteria:**
+- Missing-platform tables can be synchronized from the current tab without leaving DataStudio.
+- Delete no longer says “请先选择要删除的表” for a selected Doris-only table.
+
+## Task 6: Workflow Guidance after Task Save and Deploy
+
+**Files:**
+- `frontend/src/views/tasks/TaskEditDrawer.vue`
+- `frontend/src/views/workflows/WorkflowDetail.vue`
+- `frontend/src/views/workflows/WorkflowList.vue`
+
+**Steps:**
+1. In `TaskEditDrawer.handleSave`, capture the saved task response from create/update.
+2. Resolve the workflow ID from the saved task or form payload.
+3. If a workflow ID exists, after success show a confirm dialog:
+   - title: `工作流有变化`
+   - message: `请跳转到任务调度页面，将工作流发布到 Dolphin。`
+   - confirm: `去发布`
+   - cancel: `稍后处理`
+4. On confirm, route to `/workflows/{workflowId}?publishHint=1`.
+5. In `WorkflowDetail`, when `publishHint=1`, show a non-blocking warning or confirm that tells the user to use the existing publish button, then remove the query marker with `router.replace`.
+6. In both `WorkflowDetail.handleDeploy` and `WorkflowList.handleDeploy`, after a successful non-approval deploy, call a shared local helper that asks whether to immediately上线.
+7. If user confirms, call existing `workflowApi.publish(id, { operation: 'online', versionId, requireApproval: false, operator: 'portal-ui' })` and refresh the workflow data.
+8. Do not auto-online when deploy returns `pending_approval`.
+
+**Acceptance Criteria:**
+- Saving a task into a workflow visibly tells users the workflow needs publishing.
+- Publish success gives users a direct chance to immediately上线.
+- Existing manual deploy and online buttons continue to work.
+
+## Task 7: Verification
+
+**Backend commands:**
+- Run the narrow Maven test set for metadata sync:
+  - `./mvnw -pl backend -Dtest=DorisMetadataSyncServiceTest test`
+- If controller tests are added, include the exact controller test class in the same command.
+
+**Frontend commands:**
+- Always load nvm first:
+  - `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use`
+- Run the smallest available frontend test/build:
+  - `npm --prefix frontend run build`
+
+**Smoke checks when local services are available:**
+- DataStudio: open a Doris table that exists in Doris but not `data_table`, verify warning icon, right-panel sync prompt, successful sync, refreshed tab, and enabled delete/edit controls.
+- Workflow: create a task with `workflowId`, verify jump prompt, publish the workflow, verify post-deploy online prompt.
+
+**Reporting:**
+- Update this checklist as tasks complete.
+- If smoke cannot run because Doris or Dolphin is unavailable, state exactly which external runtime was missing.
+
+### Run Notes - 2026-05-14
+
+- Backend verification passed with Maven fallback because `./mvnw` is absent in this checkout:
+  - `mvn -o -pl backend -am -Dtest=DorisMetadataSyncServiceTest,DataTableControllerTest -DfailIfNoTests=false test`
+- Frontend verification passed after loading `.nvmrc` Node:
+  - `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build`
+- Local smoke was not run because required external runtimes were not listening:
+  - Doris FE/query checks failed on `127.0.0.1:8030` and `127.0.0.1:9030`
+  - DolphinScheduler check failed on `127.0.0.1:12345`

--- a/frontend/src/api/table.js
+++ b/frontend/src/api/table.js
@@ -219,5 +219,17 @@ export const tableApi = {
       params: { clusterId },
       timeout: METADATA_SYNC_TIMEOUT
     })
+  },
+
+  // 按库表名同步指定表的元数据（用于平台尚未存在 tableId 的 Doris 表）
+  syncTableMetadataByName(database, tableName, clusterId = null) {
+    return request.post(
+      `/v1/tables/sync-metadata/database/${encodeURIComponent(database)}/table/${encodeURIComponent(tableName)}`,
+      null,
+      {
+        params: { clusterId },
+        timeout: METADATA_SYNC_TIMEOUT
+      }
+    )
   }
 }

--- a/frontend/src/views/datastudio/DataStudioNew.vue
+++ b/frontend/src/views/datastudio/DataStudioNew.vue
@@ -99,6 +99,13 @@
 	                      <span class="table-name" :title="data.table?.tableName">
 	                        {{ data.table?.tableName }}
 	                      </span>
+                        <el-tooltip
+                          v-if="isPlatformMetadataMissing(data.table)"
+                          content="平台元数据不存在，请先同步"
+                          placement="top"
+                        >
+                          <el-icon class="metadata-warning-icon"><Warning /></el-icon>
+                        </el-tooltip>
 	                    </div>
 	                    <div v-if="data.table?.tableComment" class="table-comment" :title="data.table.tableComment">
 	                      {{ data.table.tableComment }}
@@ -1741,11 +1748,21 @@ const loadTables = async (sourceId, database, force = false, refreshTree = true)
         dorisCreateTime: item.createTime || item.CREATE_TIME || meta?.dorisCreateTime || null,
         dorisUpdateTime: item.updateTime || item.UPDATE_TIME || meta?.dorisUpdateTime || null
       }
-      if (!meta) return base
+      if (!meta) {
+        return {
+          ...base,
+          id: undefined,
+          metadataMissing: true,
+          metadataStatus: 'missing'
+        }
+      }
       return {
         ...meta,
         ...base,
-        tableComment: base.tableComment || meta.tableComment
+        id: meta.id,
+        tableComment: base.tableComment || meta.tableComment,
+        metadataMissing: false,
+        metadataStatus: 'synced'
       }
     })
     tableStore[sourceKey][database] = list
@@ -2264,6 +2281,20 @@ const isDorisTable = (table) => {
   )
 }
 
+const MISSING_PLATFORM_METADATA_MESSAGE = '该表未同步到平台，需同步后才能操作'
+
+const isPlatformMetadataMissing = (table) => {
+  if (!table) return false
+  if (table.metadataMissing === true || table.metadataStatus === 'missing') return true
+  return isDorisTable(table) && !table.id && hasText(table.dbName) && hasText(table.tableName)
+}
+
+const warnPlatformMetadataMissing = (table) => {
+  if (!isPlatformMetadataMissing(table)) return false
+  ElMessage.warning(MISSING_PLATFORM_METADATA_MESSAGE)
+  return true
+}
+
 const formatStorageSize = (size) => {
   if (size === null || size === undefined) return '-'
   if (size === 0) return '0 B'
@@ -2621,6 +2652,7 @@ const setupTableObserver = () => {
     },
     metaOriginal: {},
     metaDataDomainOptions: [],
+    metadataSyncing: false,
     fieldSubmitting: false,
     fieldsEditing: false,
     fieldsDraft: [],
@@ -2955,6 +2987,8 @@ const loadTabData = async (tabId) => {
         state.table.id = match.id
         state.table.tableComment = state.table.tableComment || match.tableComment
         state.table.layer = state.table.layer || match.layer
+        state.table.metadataMissing = false
+        state.table.metadataStatus = 'synced'
       }
     } catch (error) {
       console.error('解析表元数据失败', error)
@@ -3697,6 +3731,9 @@ const handleDeleteTable = async () => {
   const active = activeTab.value
   const state = active ? tabStates[active] : null
   const table = state?.table
+  if (warnPlatformMetadataMissing(table)) {
+    return
+  }
   if (!table?.id) {
     ElMessage.warning('请先选择要删除的表')
     return
@@ -3748,6 +3785,76 @@ const handleDeleteTable = async () => {
     if (error !== 'cancel' && error !== 'close') {
       ElMessage.error('删除表失败')
     }
+  }
+}
+
+const syncMissingTableMetadata = async (tabId) => {
+  if (isDemoMode) {
+    showDemoReadonlyMessage('同步平台元数据')
+    return
+  }
+  const state = tabStates[String(tabId || '')]
+  const table = state?.table
+  if (!isPlatformMetadataMissing(table)) return
+  const sourceId = String(table.sourceId || table.clusterId || clusterId.value || '')
+  const dbName = table.dbName || table.databaseName || table.database || ''
+  const tableName = table.tableName || ''
+  if (!sourceId || !dbName || !tableName) {
+    ElMessage.warning('缺少数据源、数据库或表名，无法同步')
+    return
+  }
+
+  try {
+    await ElMessageBox.confirm(
+      `确定将 “${dbName}.${tableName}” 同步到平台元数据吗？`,
+      '同步平台元数据',
+      {
+        type: 'warning',
+        confirmButtonText: '立即同步',
+        cancelButtonText: '取消'
+      }
+    )
+  } catch (error) {
+    return
+  }
+
+  state.metadataSyncing = true
+  try {
+    const response = await tableApi.syncTableMetadataByName(dbName, tableName, sourceId)
+    await loadTables(sourceId, dbName, true)
+    const list = tableStore[String(sourceId)]?.[dbName] || []
+    const synced = list.find((item) => {
+      if (!item) return false
+      if (response?.tableId && String(item.id) === String(response.tableId)) return true
+      return item.tableName === tableName
+    })
+    const syncedTable = synced || {
+      ...table,
+      id: response?.tableId || table.id,
+      metadataMissing: false,
+      metadataStatus: 'synced'
+    }
+    state.table = {
+      ...state.table,
+      ...syncedTable,
+      sourceId,
+      dbName,
+      metadataMissing: false,
+      metadataStatus: 'synced'
+    }
+    const tab = openTabs.value.find((item) => String(item.id) === String(tabId))
+    if (tab) {
+      tab.sourceId = sourceId
+      tab.dbName = dbName
+      tab.tableName = tableName
+    }
+    state.dataLoaded = false
+    await loadTabData(String(tabId))
+    ElMessage.success('平台元数据已同步')
+  } catch (error) {
+    ElMessage.error('同步平台元数据失败')
+  } finally {
+    state.metadataSyncing = false
   }
 }
 
@@ -4051,6 +4158,7 @@ const startMetaEdit = async (tabId) => {
   }
   const state = tabStates[tabId]
   if (!state) return
+  if (warnPlatformMetadataMissing(state.table)) return
   if (!ensureClusterSelected(state.table)) return
   if (!businessDomainOptions.value.length) {
     await loadBusinessDomains()
@@ -4074,6 +4182,7 @@ const saveMetaEdit = async (tabId) => {
     return
   }
   const state = tabStates[tabId]
+  if (warnPlatformMetadataMissing(state?.table)) return
   if (!state?.table?.id) return
   if (!ensureClusterSelected(state.table)) return
   if (!state.metaForm.layer) {
@@ -4194,6 +4303,7 @@ const startFieldsEdit = (tabId) => {
   }
   const state = tabStates[tabId]
   if (!state) return
+  if (warnPlatformMetadataMissing(state.table)) return
   if (!ensureClusterSelected(state.table)) return
   state.fieldsEditing = true
   state.fieldsDraft = state.fields.map((item) => ({ ...item }))
@@ -4294,6 +4404,7 @@ const saveFieldsEdit = async (tabId) => {
     return
   }
   const state = tabStates[tabId]
+  if (warnPlatformMetadataMissing(state?.table)) return
   if (!state?.table?.id) return
   if (!ensureClusterSelected(state.table)) return
   const draft = state.fieldsDraft || []
@@ -4451,6 +4562,7 @@ const goCreateRelatedTask = (tabId, relation) => {
     return
   }
   const state = tabStates[String(tabId || '')]
+  if (warnPlatformMetadataMissing(state?.table)) return
   const tableId = state?.table?.id
   if (!tableId) {
     ElMessage.warning('请先选择表')
@@ -4471,6 +4583,7 @@ const handleTaskSuccess = async () => {
 
 const goLineage = (tabId) => {
   const state = tabStates[tabId]
+  if (warnPlatformMetadataMissing(state?.table)) return
   if (!state?.table?.id) return
   router.push({ path: '/lineage', query: { tableId: state.table.id } })
 }
@@ -4687,6 +4800,7 @@ watch(selectedTableKey, (value) => {
   getMetaDataDomainOptions,
   handleMetaBusinessDomainChange,
   isDorisTable,
+  isPlatformMetadataMissing,
   isAggregateTable,
   isReplicaWarning,
   getLayerType,
@@ -4695,6 +4809,7 @@ watch(selectedTableKey, (value) => {
   cancelMetaEdit,
   saveMetaEdit,
   handleDeleteTable,
+  syncMissingTableMetadata,
   startFieldsEdit,
   cancelFieldsEdit,
   saveFieldsEdit,
@@ -5092,6 +5207,11 @@ onBeforeUnmount(() => {
   flex: 1;
   min-width: 0;
   max-width: 200px;
+}
+
+.metadata-warning-icon {
+  color: #ef4444;
+  flex-shrink: 0;
 }
 
 .table-comment {

--- a/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
@@ -3,6 +3,29 @@
     <div v-if="hasTableTab && state" ref="panelShellRef" class="panel-shell" :style="panelShellStyle">
 
       <section class="meta-panel" @scroll.passive>
+        <el-alert
+          v-if="isPlatformMetadataMissing(state.table)"
+          type="error"
+          show-icon
+          :closable="false"
+          class="metadata-missing-alert"
+        >
+          <template #title>
+            <div class="metadata-missing-title">
+              <span>当前表在 Doris 中存在，平台中不存在。</span>
+              <el-button
+                type="danger"
+                link
+                :loading="state.metadataSyncing"
+                :disabled="isDemoMode"
+                @click="syncMissingTableMetadata(activeTabId)"
+              >
+                立即同步
+              </el-button>
+            </div>
+          </template>
+        </el-alert>
+
         <el-tabs v-model="state.metaTab" class="meta-tabs detail-tabs">
           <el-tab-pane name="basic" label="基本信息">
             <div class="meta-section meta-section-fill">
@@ -12,7 +35,16 @@
                     <div class="section-title">表信息</div>
                     <div class="section-actions">
                       <el-tooltip
-                        v-if="!state.metaEditing && isDorisTable(state.table) && !clusterId"
+                        v-if="!state.metaEditing && isPlatformMetadataMissing(state.table)"
+                        content="请先同步到平台元数据后再操作"
+                        placement="top"
+                      >
+                        <span>
+                          <el-button type="primary" size="small" disabled>编辑</el-button>
+                        </span>
+                      </el-tooltip>
+                      <el-tooltip
+                        v-else-if="!state.metaEditing && isDorisTable(state.table) && !clusterId"
                         content="请选择 Doris 集群后再编辑"
                         placement="top"
                       >
@@ -31,7 +63,16 @@
                       </el-button>
 
                       <el-tooltip
-                        v-if="!state.metaEditing && isDorisTable(state.table) && !clusterId"
+                        v-if="!state.metaEditing && isPlatformMetadataMissing(state.table)"
+                        content="请先同步到平台元数据后再操作"
+                        placement="top"
+                      >
+                        <span>
+                          <el-button type="danger" plain size="small" disabled>删除表</el-button>
+                        </span>
+                      </el-tooltip>
+                      <el-tooltip
+                        v-else-if="!state.metaEditing && isDorisTable(state.table) && !clusterId"
                         content="请选择 Doris 集群后再删除"
                         placement="top"
                       >
@@ -250,7 +291,16 @@
                     </el-tag>
 
                     <el-tooltip
-                      v-if="!state.fieldsEditing && isDorisTable(state.table) && !clusterId"
+                      v-if="!state.fieldsEditing && isPlatformMetadataMissing(state.table)"
+                      content="请先同步到平台元数据后再操作"
+                      placement="top"
+                    >
+                      <span>
+                        <el-button type="primary" size="small" disabled>编辑</el-button>
+                      </span>
+                    </el-tooltip>
+                    <el-tooltip
+                      v-else-if="!state.fieldsEditing && isDorisTable(state.table) && !clusterId"
                       content="请选择 Doris 集群后再编辑"
                       placement="top"
                     >
@@ -568,6 +618,7 @@ const {
   getMetaDataDomainOptions,
   handleMetaBusinessDomainChange,
   isDorisTable,
+  isPlatformMetadataMissing,
   isAggregateTable,
   isReplicaWarning,
   getLayerType,
@@ -576,6 +627,7 @@ const {
   cancelMetaEdit,
   saveMetaEdit,
   handleDeleteTable,
+  syncMissingTableMetadata,
   startFieldsEdit,
   cancelFieldsEdit,
   saveFieldsEdit,
@@ -1149,6 +1201,18 @@ const formatAccessDuration = (value) => {
   background: var(--panel);
   overflow: hidden;
   min-height: 0;
+}
+
+.metadata-missing-alert {
+  border-radius: 0;
+  border-width: 0 0 1px;
+}
+
+.metadata-missing-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .panel-resizer {

--- a/frontend/src/views/tasks/TaskEditDrawer.vue
+++ b/frontend/src/views/tasks/TaskEditDrawer.vue
@@ -931,6 +931,38 @@ const handleTaskNameBlur = () => {
   checkTaskName(form.task.taskName)
 }
 
+const resolveSavedWorkflowId = (savedTask, payload) => {
+  const candidates = [
+    savedTask?.workflowId,
+    savedTask?.task?.workflowId,
+    payload?.task?.workflowId,
+    form.task.workflowId
+  ]
+  for (const value of candidates) {
+    const id = Number(value)
+    if (Number.isFinite(id) && id > 0) return id
+  }
+  return null
+}
+
+const promptWorkflowPublishAfterSave = async (workflowId) => {
+  if (!workflowId) return
+  try {
+    await ElMessageBox.confirm(
+      '请跳转到任务调度页面，将工作流发布到 Dolphin。',
+      '工作流有变化',
+      {
+        type: 'warning',
+        confirmButtonText: '去发布',
+        cancelButtonText: '稍后处理'
+      }
+    )
+    router.push({ path: `/workflows/${workflowId}`, query: { publishHint: '1' } })
+  } catch (error) {
+    // 用户选择稍后处理。
+  }
+}
+
 const handleSave = async () => {
   if (!formRef.value) return
 
@@ -954,17 +986,20 @@ const handleSave = async () => {
       outputTableIds: form.outputTableIds
     }
 
+    let savedTask = null
     if (isEdit.value) {
-      await taskApi.update(form.task.id, payload)
+      savedTask = await taskApi.update(form.task.id, payload)
       ElMessage.success('更新成功')
     } else {
-      await taskApi.create(payload)
+      savedTask = await taskApi.create(payload)
       ElMessage.success('创建成功')
     }
+    const workflowId = resolveSavedWorkflowId(savedTask, payload)
 
     visible.value = false
     emit('saved')
     emit('success')
+    await promptWorkflowPublishAfterSave(workflowId)
   } catch (error) {
     console.error(error)
     ElMessage.error(isEdit.value ? '更新失败' : '创建失败')

--- a/frontend/src/views/workflows/WorkflowDetail.vue
+++ b/frontend/src/views/workflows/WorkflowDetail.vue
@@ -2215,6 +2215,48 @@ const updatePendingFlag = (workflowId, status) => {
   }
 }
 
+const resolveDeployOnlineVersionId = (row, record) => {
+  return record?.versionId || record?.workflowVersionId || record?.targetVersionId || resolvePublishVersionId(row)
+}
+
+const promptOnlineAfterDeploy = async (row, record) => {
+  if (!row?.id || record?.status === 'pending_approval' || row.status === 'online') return
+  try {
+    await ElMessageBox.confirm(
+      '发布已成功，是否立即上线该工作流？',
+      '立即上线',
+      {
+        type: 'warning',
+        confirmButtonText: '立即上线',
+        cancelButtonText: '稍后处理'
+      }
+    )
+  } catch (error) {
+    return
+  }
+
+  setActionLoading(row.id, 'online', true)
+  try {
+    const onlineRecord = await workflowApi.publish(row.id, {
+      operation: 'online',
+      versionId: resolveDeployOnlineVersionId(row, record),
+      requireApproval: false,
+      operator: 'portal-ui'
+    })
+    updatePendingFlag(row.id, onlineRecord?.status)
+    if (onlineRecord?.status === 'pending_approval') {
+      ElMessage.warning('上线已提交审批，等待审批通过')
+    } else {
+      ElMessage.success('上线成功')
+    }
+  } catch (error) {
+    console.error('上线失败', error)
+    ElMessage.error(getErrorMessage(error))
+  } finally {
+    setActionLoading(row.id, 'online', false)
+  }
+}
+
 const isDeployDisabled = (row) => {
   if (!row) return true
   if (pendingApprovalFlags[row.id]) return true
@@ -2267,6 +2309,7 @@ const handleDeploy = async (row) => {
       ElMessage.warning('发布已提交审批，等待审批通过')
     } else {
       ElMessage.success('发布成功')
+      await promptOnlineAfterDeploy(row, record)
     }
     loadWorkflowDetail()
   } catch (error) {
@@ -2507,6 +2550,14 @@ const handleToggleSchedule = async (val) => {
   }
 }
 
+const consumePublishHint = () => {
+  if (String(route.query.publishHint || '') !== '1') return
+  ElMessage.warning('工作流有变化，请使用发布按钮将工作流发布到 Dolphin。')
+  const nextQuery = { ...route.query }
+  delete nextQuery.publishHint
+  router.replace({ path: route.path, query: nextQuery })
+}
+
 const buildDolphinInstanceUrl = (instance) => {
   const wf = workflow.value?.workflow
   if (!wf || !dolphinWebuiUrl.value) {
@@ -2543,7 +2594,13 @@ watch(currentDolphinConfigId, async (nextId, prevId) => {
 onMounted(async () => {
   await Promise.all([loadDolphinConfigs(), loadWorkflowDetail()])
   await loadDolphinConfig()
+  consumePublishHint()
 })
+
+watch(
+  () => route.query.publishHint,
+  () => consumePublishHint()
+)
 </script>
 
 <style scoped>

--- a/frontend/src/views/workflows/WorkflowList.vue
+++ b/frontend/src/views/workflows/WorkflowList.vue
@@ -512,6 +512,48 @@ const updatePendingFlag = (workflowId, status) => {
   }
 }
 
+const resolveDeployOnlineVersionId = (row, record) => {
+  return record?.versionId || record?.workflowVersionId || record?.targetVersionId || resolvePublishVersionId(row)
+}
+
+const promptOnlineAfterDeploy = async (row, record) => {
+  if (!row?.id || record?.status === 'pending_approval' || row.status === 'online') return
+  try {
+    await ElMessageBox.confirm(
+      '发布已成功，是否立即上线该工作流？',
+      '立即上线',
+      {
+        type: 'warning',
+        confirmButtonText: '立即上线',
+        cancelButtonText: '稍后处理'
+      }
+    )
+  } catch (error) {
+    return
+  }
+
+  setActionLoading(row.id, 'online', true)
+  try {
+    const onlineRecord = await workflowApi.publish(row.id, {
+      operation: 'online',
+      versionId: resolveDeployOnlineVersionId(row, record),
+      requireApproval: false,
+      operator: 'portal-ui'
+    })
+    updatePendingFlag(row.id, onlineRecord?.status)
+    if (onlineRecord?.status === 'pending_approval') {
+      ElMessage.warning('上线已提交审批，等待审批通过')
+    } else {
+      ElMessage.success('上线成功')
+    }
+  } catch (error) {
+    console.error('上线失败', error)
+    ElMessage.error(getErrorMessage(error))
+  } finally {
+    setActionLoading(row.id, 'online', false)
+  }
+}
+
 const isDeployDisabled = (row) => {
   if (!row) return true
   if (pendingApprovalFlags[row.id]) return true
@@ -644,6 +686,7 @@ const handleDeploy = async (row) => {
       ElMessage.warning('发布已提交审批，等待审批通过')
     } else {
       ElMessage.success('发布成功')
+      await promptOnlineAfterDeploy(row, record)
     }
     refreshAfterAction(row.id)
   } catch (error) {


### PR DESCRIPTION
## Summary

- Add DataAgent architecture governance evaluation modules (builtin & deepeval) with Docker images and CI integration
- Add metadata sync statistics and guidance to Data Studio, workflow detail, and workflow list views
- Add DataSourceMetadataStatisticsSyncTask scheduled task for metadata statistics
- Add DataTableController and DorisMetadataSyncService enhancements with tests

## Changes

### DataAgent Eval
- New eval modules: `evals/dataagent-arch-governance-builtin/` and `evals/dataagent-arch-governance-deepeval/`
- CI matrix updated to build eval Docker images
- Eval runner scripts and tests

### Metadata Sync Guidance
- Backend: metadata sync statistics sync task, enhanced DorisMetadataSyncService
- Frontend: guidance panels in DataStudioNew, DataStudioRightPanel, WorkflowDetail, WorkflowList
- Docs: design and plan documents

## Test plan
- [ ] DataAgent eval modules build and run successfully
- [ ] Metadata sync statistics task runs correctly
- [ ] Data Studio guidance panels render correctly
- [ ] Workflow guidance panels render correctly