### PR TITLE
feat: add DataAgent agent profiles

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260521_000007_add_agent_profiles.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260521_000007_add_agent_profiles.py
@@ -1,0 +1,168 @@
+"""add dataagent agent profiles
+
+Revision ID: 20260521_000007
+Revises: 20260429_000006
+Create Date: 2026-05-21 10:00:00
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260521_000007"
+down_revision = "20260429_000006"
+branch_labels = None
+depends_on = None
+
+DEFAULT_AGENT_ID = "agent_default"
+DEFAULT_AGENT_SNAPSHOT = {
+    "agent_id": DEFAULT_AGENT_ID,
+    "name": "默认智能问数助手",
+    "description": "使用当前 DataAgent 默认提示词、Skills、工具和 MCP 配置。",
+    "system_prompt": "",
+    "permission_mode": "inherit",
+    "allowed_tools": ["Skill", "Bash", "Read", "LS", "Glob", "Grep"],
+    "mcp_server_ids": ["portal"],
+    "skill_folders": [],
+    "max_turns": 0,
+    "env_vars": {},
+    "is_default": True,
+}
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(column.get("name") == column_name for column in inspector.get_columns(table_name))
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
+
+
+def _json(value) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def upgrade() -> None:
+    if not _has_table("da_agent_profile"):
+        op.create_table(
+            "da_agent_profile",
+            sa.Column("agent_id", sa.String(length=64), nullable=False),
+            sa.Column("name", sa.String(length=128), nullable=False),
+            sa.Column("description", sa.Text(), nullable=False),
+            sa.Column("system_prompt", sa.Text(), nullable=False),
+            sa.Column("permission_mode", sa.String(length=32), nullable=False, server_default="inherit"),
+            sa.Column("allowed_tools_json", sa.Text(), nullable=False),
+            sa.Column("mcp_server_ids_json", sa.Text(), nullable=False),
+            sa.Column("skill_folders_json", sa.Text(), nullable=False),
+            sa.Column("max_turns", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("env_vars_json", sa.Text(), nullable=False),
+            sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.PrimaryKeyConstraint("agent_id"),
+            mysql_charset="utf8mb4",
+            mysql_collate="utf8mb4_unicode_ci",
+            mysql_engine="InnoDB",
+        )
+    if not _has_index("da_agent_profile", "idx_da_agent_profile_default_updated"):
+        op.create_index("idx_da_agent_profile_default_updated", "da_agent_profile", ["is_default", "updated_at"])
+
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+        INSERT INTO da_agent_profile (
+            agent_id, name, description, system_prompt, permission_mode,
+            allowed_tools_json, mcp_server_ids_json, skill_folders_json,
+            max_turns, env_vars_json, is_default
+        ) VALUES (
+            :agent_id, :name, :description, :system_prompt, :permission_mode,
+            :allowed_tools_json, :mcp_server_ids_json, :skill_folders_json,
+            :max_turns, :env_vars_json, 1
+        )
+        ON DUPLICATE KEY UPDATE
+            is_default = 1,
+            updated_at = CURRENT_TIMESTAMP
+        """
+        ),
+        {
+            "agent_id": DEFAULT_AGENT_ID,
+            "name": DEFAULT_AGENT_SNAPSHOT["name"],
+            "description": DEFAULT_AGENT_SNAPSHOT["description"],
+            "system_prompt": "",
+            "permission_mode": "inherit",
+            "allowed_tools_json": _json(DEFAULT_AGENT_SNAPSHOT["allowed_tools"]),
+            "mcp_server_ids_json": _json(DEFAULT_AGENT_SNAPSHOT["mcp_server_ids"]),
+            "skill_folders_json": _json(DEFAULT_AGENT_SNAPSHOT["skill_folders"]),
+            "max_turns": 0,
+            "env_vars_json": _json(DEFAULT_AGENT_SNAPSHOT["env_vars"]),
+        },
+    )
+
+    default_snapshot_json = _json(DEFAULT_AGENT_SNAPSHOT)
+    if not _has_column("da_agent_topic", "agent_id"):
+        op.add_column(
+            "da_agent_topic",
+            sa.Column("agent_id", sa.String(length=64), nullable=False, server_default=DEFAULT_AGENT_ID),
+        )
+    if not _has_column("da_agent_topic", "agent_snapshot_json"):
+        op.add_column("da_agent_topic", sa.Column("agent_snapshot_json", sa.Text(), nullable=True))
+    if not _has_index("da_agent_topic", "idx_da_agent_topic_agent_updated"):
+        op.create_index("idx_da_agent_topic_agent_updated", "da_agent_topic", ["agent_id", "updated_at"])
+
+    if not _has_column("da_agent_task", "agent_id"):
+        op.add_column(
+            "da_agent_task",
+            sa.Column("agent_id", sa.String(length=64), nullable=False, server_default=DEFAULT_AGENT_ID),
+        )
+    if not _has_column("da_agent_task", "agent_snapshot_json"):
+        op.add_column("da_agent_task", sa.Column("agent_snapshot_json", sa.Text(), nullable=True))
+    if not _has_index("da_agent_task", "idx_da_agent_task_agent_created"):
+        op.create_index("idx_da_agent_task_agent_created", "da_agent_task", ["agent_id", "created_at"])
+
+    bind.execute(
+        sa.text(
+            "UPDATE da_agent_topic SET agent_id = :agent_id, agent_snapshot_json = :snapshot WHERE agent_snapshot_json IS NULL OR agent_snapshot_json = ''"
+        ),
+        {"agent_id": DEFAULT_AGENT_ID, "snapshot": default_snapshot_json},
+    )
+    bind.execute(
+        sa.text(
+            "UPDATE da_agent_task SET agent_id = :agent_id, agent_snapshot_json = :snapshot WHERE agent_snapshot_json IS NULL OR agent_snapshot_json = ''"
+        ),
+        {"agent_id": DEFAULT_AGENT_ID, "snapshot": default_snapshot_json},
+    )
+
+
+def downgrade() -> None:
+    if _has_index("da_agent_task", "idx_da_agent_task_agent_created"):
+        op.drop_index("idx_da_agent_task_agent_created", table_name="da_agent_task")
+    if _has_column("da_agent_task", "agent_snapshot_json"):
+        op.drop_column("da_agent_task", "agent_snapshot_json")
+    if _has_column("da_agent_task", "agent_id"):
+        op.drop_column("da_agent_task", "agent_id")
+
+    if _has_index("da_agent_topic", "idx_da_agent_topic_agent_updated"):
+        op.drop_index("idx_da_agent_topic_agent_updated", table_name="da_agent_topic")
+    if _has_column("da_agent_topic", "agent_snapshot_json"):
+        op.drop_column("da_agent_topic", "agent_snapshot_json")
+    if _has_column("da_agent_topic", "agent_id"):
+        op.drop_column("da_agent_topic", "agent_id")
+
+    if _has_table("da_agent_profile"):
+        op.drop_table("da_agent_profile")

