### PR TITLE
fix: harden DataAgent eval runners

### DIFF
--- a/docs/design/2026-05-12-dataagent-online-evaluation-design.md
+++ b/docs/design/2026-05-12-dataagent-online-evaluation-design.md
@@ -149,7 +149,7 @@ Runner arguments:
 - `--judge-timeout-seconds`
 - `--dry-run`
 
-The first version accepts `--concurrency` but runs sequentially unless later versions introduce a verified parallel task-submission policy.
+When `--concurrency > 1`, the runner submits and polls multiple cases in parallel while preserving dataset order in the written outputs.
 
 ## Runner Flow
 

--- a/scripts/run-dataagent-deepeval-evals.sh
+++ b/scripts/run-dataagent-deepeval-evals.sh
@@ -68,10 +68,10 @@ for ((i = 0; i < ${#ARGS[@]}; i++)); do
     fi
 done
 
-EXTRA_VOLUMES=()
+VOLUMES=(-v "$REPO_ROOT:/workspace")
 if [[ -n "$DATASET_PATH" && "$DATASET_PATH" = /* ]]; then
     DATASET_DIR="$(cd "$(dirname "$DATASET_PATH")" && pwd)"
-    EXTRA_VOLUMES+=(-v "$DATASET_DIR:$DATASET_DIR:ro")
+    VOLUMES+=(-v "$DATASET_DIR:$DATASET_DIR:ro")
 fi
 
 exec "$CONTAINER_CMD" run --rm \
@@ -82,7 +82,6 @@ exec "$CONTAINER_CMD" run --rm \
     -e DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS="${DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS:-120}" \
     -e DATAAGENT_EVAL_JUDGE_MAX_TOKENS="${DATAAGENT_EVAL_JUDGE_MAX_TOKENS:-4096}" \
     -e DATAAGENT_EVAL_DATASET="${DATAAGENT_EVAL_DATASET:-}" \
-    -v "$REPO_ROOT:/workspace" \
-    "${EXTRA_VOLUMES[@]}" \
+    "${VOLUMES[@]}" \
     -w /workspace \
     "$IMAGE" "$@"

--- a/scripts/run-dataagent-evals.sh
+++ b/scripts/run-dataagent-evals.sh
@@ -68,10 +68,10 @@ for ((i = 0; i < ${#ARGS[@]}; i++)); do
     fi
 done
 
-EXTRA_VOLUMES=()
+VOLUMES=(-v "$REPO_ROOT:/workspace")
 if [[ -n "$DATASET_PATH" && "$DATASET_PATH" = /* ]]; then
     DATASET_DIR="$(cd "$(dirname "$DATASET_PATH")" && pwd)"
-    EXTRA_VOLUMES+=(-v "$DATASET_DIR:$DATASET_DIR:ro")
+    VOLUMES+=(-v "$DATASET_DIR:$DATASET_DIR:ro")
 fi
 
 exec "$CONTAINER_CMD" run --rm \
@@ -82,7 +82,6 @@ exec "$CONTAINER_CMD" run --rm \
     -e DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS="${DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS:-120}" \
     -e DATAAGENT_EVAL_JUDGE_MAX_TOKENS="${DATAAGENT_EVAL_JUDGE_MAX_TOKENS:-4096}" \
     -e DATAAGENT_EVAL_DATASET="${DATAAGENT_EVAL_DATASET:-}" \
-    -v "$REPO_ROOT:/workspace" \
-    "${EXTRA_VOLUMES[@]}" \
+    "${VOLUMES[@]}" \
     -w /workspace \
     "$IMAGE" "$@"

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import threading
 import sys
+import time
 import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -170,6 +171,65 @@ def test_deepeval_apply_judges_uses_shared_results_when_metric_is_copied(monkeyp
     assert updated[0]["case_passed"] is True
 
 
+def test_deepeval_evaluate_error_without_all_judges_raises_runner_error(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    case = _sample_case()
+    test_case = runner.to_deepeval_test_case(
+        case,
+        {"case_id": case["case_id"], "final_answer": "answer", "auto_rule_check": {"passed": True}},
+    )
+    metric = runner.DataAgentEvaluationMetric(runner.JudgeConfig(base_url="http://judge", token="t", model="m"))
+
+    def broken_evaluate(**kwargs):
+        raise RuntimeError("deepeval crashed before measuring")
+
+    monkeypatch.setattr(runner, "deepeval_evaluate", broken_evaluate)
+
+    try:
+        runner.run_deepeval([test_case], metric)
+    except runner.EvalRunnerError as exc:
+        assert "deepeval evaluate failed before all judge results were captured" in str(exc)
+    else:
+        raise AssertionError("expected EvalRunnerError")
+
+
+def test_deepeval_evaluate_error_after_all_judges_is_nonfatal(monkeypatch, capsys):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    case = _sample_case()
+    test_case = runner.to_deepeval_test_case(
+        case,
+        {"case_id": case["case_id"], "final_answer": "answer", "auto_rule_check": {"passed": True}},
+    )
+    metric = runner.DataAgentEvaluationMetric(runner.JudgeConfig(base_url="http://judge", token="t", model="m"))
+
+    def fake_judge(config, payload):
+        return {
+            "score": 9,
+            "dimension_scores": {"intent": 1},
+            "hallucination": False,
+            "veto_rules_triggered": [],
+            "failure_attribution": [],
+            "comment": "ok",
+        }
+
+    def late_error_evaluate(**kwargs):
+        for test_case_item in kwargs["test_cases"]:
+            for metric_item in kwargs["metrics"]:
+                metric_item.measure(test_case_item)
+        raise RuntimeError("deepeval summary writer failed")
+
+    monkeypatch.setattr(runner, "call_judge_model", fake_judge)
+    monkeypatch.setattr(runner, "deepeval_evaluate", late_error_evaluate)
+
+    runner.run_deepeval([test_case], metric)
+
+    captured = capsys.readouterr()
+    assert "deepeval evaluate warning" in captured.err
+    assert metric.case_judges["ODW_SAMPLE_001"]["score"] == 9.0
+
+
 def test_deepeval_judge_request_embeds_system_prompt_in_user_content(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
@@ -243,6 +303,50 @@ def test_deepeval_auto_rule_check_adds_generic_failure_attribution(monkeypatch):
     assert {"sql_only", "wrong_domain", "placeholder_leak", "empty_result"}.issubset(
         set(result["failure_attribution"])
     )
+
+
+def test_deepeval_run_cases_parallel_preserves_dataset_order_and_records_crashes(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    calls = []
+    cases = [
+        {**_sample_case(), "case_id": "CASE_SLOW"},
+        {**_sample_case(), "case_id": "CASE_FAST"},
+        {**_sample_case(), "case_id": "CASE_CRASH"},
+    ]
+
+    def fake_run_case(base_url, case, args):
+        calls.append(case["case_id"])
+        if case["case_id"] == "CASE_SLOW":
+            time.sleep(0.05)
+        if case["case_id"] == "CASE_CRASH":
+            raise RuntimeError("case crashed")
+        return {
+            "case_id": case["case_id"],
+            "category": case.get("category"),
+            "question": case.get("question"),
+            "task_status": "finished",
+            "final_answer": "ok",
+            "tool_names": [],
+            "sql_outputs": [],
+            "chart_outputs": [],
+            "usage": {},
+            "duration_seconds": 0,
+            "auto_rule_check": {"passed": True, "failure_attribution": []},
+            "judge": {},
+            "veto_rules_triggered": [],
+            "case_passed": False,
+            "errors": [],
+        }
+
+    monkeypatch.setattr(runner, "run_case", fake_run_case)
+
+    results = runner._run_cases("http://dataagent", cases, types.SimpleNamespace(concurrency=2))
+
+    assert [item["case_id"] for item in results] == ["CASE_SLOW", "CASE_FAST", "CASE_CRASH"]
+    assert set(calls) == {"CASE_SLOW", "CASE_FAST", "CASE_CRASH"}
+    assert results[2]["task_status"] == "runner_error"
+    assert results[2]["errors"] == [{"code": "runner_crash", "message": "case crashed"}]
 
 
 def test_deepeval_dry_run_writes_unified_report(tmp_path, monkeypatch):

--- a/tests/test_deepeval_packaging_hooks.py
+++ b/tests/test_deepeval_packaging_hooks.py
@@ -44,6 +44,23 @@ def test_builtin_eval_module_is_packaged_as_parallel_image():
     assert "tools/dataagent-evals/builtin/run.py" in run_wrapper
 
 
+def test_deepeval_eval_wrapper_keeps_volume_array_non_empty_for_bash_3():
+    run_wrapper = (REPO_ROOT / "scripts" / "run-dataagent-deepeval-evals.sh").read_text(encoding="utf-8")
+
+    assert "VOLUMES=(-v \"$REPO_ROOT:/workspace\")" in run_wrapper
+    assert "EXTRA_VOLUMES=()" not in run_wrapper
+    assert "\"${VOLUMES[@]}\"" in run_wrapper
+
+
+def test_online_eval_design_documents_verified_parallel_concurrency():
+    design = (REPO_ROOT / "docs" / "design" / "2026-05-12-dataagent-online-evaluation-design.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "runs sequentially" not in design
+    assert "--concurrency > 1" in design
+
+
 def test_private_business_skill_assets_are_ignored_and_not_packaged():
     gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
     create_package = (REPO_ROOT / "scripts" / "create-offline-package.sh").read_text(encoding="utf-8")

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import threading
+import time
+import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -164,6 +166,55 @@ def test_auto_rule_check_adds_generic_failure_attribution():
     assert {"sql_only", "wrong_domain", "placeholder_leak", "empty_result"}.issubset(
         set(result["failure_attribution"])
     )
+
+
+def test_run_cases_parallel_preserves_dataset_order_and_records_crashes(monkeypatch):
+    runner = _load_runner()
+    calls = []
+    cases = [
+        _sample_case("CASE_SLOW"),
+        _sample_case("CASE_FAST"),
+        _sample_case("CASE_CRASH"),
+    ]
+
+    def fake_run_case(base_url, case, args, judge_config):
+        calls.append(case["case_id"])
+        if case["case_id"] == "CASE_SLOW":
+            time.sleep(0.05)
+        if case["case_id"] == "CASE_CRASH":
+            raise RuntimeError("case crashed")
+        return {
+            "case_id": case["case_id"],
+            "category": case.get("category"),
+            "question": case.get("question"),
+            "task_status": "success",
+            "final_answer": "ok",
+            "tool_names": [],
+            "sql_outputs": [],
+            "chart_outputs": [],
+            "usage": {},
+            "duration_seconds": 0,
+            "auto_rule_check": {"passed": True, "failure_attribution": []},
+            "judge": {"score": 9, "judge_failed": False, "failure_attribution": []},
+            "veto_rules_triggered": [],
+            "case_passed": True,
+            "errors": [],
+        }
+
+    monkeypatch.setattr(runner, "run_case", fake_run_case)
+
+    results = runner._run_cases(
+        "http://dataagent",
+        cases,
+        types.SimpleNamespace(concurrency=2),
+        runner.JudgeConfig(base_url="http://judge", token="t", model="m"),
+    )
+
+    assert [item["case_id"] for item in results] == ["CASE_SLOW", "CASE_FAST", "CASE_CRASH"]
+    assert set(calls) == {"CASE_SLOW", "CASE_FAST", "CASE_CRASH"}
+    assert results[2]["task_status"] == "runner_error"
+    assert results[2]["judge"]["judge_failed"] is True
+    assert results[2]["errors"] == [{"code": "runner_crash", "message": "case crashed"}]
 
 
 class _FakeDataAgentHandler(BaseHTTPRequestHandler):

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -11,6 +11,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
@@ -105,7 +106,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--provider-id", default="", help="Override DataAgent execution provider for evaluated tasks.")
     parser.add_argument("--model", default="", help="Override DataAgent execution model for evaluated tasks.")
     parser.add_argument("--timeout-seconds", type=int, default=900, help="Maximum wait per case.")
-    parser.add_argument("--concurrency", type=int, default=1, help="Reserved for future parallel execution; first version runs sequentially.")
+    parser.add_argument("--concurrency", type=int, default=1, help="Number of cases to run in parallel.")
     parser.add_argument("--judge-base-url", default=os.environ.get("DATAAGENT_EVAL_JUDGE_BASE_URL", ""), help="Anthropic-compatible judge base URL.")
     parser.add_argument("--judge-token", default=os.environ.get("DATAAGENT_EVAL_JUDGE_TOKEN", ""), help="Judge model API token.")
     parser.add_argument("--judge-model", default=os.environ.get("DATAAGENT_EVAL_JUDGE_MODEL", ""), help="Judge model name.")
@@ -756,6 +757,44 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     }
 
 
+def _run_cases(base_url: str, cases: list[dict[str, Any]], args: argparse.Namespace, judge_config: JudgeConfig) -> list[dict[str, Any]]:
+    if args.concurrency <= 1:
+        return [run_case(base_url, case, args, judge_config) for case in cases]
+
+    results: list[dict[str, Any] | None] = [None] * len(cases)
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        future_to_index = {pool.submit(run_case, base_url, case, args, judge_config): i for i, case in enumerate(cases)}
+        for future in as_completed(future_to_index):
+            index = future_to_index[future]
+            try:
+                results[index] = future.result()
+            except Exception as exc:
+                case = cases[index]
+                results[index] = {
+                    "case_id": case.get("case_id"),
+                    "category": case.get("category"),
+                    "question": case.get("question"),
+                    "task_status": "runner_error",
+                    "final_answer": "",
+                    "tool_names": [],
+                    "sql_outputs": [],
+                    "chart_outputs": [],
+                    "usage": {},
+                    "duration_seconds": 0,
+                    "auto_rule_check": {"passed": False, "failure_attribution": ["runner_crash"]},
+                    "judge": {"score": 0, "judge_failed": True, "failure_attribution": ["runner_crash"]},
+                    "veto_rules_triggered": [],
+                    "case_passed": False,
+                    "errors": [{"code": "runner_crash", "message": str(exc)}],
+                }
+            else:
+                result = results[index]
+                case_id = (result or {}).get("case_id") if result else "?"
+                done = len([r for r in results if r is not None])
+                print(f"[{done}/{len(cases)}] {case_id} done", file=sys.stderr)
+    return [r for r in results if r is not None]
+
+
 def _avg(values: list[float]) -> float:
     return sum(values) / len(values) if values else 0.0
 
@@ -932,7 +971,7 @@ def main(argv: list[str] | None = None) -> int:
         judge_config = _judge_config_from_args(args)
         preflight_payload = preflight(base_url)
         dataset_stats["preflight"] = preflight_payload
-        results = [run_case(base_url, case, args, judge_config) for case in cases]
+        results = _run_cases(base_url, cases, args, judge_config)
         summary = build_summary(results, dataset_stats)
         write_outputs(output_dir, results, summary)
         print(f"eval outputs written to: {output_dir}")

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -11,6 +11,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -121,7 +122,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--provider-id", default="", help="Override DataAgent execution provider for evaluated tasks.")
     parser.add_argument("--model", default="", help="Override DataAgent execution model for evaluated tasks.")
     parser.add_argument("--timeout-seconds", type=int, default=900, help="Maximum wait per case.")
-    parser.add_argument("--concurrency", type=int, default=1, help="Reserved for future parallel execution; first version runs sequentially.")
+    parser.add_argument("--concurrency", type=int, default=1, help="Number of cases to run in parallel.")
     parser.add_argument("--judge-base-url", default=os.environ.get("DATAAGENT_EVAL_JUDGE_BASE_URL", ""), help="Anthropic-compatible judge base URL.")
     parser.add_argument("--judge-token", default=os.environ.get("DATAAGENT_EVAL_JUDGE_TOKEN", ""), help="Judge model API token.")
     parser.add_argument("--judge-model", default=os.environ.get("DATAAGENT_EVAL_JUDGE_MODEL", ""), help="Judge model name.")
@@ -528,6 +529,43 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
     }
 
 
+def _run_cases(base_url: str, cases: list[dict[str, Any]], args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.concurrency <= 1:
+        return [run_case(base_url, case, args) for case in cases]
+
+    results: list[dict[str, Any] | None] = [None] * len(cases)
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        future_to_index = {pool.submit(run_case, base_url, case, args): i for i, case in enumerate(cases)}
+        for future in as_completed(future_to_index):
+            index = future_to_index[future]
+            try:
+                results[index] = future.result()
+            except Exception as exc:
+                case = cases[index]
+                results[index] = {
+                    "case_id": case.get("case_id"),
+                    "category": case.get("category"),
+                    "question": case.get("question"),
+                    "task_status": "runner_error",
+                    "final_answer": "",
+                    "tool_names": [],
+                    "sql_outputs": [],
+                    "chart_outputs": [],
+                    "usage": {},
+                    "duration_seconds": 0,
+                    "auto_rule_check": {"passed": False, "failure_attribution": ["runner_crash"]},
+                    "judge": {},
+                    "veto_rules_triggered": [],
+                    "case_passed": False,
+                    "errors": [{"code": "runner_crash", "message": str(exc)}],
+                }
+            else:
+                result = results[index]
+                case_id = (result or {}).get("case_id") if result else "?"
+                print(f"[{len([r for r in results if r is not None])}/{len(cases)}] {case_id} done", file=sys.stderr)
+    return [r for r in results if r is not None]
+
+
 def _ensure_deepeval_available() -> None:
     if deepeval_evaluate is None or LLMTestCase is None:
         raise EvalRunnerError("deepeval is not installed; run through the DeepEval eval Docker image or install requirements.txt")
@@ -805,9 +843,22 @@ def run_deepeval(test_cases: list[Any], metric: DataAgentEvaluationMetric) -> No
     _ensure_deepeval_available()
     DataAgentEvaluationMetric.shared_case_judges = {}
     try:
-        deepeval_evaluate(test_cases=test_cases, metrics=[metric], print_results=False)
-    except TypeError:
-        deepeval_evaluate(test_cases=test_cases, metrics=[metric])
+        try:
+            deepeval_evaluate(test_cases=test_cases, metrics=[metric], print_results=False)
+        except TypeError:
+            deepeval_evaluate(test_cases=test_cases, metrics=[metric])
+    except Exception as exc:
+        expected_case_ids = {
+            str(DataAgentEvaluationMetric._payload_from_test_case(test_case).get("case", {}).get("case_id") or "")
+            for test_case in test_cases
+        }
+        expected_case_ids.discard("")
+        captured_case_ids = set(metric.case_judges) | set(DataAgentEvaluationMetric.shared_case_judges)
+        if not expected_case_ids.issubset(captured_case_ids):
+            raise EvalRunnerError(
+                f"deepeval evaluate failed before all judge results were captured: {exc}"
+            ) from exc
+        print(f"deepeval evaluate warning (judge results already captured): {exc}", file=sys.stderr)
 
 
 def _apply_judges(results: list[dict[str, Any]], metric: DataAgentEvaluationMetric) -> list[dict[str, Any]]:
@@ -1010,7 +1061,7 @@ def main(argv: list[str] | None = None) -> int:
         base_url = str(args.base_url or "").rstrip("/")
         preflight_payload = preflight(base_url)
         dataset_stats["preflight"] = preflight_payload
-        results = [run_case(base_url, case, args) for case in cases]
+        results = _run_cases(base_url, cases, args)
         metric = DataAgentEvaluationMetric(judge_config)
         test_cases = [to_deepeval_test_case(case, result) for case, result in zip(cases, results)]
         run_deepeval(test_cases, metric)


### PR DESCRIPTION
## Summary
- Harden DataAgent online eval runners so parallel case execution is covered and DeepEval infrastructure failures are reported accurately.
- Keep the Docker/Podman wrappers compatible with Bash 3.2 while documenting the verified `--concurrency > 1` behavior.

## What Changed

### Behavior Changes
- Builtin and DeepEval runners now execute `--concurrency > 1` cases in parallel while preserving dataset order in reports.
- DeepEval only downgrades `deepeval.evaluate` exceptions to warnings after all judge results have been captured; early infrastructure failures now raise `EvalRunnerError`.
- DeepEval wrapper uses a non-empty `VOLUMES` array to avoid Bash 3.2 `set -u` empty-array expansion failures.

### Key Files
- `tools/dataagent-evals/builtin/run.py`: parallel case runner for builtin evals.
- `tools/dataagent-evals/deepeval/run.py`: parallel case runner plus guarded DeepEval exception handling.
- `scripts/run-dataagent-evals.sh` and `scripts/run-dataagent-deepeval-evals.sh`: wrapper volume handling.
- `tests/test_run_dataagent_evals.py`, `tests/test_dataagent_deepeval_evals.py`, `tests/test_deepeval_packaging_hooks.py`: regression coverage for parallel execution, wrapper compatibility, and DeepEval failure handling.
- `docs/design/2026-05-12-dataagent-online-evaluation-design.md`: concurrency behavior note.

## Validation
- Command: `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest tests/test_deepeval_packaging_hooks.py tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py`
  Result: pass, 31 tests passed.
- Command: `dataagent/dataagent-backend/.venv-py313/bin/python -m py_compile tools/dataagent-evals/builtin/run.py tools/dataagent-evals/deepeval/run.py`
  Result: pass.
- Command: `bash -n scripts/run-dataagent-evals.sh scripts/run-dataagent-deepeval-evals.sh`
  Result: pass.
- Command: `git diff --check`
  Result: pass.

## Risks
- Main regression risk: higher eval concurrency can put more pressure on the DataAgent backend, provider quota, and judge endpoint; default concurrency remains 1.

## Rollback
- Revert commit `fdc72b9` to restore sequential runner behavior and previous wrapper logic.

## Checklist
- [x] No secrets/credentials committed.
- [x] Compatibility impact reviewed.
- [x] Docs/config updates completed when needed.