### PR TITLE
[codex] Fix platform skill root fallback

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -220,6 +220,10 @@ def _build_runtime_env(
     enabled_folders = [str(item) for item in ((skill_runtime or {}).get("enabled_folders") or [])]
     enabled_roots = dict((skill_runtime or {}).get("enabled_roots") or {})
     platform_skill_root = str(enabled_roots.get(PLATFORM_TOOLS_SKILL_FOLDER) or "").strip()
+    if not platform_skill_root:
+        sibling_platform_root = skills_root.parent / PLATFORM_TOOLS_SKILL_FOLDER
+        if sibling_platform_root.is_dir():
+            platform_skill_root = str(sibling_platform_root)
     existing_path = str(os.getenv("PATH") or "").strip()
     runtime_path = python_dir if not existing_path else f"{python_dir}:{existing_path}"
     # Preserve the current process environment so skill-private env vars can be

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -68,6 +68,26 @@ def test_build_runtime_env_defaults_query_limit_to_backend_max(monkeypatch):
     assert runtime_env["DATAAGENT_RESULT_PREVIEW_ROWS"] == "20"
 
 
+def test_build_runtime_env_derives_platform_root_from_primary_root_when_enabled_roots_lag(tmp_path: Path):
+    primary_root = tmp_path / ".claude" / "skills" / "dataagent-nl2sql"
+    platform_root = tmp_path / ".claude" / "skills" / "opendataworks-platform-tools"
+    primary_root.mkdir(parents=True)
+    platform_root.mkdir(parents=True)
+
+    runtime_env = agent_runtime._build_runtime_env(
+        SimpleNamespace(query_result_limit=1000),
+        {},
+        SimpleNamespace(question="", sql_read_timeout_seconds=0),
+        {
+            "primary_root": str(primary_root),
+            "enabled_folders": ["dataagent-nl2sql"],
+            "enabled_roots": {"dataagent-nl2sql": str(primary_root)},
+        },
+    )
+
+    assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(platform_root.resolve())
+
+
 def test_safe_base_url_preserves_path_without_query_or_fragment():
     actual = agent_runtime._safe_base_url("http://relay.example.internal/maas?token=secret#frag")
 


### PR DESCRIPTION
## Summary
- Ensure `DATAAGENT_PLATFORM_SKILL_ROOT` is still injected when runtime `enabled_roots` lags behind the newly split platform tools skill.
- Derive the platform tools root from the primary skill sibling directory when it exists.
- Add a regression test for legacy runtime configurations that only expose `dataagent-nl2sql` in `enabled_roots`.

## Validation
- `cd dataagent/dataagent-backend && /Users/guoruping/project/bigdata/opendataworks/dataagent/dataagent-backend/.venv-py313/bin/python -m pytest -q`
- Result: 118 passed, 5 existing deprecation warnings.

## Risk / Rollback
- Risk: low; fallback only applies when the platform tools directory exists beside the primary skill and `enabled_roots` omitted it.
- Rollback: revert this commit to return to strict `enabled_roots`-only platform root injection.