--- a/dataagent/dataagent-backend/api/admin_routes.py
+++ b/dataagent/dataagent-backend/api/admin_routes.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
+from core.agent_profile_service import (
+    agent_capabilities,
+    create_agent_profile,
+    delete_agent_profile,
+    get_agent_profile,
+    list_agent_profiles,
+    skill_folders_from_documents,
+    update_agent_profile,
+)
 from core.skill_admin_service import (
     compare_document_versions,
     current_settings_payload,
@@ -20,6 +29,10 @@ from core.skill_discovery import resolve_skills_root_dir
 from models.schemas import (
     AdminSettingsResponse,
     AdminSettingsUpdateRequest,
+    AgentCapabilitiesResponse,
+    AgentProfile,
+    AgentProfileCreateRequest,
+    AgentProfileUpdateRequest,
     ModelDetectionRequest,
     ModelDetectionResponse,
     ProviderConfig,
@@ -97,6 +110,62 @@ async def create_model_detection(request: ModelDetectionRequest):
 @skills_router.get("/skills/documents", response_model=list[SkillDocumentSummary])
 async def get_skill_documents():
     return [SkillDocumentSummary.model_validate(item) for item in list_documents()]
+
+
+@skills_router.get("/agents/capabilities", response_model=AgentCapabilitiesResponse)
+async def get_agent_capabilities():
+    return AgentCapabilitiesResponse.model_validate(agent_capabilities(list_documents()))
+
+
+@skills_router.get("/agents", response_model=list[AgentProfile])
+async def get_agents():
+    return [AgentProfile.model_validate(item) for item in list_agent_profiles()]
+
+
+@skills_router.post("/agents", response_model=AgentProfile)
+async def create_agent(request: AgentProfileCreateRequest):
+    try:
+        profile = create_agent_profile(
+            request.model_dump(exclude_none=True, exclude_unset=True),
+            available_skill_folders=skill_folders_from_documents(list_documents()),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return AgentProfile.model_validate(profile)
+
+
+@skills_router.get("/agents/{agent_id}", response_model=AgentProfile)
+async def get_agent(agent_id: str):
+    profile = get_agent_profile(agent_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="agent not found")
+    return AgentProfile.model_validate(profile)
+
+
+@skills_router.put("/agents/{agent_id}", response_model=AgentProfile)
+async def update_agent(agent_id: str, request: AgentProfileUpdateRequest):
+    try:
+        profile = update_agent_profile(
+            agent_id,
+            request.model_dump(exclude_none=True, exclude_unset=True),
+            available_skill_folders=skill_folders_from_documents(list_documents()),
+        )
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 404 if "not found" in message else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    return AgentProfile.model_validate(profile)
+
+
+@skills_router.delete("/agents/{agent_id}")
+async def delete_agent(agent_id: str):
+    try:
+        deleted = delete_agent_profile(agent_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=404, detail="agent not found")
+    return {"status": "ok"}
 
 
 @skills_router.get("/skills/documents/{document_id}", response_model=SkillDocumentDetail)

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from config import get_settings
+from core.agent_profile_service import DEFAULT_AGENT_ID, build_agent_snapshot, get_agent_profile
 from core.magic_events import TERMINAL_TASK_STATUSES, encode_sse
 from core.skill_admin_service import resolved_chat_settings_payload
 from core.task_coordinator import get_task_coordinator
@@ -165,14 +166,19 @@ async def api_create_topic(http_request: Request, request: CreateTopicRequest | 
     store = _get_store()
     context = _request_context(http_request)
     payload = request or CreateTopicRequest()
-    topic = store.create_topic(title=str(payload.title or "").strip() or "新话题", context=context)
+    profile = _require_agent_profile(payload.agent_id)
+    topic = store.create_topic(
+        title=str(payload.title or "").strip() or "新话题",
+        agent_snapshot=build_agent_snapshot(profile),
+        context=context,
+    )
     return TopicDetail.model_validate(topic)
 
 
 @topic_router.get("", response_model=list[TopicSummary])
-async def api_list_topics(request: Request):
+async def api_list_topics(request: Request, agent_id: str | None = Query(default=None)):
     store = _get_store()
-    topics = store.list_topics(include_messages=False, context=_request_context(request))
+    topics = store.list_topics(include_messages=False, context=_request_context(request), agent_id=agent_id)
     return [TopicSummary.model_validate(item) for item in topics]
 
 
@@ -238,6 +244,7 @@ async def api_deliver_message(payload: DeliverMessageRequest, request: Request):
             database_hint=payload.database,
             debug=bool(payload.debug),
             execution_mode=payload.execution_mode,
+            agent_id=payload.agent_id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -261,6 +268,7 @@ async def api_create_task(payload: CreateTaskRequest, request: Request):
             database_hint=payload.database,
             debug=bool(payload.debug),
             execution_mode=payload.execution_mode,
+            agent_id=payload.agent_id,
             source_queue_id=payload.source_queue_id,
             source_schedule_id=payload.source_schedule_id,
             source_schedule_log_id=payload.source_schedule_log_id,
@@ -578,3 +586,10 @@ def _require_topic(topic_id: str, context: dict[str, str] | None = None) -> dict
     if not topic:
         raise HTTPException(status_code=404, detail="Topic not found")
     return topic
+
+
+def _require_agent_profile(agent_id: str | None = None) -> dict:
+    profile = get_agent_profile(str(agent_id or "").strip() or DEFAULT_AGENT_ID)
+    if not profile:
+        raise HTTPException(status_code=400, detail="agent not found")
+    return profile

--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -1,0 +1,597 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pymysql
+
+from config import get_settings
+
+DEFAULT_AGENT_ID = "agent_default"
+DEFAULT_AGENT_NAME = "默认智能问数助手"
+PERMISSION_MODES = {"inherit", "default", "bypassPermissions"}
+SAFE_AGENT_TOOLS = ["Skill", "Bash", "Read", "LS", "Glob", "Grep"]
+PORTAL_MCP_SERVER_ID = "portal"
+PORTAL_MCP_TOOL_NAMES = [
+    "portal_search_tables",
+    "portal_get_lineage",
+    "portal_resolve_datasource",
+    "portal_export_metadata",
+    "portal_get_table_ddl",
+    "portal_query_readonly",
+]
+
+RESERVED_ENV_KEYS = {"PATH", "HOME", "VIRTUAL_ENV", "TZ"}
+RESERVED_ENV_PREFIXES = (
+    "ANTHROPIC_",
+    "DATAAGENT_",
+    "MYSQL_",
+    "DORIS_",
+    "REDIS_",
+    "ODW_",
+    "PORTAL_MCP_",
+)
+ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _to_iso(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat(timespec="seconds")
+    return str(value) if value is not None else ""
+
+
+def _safe_json_load(raw: Any, fallback: Any) -> Any:
+    if raw is None:
+        return fallback
+    if isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(str(raw))
+    except Exception:
+        return fallback
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _dedupe_strings(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        iterable: list[Any] = [values]
+    elif isinstance(values, (list, tuple, set)):
+        iterable = list(values)
+    else:
+        iterable = []
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in iterable:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        result.append(text)
+        seen.add(text)
+    return result
+
+
+def _validate_name(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("agent name is required")
+    if len(text) > 128:
+        raise ValueError("agent name must be at most 128 characters")
+    return text
+
+
+def _validate_permission_mode(value: Any) -> str:
+    text = str(value or "inherit").strip() or "inherit"
+    if text not in PERMISSION_MODES:
+        raise ValueError("permission_mode must be inherit, default, or bypassPermissions")
+    return text
+
+
+def _validate_tools(values: Any) -> list[str]:
+    tools = _dedupe_strings(values)
+    allowed = set(SAFE_AGENT_TOOLS)
+    unknown = [tool for tool in tools if tool not in allowed]
+    if unknown:
+        raise ValueError(f"unsupported allowed tool: {unknown[0]}")
+    return tools
+
+
+def _validate_members(values: Any, available: set[str], *, label: str) -> list[str]:
+    selected = _dedupe_strings(values)
+    unknown = [item for item in selected if item not in available]
+    if unknown:
+        raise ValueError(f"unknown {label}: {unknown[0]}")
+    return selected
+
+
+def _validate_max_turns(value: Any) -> int:
+    if value in (None, ""):
+        return 0
+    try:
+        turns = int(value)
+    except Exception as exc:
+        raise ValueError("max_turns must be an integer") from exc
+    if turns < 0:
+        raise ValueError("max_turns must be greater than or equal to 0")
+    if turns > 200:
+        raise ValueError("max_turns must be at most 200")
+    return turns
+
+
+def _validate_env_vars(value: Any) -> dict[str, str]:
+    if value in (None, ""):
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("env_vars must be an object")
+
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = str(raw_key or "").strip()
+        upper_key = key.upper()
+        if not key or not ENV_KEY_RE.match(key):
+            raise ValueError(f"invalid environment variable name: {key}")
+        if upper_key in RESERVED_ENV_KEYS or any(upper_key.startswith(prefix) for prefix in RESERVED_ENV_PREFIXES):
+            raise ValueError(f"reserved environment variable: {key}")
+        normalized[key] = str(raw_value or "")
+    return dict(sorted(normalized.items()))
+
+
+def available_mcp_servers() -> list[dict[str, Any]]:
+    cfg = get_settings()
+    configured = bool(
+        getattr(cfg, "dataagent_portal_mcp_enabled", True)
+        and str(getattr(cfg, "dataagent_portal_mcp_base_url", "") or "").strip()
+        and str(getattr(cfg, "dataagent_portal_mcp_token", "") or "").strip()
+    )
+    return [
+        {
+            "id": PORTAL_MCP_SERVER_ID,
+            "name": "Portal MCP",
+            "enabled": configured,
+            "tool_names": list(PORTAL_MCP_TOOL_NAMES),
+        }
+    ]
+
+
+def available_mcp_server_ids() -> set[str]:
+    return {str(item.get("id") or "") for item in available_mcp_servers() if str(item.get("id") or "")}
+
+
+def normalize_agent_profile_payload(
+    payload: dict[str, Any],
+    *,
+    available_skill_folders: set[str],
+    available_mcp_server_ids: set[str],
+    existing: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data = dict(payload or {})
+    base = dict(existing or {})
+    has_existing = bool(existing)
+
+    name = _validate_name(data.get("name", base.get("name") if has_existing else ""))
+    description = str(data.get("description", base.get("description") or "") or "").strip()
+    system_prompt = str(data.get("system_prompt", base.get("system_prompt") or "") or "").strip()
+    permission_mode = _validate_permission_mode(data.get("permission_mode", base.get("permission_mode") or "inherit"))
+    allowed_tools = _validate_tools(data.get("allowed_tools", base.get("allowed_tools") or list(SAFE_AGENT_TOOLS)))
+    mcp_server_ids = _validate_members(
+        data.get("mcp_server_ids", base.get("mcp_server_ids") or []),
+        available_mcp_server_ids,
+        label="mcp server",
+    )
+    skill_folders = _validate_members(
+        data.get("skill_folders", base.get("skill_folders") or []),
+        available_skill_folders,
+        label="skill folder",
+    )
+    max_turns = _validate_max_turns(data.get("max_turns", base.get("max_turns") or 0))
+    env_vars = _validate_env_vars(data.get("env_vars", base.get("env_vars") or {}))
+
+    return {
+        "name": name,
+        "description": description,
+        "system_prompt": system_prompt,
+        "permission_mode": permission_mode,
+        "allowed_tools": allowed_tools,
+        "mcp_server_ids": mcp_server_ids,
+        "skill_folders": skill_folders,
+        "max_turns": max_turns,
+        "env_vars": env_vars,
+    }
+
+
+def build_agent_snapshot(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "agent_id": str(profile.get("agent_id") or DEFAULT_AGENT_ID),
+        "name": str(profile.get("name") or DEFAULT_AGENT_NAME),
+        "description": str(profile.get("description") or ""),
+        "system_prompt": str(profile.get("system_prompt") or ""),
+        "permission_mode": str(profile.get("permission_mode") or "inherit"),
+        "allowed_tools": _dedupe_strings(profile.get("allowed_tools")),
+        "mcp_server_ids": _dedupe_strings(profile.get("mcp_server_ids")),
+        "skill_folders": _dedupe_strings(profile.get("skill_folders")),
+        "max_turns": int(profile.get("max_turns") or 0),
+        "env_vars": _validate_env_vars(profile.get("env_vars") or {}),
+        "is_default": bool(profile.get("is_default")),
+    }
+
+
+def agent_summary_from_snapshot(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    payload = snapshot or default_agent_payload()
+    return {
+        "agent_id": str(payload.get("agent_id") or DEFAULT_AGENT_ID),
+        "name": str(payload.get("name") or DEFAULT_AGENT_NAME),
+        "description": str(payload.get("description") or ""),
+        "is_default": bool(payload.get("is_default")),
+    }
+
+
+def normalize_agent_snapshot(raw: Any) -> dict[str, Any]:
+    payload = _safe_json_load(raw, None)
+    if not isinstance(payload, dict):
+        payload = default_agent_payload()
+    if not payload.get("agent_id"):
+        payload["agent_id"] = DEFAULT_AGENT_ID
+    if not payload.get("name"):
+        payload["name"] = DEFAULT_AGENT_NAME
+    return build_agent_snapshot(payload)
+
+
+def default_agent_payload() -> dict[str, Any]:
+    return {
+        "agent_id": DEFAULT_AGENT_ID,
+        "name": DEFAULT_AGENT_NAME,
+        "description": "使用当前 DataAgent 默认提示词、Skills、工具和 MCP 配置。",
+        "system_prompt": "",
+        "permission_mode": "inherit",
+        "allowed_tools": list(SAFE_AGENT_TOOLS),
+        "mcp_server_ids": [PORTAL_MCP_SERVER_ID],
+        "skill_folders": [],
+        "max_turns": 0,
+        "env_vars": {},
+        "is_default": True,
+    }
+
+
+def _runtime_root() -> Path:
+    cfg = get_settings()
+    value = str(getattr(cfg, "dataagent_runtime_project_cwd", "") or "").strip()
+    if value:
+        path = Path(value).expanduser()
+        if path.is_absolute():
+            return path.resolve()
+        return (Path(__file__).resolve().parent.parent / path).resolve()
+    home = Path(os.environ.get("HOME") or str(Path.home())).expanduser()
+    return (home / ".dataagent" / "runtime" / "enabled-skills").resolve()
+
+
+def resolved_agent_workdir(agent_id: str, *, is_default: bool = False) -> str:
+    if is_default:
+        return str(_runtime_root())
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(agent_id or "").strip()) or "agent"
+    return str((_runtime_root().parent / "agents" / safe_id).resolve())
+
+
+def _new_agent_id() -> str:
+    return f"agent_{uuid.uuid4().hex[:24]}"
+
+
+class AgentProfileStore:
+    def __init__(self):
+        self._ready = False
+        self._ready_lock = threading.Lock()
+
+    def _connect(self, database: str | None):
+        cfg = get_settings()
+        return pymysql.connect(
+            host=cfg.mysql_host,
+            port=cfg.mysql_port,
+            user=cfg.mysql_user,
+            password=cfg.mysql_password,
+            database=database,
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor,
+            autocommit=False,
+        )
+
+    def _schema_name(self) -> str:
+        return get_settings().session_mysql_database
+
+    def init_schema(self):
+        if self._ready:
+            return
+        with self._ready_lock:
+            if self._ready:
+                return
+            self._ready = True
+
+    def _ensure_ready(self):
+        if not self._ready:
+            self.init_schema()
+
+    def _normalize_row(self, row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not row:
+            return None
+        item = {
+            "agent_id": str(row.get("agent_id") or ""),
+            "name": str(row.get("name") or ""),
+            "description": str(row.get("description") or ""),
+            "system_prompt": str(row.get("system_prompt") or ""),
+            "permission_mode": str(row.get("permission_mode") or "inherit"),
+            "allowed_tools": _dedupe_strings(_safe_json_load(row.get("allowed_tools_json"), [])),
+            "mcp_server_ids": _dedupe_strings(_safe_json_load(row.get("mcp_server_ids_json"), [])),
+            "skill_folders": _dedupe_strings(_safe_json_load(row.get("skill_folders_json"), [])),
+            "max_turns": int(row.get("max_turns") or 0),
+            "env_vars": _validate_env_vars(_safe_json_load(row.get("env_vars_json"), {})),
+            "is_default": bool(row.get("is_default")),
+            "created_at": _to_iso(row.get("created_at")),
+            "updated_at": _to_iso(row.get("updated_at")),
+        }
+        item["resolved_workdir"] = resolved_agent_workdir(item["agent_id"], is_default=item["is_default"])
+        return item
+
+    def list_profiles(self) -> list[dict[str, Any]]:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT agent_id, name, description, system_prompt, permission_mode,
+                           allowed_tools_json, mcp_server_ids_json, skill_folders_json,
+                           max_turns, env_vars_json, is_default, created_at, updated_at
+                    FROM da_agent_profile
+                    ORDER BY is_default DESC, updated_at DESC, created_at DESC
+                    """
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+        return [item for item in (self._normalize_row(row) for row in rows) if item]
+
+    def get_profile(self, agent_id: str) -> dict[str, Any] | None:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT agent_id, name, description, system_prompt, permission_mode,
+                           allowed_tools_json, mcp_server_ids_json, skill_folders_json,
+                           max_turns, env_vars_json, is_default, created_at, updated_at
+                    FROM da_agent_profile
+                    WHERE agent_id = %s
+                    LIMIT 1
+                    """,
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+        return self._normalize_row(row)
+
+    def save_profile(self, profile: dict[str, Any]) -> dict[str, Any]:
+        self._ensure_ready()
+        agent_id = str(profile.get("agent_id") or "").strip() or _new_agent_id()
+        is_default = bool(profile.get("is_default"))
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                if is_default:
+                    cur.execute("UPDATE da_agent_profile SET is_default = 0 WHERE agent_id <> %s", (agent_id,))
+                cur.execute(
+                    """
+                    INSERT INTO da_agent_profile (
+                        agent_id, name, description, system_prompt, permission_mode,
+                        allowed_tools_json, mcp_server_ids_json, skill_folders_json,
+                        max_turns, env_vars_json, is_default
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON DUPLICATE KEY UPDATE
+                        name = VALUES(name),
+                        description = VALUES(description),
+                        system_prompt = VALUES(system_prompt),
+                        permission_mode = VALUES(permission_mode),
+                        allowed_tools_json = VALUES(allowed_tools_json),
+                        mcp_server_ids_json = VALUES(mcp_server_ids_json),
+                        skill_folders_json = VALUES(skill_folders_json),
+                        max_turns = VALUES(max_turns),
+                        env_vars_json = VALUES(env_vars_json),
+                        is_default = VALUES(is_default),
+                        updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (
+                        agent_id,
+                        str(profile.get("name") or ""),
+                        str(profile.get("description") or ""),
+                        str(profile.get("system_prompt") or ""),
+                        str(profile.get("permission_mode") or "inherit"),
+                        _json_dump(_dedupe_strings(profile.get("allowed_tools"))),
+                        _json_dump(_dedupe_strings(profile.get("mcp_server_ids"))),
+                        _json_dump(_dedupe_strings(profile.get("skill_folders"))),
+                        int(profile.get("max_turns") or 0),
+                        _json_dump(_validate_env_vars(profile.get("env_vars") or {})),
+                        1 if is_default else 0,
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        return self.get_profile(agent_id) or {}
+
+    def delete_profile(self, agent_id: str) -> bool:
+        self._ensure_ready()
+        profile = self.get_profile(agent_id)
+        if not profile:
+            return False
+        if profile.get("is_default"):
+            raise ValueError("default agent cannot be deleted")
+        if self.count_topic_references(agent_id) > 0:
+            raise ValueError("agent is referenced by topics")
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM da_agent_profile WHERE agent_id = %s", (agent_id,))
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+
+    def count_topic_references(self, agent_id: str) -> int:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) AS total FROM da_agent_topic WHERE agent_id = %s", (agent_id,))
+                row = cur.fetchone() or {}
+        finally:
+            conn.close()
+        return int(row.get("total") or 0)
+
+    def backfill_default_bindings(self, default_snapshot: dict[str, Any]) -> None:
+        self._ensure_ready()
+        snapshot_json = _json_dump(build_agent_snapshot(default_snapshot))
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE da_agent_topic
+                    SET agent_id = %s,
+                        agent_snapshot_json = %s
+                    WHERE agent_id IS NULL
+                       OR agent_id = ''
+                       OR agent_snapshot_json IS NULL
+                       OR agent_snapshot_json = ''
+                    """,
+                    (DEFAULT_AGENT_ID, snapshot_json),
+                )
+                cur.execute(
+                    """
+                    UPDATE da_agent_task
+                    SET agent_id = %s,
+                        agent_snapshot_json = %s
+                    WHERE agent_id IS NULL
+                       OR agent_id = ''
+                       OR agent_snapshot_json IS NULL
+                       OR agent_snapshot_json = ''
+                    """,
+                    (DEFAULT_AGENT_ID, snapshot_json),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+_agent_profile_store = AgentProfileStore()
+
+
+def get_agent_profile_store() -> AgentProfileStore:
+    return _agent_profile_store
+
+
+def bootstrap_default_agent_profile() -> dict[str, Any]:
+    store = get_agent_profile_store()
+    store.init_schema()
+    existing = store.get_profile(DEFAULT_AGENT_ID)
+    if existing:
+        store.backfill_default_bindings(existing)
+        return existing
+    created = store.save_profile(default_agent_payload())
+    store.backfill_default_bindings(created)
+    return created
+
+
+def list_agent_profiles() -> list[dict[str, Any]]:
+    bootstrap_default_agent_profile()
+    return get_agent_profile_store().list_profiles()
+
+
+def get_agent_profile(agent_id: str) -> dict[str, Any] | None:
+    bootstrap_default_agent_profile()
+    return get_agent_profile_store().get_profile(str(agent_id or "").strip())
+
+
+def create_agent_profile(payload: dict[str, Any], *, available_skill_folders: set[str] | None = None) -> dict[str, Any]:
+    skill_folders = available_skill_folders
+    if skill_folders is None:
+        skill_folders = set(_dedupe_strings((payload or {}).get("skill_folders")))
+    normalized = normalize_agent_profile_payload(
+        payload,
+        available_skill_folders=skill_folders,
+        available_mcp_server_ids=available_mcp_server_ids(),
+    )
+    normalized["agent_id"] = _new_agent_id()
+    normalized["is_default"] = False
+    return get_agent_profile_store().save_profile(normalized)
+
+
+def update_agent_profile(
+    agent_id: str,
+    payload: dict[str, Any],
+    *,
+    available_skill_folders: set[str] | None = None,
+) -> dict[str, Any]:
+    existing = get_agent_profile(agent_id)
+    if not existing:
+        raise ValueError("agent not found")
+    skill_folders = available_skill_folders
+    if skill_folders is None:
+        skill_folders = set(_dedupe_strings((payload or {}).get("skill_folders") or existing.get("skill_folders")))
+    normalized = normalize_agent_profile_payload(
+        payload,
+        existing=existing,
+        available_skill_folders=skill_folders,
+        available_mcp_server_ids=available_mcp_server_ids(),
+    )
+    normalized["agent_id"] = existing["agent_id"]
+    normalized["is_default"] = bool(existing.get("is_default"))
+    return get_agent_profile_store().save_profile(normalized)
+
+
+def delete_agent_profile(agent_id: str) -> bool:
+    return get_agent_profile_store().delete_profile(str(agent_id or "").strip())
+
+
+def agent_capabilities(skill_documents: list[dict[str, Any]]) -> dict[str, Any]:
+    folders: dict[str, dict[str, Any]] = {}
+    for document in skill_documents:
+        folder = str(document.get("folder") or "").strip()
+        if not folder:
+            relative = str(document.get("relative_path") or "").strip("/")
+            folder = relative.split("/", 1)[0] if "/" in relative else ""
+        if not folder:
+            continue
+        item = folders.setdefault(
+            folder,
+            {
+                "folder": folder,
+                "source": str(document.get("source") or "bundled"),
+                "enabled": bool(document.get("enabled")),
+            },
+        )
+        item["enabled"] = bool(item.get("enabled")) or bool(document.get("enabled"))
+    return {
+        "tools": list(SAFE_AGENT_TOOLS),
+        "mcp_servers": available_mcp_servers(),
+        "skills": sorted(folders.values(), key=lambda item: item["folder"]),
+        "permission_modes": sorted(PERMISSION_MODES),
+    }
+
+
+def skill_folders_from_documents(skill_documents: list[dict[str, Any]]) -> set[str]:
+    folders: set[str] = set()
+    for item in agent_capabilities(skill_documents).get("skills") or []:
+        folder = str(item.get("folder") or "").strip()
+        if folder:
+            folders.add(folder)
+    return folders

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -14,7 +14,11 @@ from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
-from core.skill_discovery import prepare_enabled_skills_project_cwd, resolve_builtin_skill_root_dir
+from core.skill_discovery import (
+    prepare_enabled_skills_project_cwd,
+    resolve_builtin_skill_root_dir,
+    resolve_skill_discovery_root_dir,
+)
 
 SAFE_AUTO_ALLOWED_TOOLS = ["Skill", "Bash", "Read", "LS", "Glob", "Grep"]
 PORTAL_MCP_SERVER_NAME = "portal"
@@ -46,13 +50,62 @@ def _load_system_prompt_template() -> str:
     return SYSTEM_PROMPT_PATH.read_text(encoding="utf-8").strip()
 
 
-def _build_system_prompt(database_hint: str | None, skill_runtime: dict[str, Any] | None = None) -> str:
+def _dedupe_strings(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    result: list[str] = []
+    seen: set[str] = set()
+    iterable = values if isinstance(values, (list, tuple, set)) else []
+    for value in iterable:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        result.append(text)
+        seen.add(text)
+    return result
+
+
+def _build_system_prompt(
+    database_hint: str | None,
+    skill_runtime: dict[str, Any] | None = None,
+    agent_snapshot: dict[str, Any] | None = None,
+) -> str:
     enabled_skills = list((skill_runtime or {}).get("enabled_folders") or [])
     enabled_skills_text = "、".join(enabled_skills) if enabled_skills else "未配置"
     lines = [_load_system_prompt_template(), "", "# 运行时上下文", f"- 已启用 Skills：当前已启用：{enabled_skills_text}。"]
+    custom_prompt = str((agent_snapshot or {}).get("system_prompt") or "").strip()
+    if custom_prompt:
+        lines.extend(["", "# 智能体系统提示词", custom_prompt])
     if database_hint:
         lines.append(f"- 用户显式提供的 database hint: {database_hint}")
     return "\n".join(lines)
+
+
+def resolve_agent_skill_runtime(
+    agent_snapshot: dict[str, Any] | None,
+    fallback_runtime: dict[str, Any],
+) -> dict[str, Any]:
+    selected = _dedupe_strings((agent_snapshot or {}).get("skill_folders"))
+    if not selected:
+        if agent_snapshot and not bool(agent_snapshot.get("is_default")):
+            return {
+                "primary_folder": "",
+                "primary_root": str(resolve_builtin_skill_root_dir()),
+                "enabled_folders": [],
+                "enabled_roots": {},
+            }
+        return fallback_runtime
+    discovery_root = resolve_skill_discovery_root_dir()
+    roots = {folder: str((discovery_root / folder).resolve()) for folder in selected}
+    primary_folder = selected[0]
+    return {
+        "primary_folder": primary_folder,
+        "primary_root": roots.get(primary_folder, str(resolve_builtin_skill_root_dir())),
+        "enabled_folders": selected,
+        "enabled_roots": roots,
+    }
 
 
 def _looks_like_procedural_preamble(text: str) -> bool:
@@ -205,6 +258,11 @@ def _build_runtime_env(
     )
     if platform_skill_root:
         runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] = str(Path(platform_skill_root).resolve())
+    agent_env = getattr(params, "agent_env_vars", None)
+    if not agent_env and getattr(params, "agent_snapshot", None):
+        agent_env = dict((getattr(params, "agent_snapshot", None) or {}).get("env_vars") or {})
+    if isinstance(agent_env, dict):
+        runtime_env.update({str(key): str(value) for key, value in agent_env.items()})
     return runtime_env
 
 
@@ -218,15 +276,26 @@ def _is_running_as_root() -> bool:
         return False
 
 
-def _resolve_sdk_permission_mode() -> str:
+def _resolve_sdk_permission_mode(permission_mode: str | None = None) -> str:
+    requested = str(permission_mode or "inherit").strip() or "inherit"
+    if requested == "default":
+        return "default"
     if _is_running_as_root():
         # Claude Code rejects bypassPermissions under root/sudo. Fall back to the
         # standard mode and rely on allowed_tools for the read-only + script path.
         return "default"
+    if requested == "bypassPermissions":
+        return "bypassPermissions"
     return "bypassPermissions"
 
 
-def _build_portal_mcp_servers(cfg: Any) -> dict[str, dict[str, Any]]:
+def _build_portal_mcp_servers(
+    cfg: Any,
+    mcp_server_ids: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, dict[str, Any]]:
+    selected = _dedupe_strings(mcp_server_ids)
+    if mcp_server_ids is not None and PORTAL_MCP_SERVER_NAME not in selected:
+        return {}
     enabled = bool(getattr(cfg, "dataagent_portal_mcp_enabled", True))
     if not enabled:
         return {}
@@ -253,8 +322,11 @@ def _build_portal_mcp_servers(cfg: Any) -> dict[str, dict[str, Any]]:
     }
 
 
-def _build_allowed_tools(mcp_servers: dict[str, Any] | None = None) -> list[str]:
-    allowed = list(SAFE_AUTO_ALLOWED_TOOLS)
+def _build_allowed_tools(
+    mcp_servers: dict[str, Any] | None = None,
+    allowed_tools: list[str] | tuple[str, ...] | None = None,
+) -> list[str]:
+    allowed = _dedupe_strings(allowed_tools) if allowed_tools is not None else list(SAFE_AUTO_ALLOWED_TOOLS)
     if mcp_servers and PORTAL_MCP_SERVER_NAME in mcp_servers:
         allowed.extend(
             f"mcp__{PORTAL_MCP_SERVER_NAME}__{tool_name}"
@@ -291,7 +363,9 @@ def _result_subtype_to_reason(subtype: str, detail: str) -> str:
     return "模型会话未正常结束"
 
 
-def _resolve_max_turns(cfg, execution_mode: str | None) -> int:
+def _resolve_max_turns(cfg, execution_mode: str | None, agent_max_turns: int | None = None) -> int:
+    if int(agent_max_turns or 0) > 0:
+        return max(1, int(agent_max_turns or 0))
     mode = str(execution_mode or "").strip().lower()
     if mode in {"background", "auto"}:
         return max(1, int(getattr(cfg, "agent_background_max_turns", 0) or getattr(cfg, "agent_max_turns", 0) or 40))

--- a/dataagent/dataagent-backend/core/skill_discovery.py
+++ b/dataagent/dataagent-backend/core/skill_discovery.py
@@ -65,15 +65,24 @@ def resolve_agent_project_cwd() -> Path:
     return discovery_root.parent.parent
 
 
-def prepare_enabled_skills_project_cwd(enabled_folders: list[str] | tuple[str, ...]) -> Path:
+def prepare_enabled_skills_project_cwd(
+    enabled_folders: list[str] | tuple[str, ...],
+    *,
+    runtime_project_cwd: str | Path | None = None,
+    allow_empty: bool = False,
+) -> Path:
     discovery_root = resolve_skill_discovery_root_dir()
     cfg = get_settings()
-    runtime_root = _resolve_runtime_project_cwd(cfg.dataagent_runtime_project_cwd)
+    runtime_root = (
+        Path(runtime_project_cwd).expanduser().resolve()
+        if runtime_project_cwd
+        else _resolve_runtime_project_cwd(cfg.dataagent_runtime_project_cwd)
+    )
     runtime_skills_dir = runtime_root / ".claude" / "skills"
     runtime_skills_dir.mkdir(parents=True, exist_ok=True)
 
     enabled = [str(folder or "").strip() for folder in enabled_folders if str(folder or "").strip()]
-    if not enabled:
+    if not enabled and not allow_empty:
         raise SkillDiscoveryError("no enabled skills configured")
     enabled_set = set(enabled)
     for existing in runtime_skills_dir.iterdir():

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -136,6 +136,7 @@ class TaskCoordinator:
                         timeout_seconds=int(task.get("timeout_seconds") or 0),
                         sql_read_timeout_seconds=int(task.get("sql_read_timeout_seconds") or 0),
                         sql_write_timeout_seconds=int(task.get("sql_write_timeout_seconds") or 0),
+                        agent_snapshot=task.get("agent_snapshot"),
                     ),
                     emit=writer.persist,
                     is_cancel_requested=lambda: self._should_stop_task(task_id, lease_lost),

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -33,9 +33,11 @@ from core.agent_runtime import (
     _safe_base_url,
     _safe_stringify,
     prepare_enabled_skills_project_cwd,
+    resolve_agent_skill_runtime,
     resolve_enabled_skill_runtime,
     resolve_runtime_provider_selection,
 )
+from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, resolved_agent_workdir
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +61,7 @@ class TaskExecutionInput:
     sql_read_timeout_seconds: int | None = None
     sql_write_timeout_seconds: int | None = None
     execution_mode: str = "background"
+    agent_snapshot: dict[str, Any] | None = None
 
 
 @dataclass
@@ -763,8 +766,9 @@ async def execute_task_stream(
     adapter = ClaudeToMagicAdapter(params, provider_id=provider_id, model=model)
 
     prompt = str(params.question or "").strip() if params.resume_session_id else _build_prompt(params.history, params.question)
-    skill_runtime = resolve_enabled_skill_runtime()
-    system_prompt = _build_system_prompt(params.database_hint, skill_runtime)
+    agent_snapshot = normalize_agent_snapshot(params.agent_snapshot) if params.agent_snapshot else None
+    skill_runtime = resolve_agent_skill_runtime(agent_snapshot, resolve_enabled_skill_runtime())
+    system_prompt = _build_system_prompt(params.database_hint, skill_runtime, agent_snapshot)
 
     if params.debug:
         await _emit_records(
@@ -779,6 +783,7 @@ async def execute_task_stream(
                         "model": model,
                         "prompt_preview": _clip_text(prompt, 4000),
                         "system_prompt_preview": _clip_text(system_prompt, 1200),
+                        "agent_id": str((agent_snapshot or {}).get("agent_id") or DEFAULT_AGENT_ID),
                     },
                 }
             ],
@@ -824,12 +829,20 @@ async def execute_task_stream(
     for key, value in runtime_env.items():
         os.environ[key] = value
 
-    project_cwd = prepare_enabled_skills_project_cwd(skill_runtime.get("enabled_folders") or [])
-    permission_mode = _resolve_sdk_permission_mode()
-    max_turns = _resolve_max_turns(cfg, params.execution_mode)
+    enabled_folders = skill_runtime.get("enabled_folders") or []
+    if agent_snapshot and not bool(agent_snapshot.get("is_default")):
+        project_cwd = prepare_enabled_skills_project_cwd(
+            enabled_folders,
+            runtime_project_cwd=resolved_agent_workdir(str(agent_snapshot.get("agent_id") or ""), is_default=False),
+            allow_empty=True,
+        )
+    else:
+        project_cwd = prepare_enabled_skills_project_cwd(enabled_folders)
+    permission_mode = _resolve_sdk_permission_mode(str((agent_snapshot or {}).get("permission_mode") or "inherit"))
+    max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]
-    mcp_servers = _build_portal_mcp_servers(cfg)
-    allowed_tools = _build_allowed_tools(mcp_servers)
+    mcp_servers = _build_portal_mcp_servers(cfg, (agent_snapshot or {}).get("mcp_server_ids") if agent_snapshot else None)
+    allowed_tools = _build_allowed_tools(mcp_servers, (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None)
     options_kwargs = dict(
         system_prompt=system_prompt,
         model=model,

--- a/dataagent/dataagent-backend/core/task_submission_service.py
+++ b/dataagent/dataagent-backend/core/task_submission_service.py
@@ -64,6 +64,7 @@ async def submit_message_task(
     topic_id: str,
     message_type: str,
     message_content: Any,
+    agent_id: str | None = None,
     provider_id: str | None = None,
     model: str | None = None,
     database_hint: str | None = None,
@@ -83,6 +84,13 @@ async def submit_message_task(
     prompt = normalize_message_prompt(message_type, message_content)
     if not prompt:
         raise ValueError("message_content is required")
+    topic = store.get_topic(topic_id)
+    if not topic:
+        raise ValueError("topic not found")
+    bound_agent_id = str(topic.get("agent_id") or "").strip()
+    requested_agent_id = str(agent_id or "").strip()
+    if requested_agent_id and bound_agent_id and requested_agent_id != bound_agent_id:
+        raise ValueError("agent_id does not match topic agent")
 
     runtime_target = resolve_runtime_provider_selection(provider_id, model)
     timeouts = resolve_task_timeouts(execution_mode)

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -10,6 +10,7 @@ from typing import Any
 import pymysql
 
 from config import get_settings
+from core.agent_profile_service import DEFAULT_AGENT_ID, agent_summary_from_snapshot, default_agent_payload, normalize_agent_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -26,13 +27,19 @@ def _json_default(value):
     return str(value)
 
 
-def _safe_json_load(raw: str | None) -> Any:
+def _safe_json_load(raw: Any) -> Any:
     if not raw:
         return None
+    if isinstance(raw, (dict, list)):
+        return raw
     try:
         return json.loads(raw)
     except Exception:
         return None
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=_json_default)
 
 
 def _new_id(prefix: str) -> str:
@@ -315,9 +322,17 @@ class TopicTaskStore:
         row = cur.fetchone() or {}
         return int(row.get("last_event_seq") or 0)
 
-    def create_topic(self, *, title: str, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    def create_topic(
+        self,
+        *,
+        title: str,
+        agent_snapshot: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         self._ensure_ready()
         normalized_context = self._normalize_context(context)
+        snapshot = normalize_agent_snapshot(agent_snapshot or default_agent_payload())
+        agent_id = str(snapshot.get("agent_id") or DEFAULT_AGENT_ID)
         topic_id = _new_id("topic")
         chat_topic_id = _new_id("chat_topic")
         chat_conversation_id = _new_id("chat_conv")
@@ -329,14 +344,17 @@ class TopicTaskStore:
                     INSERT INTO da_agent_topic (
                         topic_id, title, chat_topic_id, chat_conversation_id,
                         current_task_id, current_task_status, last_message_seq,
+                        agent_id, agent_snapshot_json,
                         source, website_id, external_user_id, visitor_id
-                    ) VALUES (%s, %s, %s, %s, NULL, NULL, 0, %s, %s, %s, %s)
+                    ) VALUES (%s, %s, %s, %s, NULL, NULL, 0, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         topic_id,
                         title or "新话题",
                         chat_topic_id,
                         chat_conversation_id,
+                        agent_id,
+                        _json_dump(snapshot),
                         normalized_context["source"],
                         normalized_context["website_id"],
                         normalized_context["external_user_id"],
@@ -348,9 +366,21 @@ class TopicTaskStore:
             conn.close()
         return self.get_topic(topic_id, context=normalized_context) or {}
 
-    def list_topics(self, include_messages: bool = False, context: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    def list_topics(
+        self,
+        include_messages: bool = False,
+        context: dict[str, Any] | None = None,
+        agent_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         self._ensure_ready()
         context_sql, context_params = self._topic_context_predicate(context, alias="t")
+        filters = [context_sql]
+        params: list[Any] = [*context_params]
+        safe_agent_id = str(agent_id or "").strip()
+        if safe_agent_id:
+            filters.append("t.agent_id = %s")
+            params.append(safe_agent_id)
+        where_sql = " AND ".join(filters)
         conn = self._connect(database=self._schema_name())
         try:
             with conn.cursor() as cur:
@@ -358,7 +388,8 @@ class TopicTaskStore:
                     f"""
                     SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
                            t.current_task_id, t.current_task_status, t.source, t.website_id,
-                           t.external_user_id, t.visitor_id, t.created_at, t.updated_at,
+                           t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.created_at, t.updated_at,
                            COALESCE(stats.message_count, 0) AS message_count,
                            COALESCE(stats.last_message_preview, '') AS last_message_preview
                     FROM da_agent_topic t
@@ -374,10 +405,10 @@ class TopicTaskStore:
                         WHERE show_in_ui = 1
                         GROUP BY topic_id
                     ) stats ON stats.topic_id = t.topic_id
-                    WHERE {context_sql}
+                    WHERE {where_sql}
                     ORDER BY t.updated_at DESC, t.created_at DESC
                     """,
-                    context_params,
+                    params,
                 )
                 rows = cur.fetchall() or []
         finally:
@@ -399,7 +430,8 @@ class TopicTaskStore:
                     f"""
                     SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
                            t.current_task_id, t.current_task_status, t.source, t.website_id,
-                           t.external_user_id, t.visitor_id, t.created_at, t.updated_at,
+                           t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.created_at, t.updated_at,
                            COALESCE(stats.message_count, 0) AS message_count,
                            COALESCE(stats.last_message_preview, '') AS last_message_preview
                     FROM da_agent_topic t
@@ -746,8 +778,12 @@ class TopicTaskStore:
         source_queue_id: str | None = None,
         source_schedule_id: str | None = None,
         source_schedule_log_id: str | None = None,
+        agent_snapshot: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         self._ensure_ready()
+        topic = self.get_topic(topic_id) or {}
+        snapshot = normalize_agent_snapshot(agent_snapshot or topic.get("agent_snapshot") or default_agent_payload())
+        agent_id = str(snapshot.get("agent_id") or DEFAULT_AGENT_ID)
         task_id = _new_id("task")
         conn = self._connect(database=self._schema_name())
         try:
@@ -756,10 +792,10 @@ class TopicTaskStore:
                     """
                     INSERT INTO da_agent_task (
                         task_id, topic_id, from_task_id, source_queue_id, source_schedule_id, source_schedule_log_id,
-                        task_status, prompt, provider_id, model_name,
+                        task_status, prompt, provider_id, model_name, agent_id, agent_snapshot_json,
                         database_hint, debug_enabled, timeout_seconds, sql_read_timeout_seconds,
                         sql_write_timeout_seconds, last_event_seq
-                    ) VALUES (%s, %s, %s, %s, %s, %s, 'waiting', %s, %s, %s, %s, %s, %s, %s, %s, 0)
+                    ) VALUES (%s, %s, %s, %s, %s, %s, 'waiting', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 0)
                     """,
                     (
                         task_id,
@@ -771,6 +807,8 @@ class TopicTaskStore:
                         prompt or "",
                         provider_id or "",
                         model or "",
+                        agent_id,
+                        _json_dump(snapshot),
                         database_hint,
                         1 if debug else 0,
                         int(timeout_seconds or 0),
@@ -804,6 +842,7 @@ class TopicTaskStore:
                     SELECT task.task_id, task.topic_id, task.from_task_id, task.source_queue_id,
                            task.source_schedule_id, task.source_schedule_log_id,
                            task.task_status, task.prompt, task.provider_id, task.model_name,
+                           task.agent_id, task.agent_snapshot_json,
                            task.database_hint, task.debug_enabled, task.timeout_seconds,
                            task.sql_read_timeout_seconds, task.sql_write_timeout_seconds,
                            task.last_event_seq, task.cancel_requested_at, task.started_at,
@@ -831,6 +870,7 @@ class TopicTaskStore:
                     """
                     SELECT task_id, topic_id, from_task_id, source_queue_id, source_schedule_id, source_schedule_log_id,
                            task_status, prompt, provider_id, model_name,
+                           agent_id, agent_snapshot_json,
                            database_hint, debug_enabled, timeout_seconds, sql_read_timeout_seconds,
                            sql_write_timeout_seconds, last_event_seq, cancel_requested_at, started_at,
                            heartbeat_at, finished_at, error_json, created_at, updated_at
@@ -856,6 +896,7 @@ class TopicTaskStore:
                     """
                     SELECT task_id, topic_id, from_task_id, source_queue_id, source_schedule_id, source_schedule_log_id,
                            task_status, prompt, provider_id, model_name,
+                           agent_id, agent_snapshot_json,
                            database_hint, debug_enabled, timeout_seconds, sql_read_timeout_seconds,
                            sql_write_timeout_seconds, last_event_seq, cancel_requested_at, started_at,
                            heartbeat_at, finished_at, error_json, created_at, updated_at
@@ -1336,7 +1377,7 @@ class TopicTaskStore:
                     f"""
                     SELECT q.queue_id, q.topic_id, q.source_schedule_id, q.source_schedule_log_id,
                            q.message_type, q.message_content_json, q.status, q.last_task_id,
-                           q.error_message, q.created_at, q.updated_at
+                           q.error_message, t.agent_id, t.agent_snapshot_json, q.created_at, q.updated_at
                     FROM da_agent_message_queue q
                     JOIN da_agent_topic t ON t.topic_id = q.topic_id
                     WHERE q.queue_id = %s
@@ -1386,7 +1427,7 @@ class TopicTaskStore:
                     f"""
                     SELECT q.queue_id, q.topic_id, q.source_schedule_id, q.source_schedule_log_id,
                            q.message_type, q.message_content_json, q.status, q.last_task_id,
-                           q.error_message, q.created_at, q.updated_at
+                           q.error_message, t.agent_id, t.agent_snapshot_json, q.created_at, q.updated_at
                     FROM da_agent_message_queue q
                     JOIN da_agent_topic t ON t.topic_id = q.topic_id
                     {where_sql}
@@ -1546,7 +1587,8 @@ class TopicTaskStore:
                     f"""
                     SELECT s.schedule_id, s.topic_id, s.name, s.message_type, s.message_content_json,
                            s.cron_expr, s.timezone, s.enabled, s.last_task_id, s.last_queue_id,
-                           s.last_run_at, s.next_run_at, s.last_error_message, s.created_at, s.updated_at
+                           s.last_run_at, s.next_run_at, s.last_error_message,
+                           t.agent_id, t.agent_snapshot_json, s.created_at, s.updated_at
                     FROM da_agent_message_schedule s
                     JOIN da_agent_topic t ON t.topic_id = s.topic_id
                     WHERE s.schedule_id = %s
@@ -1596,7 +1638,8 @@ class TopicTaskStore:
                     f"""
                     SELECT s.schedule_id, s.topic_id, s.name, s.message_type, s.message_content_json,
                            s.cron_expr, s.timezone, s.enabled, s.last_task_id, s.last_queue_id,
-                           s.last_run_at, s.next_run_at, s.last_error_message, s.created_at, s.updated_at
+                           s.last_run_at, s.next_run_at, s.last_error_message,
+                           t.agent_id, t.agent_snapshot_json, s.created_at, s.updated_at
                     FROM da_agent_message_schedule s
                     JOIN da_agent_topic t ON t.topic_id = s.topic_id
                     {where_sql}
@@ -1941,6 +1984,7 @@ class TopicTaskStore:
             source_queue_id=str(parent.get("source_queue_id") or "") or None,
             source_schedule_id=str(parent.get("source_schedule_id") or "") or None,
             source_schedule_log_id=str(parent.get("source_schedule_log_id") or "") or None,
+            agent_snapshot=parent.get("agent_snapshot"),
         )
         self.finish_task(
             task_id=parent_task_id,
@@ -1955,11 +1999,15 @@ class TopicTaskStore:
         return replacement
 
     def _normalize_topic_row(self, row: dict[str, Any], *, include_messages: bool) -> dict[str, Any]:
+        snapshot = normalize_agent_snapshot(row.get("agent_snapshot_json") or row.get("agent_snapshot") or default_agent_payload())
         topic = {
             "topic_id": str(row.get("topic_id") or ""),
             "title": str(row.get("title") or "新话题"),
             "chat_topic_id": str(row.get("chat_topic_id") or ""),
             "chat_conversation_id": str(row.get("chat_conversation_id") or ""),
+            "agent_id": str(row.get("agent_id") or snapshot.get("agent_id") or DEFAULT_AGENT_ID),
+            "agent_snapshot": snapshot,
+            "agent": agent_summary_from_snapshot(snapshot),
             "current_task_id": str(row.get("current_task_id") or "") or None,
             "current_task_status": str(row.get("current_task_status") or "") or None,
             "source": str(row.get("source") or "portal"),
@@ -2131,9 +2179,13 @@ class TopicTaskStore:
         return normalized
 
     def _normalize_task_row(self, row: dict[str, Any]) -> dict[str, Any]:
+        snapshot = normalize_agent_snapshot(row.get("agent_snapshot_json") or row.get("agent_snapshot") or default_agent_payload())
         return {
             "task_id": str(row.get("task_id") or ""),
             "topic_id": str(row.get("topic_id") or ""),
+            "agent_id": str(row.get("agent_id") or snapshot.get("agent_id") or DEFAULT_AGENT_ID),
+            "agent_snapshot": snapshot,
+            "agent": agent_summary_from_snapshot(snapshot),
             "from_task_id": str(row.get("from_task_id") or "") or None,
             "source_queue_id": str(row.get("source_queue_id") or "") or None,
             "source_schedule_id": str(row.get("source_schedule_id") or "") or None,
@@ -2158,9 +2210,12 @@ class TopicTaskStore:
         }
 
     def _normalize_queue_row(self, row: dict[str, Any]) -> dict[str, Any]:
+        snapshot = normalize_agent_snapshot(row.get("agent_snapshot_json") or row.get("agent_snapshot") or default_agent_payload())
         return {
             "queue_id": str(row.get("queue_id") or ""),
             "topic_id": str(row.get("topic_id") or ""),
+            "agent_id": str(row.get("agent_id") or snapshot.get("agent_id") or DEFAULT_AGENT_ID),
+            "agent": agent_summary_from_snapshot(snapshot),
             "source_schedule_id": str(row.get("source_schedule_id") or "") or None,
             "source_schedule_log_id": str(row.get("source_schedule_log_id") or "") or None,
             "message_type": str(row.get("message_type") or ""),
@@ -2173,9 +2228,12 @@ class TopicTaskStore:
         }
 
     def _normalize_schedule_row(self, row: dict[str, Any]) -> dict[str, Any]:
+        snapshot = normalize_agent_snapshot(row.get("agent_snapshot_json") or row.get("agent_snapshot") or default_agent_payload())
         return {
             "schedule_id": str(row.get("schedule_id") or ""),
             "topic_id": str(row.get("topic_id") or ""),
+            "agent_id": str(row.get("agent_id") or snapshot.get("agent_id") or DEFAULT_AGENT_ID),
+            "agent": agent_summary_from_snapshot(snapshot),
             "name": str(row.get("name") or ""),
             "message_type": str(row.get("message_type") or ""),
             "message_content": _safe_json_load(row.get("message_content_json")),

--- a/dataagent/dataagent-backend/main.py
+++ b/dataagent/dataagent-backend/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from api.admin_routes import router as admin_router
 from api.routes import router
 from config import get_settings
+from core.agent_profile_service import bootstrap_default_agent_profile
 from core.skill_admin_service import bootstrap_admin_settings, reindex_documents_from_disk
 from core.skill_admin_store import get_skill_admin_store
 from core.skill_discovery import resolve_agent_project_cwd, resolve_skills_root_dir
@@ -86,6 +87,13 @@ async def startup():
         logger.info("Topic/task store ready for schema `%s`", cfg.session_mysql_database)
     except Exception as e:
         logger.exception("Topic/task store bootstrap failed: %s", e)
+        raise
+
+    try:
+        profile = bootstrap_default_agent_profile()
+        logger.info("Default agent profile ready agent_id=%s", profile.get("agent_id"))
+    except Exception as e:
+        logger.exception("Agent profile bootstrap failed: %s", e)
         raise
 
     try:

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -49,6 +49,7 @@ class QAExample(BaseModel):
 
 class CreateTopicRequest(BaseModel):
     title: Optional[str] = None
+    agent_id: Optional[str] = None
 
 
 class UpdateTopicRequest(BaseModel):
@@ -58,6 +59,7 @@ class UpdateTopicRequest(BaseModel):
 class DeliverMessageRequest(BaseModel):
     topic_id: str
     content: str
+    agent_id: Optional[str] = None
     provider_id: Optional[str] = None
     model: Optional[str] = None
     debug: bool = False
@@ -69,6 +71,7 @@ class CreateTaskRequest(BaseModel):
     topic_id: str
     message_type: str
     message_content: Any
+    agent_id: Optional[str] = None
     provider_id: Optional[str] = None
     model: Optional[str] = None
     debug: bool = False
@@ -359,6 +362,70 @@ class SkillDocumentCompareResponse(BaseModel):
     changed_lines: int = 0
 
 
+class AgentSummary(BaseModel):
+    agent_id: str
+    name: str
+    description: str = ""
+    is_default: bool = False
+
+
+class AgentProfileBase(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    system_prompt: Optional[str] = None
+    permission_mode: Optional[str] = None
+    allowed_tools: Optional[List[str]] = None
+    mcp_server_ids: Optional[List[str]] = None
+    skill_folders: Optional[List[str]] = None
+    max_turns: Optional[int] = None
+    env_vars: Optional[Dict[str, str]] = None
+
+
+class AgentProfileCreateRequest(AgentProfileBase):
+    name: str
+
+
+class AgentProfileUpdateRequest(AgentProfileBase):
+    pass
+
+
+class AgentSkillCapability(BaseModel):
+    folder: str
+    source: str = "bundled"
+    enabled: bool = False
+
+
+class AgentMcpServerCapability(BaseModel):
+    id: str
+    name: str
+    enabled: bool = False
+    tool_names: List[str] = Field(default_factory=list)
+
+
+class AgentCapabilitiesResponse(BaseModel):
+    tools: List[str] = Field(default_factory=list)
+    mcp_servers: List[AgentMcpServerCapability] = Field(default_factory=list)
+    skills: List[AgentSkillCapability] = Field(default_factory=list)
+    permission_modes: List[str] = Field(default_factory=list)
+
+
+class AgentProfile(BaseModel):
+    agent_id: str
+    name: str
+    description: str = ""
+    resolved_workdir: str = ""
+    system_prompt: str = ""
+    permission_mode: str = "inherit"
+    allowed_tools: List[str] = Field(default_factory=list)
+    mcp_server_ids: List[str] = Field(default_factory=list)
+    skill_folders: List[str] = Field(default_factory=list)
+    max_turns: int = 0
+    env_vars: Dict[str, str] = Field(default_factory=dict)
+    is_default: bool = False
+    created_at: str = ""
+    updated_at: str = ""
+
+
 class TopicMessage(BaseModel):
     message_id: str
     topic_id: str
@@ -388,6 +455,8 @@ class TopicSummary(BaseModel):
     title: str
     chat_topic_id: str
     chat_conversation_id: str
+    agent_id: str = ""
+    agent: Optional[AgentSummary] = None
     current_task_id: Optional[str] = None
     current_task_status: Optional[str] = None
     message_count: int = 0
@@ -401,6 +470,8 @@ class TopicDetail(BaseModel):
     title: str
     chat_topic_id: str
     chat_conversation_id: str
+    agent_id: str = ""
+    agent: Optional[AgentSummary] = None
     current_task_id: Optional[str] = None
     current_task_status: Optional[str] = None
     created_at: str = ""
@@ -428,6 +499,8 @@ class TaskSubmissionResponse(BaseModel):
 class TaskStatusResponse(BaseModel):
     task_id: str
     topic_id: str
+    agent_id: str = ""
+    agent: Optional[AgentSummary] = None
     from_task_id: Optional[str] = None
     task_status: str
     prompt: str = ""
@@ -477,6 +550,8 @@ class CancelTaskResponse(BaseModel):
 class MessageQueueRecord(BaseModel):
     queue_id: str
     topic_id: str
+    agent_id: str = ""
+    agent: Optional[AgentSummary] = None
     message_type: str
     message_content: Any = None
     status: str
@@ -498,6 +573,8 @@ class MessageQueuePageResponse(BaseModel):
 class MessageScheduleRecord(BaseModel):
     schedule_id: str
     topic_id: str
+    agent_id: str = ""
+    agent: Optional[AgentSummary] = None
     name: str
     message_type: str
     message_content: Any = None

--- a/dataagent/dataagent-backend/tests/test_admin_routes.py
+++ b/dataagent/dataagent-backend/tests/test_admin_routes.py
@@ -322,3 +322,94 @@ def test_skill_uninstall_route_rejects_service_errors(monkeypatch):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "内置 Skill 不支持卸载"
+
+
+def test_agent_profile_routes_contract(monkeypatch):
+    profile = {
+        "agent_id": "agent_1",
+        "name": "营销分析智能体",
+        "description": "营销场景",
+        "resolved_workdir": "/tmp/dataagent/agents/agent_1",
+        "system_prompt": "只回答营销问题",
+        "permission_mode": "inherit",
+        "allowed_tools": ["Skill", "Read"],
+        "mcp_server_ids": ["portal"],
+        "skill_folders": ["marketing-insights"],
+        "max_turns": 12,
+        "env_vars": {"SAFE_FLAG": "1"},
+        "is_default": False,
+        "created_at": "2026-05-21T10:00:00",
+        "updated_at": "2026-05-21T10:00:00",
+    }
+    calls = {}
+
+    monkeypatch.setattr(
+        admin_routes,
+        "list_documents",
+        lambda: [
+            {
+                "folder": "marketing-insights",
+                "relative_path": "SKILL.md",
+                "source": "managed",
+                "enabled": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(admin_routes, "list_agent_profiles", lambda: [profile])
+    monkeypatch.setattr(admin_routes, "get_agent_profile", lambda agent_id: profile if agent_id == "agent_1" else None)
+    monkeypatch.setattr(admin_routes, "agent_capabilities", lambda documents: {
+        "tools": ["Skill", "Read"],
+        "mcp_servers": [{"id": "portal", "name": "Portal MCP", "enabled": True, "tool_names": ["portal_query_readonly"]}],
+        "skills": [{"folder": "marketing-insights", "source": "managed", "enabled": True}],
+        "permission_modes": ["inherit", "default", "bypassPermissions"],
+    })
+
+    def _create(payload, *, available_skill_folders):
+        calls["create"] = {"payload": payload, "available_skill_folders": available_skill_folders}
+        return profile
+
+    def _update(agent_id, payload, *, available_skill_folders):
+        calls["update"] = {"agent_id": agent_id, "payload": payload, "available_skill_folders": available_skill_folders}
+        return {**profile, **payload}
+
+    monkeypatch.setattr(admin_routes, "create_agent_profile", _create)
+    monkeypatch.setattr(admin_routes, "update_agent_profile", _update)
+    monkeypatch.setattr(admin_routes, "delete_agent_profile", lambda agent_id: agent_id == "agent_1")
+
+    client = TestClient(app)
+
+    capabilities = client.get("/api/v1/dataagent/agents/capabilities")
+    assert capabilities.status_code == 200
+    assert capabilities.json()["skills"][0]["folder"] == "marketing-insights"
+    assert capabilities.json()["mcp_servers"][0]["id"] == "portal"
+
+    listed = client.get("/api/v1/dataagent/agents")
+    assert listed.status_code == 200
+    assert listed.json()[0]["agent_id"] == "agent_1"
+
+    created = client.post(
+        "/api/v1/dataagent/agents",
+        json={
+            "name": "营销分析智能体",
+            "allowed_tools": ["Skill", "Read"],
+            "mcp_server_ids": ["portal"],
+            "skill_folders": ["marketing-insights"],
+            "env_vars": {"SAFE_FLAG": "1"},
+        },
+    )
+    assert created.status_code == 200
+    assert calls["create"]["payload"]["name"] == "营销分析智能体"
+    assert calls["create"]["available_skill_folders"] == {"marketing-insights"}
+
+    detail = client.get("/api/v1/dataagent/agents/agent_1")
+    assert detail.status_code == 200
+    assert detail.json()["resolved_workdir"] == "/tmp/dataagent/agents/agent_1"
+
+    updated = client.put("/api/v1/dataagent/agents/agent_1", json={"description": "更新后"})
+    assert updated.status_code == 200
+    assert calls["update"]["agent_id"] == "agent_1"
+    assert updated.json()["description"] == "更新后"
+
+    deleted = client.delete("/api/v1/dataagent/agents/agent_1")
+    assert deleted.status_code == 200
+    assert deleted.json()["status"] == "ok"

--- a/dataagent/dataagent-backend/tests/test_agent_profile_service.py
+++ b/dataagent/dataagent-backend/tests/test_agent_profile_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from core import agent_profile_service
+
+
+def test_normalize_agent_profile_payload_accepts_scoped_runtime_config():
+    payload = agent_profile_service.normalize_agent_profile_payload(
+        {
+            "name": "质量巡检助手",
+            "description": "只处理数据质量规则和巡检结果分析。",
+            "system_prompt": "你是数据质量巡检场景的智能体。",
+            "permission_mode": "bypassPermissions",
+            "allowed_tools": ["Read", "Skill", "Read", "Grep"],
+            "mcp_server_ids": ["portal"],
+            "skill_folders": ["opendataworks-business-knowledge"],
+            "max_turns": 12,
+            "env_vars": {"AGENT_SCENE": "quality"},
+        },
+        available_skill_folders={"opendataworks-business-knowledge", "opendataworks-platform-tools"},
+        available_mcp_server_ids={"portal"},
+    )
+
+    assert payload["name"] == "质量巡检助手"
+    assert payload["permission_mode"] == "bypassPermissions"
+    assert payload["allowed_tools"] == ["Read", "Skill", "Grep"]
+    assert payload["mcp_server_ids"] == ["portal"]
+    assert payload["skill_folders"] == ["opendataworks-business-knowledge"]
+    assert payload["max_turns"] == 12
+    assert payload["env_vars"] == {"AGENT_SCENE": "quality"}
+
+
+def test_normalize_agent_profile_payload_rejects_reserved_environment_keys():
+    with pytest.raises(ValueError, match="reserved environment variable"):
+        agent_profile_service.normalize_agent_profile_payload(
+            {
+                "name": "危险配置",
+                "env_vars": {"DATAAGENT_TOKEN": "bad"},
+            },
+            available_skill_folders=set(),
+            available_mcp_server_ids=set(),
+        )
+
+
+def test_build_agent_snapshot_keeps_runtime_fields_without_timestamps():
+    snapshot = agent_profile_service.build_agent_snapshot(
+        {
+            "agent_id": "agent_quality",
+            "name": "质量巡检助手",
+            "description": "只处理数据质量规则和巡检结果分析。",
+            "system_prompt": "你是数据质量巡检场景的智能体。",
+            "permission_mode": "default",
+            "allowed_tools": ["Skill", "Read"],
+            "mcp_server_ids": ["portal"],
+            "skill_folders": ["opendataworks-business-knowledge"],
+            "max_turns": 8,
+            "env_vars": {"AGENT_SCENE": "quality"},
+            "resolved_workdir": "/tmp/agent",
+            "is_default": False,
+            "created_at": "2026-05-21T10:00:00",
+            "updated_at": "2026-05-21T11:00:00",
+        }
+    )
+
+    assert snapshot == {
+        "agent_id": "agent_quality",
+        "name": "质量巡检助手",
+        "description": "只处理数据质量规则和巡检结果分析。",
+        "system_prompt": "你是数据质量巡检场景的智能体。",
+        "permission_mode": "default",
+        "allowed_tools": ["Skill", "Read"],
+        "mcp_server_ids": ["portal"],
+        "skill_folders": ["opendataworks-business-knowledge"],
+        "max_turns": 8,
+        "env_vars": {"AGENT_SCENE": "quality"},
+        "is_default": False,
+    }

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -15,6 +15,24 @@ import api.routes as routes
 import main
 
 
+DEFAULT_AGENT = {
+    "agent_id": "agent_default",
+    "name": "默认智能问数助手",
+    "description": "default",
+    "system_prompt": "",
+    "permission_mode": "inherit",
+    "allowed_tools": ["Skill", "Bash", "Read", "LS", "Glob", "Grep"],
+    "mcp_server_ids": ["portal"],
+    "skill_folders": [],
+    "max_turns": 0,
+    "env_vars": {},
+    "is_default": True,
+    "resolved_workdir": "/tmp/dataagent/default",
+    "created_at": "",
+    "updated_at": "",
+}
+
+
 def _now() -> str:
     return datetime.now().isoformat(timespec="seconds")
 
@@ -62,13 +80,22 @@ class _FakeStore:
         self._schedule_log_seq += 1
         return f"schedule_log_{self._schedule_log_seq}"
 
-    def create_topic(self, *, title: str, context=None):
+    def create_topic(self, *, title: str, agent_snapshot=None, context=None):
         topic_id = self._new_topic()
+        snapshot = dict(agent_snapshot or DEFAULT_AGENT)
         self.topics[topic_id] = {
             "topic_id": topic_id,
             "title": title or "新话题",
             "chat_topic_id": f"chat_topic_{topic_id}",
             "chat_conversation_id": f"chat_conversation_{topic_id}",
+            "agent_id": snapshot["agent_id"],
+            "agent_snapshot": snapshot,
+            "agent": {
+                "agent_id": snapshot["agent_id"],
+                "name": snapshot["name"],
+                "description": snapshot.get("description", ""),
+                "is_default": bool(snapshot.get("is_default")),
+            },
             "current_task_id": None,
             "current_task_status": None,
             "message_count": 0,
@@ -79,8 +106,10 @@ class _FakeStore:
         self.topic_messages[topic_id] = []
         return self.get_topic(topic_id)
 
-    def list_topics(self, include_messages: bool = False, context=None):
+    def list_topics(self, include_messages: bool = False, context=None, agent_id=None):
         rows = [dict(self.get_topic(topic_id) or {}) for topic_id in self.topics]
+        if agent_id:
+            rows = [row for row in rows if row.get("agent_id") == agent_id]
         if include_messages:
             for row in rows:
                 row["messages"] = self.list_topic_messages(row["topic_id"])
@@ -143,6 +172,9 @@ class _FakeStore:
             "task_id": task_id,
             "topic_id": topic_id,
             "from_task_id": None,
+            "agent_id": self.topics[topic_id].get("agent_id", "agent_default"),
+            "agent_snapshot": self.topics[topic_id].get("agent_snapshot", DEFAULT_AGENT),
+            "agent": self.topics[topic_id].get("agent"),
             "task_status": "waiting",
             "prompt": prompt,
             "provider_id": provider_id,
@@ -495,6 +527,7 @@ def _build_client(monkeypatch):
 
     monkeypatch.setattr(routes, "get_topic_task_store", lambda: store)
     monkeypatch.setattr(routes, "get_task_coordinator", lambda: coordinator)
+    monkeypatch.setattr(routes, "get_agent_profile", lambda agent_id: DEFAULT_AGENT if agent_id == "agent_default" else None)
     monkeypatch.setattr(routes, "submit_message_task", _submit_message_task_factory(store, submit_calls))
     monkeypatch.setattr(routes, "compute_next_run_at", lambda cron_expr, timezone: datetime(2026, 3, 23, 4, 0, 0))
 
@@ -502,6 +535,7 @@ def _build_client(monkeypatch):
     monkeypatch.setattr(main, "get_task_coordinator", lambda: coordinator)
     monkeypatch.setattr(main, "get_skill_admin_store", lambda: SimpleNamespace(init_schema=lambda: None))
     monkeypatch.setattr(main, "bootstrap_admin_settings", lambda: None)
+    monkeypatch.setattr(main, "bootstrap_default_agent_profile", lambda: DEFAULT_AGENT)
     monkeypatch.setattr(main, "reindex_documents_from_disk", lambda: [])
 
     return TestClient(main.app), store, coordinator, submit_calls

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -99,7 +99,7 @@ def _install_fake_sdk(monkeypatch, messages, *, final_exception=None):
     )
 
 
-def _build_input(*, history=None, resume_session_id=None):
+def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None):
     return task_executor.TaskExecutionInput(
         task_id="task-1",
         topic_id="topic-1",
@@ -113,6 +113,7 @@ def _build_input(*, history=None, resume_session_id=None):
         timeout_seconds=60,
         sql_read_timeout_seconds=30,
         sql_write_timeout_seconds=30,
+        agent_snapshot=agent_snapshot,
     )
 
 
@@ -266,6 +267,74 @@ def test_execute_task_stream_logs_safe_runtime_base_url_and_preserves_env(monkey
     assert "env_base_url=http://relay.example.internal/maas" in caplog.text
     assert "auth_token_set=True" in caplog.text
     assert "api_key_set=False" in caplog.text
+
+
+def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatch, tmp_path: Path):
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            AssistantMessage([TextBlock("custom-agent-ok")]),
+            ResultMessage("success", session_id="sdk-session-agent"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": provider_id,
+            "model": model,
+            "api_key": "",
+            "auth_token": "",
+            "base_url": "https://example.invalid",
+            "supports_partial_messages": False,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    agent_cwd = tmp_path / "agents" / "agent_1"
+    captured: dict[str, object] = {}
+
+    def fake_prepare_enabled_skills_project_cwd(folders, **kwargs):
+        captured["folders"] = list(folders)
+        captured["kwargs"] = dict(kwargs)
+        return agent_cwd
+
+    monkeypatch.setattr(task_executor, "prepare_enabled_skills_project_cwd", fake_prepare_enabled_skills_project_cwd)
+    monkeypatch.setattr(task_executor, "resolved_agent_workdir", lambda agent_id, is_default=False: str(agent_cwd))
+
+    async def _run():
+        return await task_executor.execute_task_stream(
+            _build_input(
+                agent_snapshot={
+                    "agent_id": "agent_1",
+                    "name": "自定义智能体",
+                    "description": "",
+                    "system_prompt": "只返回自定义智能体结果。",
+                    "permission_mode": "default",
+                    "allowed_tools": ["Read"],
+                    "mcp_server_ids": [],
+                    "skill_folders": [],
+                    "max_turns": 7,
+                    "env_vars": {"SAFE_FLAG": "1"},
+                    "is_default": False,
+                }
+            ),
+            emit=lambda record: None,
+        )
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    assert result.content == "custom-agent-ok"
+    assert captured["folders"] == []
+    assert captured["kwargs"]["runtime_project_cwd"] == str(agent_cwd)
+    assert captured["kwargs"]["allow_empty"] is True
+    assert ClaudeAgentOptions.last_kwargs["cwd"] == str(agent_cwd)
+    assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read"]
+    assert ClaudeAgentOptions.last_kwargs["mcp_servers"] == {}
+    assert ClaudeAgentOptions.last_kwargs["max_turns"] == 7
+    assert ClaudeAgentOptions.last_kwargs["permission_mode"] == "default"
+    assert ClaudeAgentOptions.last_kwargs["env"]["SAFE_FLAG"] == "1"
+    assert "只返回自定义智能体结果。" in ClaudeAgentOptions.last_kwargs["system_prompt"]
 
 
 def test_execute_task_stream_buffers_partial_text_until_turn_end(monkeypatch, tmp_path: Path):

--- a/docs/design/2026-05-21-dataagent-agent-profiles-design.md
+++ b/docs/design/2026-05-21-dataagent-agent-profiles-design.md
@@ -1,0 +1,133 @@
+# DataAgent Agent Profiles Design
+
+**Date:** 2026-05-21
+**Goal:** Add configurable DataAgent profiles so intelligent query can serve multiple usage scenarios through scoped prompts, skills, tools, MCP services, and runtime settings.
+**Tech Stack:** DataAgent FastAPI / Claude Agent SDK, MySQL/Alembic, Vue 3 + Element Plus.
+
+## Current State
+
+The current intelligent-query runtime has one global behavior surface:
+
+- global system prompt from `dataagent-backend/prompts/data_agent_system_prompt.md`
+- globally enabled skills from DataAgent settings
+- fixed safe tools and optional `portal` MCP injection
+- global interactive/background max-turn settings
+- one topic list in the frontend chat UI
+
+This makes all questions share the same role, prompt, skill set, and tool boundary. It works for the current intelligent-query path, but it cannot represent scenario-specific assistants such as platform operations, workflow analysis, quality inspection, or narrow business-domain agents.
+
+## Problem
+
+Administrators need multiple intelligent-query agents. Each agent should have a clear positioning prompt and only a small set of relevant skills/tools/services. A chat topic should be reproducible: future messages in that topic must keep using the same agent profile snapshot that was selected when the topic was created.
+
+## Scope
+
+In scope:
+
+- Add a DataAgent profile model and API.
+- Add an “智能体” tab inside the existing intelligent-query module.
+- Show agents in a multi-column card list.
+- Support create, detail, edit, save, and “start chat with this agent”.
+- Add an agent selector in the intelligent-query chat header.
+- Bind each topic and task to an agent profile snapshot.
+- Apply agent-specific prompt, skills, allowed tools, existing MCP services, max turns, environment variables, and managed runtime cwd.
+
+Out of scope:
+
+- Top-level main navigation changes.
+- MCP server CRUD.
+- Memory management UI or persistence.
+- Arbitrary server filesystem workdir input.
+- Per-message agent switching inside an existing topic.
+
+## Design
+
+### Agent Profile Model
+
+Add `da_agent_profile` in the DataAgent session schema. Each profile stores:
+
+- `agent_id`
+- `name`
+- `description`
+- `system_prompt`
+- `permission_mode`: `inherit`, `default`, or `bypassPermissions`
+- `allowed_tools_json`
+- `mcp_server_ids_json`
+- `skill_folders_json`
+- `max_turns`
+- `env_vars_json`
+- `is_default`
+- timestamps
+
+The backend resolves `resolved_workdir` from runtime configuration instead of storing arbitrary paths. The default profile preserves the existing DataAgent runtime behavior. Non-default profiles use a managed cwd under the DataAgent runtime home.
+
+### Topic And Task Binding
+
+Add `agent_id` and `agent_snapshot_json` to `da_agent_topic` and `da_agent_task`.
+
+Topic creation accepts `agent_id`. The backend snapshots the selected profile into the topic. Every task created in that topic copies the topic snapshot, so later profile edits only affect new topics.
+
+Existing topics are backfilled to the default agent. Existing tasks can have a null snapshot but are normalized to the default profile at runtime.
+
+### Runtime Integration
+
+`execute_task_stream` receives an agent snapshot through `TaskExecutionInput`. Runtime helpers accept an optional agent profile:
+
+- system prompt = base DataAgent prompt + agent positioning prompt + runtime context
+- enabled skills = agent `skill_folders` when set, otherwise global enabled skills
+- allowed tools = agent `allowed_tools` plus selected MCP tools
+- MCP servers = only selected existing MCP services; v1 includes current `portal`
+- max turns = agent `max_turns` when positive, otherwise existing interactive/background defaults
+- env vars = validated agent env merged after provider/runtime env, excluding reserved runtime keys
+- cwd = default agent uses existing enabled-skills cwd; custom agents use managed per-agent cwd
+
+Root execution still downgrades `bypassPermissions` to SDK-compatible default behavior.
+
+### Frontend UX
+
+The existing intelligent-query shell gains an “智能体” tab. The list uses cards in a responsive grid and shows name, description, enabled skills, allowed tools, MCP services, max turns, and default marker.
+
+The detail view is an Element Plus form with sections:
+
+- basic info: name, description
+- positioning: system prompt
+- capabilities: skills, tools, MCP services
+- advanced: permission mode, max turns, env vars
+
+Memory management is intentionally omitted in v1.
+
+The chat view adds an agent selector in the upper-left. Selecting an agent reloads the topic list for that agent. New topics and submitted messages use the active agent. Existing topics cannot switch agents.
+
+## Interfaces
+
+New routes:
+
+- `GET /api/v1/dataagent/agents`
+- `POST /api/v1/dataagent/agents`
+- `GET /api/v1/dataagent/agents/{agent_id}`
+- `PUT /api/v1/dataagent/agents/{agent_id}`
+- `DELETE /api/v1/dataagent/agents/{agent_id}`
+- `GET /api/v1/dataagent/agents/capabilities`
+
+Changed routes:
+
+- `POST /api/v1/nl2sql/topics` accepts `agent_id`
+- `GET /api/v1/nl2sql/topics` accepts optional `agent_id`
+- topic/task responses include agent summary fields
+- task submission accepts optional `agent_id` only for validation against the topic binding
+
+## Risks And Tradeoffs
+
+Keeping snapshots on topics/tasks duplicates profile data, but it protects historical conversations from later admin edits and keeps SDK resume behavior deterministic.
+
+Using managed workdirs reduces flexibility, but avoids exposing arbitrary server paths and keeps deployment behavior consistent.
+
+Omitting memory management leaves one requested label out of v1, but prevents adding unclear persistence semantics before the product behavior is defined.
+
+## Verification
+
+- Unit tests for profile validation, default bootstrap, env-var filtering, and profile snapshots.
+- API contract tests for agent CRUD, capabilities, topic filtering, and task submission payloads.
+- Runtime tests for prompt/tool/MCP/skill/max-turn/env/cwd overrides.
+- Frontend tests for agent list/detail, chat selector filtering, and submitted `agent_id`.
+- If local MySQL, Redis, provider settings, and `.venv-py313` are available, run one real HTTP smoke through agent creation and chat execution.

--- a/docs/plans/2026-05-21-dataagent-agent-profiles-plan.md
+++ b/docs/plans/2026-05-21-dataagent-agent-profiles-plan.md
@@ -1,0 +1,67 @@
+# DataAgent Agent Profiles Implementation Plan
+
+> **For agentic workers:** Use an isolated worktree on branch `codex/dataagent-agent-profiles`. Apply TDD for backend and frontend behavior. Keep commits/checkpoints small if committing.
+
+**Goal:** Add scenario-specific DataAgent profiles and bind intelligent-query topics to profile snapshots.
+
+**Architecture:** Store agents in a new DataAgent table, snapshot profile config onto topics/tasks, and pass the snapshot into the Claude Agent SDK runtime. The frontend adds an intelligent-query-local “智能体” tab plus a chat selector that filters topics and creates new topics under the selected agent.
+
+**Tech Stack:** FastAPI, Pydantic, PyMySQL, Alembic, Claude Agent SDK, Vue 3, Element Plus, Vitest, pytest.
+
+---
+
+## Tasks
+
+1. Add Alembic migration for `da_agent_profile`, topic/task `agent_id`, and snapshot columns.
+2. Add Pydantic schemas for agent profiles, capabilities, agent summaries on topics/tasks, and request payloads.
+3. Add backend profile store/service with default bootstrap, validation, snapshot creation, delete guards, and capability discovery.
+4. Add agent profile API routes under `/api/v1/dataagent/agents`.
+5. Extend topic/task store and submission flow so topics and tasks carry immutable agent snapshots.
+6. Extend runtime helpers and task execution to apply agent prompt, tools, MCP services, skills, max turns, env vars, and managed cwd.
+7. Add frontend API helpers for agents.
+8. Add `AgentStudio.vue` and `AgentDetailView.vue`; register intelligent-query routes and menu item.
+9. Update `NL2SqlChat.vue` to load/select agents, filter topics by `agent_id`, create topics with active agent, and submit `agent_id`.
+10. Add/adjust backend pytest and frontend Vitest coverage.
+11. Run focused verification; run local HTTP smoke if the environment is available.
+
+## File Map
+
+- `dataagent/dataagent-backend/alembic/versions/20260521_000007_add_agent_profiles.py`: database migration.
+- `dataagent/dataagent-backend/models/schemas.py`: API contracts.
+- `dataagent/dataagent-backend/core/agent_profile_service.py`: profile validation, persistence helpers, snapshots, runtime conversion.
+- `dataagent/dataagent-backend/api/admin_routes.py`: agent profile admin routes.
+- `dataagent/dataagent-backend/core/topic_task_store.py`: topic/task columns, filtering, snapshot persistence.
+- `dataagent/dataagent-backend/core/task_submission_service.py`: bind submissions to topic agent snapshot.
+- `dataagent/dataagent-backend/core/task_coordinator.py`: pass task agent snapshot to execution.
+- `dataagent/dataagent-backend/core/agent_runtime.py` and `core/task_executor.py`: apply runtime overrides.
+- `frontend/src/api/dataagent.js`: agent profile API.
+- `frontend/src/views/intelligence/IntelligentQueryView.vue`: menu/router host.
+- `frontend/src/views/intelligence/AgentStudio.vue`: agent grid.
+- `frontend/src/views/intelligence/AgentDetailView.vue`: agent edit form.
+- `frontend/src/views/intelligence/NL2SqlChat.vue`: agent selector and topic filtering.
+
+## Verification Commands
+
+Backend:
+
+```bash
+cd dataagent/dataagent-backend
+./.venv-py313/bin/python -m pytest tests/test_agent_profile_service.py tests/test_admin_routes.py tests/test_routes_contract.py tests/test_task_executor.py tests/test_topic_task_store.py -q
+```
+
+Frontend:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use
+npm --prefix frontend run test -- AgentStudio AgentDetailView NL2SqlChat
+```
+
+Smoke when available:
+
+```bash
+cd dataagent/dataagent-backend
+./.venv-py313/bin/python -m alembic upgrade head
+./.venv-py313/bin/uvicorn main:app --host 127.0.0.1 --port 8900
+```
+
+Then call the real HTTP flow: create an agent, create a topic with that `agent_id`, submit `你好，请直接回复 smoke-ok。`, consume events, and confirm final assistant message persistence.

--- a/frontend/src/api/dataagent.js
+++ b/frontend/src/api/dataagent.js
@@ -63,5 +63,29 @@ export const dataagentApi = {
 
   rollbackSkillDocument(documentId, versionId) {
     return dataagentRequest.post(`/v1/dataagent/skills/documents/${documentId}/versions/${versionId}/rollback`)
+  },
+
+  listAgents() {
+    return dataagentRequest.get('/v1/dataagent/agents')
+  },
+
+  getAgent(agentId) {
+    return dataagentRequest.get(`/v1/dataagent/agents/${encodeURIComponent(agentId)}`)
+  },
+
+  createAgent(data) {
+    return dataagentRequest.post('/v1/dataagent/agents', data)
+  },
+
+  updateAgent(agentId, data) {
+    return dataagentRequest.put(`/v1/dataagent/agents/${encodeURIComponent(agentId)}`, data)
+  },
+
+  deleteAgent(agentId) {
+    return dataagentRequest.delete(`/v1/dataagent/agents/${encodeURIComponent(agentId)}`)
+  },
+
+  getAgentCapabilities() {
+    return dataagentRequest.get('/v1/dataagent/agents/capabilities')
   }
 }

--- a/frontend/src/api/nl2sql.js
+++ b/frontend/src/api/nl2sql.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 const DEFAULT_TIMEOUT = 120000
 const RUNTIME_PREFIX = '/api/v1/nl2sql'
 const ADMIN_PREFIX = '/api/v1/nl2sql-admin'
+const DATAAGENT_PREFIX = '/api/v1/dataagent'
 
 function getDefaultBaseUrl() {
   if (typeof window === 'undefined') {
@@ -109,6 +110,7 @@ export function createNl2SqlApiClient(options = {}) {
   const defaultHeaders = options.defaultHeaders || options.headers || {}
   const runtimeRequest = createAxiosClient(baseURL, RUNTIME_PREFIX, timeout, defaultHeaders)
   const adminRequest = createAxiosClient(baseURL, ADMIN_PREFIX, timeout, defaultHeaders)
+  const dataagentRequest = createAxiosClient(baseURL, DATAAGENT_PREFIX, timeout, defaultHeaders)
 
   const runtimeApi = {
     getConfig() {
@@ -117,11 +119,11 @@ export function createNl2SqlApiClient(options = {}) {
   }
 
   const topicApi = {
-    createTopic(title = '新话题') {
-      return runtimeRequest.post('/topics', { title })
+    createTopic(title = '新话题', data = {}) {
+      return runtimeRequest.post('/topics', { title, ...data })
     },
-    listTopics() {
-      return runtimeRequest.get('/topics')
+    listTopics(params = {}) {
+      return runtimeRequest.get('/topics', { params })
     },
     getTopic(topicId) {
       return runtimeRequest.get(`/topics/${topicId}`)
@@ -236,6 +238,27 @@ export function createNl2SqlApiClient(options = {}) {
     }
   }
 
+  const agentApi = {
+    listAgents() {
+      return dataagentRequest.get('/agents')
+    },
+    getAgent(agentId) {
+      return dataagentRequest.get(`/agents/${encodeURIComponent(agentId)}`)
+    },
+    createAgent(data) {
+      return dataagentRequest.post('/agents', data)
+    },
+    updateAgent(agentId, data) {
+      return dataagentRequest.put(`/agents/${encodeURIComponent(agentId)}`, data)
+    },
+    deleteAgent(agentId) {
+      return dataagentRequest.delete(`/agents/${encodeURIComponent(agentId)}`)
+    },
+    getCapabilities() {
+      return dataagentRequest.get('/agents/capabilities')
+    }
+  }
+
   return {
     runtimeApi,
     topicApi,
@@ -243,6 +266,7 @@ export function createNl2SqlApiClient(options = {}) {
     messageQueueApi,
     scheduleApi,
     adminApi,
+    agentApi,
     health() {
       return runtimeRequest.get('/health')
     }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -84,6 +84,12 @@ const routes = [
         meta: { title: 'Skill 详情' }
       },
       {
+        path: '/intelligent-query/agents/:agentId',
+        name: 'IntelligentQueryAgentDetail',
+        component: () => import('@/views/intelligence/IntelligentQueryView.vue'),
+        meta: { title: '智能体详情' }
+      },
+      {
         path: '/nl2sql',
         redirect: (to) => ({ path: '/intelligent-query', query: to.query, hash: to.hash })
       },

--- a/frontend/src/views/intelligence/AgentDetailView.vue
+++ b/frontend/src/views/intelligence/AgentDetailView.vue
@@ -1,0 +1,275 @@
+<template>
+  <section class="agent-detail">
+    <header class="agent-detail-head">
+      <div>
+        <el-button text @click="goBack">返回智能体</el-button>
+        <h2>{{ form.name || '智能体详情' }}</h2>
+        <p>{{ form.resolved_workdir || '托管工作目录将在保存后生成' }}</p>
+      </div>
+      <div class="agent-detail-actions">
+        <el-button :icon="ChatLineRound" @click="openChat">开启对话</el-button>
+        <el-button type="primary" :loading="saving" @click="handleSave">保存</el-button>
+      </div>
+    </header>
+
+    <el-skeleton v-if="loading" :rows="10" animated />
+
+    <el-form v-else label-position="top" class="agent-form">
+      <section class="agent-section">
+        <h3>基础信息</h3>
+        <el-form-item label="名称">
+          <el-input v-model="form.name" maxlength="128" show-word-limit />
+        </el-form-item>
+        <el-form-item label="描述">
+          <el-input v-model="form.description" type="textarea" :rows="3" />
+        </el-form-item>
+        <el-form-item label="系统提示词">
+          <el-input v-model="form.system_prompt" type="textarea" :rows="8" />
+        </el-form-item>
+      </section>
+
+      <section class="agent-section">
+        <h3>能力范围</h3>
+        <el-form-item label="权限模式">
+          <el-select v-model="form.permission_mode">
+            <el-option
+              v-for="mode in capabilities.permission_modes"
+              :key="mode"
+              :label="mode"
+              :value="mode"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="允许工具">
+          <el-checkbox-group v-model="form.allowed_tools">
+            <el-checkbox-button
+              v-for="tool in capabilities.tools"
+              :key="tool"
+              :label="tool"
+            />
+          </el-checkbox-group>
+        </el-form-item>
+        <el-form-item label="允许 MCP 服务">
+          <el-checkbox-group v-model="form.mcp_server_ids">
+            <el-checkbox
+              v-for="server in capabilities.mcp_servers"
+              :key="server.id"
+              :label="server.id"
+            >
+              {{ server.name }}
+            </el-checkbox>
+          </el-checkbox-group>
+        </el-form-item>
+        <el-form-item label="Skills">
+          <el-checkbox-group v-model="form.skill_folders" class="agent-skill-list">
+            <el-checkbox
+              v-for="skill in capabilities.skills"
+              :key="skill.folder"
+              :label="skill.folder"
+            >
+              {{ skill.folder }}
+            </el-checkbox>
+          </el-checkbox-group>
+        </el-form-item>
+      </section>
+
+      <section class="agent-section">
+        <h3>高级设置</h3>
+        <el-form-item label="会话轮次数上限">
+          <el-input-number v-model="form.max_turns" :min="0" :max="200" />
+        </el-form-item>
+        <el-form-item label="环境变量 JSON">
+          <el-input v-model="envVarsText" type="textarea" :rows="6" />
+        </el-form-item>
+      </section>
+    </el-form>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { ChatLineRound } from '@element-plus/icons-vue'
+import { dataagentApi } from '@/api/dataagent'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(false)
+const saving = ref(false)
+const envVarsText = ref('{}')
+
+const capabilities = reactive({
+  tools: [],
+  mcp_servers: [],
+  skills: [],
+  permission_modes: ['inherit', 'default', 'bypassPermissions']
+})
+
+const form = reactive({
+  agent_id: '',
+  name: '',
+  description: '',
+  resolved_workdir: '',
+  system_prompt: '',
+  permission_mode: 'inherit',
+  allowed_tools: [],
+  mcp_server_ids: [],
+  skill_folders: [],
+  max_turns: 0,
+  env_vars: {},
+  is_default: false
+})
+
+const agentId = computed(() => String(route.params.agentId || ''))
+
+const applyAgent = (agent) => {
+  Object.assign(form, {
+    agent_id: String(agent?.agent_id || ''),
+    name: String(agent?.name || ''),
+    description: String(agent?.description || ''),
+    resolved_workdir: String(agent?.resolved_workdir || ''),
+    system_prompt: String(agent?.system_prompt || ''),
+    permission_mode: String(agent?.permission_mode || 'inherit'),
+    allowed_tools: Array.isArray(agent?.allowed_tools) ? [...agent.allowed_tools] : [],
+    mcp_server_ids: Array.isArray(agent?.mcp_server_ids) ? [...agent.mcp_server_ids] : [],
+    skill_folders: Array.isArray(agent?.skill_folders) ? [...agent.skill_folders] : [],
+    max_turns: Number(agent?.max_turns || 0),
+    env_vars: agent?.env_vars && typeof agent.env_vars === 'object' ? { ...agent.env_vars } : {},
+    is_default: Boolean(agent?.is_default)
+  })
+  envVarsText.value = JSON.stringify(form.env_vars || {}, null, 2)
+}
+
+const loadDetail = async () => {
+  loading.value = true
+  try {
+    const [agent, caps] = await Promise.all([
+      dataagentApi.getAgent(agentId.value),
+      dataagentApi.getAgentCapabilities()
+    ])
+    Object.assign(capabilities, {
+      tools: caps?.tools || [],
+      mcp_servers: caps?.mcp_servers || [],
+      skills: caps?.skills || [],
+      permission_modes: caps?.permission_modes || capabilities.permission_modes
+    })
+    applyAgent(agent)
+  } finally {
+    loading.value = false
+  }
+}
+
+const buildPayload = () => {
+  let envVars = {}
+  try {
+    envVars = JSON.parse(envVarsText.value || '{}')
+  } catch (_error) {
+    throw new Error('环境变量必须是合法 JSON')
+  }
+  if (!envVars || Array.isArray(envVars) || typeof envVars !== 'object') {
+    throw new Error('环境变量必须是 JSON 对象')
+  }
+  return {
+    name: form.name,
+    description: form.description,
+    system_prompt: form.system_prompt,
+    permission_mode: form.permission_mode,
+    allowed_tools: [...form.allowed_tools],
+    mcp_server_ids: [...form.mcp_server_ids],
+    skill_folders: [...form.skill_folders],
+    max_turns: Number(form.max_turns || 0),
+    env_vars: envVars
+  }
+}
+
+const handleSave = async () => {
+  saving.value = true
+  try {
+    const saved = await dataagentApi.updateAgent(form.agent_id, buildPayload())
+    applyAgent(saved)
+    ElMessage.success('已保存')
+  } catch (error) {
+    ElMessage.error(String(error?.message || '保存失败'))
+  } finally {
+    saving.value = false
+  }
+}
+
+const goBack = () => {
+  router.push({ path: '/intelligent-query', query: { tab: 'agents' } })
+}
+
+const openChat = () => {
+  router.push({ path: '/intelligent-query', query: { agent_id: form.agent_id } })
+}
+
+onMounted(loadDetail)
+</script>
+
+<style scoped>
+.agent-detail {
+  min-height: 100%;
+}
+
+.agent-detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.agent-detail-head h2 {
+  margin: 8px 0 0;
+  color: #1f2937;
+  font-size: 22px;
+}
+
+.agent-detail-head p {
+  margin: 6px 0 0;
+  color: #98a2b3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.agent-detail-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.agent-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 16px;
+}
+
+.agent-section {
+  padding: 18px;
+  border: 1px solid #dfe7f1;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.agent-section:first-child {
+  grid-row: span 2;
+}
+
+.agent-section h3 {
+  margin: 0 0 14px;
+  color: #1f2937;
+  font-size: 16px;
+}
+
+.agent-skill-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 6px 12px;
+}
+
+@media (max-width: 960px) {
+  .agent-form {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/intelligence/AgentStudio.vue
+++ b/frontend/src/views/intelligence/AgentStudio.vue
@@ -1,0 +1,230 @@
+<template>
+  <section class="agent-studio">
+    <header class="agent-studio-head">
+      <div>
+        <h2>智能体</h2>
+        <p>为不同数据问答场景配置专属 Skills、工具与提示词。</p>
+      </div>
+      <el-button type="primary" :icon="Plus" :loading="creating" @click="handleCreate">新建智能体</el-button>
+    </header>
+
+    <el-skeleton v-if="loading" :rows="6" animated />
+
+    <div v-else class="agent-grid">
+      <article
+        v-for="agent in agents"
+        :key="agent.agent_id"
+        class="agent-card"
+      >
+        <div class="agent-card-main">
+          <div class="agent-card-title-row">
+            <h3>{{ agent.name }}</h3>
+            <el-tag v-if="agent.is_default" size="small" type="info">默认</el-tag>
+          </div>
+          <p>{{ agent.description || '未配置描述' }}</p>
+        </div>
+
+        <div class="agent-card-meta">
+          <span>{{ agent.skill_folders?.length || 0 }} Skills</span>
+          <span>{{ agent.allowed_tools?.length || 0 }} 工具</span>
+          <span>{{ agent.mcp_server_ids?.length || 0 }} MCP</span>
+        </div>
+
+        <div class="agent-workdir">{{ agent.resolved_workdir || '-' }}</div>
+
+        <div class="agent-card-actions">
+          <el-tooltip content="开启对话" placement="top">
+            <el-button :icon="ChatLineRound" circle @click="handleChat(agent)" />
+          </el-tooltip>
+          <el-tooltip content="查看编辑" placement="top">
+            <el-button :icon="Edit" circle @click="handleDetail(agent)" />
+          </el-tooltip>
+          <el-tooltip v-if="!agent.is_default" content="删除" placement="top">
+            <el-button :icon="Delete" circle type="danger" plain @click="handleDelete(agent)" />
+          </el-tooltip>
+        </div>
+      </article>
+
+      <el-empty v-if="!agents.length" description="暂无智能体" />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { ChatLineRound, Delete, Edit, Plus } from '@element-plus/icons-vue'
+import { dataagentApi } from '@/api/dataagent'
+
+const router = useRouter()
+const agents = ref([])
+const loading = ref(false)
+const creating = ref(false)
+
+const loadAgents = async () => {
+  loading.value = true
+  try {
+    agents.value = await dataagentApi.listAgents()
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleCreate = async () => {
+  creating.value = true
+  try {
+    const created = await dataagentApi.createAgent({
+      name: '新智能体',
+      description: '',
+      system_prompt: '',
+      permission_mode: 'inherit',
+      allowed_tools: ['Skill', 'Bash', 'Read', 'LS', 'Glob', 'Grep'],
+      mcp_server_ids: [],
+      skill_folders: [],
+      max_turns: 0,
+      env_vars: {}
+    })
+    await router.push({
+      name: 'IntelligentQueryAgentDetail',
+      params: { agentId: created.agent_id }
+    })
+  } finally {
+    creating.value = false
+  }
+}
+
+const handleDetail = (agent) => {
+  router.push({
+    name: 'IntelligentQueryAgentDetail',
+    params: { agentId: agent.agent_id }
+  })
+}
+
+const handleChat = (agent) => {
+  router.push({
+    path: '/intelligent-query',
+    query: { agent_id: agent.agent_id }
+  })
+}
+
+const handleDelete = async (agent) => {
+  await ElMessageBox.confirm(`确认删除智能体「${agent.name}」？`, '删除智能体', {
+    type: 'warning',
+    confirmButtonText: '删除',
+    cancelButtonText: '取消'
+  })
+  await dataagentApi.deleteAgent(agent.agent_id)
+  ElMessage.success('已删除')
+  await loadAgents()
+}
+
+onMounted(loadAgents)
+</script>
+
+<style scoped>
+.agent-studio {
+  min-height: 100%;
+}
+
+.agent-studio-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.agent-studio-head h2 {
+  margin: 0;
+  color: #1f2937;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.agent-studio-head p {
+  margin: 6px 0 0;
+  color: #667085;
+  font-size: 13px;
+}
+
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.agent-card {
+  display: flex;
+  min-height: 208px;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid #dfe7f1;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.035);
+}
+
+.agent-card-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.agent-card h3 {
+  margin: 0;
+  overflow: hidden;
+  color: #1f2937;
+  font-size: 17px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-card p {
+  display: -webkit-box;
+  margin: 10px 0 0;
+  overflow: hidden;
+  color: #667085;
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.agent-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.agent-card-meta span {
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: #f1f5f9;
+  color: #475467;
+  font-size: 12px;
+}
+
+.agent-workdir {
+  overflow: hidden;
+  color: #98a2b3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -14,6 +14,10 @@
           <el-icon><Collection /></el-icon>
           <span>Skills</span>
         </el-menu-item>
+        <el-menu-item index="agents">
+          <el-icon><User /></el-icon>
+          <span>智能体</span>
+        </el-menu-item>
         <el-menu-item index="models">
           <el-icon><Cpu /></el-icon>
           <span>模型管理</span>
@@ -23,6 +27,8 @@
 
     <main class="intelligent-query-content" :class="{ 'is-chat': activeMenu === 'chat' }">
       <SkillDetailView v-if="isSkillDetailRoute" />
+      <AgentDetailView v-else-if="isAgentDetailRoute" />
+      <AgentStudio v-else-if="activeTab === 'agents'" />
       <SkillStudio v-else-if="activeTab === 'skills'" />
       <DataAgentConfig v-else-if="activeTab === 'models'" />
       <NL2SqlChat v-else />
@@ -33,23 +39,32 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChatDotRound, Collection, Cpu } from '@element-plus/icons-vue'
+import { ChatDotRound, Collection, Cpu, User } from '@element-plus/icons-vue'
 import NL2SqlChat from './NL2SqlChat.vue'
+import AgentStudio from './AgentStudio.vue'
+import AgentDetailView from './AgentDetailView.vue'
 import SkillStudio from '../settings/SkillStudio.vue'
 import DataAgentConfig from '../settings/DataAgentConfig.vue'
 import SkillDetailView from '../settings/SkillDetailView.vue'
 
 const route = useRoute()
 const router = useRouter()
-const validTabs = new Set(['chat', 'skills', 'models'])
+const validTabs = new Set(['chat', 'skills', 'agents', 'models'])
 
 const isSkillDetailRoute = computed(() => (
   route.name === 'IntelligentQuerySkillDetail' || route.path.startsWith('/intelligent-query/skills/')
 ))
 
+const isAgentDetailRoute = computed(() => (
+  route.name === 'IntelligentQueryAgentDetail' || route.path.startsWith('/intelligent-query/agents/')
+))
+
 const activeTab = computed(() => {
   if (isSkillDetailRoute.value) {
     return 'skills'
+  }
+  if (isAgentDetailRoute.value) {
+    return 'agents'
   }
   const tab = String(route.query.tab || 'chat')
   return validTabs.has(tab) ? tab : 'chat'

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -2,12 +2,20 @@
   <div class="query-workbench">
     <aside class="query-sidebar">
       <div class="query-sidebar-head">
-          <div>
-            <div class="query-brand">智能问数</div>
-            <div class="query-brand-meta">数据分析</div>
-          </div>
-          <button class="query-btn-new" @click="handleNewTopic">新建</button>
+        <div class="query-agent-panel">
+          <div class="query-brand">智能问数</div>
+          <select v-model="selectedAgentId" class="query-agent-select" :disabled="!agents.length">
+            <option
+              v-for="agent in agents"
+              :key="agent.agent_id"
+              :value="agent.agent_id"
+            >
+              {{ agent.name }}
+            </option>
+          </select>
         </div>
+        <button class="query-btn-new" @click="handleNewTopic">新建</button>
+      </div>
 
       <div class="query-sidebar-search">
         <input
@@ -41,7 +49,7 @@
           <div class="query-main-head">
             <div>
               <h3>{{ activeTopic ? truncate(activeTopic.title, 48) : '开始一次新的数据分析' }}</h3>
-              <p class="query-main-subtitle">围绕数据查询与分析开展连续对话。</p>
+              <p class="query-main-subtitle">{{ activeAgent?.description || '围绕数据查询与分析开展连续对话。' }}</p>
             </div>
             <div class="query-model-badge">
               <span>{{ activeProviderConfig?.display_name || '未配置' }}</span>
@@ -243,6 +251,7 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, triggerRef, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { marked } from 'marked'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
@@ -258,10 +267,13 @@ import {
 marked.setOptions({ breaks: true, gfm: true })
 
 const api = createNl2SqlApiClient({ timeout: 300000 })
-const { topicApi, taskApi, adminApi } = api
+const { topicApi, taskApi, adminApi, agentApi } = api
+const route = useRoute()
 
 const topics = ref([])
+const agents = ref([])
 const activeTopicId = ref('')
+const selectedAgentId = ref('')
 const inputText = ref('')
 const searchKeyword = ref('')
 const messagesScrollbarRef = ref(null)
@@ -278,6 +290,7 @@ const settings = reactive({
 
 const selectedProvider = ref(settings.default_provider_id)
 const selectedModel = ref(settings.default_model)
+const agentSelectionReady = ref(false)
 
 const suggestions = [
   '各数据层表数量对比',
@@ -287,6 +300,7 @@ const suggestions = [
 ]
 
 const activeTopic = computed(() => topics.value.find((topic) => topic.topic_id === activeTopicId.value) || null)
+const activeAgent = computed(() => agents.value.find((agent) => agent.agent_id === selectedAgentId.value) || agents.value[0] || null)
 const activeMessages = computed(() => activeTopic.value?.messages || [])
 const activeCancelableMessage = computed(() => [...activeMessages.value]
   .reverse()
@@ -351,6 +365,7 @@ const canSendMessage = computed(() => (
   && !activeCancelableMessage.value
   && Boolean(selectedProvider.value)
   && Boolean(selectedModel.value)
+  && Boolean(selectedAgentId.value)
 ))
 const composerActionDisabled = computed(() => (
   composerActionMode.value === 'cancel'
@@ -567,6 +582,8 @@ const sortTopics = () => {
 const normalizeTopicSummary = (topic) => ({
   topic_id: String(topic?.topic_id || ''),
   title: String(topic?.title || '新话题'),
+  agent_id: String(topic?.agent_id || topic?.agent?.agent_id || selectedAgentId.value || ''),
+  agent: topic?.agent || null,
   message_count: Number(topic?.message_count || 0),
   current_task_id: String(topic?.current_task_id || ''),
   current_task_status: String(topic?.current_task_status || ''),
@@ -914,6 +931,33 @@ const loadSettings = async () => {
   }
 }
 
+const normalizeAgent = (agent) => ({
+  agent_id: String(agent?.agent_id || ''),
+  name: String(agent?.name || '默认智能体'),
+  description: String(agent?.description || ''),
+  is_default: Boolean(agent?.is_default)
+})
+
+const loadAgents = async () => {
+  try {
+    const list = await agentApi.listAgents()
+    const normalized = (Array.isArray(list) ? list : []).map(normalizeAgent).filter((agent) => agent.agent_id)
+    agents.value = normalized.length
+      ? normalized
+      : [{ agent_id: 'agent_default', name: '默认智能问数助手', description: '', is_default: true }]
+    const routeAgentId = String(route.query.agent_id || '').trim()
+    if (routeAgentId && agents.value.some((agent) => agent.agent_id === routeAgentId)) {
+      selectedAgentId.value = routeAgentId
+    } else if (!agents.value.some((agent) => agent.agent_id === selectedAgentId.value)) {
+      selectedAgentId.value = (agents.value.find((agent) => agent.is_default) || agents.value[0])?.agent_id || ''
+    }
+  } catch (error) {
+    console.warn('load agents failed', error)
+    agents.value = [{ agent_id: 'agent_default', name: '默认智能问数助手', description: '', is_default: true }]
+    selectedAgentId.value = selectedAgentId.value || 'agent_default'
+  }
+}
+
 const hydrateTopic = async (topicId) => {
   if (!topicId || hydratedIds.has(topicId)) return
 
@@ -925,6 +969,8 @@ const hydrateTopic = async (topicId) => {
     const target = topics.value.find((topic) => topic.topic_id === topicId)
     if (target && detail) {
       target.title = String(detail.title || target.title)
+      target.agent_id = String(detail.agent_id || target.agent_id || '')
+      target.agent = detail.agent || target.agent || null
       target.updated_at = String(detail.updated_at || target.updated_at)
       target.current_task_id = String(detail.current_task_id || target.current_task_id || '')
       target.current_task_status = String(detail.current_task_status || target.current_task_status || '')
@@ -955,7 +1001,7 @@ const hydrateTopic = async (topicId) => {
 
 const loadTopics = async () => {
   try {
-    const list = await topicApi.listTopics()
+    const list = await topicApi.listTopics(selectedAgentId.value ? { agent_id: selectedAgentId.value } : {})
     topics.value = (Array.isArray(list) ? list : []).map(normalizeTopicSummary)
     sortTopics()
     if (!activeTopicId.value && topics.value.length) {
@@ -970,7 +1016,7 @@ const loadTopics = async () => {
 }
 
 const handleNewTopic = async () => {
-  const topic = normalizeTopicSummary(await topicApi.createTopic())
+  const topic = normalizeTopicSummary(await topicApi.createTopic('新话题', { agent_id: selectedAgentId.value }))
   topics.value.unshift(topic)
   hydratedIds.add(topic.topic_id)
   activeTopicId.value = topic.topic_id
@@ -1022,7 +1068,7 @@ const handleSend = async () => {
   try {
     if (!activeTopicId.value) {
       const title = deriveTopicTitle(text, 20)
-      const created = normalizeTopicSummary(await topicApi.createTopic(title))
+      const created = normalizeTopicSummary(await topicApi.createTopic(title, { agent_id: selectedAgentId.value }))
       topics.value.unshift(created)
       hydratedIds.add(created.topic_id)
       activeTopicId.value = created.topic_id
@@ -1057,6 +1103,7 @@ const handleSend = async () => {
     const response = await taskApi.deliverMessage({
       topic_id: submitTopicId,
       content: text,
+      agent_id: selectedAgentId.value,
       provider_id: selectedProvider.value,
       model: selectedModel.value,
       debug: true,
@@ -1146,9 +1193,20 @@ watch(
   }
 )
 
+watch(selectedAgentId, async (next, prev) => {
+  if (!agentSelectionReady.value || !next || next === prev) return
+  stopAllTaskSubscriptions()
+  hydratedIds.clear()
+  topics.value = []
+  activeTopicId.value = ''
+  await loadTopics()
+})
+
 onMounted(async () => {
   await loadSettings()
+  await loadAgents()
   await loadTopics()
+  agentSelectionReady.value = true
   scrollToBottom(true)
 })
 
@@ -1205,6 +1263,11 @@ onBeforeUnmount(() => {
   padding: 4px 8px 16px;
 }
 
+.query-agent-panel {
+  flex: 1;
+  min-width: 0;
+}
+
 .query-brand {
   font-size: 17px;
   font-weight: 700;
@@ -1212,10 +1275,22 @@ onBeforeUnmount(() => {
   color: #1F1F1F;
 }
 
-.query-brand-meta {
-  margin-top: 3px;
-  font-size: 12px;
-  color: #A0AABF;
+.query-agent-select {
+  width: 100%;
+  height: 32px;
+  margin-top: 8px;
+  padding: 0 9px;
+  border: 1px solid #d8e0ec;
+  border-radius: 8px;
+  background: #f9fafc;
+  color: #344054;
+  font-size: 13px;
+  outline: none;
+}
+
+.query-agent-select:focus {
+  border-color: #4F81FF;
+  background: #ffffff;
 }
 
 .query-btn-new {

--- a/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
@@ -1,0 +1,130 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerPush = vi.hoisted(() => vi.fn())
+const routeState = vi.hoisted(() => ({
+  params: { agentId: 'agent_1' }
+}))
+const dataagentApi = vi.hoisted(() => ({
+  getAgent: vi.fn(),
+  getAgentCapabilities: vi.fn(),
+  updateAgent: vi.fn()
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ push: routerPush })
+}))
+
+vi.mock('@/api/dataagent', () => ({
+  dataagentApi
+}))
+
+vi.mock('element-plus', () => ({
+  ElButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  ElSkeleton: { template: '<div />' },
+  ElForm: { template: '<form><slot /></form>' },
+  ElFormItem: { template: '<label><slot /></label>' },
+  ElInput: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+  },
+  ElSelect: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>'
+  },
+  ElOption: { props: ['label', 'value'], template: '<option :value="value">{{ label }}</option>' },
+  ElInputNumber: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<input type="number" :value="modelValue" @input="$emit(\'update:modelValue\', Number($event.target.value))" />'
+  },
+  ElCheckboxGroup: { template: '<div><slot /></div>' },
+  ElCheckbox: { props: ['label'], template: '<label>{{ label }}</label>' },
+  ElCheckboxButton: { props: ['label'], template: '<button type="button">{{ label }}</button>' },
+  ElMessage: { success: vi.fn(), error: vi.fn() }
+}))
+
+import AgentDetailView from '../AgentDetailView.vue'
+
+const stubs = {
+  ElButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  ElSkeleton: { template: '<div />' },
+  ElForm: { template: '<form><slot /></form>' },
+  ElFormItem: { template: '<label><slot /></label>' },
+  ElInput: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<textarea :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />'
+  },
+  ElSelect: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>'
+  },
+  ElOption: { props: ['label', 'value'], template: '<option :value="value">{{ label }}</option>' },
+  ElInputNumber: {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<input type="number" :value="modelValue" @input="$emit(\'update:modelValue\', Number($event.target.value))" />'
+  },
+  ElCheckboxGroup: { template: '<div><slot /></div>' },
+  ElCheckbox: { props: ['label'], template: '<label>{{ label }}</label>' },
+  ElCheckboxButton: { props: ['label'], template: '<button type="button">{{ label }}</button>' }
+}
+
+describe('AgentDetailView', () => {
+  beforeEach(() => {
+    routerPush.mockReset()
+    Object.values(dataagentApi).forEach((fn) => fn.mockReset())
+    dataagentApi.getAgent.mockResolvedValue({
+      agent_id: 'agent_1',
+      name: '营销分析',
+      description: '营销场景',
+      resolved_workdir: '/tmp/agents/agent_1',
+      system_prompt: '只做营销分析',
+      permission_mode: 'inherit',
+      allowed_tools: ['Skill', 'Read'],
+      mcp_server_ids: ['portal'],
+      skill_folders: ['marketing-insights'],
+      max_turns: 12,
+      env_vars: { SAFE_FLAG: '1' },
+      is_default: false
+    })
+    dataagentApi.getAgentCapabilities.mockResolvedValue({
+      tools: ['Skill', 'Read', 'Bash'],
+      mcp_servers: [{ id: 'portal', name: 'Portal MCP', enabled: true, tool_names: [] }],
+      skills: [{ folder: 'marketing-insights', source: 'managed', enabled: true }],
+      permission_modes: ['inherit', 'default', 'bypassPermissions']
+    })
+    dataagentApi.updateAgent.mockImplementation(async (_agentId, data) => ({
+      agent_id: 'agent_1',
+      resolved_workdir: '/tmp/agents/agent_1',
+      is_default: false,
+      ...data
+    }))
+  })
+
+  it('loads profile data and saves edited values', async () => {
+    const wrapper = shallowMount(AgentDetailView, { global: { stubs } })
+
+    await flushPromises()
+
+    expect(dataagentApi.getAgent).toHaveBeenCalledWith('agent_1')
+    expect(wrapper.text()).toContain('营销分析')
+
+    wrapper.vm.form.name = '营销分析 Plus'
+    await wrapper.vm.handleSave()
+    await flushPromises()
+
+    expect(dataagentApi.updateAgent).toHaveBeenCalledWith(
+      'agent_1',
+      expect.objectContaining({
+        name: '营销分析 Plus',
+        env_vars: { SAFE_FLAG: '1' }
+      })
+    )
+  })
+})

--- a/frontend/src/views/intelligence/__tests__/AgentStudio.spec.js
+++ b/frontend/src/views/intelligence/__tests__/AgentStudio.spec.js
@@ -1,0 +1,82 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerPush = vi.hoisted(() => vi.fn())
+const dataagentApi = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  createAgent: vi.fn(),
+  deleteAgent: vi.fn()
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush })
+}))
+
+vi.mock('@/api/dataagent', () => ({
+  dataagentApi
+}))
+
+vi.mock('element-plus', () => ({
+  ElButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  ElTag: { template: '<span><slot /></span>' },
+  ElTooltip: { template: '<span><slot /></span>' },
+  ElSkeleton: { template: '<div />' },
+  ElEmpty: { template: '<div />' },
+  ElMessage: { success: vi.fn(), error: vi.fn() },
+  ElMessageBox: { confirm: vi.fn().mockResolvedValue(undefined) }
+}))
+
+import AgentStudio from '../AgentStudio.vue'
+
+const stubs = {
+  ElButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  ElTag: { template: '<span><slot /></span>' },
+  ElTooltip: { template: '<span><slot /></span>' },
+  ElSkeleton: { template: '<div />' },
+  ElEmpty: { template: '<div />' }
+}
+
+describe('AgentStudio', () => {
+  beforeEach(() => {
+    routerPush.mockReset()
+    Object.values(dataagentApi).forEach((fn) => fn.mockReset())
+    dataagentApi.listAgents.mockResolvedValue([
+      {
+        agent_id: 'agent_default',
+        name: '默认智能问数助手',
+        description: '默认',
+        resolved_workdir: '/tmp/default',
+        allowed_tools: ['Skill', 'Read'],
+        mcp_server_ids: ['portal'],
+        skill_folders: ['dataagent-nl2sql'],
+        is_default: true
+      }
+    ])
+  })
+
+  it('renders agent cards from the profile API', async () => {
+    const wrapper = shallowMount(AgentStudio, { global: { stubs } })
+
+    await flushPromises()
+
+    expect(dataagentApi.listAgents).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('默认智能问数助手')
+    expect(wrapper.text()).toContain('/tmp/default')
+    expect(wrapper.text()).toContain('1 Skills')
+  })
+
+  it('creates an agent and navigates to detail', async () => {
+    dataagentApi.createAgent.mockResolvedValue({ agent_id: 'agent_1' })
+    const wrapper = shallowMount(AgentStudio, { global: { stubs } })
+
+    await flushPromises()
+    await wrapper.vm.handleCreate()
+    await flushPromises()
+
+    expect(dataagentApi.createAgent).toHaveBeenCalledWith(expect.objectContaining({ name: '新智能体' }))
+    expect(routerPush).toHaveBeenCalledWith({
+      name: 'IntelligentQueryAgentDetail',
+      params: { agentId: 'agent_1' }
+    })
+  })
+})

--- a/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
@@ -21,6 +21,8 @@ import IntelligentQueryView from '../IntelligentQueryView.vue'
 
 const stubs = {
   NL2SqlChat: { template: '<div data-test="nl2sql-chat">智能问数聊天</div>' },
+  AgentStudio: { template: '<div data-test="agent-studio">智能体内容</div>' },
+  AgentDetailView: { template: '<div data-test="agent-detail">智能体详情</div>' },
   SkillStudio: { template: '<div data-test="skill-studio">Skills 内容</div>' },
   DataAgentConfig: { template: '<div data-test="dataagent-config">模型管理内容</div>' },
   SkillDetailView: { template: '<div data-test="skill-detail">Skill 详情</div>' },
@@ -56,6 +58,7 @@ describe('IntelligentQueryView', () => {
 
     expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="skill-studio"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="agent-studio"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="dataagent-config"]').exists()).toBe(false)
     expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('chat')
   })
@@ -82,6 +85,14 @@ describe('IntelligentQueryView', () => {
     expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('models')
   })
 
+  it('renders agent studio from the tab query', () => {
+    const wrapper = mountView({ query: { tab: 'agents' } })
+
+    expect(wrapper.find('[data-test="agent-studio"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('agents')
+  })
+
   it('keeps Skills selected when rendering the skill detail route', () => {
     const wrapper = mountView({
       path: '/intelligent-query/skills/marketing-insights',
@@ -92,5 +103,17 @@ describe('IntelligentQueryView', () => {
     expect(wrapper.find('[data-test="skill-detail"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="skill-studio"]').exists()).toBe(false)
     expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('skills')
+  })
+
+  it('keeps agents selected when rendering the agent detail route', () => {
+    const wrapper = mountView({
+      path: '/intelligent-query/agents/agent_1',
+      name: 'IntelligentQueryAgentDetail',
+      params: { agentId: 'agent_1' }
+    })
+
+    expect(wrapper.find('[data-test="agent-detail"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="agent-studio"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('agents')
   })
 })

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -37,11 +37,23 @@ const apiMocks = vi.hoisted(() => ({
     getSettings: vi.fn(),
     updateSettings: vi.fn()
   },
+  agentApi: {
+    listAgents: vi.fn(),
+    getAgent: vi.fn(),
+    createAgent: vi.fn(),
+    updateAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    getCapabilities: vi.fn()
+  },
   health: vi.fn()
 }))
 
 vi.mock('@/api/nl2sql', () => ({
   createNl2SqlApiClient: () => apiMocks
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, params: {}, path: '/intelligent-query', name: 'IntelligentQuery' })
 }))
 
 vi.mock('element-plus', () => ({
@@ -90,6 +102,13 @@ const deferred = () => {
 const makeTopicSummary = (topicId, title) => ({
   topic_id: topicId,
   title,
+  agent_id: 'agent_default',
+  agent: {
+    agent_id: 'agent_default',
+    name: '默认智能问数助手',
+    description: '默认描述',
+    is_default: true
+  },
   chat_topic_id: `chat_${topicId}`,
   chat_conversation_id: `conversation_${topicId}`,
   current_task_id: '',
@@ -103,6 +122,13 @@ const makeTopicSummary = (topicId, title) => ({
 const makeTopicDetail = (topicId, title) => ({
   topic_id: topicId,
   title,
+  agent_id: 'agent_default',
+  agent: {
+    agent_id: 'agent_default',
+    name: '默认智能问数助手',
+    description: '默认描述',
+    is_default: true
+  },
   chat_topic_id: `chat_${topicId}`,
   chat_conversation_id: `conversation_${topicId}`,
   current_task_id: '',
@@ -118,6 +144,7 @@ describe('NL2SqlChat', () => {
     Object.values(apiMocks.messageQueueApi).forEach((fn) => fn.mockReset())
     Object.values(apiMocks.scheduleApi).forEach((fn) => fn.mockReset())
     Object.values(apiMocks.adminApi).forEach((fn) => fn.mockReset())
+    Object.values(apiMocks.agentApi).forEach((fn) => fn.mockReset())
     apiMocks.health.mockReset()
 
     apiMocks.adminApi.getSettings.mockResolvedValue({
@@ -134,6 +161,14 @@ describe('NL2SqlChat', () => {
         }
       ]
     })
+    apiMocks.agentApi.listAgents.mockResolvedValue([
+      {
+        agent_id: 'agent_default',
+        name: '默认智能问数助手',
+        description: '默认描述',
+        is_default: true
+      }
+    ])
     apiMocks.topicApi.createTopic.mockResolvedValue(makeTopicSummary('topic-new', '新话题'))
     apiMocks.topicApi.listTopics.mockResolvedValue([
       makeTopicSummary('topic-1', '流式话题')
@@ -667,6 +702,7 @@ describe('NL2SqlChat', () => {
     expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledTimes(2)
     const requestedTopicIds = apiMocks.taskApi.deliverMessage.mock.calls.map((call) => call[0].topic_id).sort()
     expect(requestedTopicIds).toEqual(['topic-1', 'topic-2'])
+    expect(apiMocks.taskApi.deliverMessage.mock.calls[0][0].agent_id).toBe('agent_default')
 
     firstPending.resolve({
       accepted: true,
@@ -723,6 +759,7 @@ describe('NL2SqlChat', () => {
       'topic-new',
       { title: '这是一个新的会话标题' }
     )
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('这是一个新的会话标题', { agent_id: 'agent_default' })
     expect(wrapper.text()).toContain('这是一个新的会话标题')
   })
 })


### PR DESCRIPTION
## Summary
- Add DataAgent agent profile persistence, default profile bootstrap, and topic/task agent snapshot binding.
- Add DataAgent agent CRUD/capabilities APIs and extend topic/task contracts with `agent_id` and agent summaries.
- Add the intelligent-query agent menu, profile detail editor, chat entrypoints, and chat-side agent selector with topic filtering.

## Key Changes
- Introduces `da_agent_profile` plus `agent_id` and `agent_snapshot_json` on `da_agent_topic` and `da_agent_task` through Alembic.
- Applies profile snapshots at runtime for system prompt, skills, allowed tools, MCP servers, permission mode, max turns, env vars, and managed SDK cwd.
- Adds frontend agent grid/detail views and wires selected agent state into topic creation and message delivery.
- Adds design and execution plan docs for the cross-layer change.

## Validation
- `python - <<'PY' ... import fastapi, uvicorn, alembic, pymysql, anyio, claude_agent_sdk ... PY` -> `imports-ok`
- `python -m compileall dataagent/dataagent-backend/core dataagent/dataagent-backend/api dataagent/dataagent-backend/models dataagent/dataagent-backend/alembic/versions/20260521_000007_add_agent_profiles.py` -> passed
- `python -m pytest tests/test_agent_profile_service.py tests/test_admin_routes.py tests/test_routes_contract.py tests/test_task_executor.py tests/test_topic_task_store.py -q` -> 26 passed, 5 warnings
- `nvm use && npm --prefix frontend run test -- IntelligentQueryView NL2SqlChat AgentStudio AgentDetailView` -> 4 files passed, 21 tests passed
- `nvm use && npm --prefix frontend run build` -> passed; existing Sass legacy API and chunk-size warnings only
- `git diff --check` -> passed

## End-to-End Smoke
- DataAgent DB: Podman MySQL on `127.0.0.1:3306`, session schema `dataagent`, query DB `opendataworks`; ran `alembic upgrade head` to `20260521_000007`.
- Redis: Podman Redis on `127.0.0.1:6379`.
- Python: `/Users/guoruping/project/bigdata/opendataworks/dataagent/dataagent-backend/.venv-py313/bin/python`.
- Provider/model: existing `da_agent_settings` provider `anthropic_compatible`, model `deepseek-v4-pro`, real auth token present; real model execution was used.
- Runtime note: host default/bundled Claude CLI was x64 on arm64, so smoke started DataAgent with arm64 Claude Code CLI from a temporary npm install via `DATAAGENT_CLAUDE_CLI_PATH`.
- HTTP smoke passed: capabilities -> create agent -> edit agent -> create topic with `agent_id` -> filtered topic list -> `deliver-message` accepted -> task reached `finished` -> persisted events returned -> SSE `data:` frames returned -> topic messages contained `smoke-ok` -> smoke topic/agent cleanup succeeded.
- Browser smoke passed via Playwright CLI against frontend dev server: intelligent-query agent menu rendered card grid, agent detail page rendered editable fields and “开启对话”, chat route rendered left-top agent selector, and a non-default temporary agent was selected from `?agent_id=` with empty filtered topics.

## Risk / Rollback
- Risk: schema migration and runtime profile snapshot behavior affect topic/task persistence and agent execution options.
- Rollback: revert this commit and downgrade/remove the migration before deploying dependent frontend routes.
