### PR TITLE
fix: improve workflow guidance prompts

### DIFF
--- a/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
@@ -14,7 +14,8 @@
             <div class="metadata-missing-title">
               <span>当前表在 Doris 中存在，平台中不存在。</span>
               <el-button
-                type="danger"
+                class="metadata-sync-action"
+                type="primary"
                 link
                 :loading="state.metadataSyncing"
                 :disabled="isDemoMode"
@@ -1166,6 +1167,15 @@ const formatAccessDuration = (value) => {
   --tab-active: #ffffff;
   --flow-task-bg: #ffffff;
   --flow-table-bg: #fafbfd;
+}
+
+.metadata-missing-alert :deep(.metadata-sync-action.el-button--primary.is-link) {
+  color: #2563eb;
+}
+
+.metadata-missing-alert :deep(.metadata-sync-action.el-button--primary.is-link:hover),
+.metadata-missing-alert :deep(.metadata-sync-action.el-button--primary.is-link:focus) {
+  color: #1d4ed8;
 }
 
 .variant-data-console {

--- a/frontend/src/views/tasks/TaskEditDrawer.vue
+++ b/frontend/src/views/tasks/TaskEditDrawer.vue
@@ -339,11 +339,19 @@
 <script setup>
 import { ref, reactive, computed, watch, onBeforeUnmount, nextTick, defineAsyncComponent } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { taskApi } from '@/api/task'
 import { workflowApi } from '@/api/workflow'
 import { tableApi } from '@/api/table'
-import { buildTaskPayload, createDefaultTaskModel, normalizeDolphinFlag, syncTaskDatasourceType } from './taskEditForm'
+import {
+  buildTaskPayload,
+  buildTaskSaveSuccessMessage,
+  createDefaultTaskModel,
+  normalizeDolphinFlag,
+  resolveTaskWorkflowId,
+  shouldPromptUnboundWorkflowGuidance,
+  syncTaskDatasourceType
+} from './taskEditForm'
 
 const SqlEditor = defineAsyncComponent({
   loader: () => import('@/components/SqlEditor.vue'),
@@ -374,6 +382,7 @@ const originalTaskName = ref('')
 const workflowOptions = ref([])
 const isWriteTask = ref(false)
 const contextDolphinConfigId = ref(null)
+const openedFromRelatedTask = ref(false)
 
 const datasourceOptions = ref([])
 const tableOptions = ref([])
@@ -800,6 +809,7 @@ const open = async (id = null, initialData = {}) => {
   contextDolphinConfigId.value = initialData.dolphinConfigId || null
 
   resetForm()
+  openedFromRelatedTask.value = Boolean(initialData.relation && initialData.tableId)
   lockedWorkflowId.value = null
   if (initialData.workflowId) {
     form.task.workflowId = initialData.workflowId
@@ -931,22 +941,26 @@ const handleTaskNameBlur = () => {
   checkTaskName(form.task.taskName)
 }
 
-const resolveSavedWorkflowId = (savedTask, payload) => {
-  const candidates = [
-    savedTask?.workflowId,
-    savedTask?.task?.workflowId,
-    payload?.task?.workflowId,
-    form.task.workflowId
-  ]
-  for (const value of candidates) {
-    const id = Number(value)
-    if (Number.isFinite(id) && id > 0) return id
+const promptWorkflowPublishAfterSave = async (workflowId, options = {}) => {
+  if (!workflowId) {
+    if (!shouldPromptUnboundWorkflowGuidance(workflowId, options)) return
+    try {
+      await ElMessageBox.confirm(
+        '任务已创建，但尚未绑定工作流。如需进入 Dolphin 调度，请到任务调度页面将任务加入工作流，发布后再上线。',
+        '任务尚未进入工作流',
+        {
+          type: 'warning',
+          confirmButtonText: '去任务调度',
+          cancelButtonText: '稍后处理'
+        }
+      )
+      router.push({ path: '/workflows', query: { tab: 'tasks' } })
+    } catch (error) {
+      // 用户选择稍后处理。
+    }
+    return
   }
-  return null
-}
 
-const promptWorkflowPublishAfterSave = async (workflowId) => {
-  if (!workflowId) return
   try {
     await ElMessageBox.confirm(
       '请跳转到任务调度页面，将工作流发布到 Dolphin。',
@@ -989,17 +1003,17 @@ const handleSave = async () => {
     let savedTask = null
     if (isEdit.value) {
       savedTask = await taskApi.update(form.task.id, payload)
-      ElMessage.success('更新成功')
     } else {
       savedTask = await taskApi.create(payload)
-      ElMessage.success('创建成功')
     }
-    const workflowId = resolveSavedWorkflowId(savedTask, payload)
+    const workflowId = resolveTaskWorkflowId(savedTask, payload, form.task)
+    const saveOptions = { fromRelatedTask: openedFromRelatedTask.value }
+    ElMessage.success(buildTaskSaveSuccessMessage(isEdit.value, workflowId, saveOptions))
 
     visible.value = false
     emit('saved')
     emit('success')
-    await promptWorkflowPublishAfterSave(workflowId)
+    await promptWorkflowPublishAfterSave(workflowId, saveOptions)
   } catch (error) {
     console.error(error)
     ElMessage.error(isEdit.value ? '更新失败' : '创建失败')
@@ -1016,6 +1030,7 @@ const resetForm = () => {
   taskNameError.value = ''
   originalTaskName.value = ''
   isWriteTask.value = false
+  openedFromRelatedTask.value = false
   inputSelectionTouched.value = false
   outputSelectionTouched.value = false
   clearSqlAnalysis()

--- a/frontend/src/views/tasks/__tests__/taskEditForm.spec.js
+++ b/frontend/src/views/tasks/__tests__/taskEditForm.spec.js
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { buildTaskPayload, createDefaultTaskModel, syncTaskDatasourceType } from '../taskEditForm'
+import {
+  buildTaskPayload,
+  buildTaskSaveSuccessMessage,
+  createDefaultTaskModel,
+  resolveTaskWorkflowId,
+  shouldPromptUnboundWorkflowGuidance,
+  syncTaskDatasourceType
+} from '../taskEditForm'
 
 describe('taskEditForm', () => {
   it('defaults dolphinFlag to YES and datasourceType to null for new tasks', () => {
@@ -49,5 +56,25 @@ describe('taskEditForm', () => {
     expect(task.datasourceName).toBe('')
     expect(task.datasourceType).toBeNull()
     expect(buildTaskPayload(task).datasourceType).toBeNull()
+  })
+
+  it('resolves workflowId from saved response, payload, or draft task', () => {
+    expect(resolveTaskWorkflowId({ workflowId: 12 }, {}, {})).toBe(12)
+    expect(resolveTaskWorkflowId({ task: { workflowId: 13 } }, {}, {})).toBe(13)
+    expect(resolveTaskWorkflowId({}, { task: { workflowId: 14 } }, {})).toBe(14)
+    expect(resolveTaskWorkflowId({}, {}, { workflowId: 15 })).toBe(15)
+    expect(resolveTaskWorkflowId({}, { task: { workflowId: '' } }, { workflowId: null })).toBeNull()
+  })
+
+  it('marks related task saves without workflow as needing workflow guidance', () => {
+    expect(shouldPromptUnboundWorkflowGuidance(null, { fromRelatedTask: true })).toBe(true)
+    expect(shouldPromptUnboundWorkflowGuidance(12, { fromRelatedTask: true })).toBe(false)
+    expect(shouldPromptUnboundWorkflowGuidance(null, { fromRelatedTask: false })).toBe(false)
+  })
+
+  it('uses workflow-aware success messages after related task saves', () => {
+    expect(buildTaskSaveSuccessMessage(false, 12, { fromRelatedTask: true })).toBe('创建成功，工作流有变化')
+    expect(buildTaskSaveSuccessMessage(false, null, { fromRelatedTask: true })).toBe('创建成功，请绑定工作流后发布上线')
+    expect(buildTaskSaveSuccessMessage(true, null, { fromRelatedTask: false })).toBe('更新成功')
   })
 })

--- a/frontend/src/views/tasks/taskEditForm.js
+++ b/frontend/src/views/tasks/taskEditForm.js
@@ -78,3 +78,32 @@ export const buildTaskPayload = (task) => {
   }
   return payload
 }
+
+export const resolveTaskWorkflowId = (savedTask, payload, draftTask) => {
+  const candidates = [
+    savedTask?.workflowId,
+    savedTask?.task?.workflowId,
+    payload?.task?.workflowId,
+    draftTask?.workflowId
+  ]
+  for (const value of candidates) {
+    const id = Number(value)
+    if (Number.isFinite(id) && id > 0) return id
+  }
+  return null
+}
+
+export const shouldPromptUnboundWorkflowGuidance = (workflowId, options = {}) => {
+  return !workflowId && options.fromRelatedTask === true
+}
+
+export const buildTaskSaveSuccessMessage = (isEdit, workflowId, options = {}) => {
+  const action = isEdit ? '更新' : '创建'
+  if (workflowId) {
+    return `${action}成功，工作流有变化`
+  }
+  if (shouldPromptUnboundWorkflowGuidance(workflowId, options)) {
+    return `${action}成功，请绑定工作流后发布上线`
+  }
+  return `${action}成功`
+}

--- a/frontend/src/views/workflows/WorkflowDetail.vue
+++ b/frontend/src/views/workflows/WorkflowDetail.vue
@@ -835,7 +835,8 @@ import {
   buildPublishRepairHtml,
   firstPreviewErrorMessage,
   isDialogCancel,
-  resolvePublishVersionId
+  resolvePublishVersionId,
+  shouldPromptOnlineAfterDeploy
 } from './publishPreviewHelper'
 import QuartzCronBuilder from '@/components/QuartzCronBuilder.vue'
 
@@ -2220,7 +2221,7 @@ const resolveDeployOnlineVersionId = (row, record) => {
 }
 
 const promptOnlineAfterDeploy = async (row, record) => {
-  if (!row?.id || record?.status === 'pending_approval' || row.status === 'online') return
+  if (!shouldPromptOnlineAfterDeploy(row, record)) return
   try {
     await ElMessageBox.confirm(
       '发布已成功，是否立即上线该工作流？',

--- a/frontend/src/views/workflows/WorkflowList.vue
+++ b/frontend/src/views/workflows/WorkflowList.vue
@@ -246,7 +246,8 @@ import {
   buildPublishRepairHtml,
   firstPreviewErrorMessage,
   isDialogCancel,
-  resolvePublishVersionId
+  resolvePublishVersionId,
+  shouldPromptOnlineAfterDeploy
 } from './publishPreviewHelper'
 import WorkflowCreateDrawer from './WorkflowCreateDrawer.vue'
 import WorkflowBackfillDialog from './WorkflowBackfillDialog.vue'
@@ -517,7 +518,7 @@ const resolveDeployOnlineVersionId = (row, record) => {
 }
 
 const promptOnlineAfterDeploy = async (row, record) => {
-  if (!row?.id || record?.status === 'pending_approval' || row.status === 'online') return
+  if (!shouldPromptOnlineAfterDeploy(row, record)) return
   try {
     await ElMessageBox.confirm(
       '发布已成功，是否立即上线该工作流？',

--- a/frontend/src/views/workflows/__tests__/publishPreviewHelper.spec.js
+++ b/frontend/src/views/workflows/__tests__/publishPreviewHelper.spec.js
@@ -1,4 +1,4 @@
-import { buildPublishPreviewHtml, resolvePublishVersionId } from '../publishPreviewHelper'
+import { buildPublishPreviewHtml, resolvePublishVersionId, shouldPromptOnlineAfterDeploy } from '../publishPreviewHelper'
 import { buildTaskFieldDiffRows } from '../publishPreviewDiffHelper'
 
 describe('publishPreviewHelper', () => {
@@ -60,5 +60,12 @@ describe('publishPreviewHelper', () => {
     })).toBe(101)
 
     expect(resolvePublishVersionId({})).toBeUndefined()
+  })
+
+  it('prompts for online after successful deploy even when stale row was already online', () => {
+    expect(shouldPromptOnlineAfterDeploy({ id: 1, status: 'online' }, { status: 'success' })).toBe(true)
+    expect(shouldPromptOnlineAfterDeploy({ id: 1, status: 'offline' }, { status: 'success' })).toBe(true)
+    expect(shouldPromptOnlineAfterDeploy({ id: 1, status: 'offline' }, { status: 'pending_approval' })).toBe(false)
+    expect(shouldPromptOnlineAfterDeploy(null, { status: 'success' })).toBe(false)
   })
 })

--- a/frontend/src/views/workflows/publishPreviewHelper.js
+++ b/frontend/src/views/workflows/publishPreviewHelper.js
@@ -241,6 +241,11 @@ export const resolvePublishVersionId = (workflow) => {
   return undefined
 }
 
+export const shouldPromptOnlineAfterDeploy = (row, record) => {
+  if (!row?.id) return false
+  return record?.status !== 'pending_approval'
+}
+
 export const buildPublishRepairHtml = (preview) => {
   const repairIssues = Array.isArray(preview?.repairIssues) ? preview.repairIssues : []
   const warnings = Array.isArray(preview?.warnings) ? preview.warnings : []


### PR DESCRIPTION
## Summary
- make the DataStudio missing-platform `立即同步` action render as a blue clickable link instead of a danger action
- restore workflow publish guidance after saving tasks bound to workflows by importing `ElMessageBox` and centralizing workflow ID resolution
- prompt for immediate online after workflow deploy from both list and detail views, even when the pre-deploy row was already online

## Validation
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run test -- src/views/workflows/__tests__/publishPreviewHelper.spec.js src/views/tasks/__tests__/taskEditForm.spec.js`
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run build`

## Risk
Low; changes are scoped to frontend prompt/display logic and helper tests.

## Rollback
Revert commit `07b872f` to restore the prior UI behavior.
