### PR TITLE
[codex] Enforce agent data scope

### DIFF
--- a/backend/src/main/java/com/onedata/portal/agentapi/scope/AgentDataScopeContext.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/scope/AgentDataScopeContext.java
@@ -1,0 +1,177 @@
+package com.onedata.portal.agentapi.scope;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class AgentDataScopeContext {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ThreadLocal<String> ENCODED_SCOPE = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> ACTIVE = new ThreadLocal<>();
+
+    private AgentDataScopeContext() {
+    }
+
+    public static void setEncodedScope(String encodedScope) {
+        ACTIVE.set(true);
+        ENCODED_SCOPE.set(encodedScope == null ? "" : encodedScope.trim());
+    }
+
+    public static boolean isActive() {
+        return Boolean.TRUE.equals(ACTIVE.get());
+    }
+
+    public static void clear() {
+        ENCODED_SCOPE.remove();
+        ACTIVE.remove();
+    }
+
+    public static boolean isDatabaseNameAllowed(String database) {
+        if (!isActive()) {
+            return true;
+        }
+        if (!StringUtils.hasText(database)) {
+            return false;
+        }
+        String normalizedDatabase = database.trim();
+        for (DataScopeItem item : currentScopes()) {
+            if (normalizedDatabase.equals(item.getDatabase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isAllowed(Long clusterId, String database) {
+        if (!isActive()) {
+            return true;
+        }
+        if (!StringUtils.hasText(database)) {
+            return false;
+        }
+        String normalizedDatabase = database.trim();
+        for (DataScopeItem item : currentScopes()) {
+            if (!normalizedDatabase.equals(item.getDatabase())) {
+                continue;
+            }
+            if (clusterId == null && item.getClusterId() == null) {
+                return true;
+            }
+            if (clusterId != null && Objects.equals(clusterId, item.getClusterId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void requireDatabaseNameAllowed(String database) {
+        if (!isDatabaseNameAllowed(database)) {
+            throw new IllegalArgumentException("数据范围限制: 未授权访问 database `" + trimToEmpty(database) + "`");
+        }
+    }
+
+    public static void requireAllowed(Long clusterId, String database) {
+        if (!isAllowed(clusterId, database)) {
+            throw new IllegalArgumentException("数据范围限制: 未授权访问 database `" + trimToEmpty(database) + "`");
+        }
+    }
+
+    public static void requireSqlSchemaAllowed(String schema) {
+        if (!isDatabaseNameAllowed(schema)) {
+            throw new IllegalArgumentException("数据范围限制: SQL 引用了未授权 schema `" + trimToEmpty(schema) + "`");
+        }
+    }
+
+    public static List<String> allowedDatabases() {
+        if (!isActive()) {
+            return Collections.emptyList();
+        }
+        List<String> databases = new ArrayList<>();
+        for (DataScopeItem item : currentScopes()) {
+            if (StringUtils.hasText(item.getDatabase()) && !databases.contains(item.getDatabase())) {
+                databases.add(item.getDatabase());
+            }
+        }
+        return databases;
+    }
+
+    private static List<DataScopeItem> currentScopes() {
+        String encoded = ENCODED_SCOPE.get();
+        if (!StringUtils.hasText(encoded)) {
+            return Collections.emptyList();
+        }
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(padBase64(encoded.trim()));
+            JsonNode root = OBJECT_MAPPER.readTree(new String(decoded, StandardCharsets.UTF_8));
+            JsonNode scopes = root.path("allowed_scopes");
+            if (!scopes.isArray()) {
+                return Collections.emptyList();
+            }
+            List<DataScopeItem> result = new ArrayList<>();
+            for (JsonNode scope : scopes) {
+                String database = scope.path("database").asText("");
+                if (!StringUtils.hasText(database)) {
+                    continue;
+                }
+                DataScopeItem item = new DataScopeItem();
+                item.setDatabase(database.trim());
+                item.setClusterId(scope.hasNonNull("cluster_id") ? scope.path("cluster_id").asLong() : null);
+                item.setSourceType(scope.path("source_type").asText(""));
+                result.add(item);
+            }
+            return result;
+        } catch (Exception ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static String padBase64(String value) {
+        int remainder = value.length() % 4;
+        if (remainder == 0) {
+            return value;
+        }
+        StringBuilder builder = new StringBuilder(value);
+        for (int i = remainder; i < 4; i++) {
+            builder.append('=');
+        }
+        return builder.toString();
+    }
+
+    private static String trimToEmpty(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static final class DataScopeItem {
+        private Long clusterId;
+        private String sourceType;
+        private String database;
+
+        Long getClusterId() {
+            return clusterId;
+        }
+
+        void setClusterId(Long clusterId) {
+            this.clusterId = clusterId;
+        }
+
+        String getDatabase() {
+            return database;
+        }
+
+        void setDatabase(String database) {
+            this.database = database;
+        }
+
+        void setSourceType(String sourceType) {
+            this.sourceType = sourceType;
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/scope/AgentDataScopeFilter.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/scope/AgentDataScopeFilter.java
@@ -1,0 +1,35 @@
+package com.onedata.portal.agentapi.scope;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class AgentDataScopeFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_NAME = "X-Agent-Data-Scope";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String path = request.getRequestURI();
+        if (path == null || (!path.startsWith("/v1/ai/") && !path.startsWith("/api/v1/ai/"))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        AgentDataScopeContext.setEncodedScope(request.getHeader(HEADER_NAME));
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            AgentDataScopeContext.clear();
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentMetadataService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentMetadataService.java
@@ -8,6 +8,7 @@ import com.onedata.portal.agentapi.dto.AgentLineageRecord;
 import com.onedata.portal.agentapi.dto.AgentLineageResponse;
 import com.onedata.portal.agentapi.dto.AgentTableMetadata;
 import com.onedata.portal.agentapi.dto.AgentTableDdlResponse;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import com.onedata.portal.entity.DataField;
 import com.onedata.portal.entity.DataLineage;
 import com.onedata.portal.entity.DataTable;
@@ -94,7 +95,10 @@ public class BackendAgentMetadataService implements AgentMetadataService {
             throw new IllegalArgumentException("table 或 tableId 至少提供一个");
         }
 
-        List<DataTable> targets = resolveLineageTargets(normalizedTable, normalizedDbName, tableId);
+        List<DataTable> targets = filterTablesByScope(resolveLineageTargets(normalizedTable, normalizedDbName, tableId));
+        if (tableId != null && targets.isEmpty()) {
+            throw new IllegalArgumentException("数据范围限制: 未授权访问 tableId `" + tableId + "`");
+        }
         AgentLineageResponse response = new AgentLineageResponse();
         response.setDbName(normalizedDbName);
         response.setTable(normalizedTable);
@@ -154,6 +158,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
 
         JdbcMysqlTarget platformMysql = parsePlatformMysql(dataSourceProperties.getUrl());
         if (platformMysql != null && targetDatabase.equals(platformMysql.getDatabase())) {
+            AgentDataScopeContext.requireAllowed(null, targetDatabase);
             ensurePreferredEngine(targetDatabase, normalizedPreferredEngine, "mysql");
             AgentDatasourceResolution response = new AgentDatasourceResolution();
             response.setEngine("mysql");
@@ -183,6 +188,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         if (cluster == null) {
             throw new IllegalArgumentException("cluster_id `" + clusterId + "` 不存在");
         }
+        AgentDataScopeContext.requireAllowed(clusterId, targetDatabase);
 
         String sourceType = normalizeSourceType(cluster.getSourceType());
         String engine = "MYSQL".equals(sourceType) ? "mysql" : "doris";
@@ -233,6 +239,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         String targetDatabase = normalizedDatabase;
         String rawTableName = normalizedTable;
         if (matchedTable != null) {
+            AgentDataScopeContext.requireAllowed(matchedTable.getClusterId(), matchedTable.getDbName());
             if (StringUtils.hasText(matchedTable.getDbName())) {
                 targetDatabase = matchedTable.getDbName();
             }
@@ -307,6 +314,9 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         for (DataLineage lineage : lineages) {
             DataTable upstream = tableMap.get(lineage.getUpstreamTableId());
             DataTable downstream = tableMap.get(lineage.getDownstreamTableId());
+            if (!isTableAllowed(upstream) && !isTableAllowed(downstream)) {
+                continue;
+            }
             if (StringUtils.hasText(normalizedDatabase)) {
                 String upstreamDb = upstream == null ? null : upstream.getDbName();
                 String downstreamDb = downstream == null ? null : downstream.getDbName();
@@ -374,6 +384,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         }
 
         return candidates.values().stream()
+                .filter(candidate -> isTableAllowed(candidate.getTable()))
                 .filter(candidate -> candidate.matches(table, keyword))
                 .sorted(Comparator
                         .comparingLong(SearchCandidate::getScore).reversed()
@@ -478,7 +489,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         return fields.stream()
                 .filter(field -> {
                     DataTable table = tableMap.get(field.getTableId());
-                    return isSearchableTable(table, database);
+                    return isSearchableTable(table, database) && isTableAllowed(table);
                 })
                 .collect(Collectors.toList());
     }
@@ -508,7 +519,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         if ("deprecated".equalsIgnoreCase(trimToEmpty(table.getStatus()))) {
             return false;
         }
-        return !StringUtils.hasText(database) || database.equals(table.getDbName());
+        return (!StringUtils.hasText(database) || database.equals(table.getDbName())) && isTableAllowed(table);
     }
 
     private long scoreTextMatch(String source, String term, long exactScore, long containsScore) {
@@ -616,6 +627,9 @@ public class BackendAgentMetadataService implements AgentMetadataService {
             AgentLineageRecord record = new AgentLineageRecord();
             record.setId(lineage.getId());
             record.setLineageType(lineage.getLineageType());
+            if (!isTableAllowed(upstream) && !isTableAllowed(downstream)) {
+                continue;
+            }
             record.setUpstreamDb(upstream == null ? null : upstream.getDbName());
             record.setUpstreamTable(upstream == null ? null : upstream.getTableName());
             record.setDownstreamDb(downstream == null ? null : downstream.getDbName());
@@ -663,7 +677,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         if (StringUtils.hasText(dbName)) {
             wrapper.eq(DataTable::getDbName, dbName);
         }
-        return dataTableMapper.selectList(wrapper);
+        return filterTablesByScope(dataTableMapper.selectList(wrapper));
     }
 
     private Long resolveClusterIdFromTables(String database) {
@@ -713,6 +727,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
                         .orderByAsc(DataTable::getId)
                         .last("LIMIT 4")
         );
+        matched = filterTablesByScope(matched);
         if (matched.size() > 1) {
             throw new IllegalArgumentException("database `" + database + "` 与 table `" + table + "` 命中了多张表，请改用 tableId");
         }
@@ -744,7 +759,24 @@ public class BackendAgentMetadataService implements AgentMetadataService {
         if (StringUtils.hasText(database)) {
             wrapper.eq(DataTable::getDbName, database);
         }
-        return dataTableMapper.selectList(wrapper);
+        return filterTablesByScope(dataTableMapper.selectList(wrapper));
+    }
+
+    private List<DataTable> filterTablesByScope(List<DataTable> tables) {
+        if (!AgentDataScopeContext.isActive()) {
+            return tables;
+        }
+        if (tables == null || tables.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return tables.stream().filter(this::isTableAllowed).collect(Collectors.toList());
+    }
+
+    private boolean isTableAllowed(DataTable table) {
+        if (!AgentDataScopeContext.isActive()) {
+            return true;
+        }
+        return table != null && AgentDataScopeContext.isAllowed(table.getClusterId(), table.getDbName());
     }
 
     private Map<String, DorisDbUser> loadReadonlyUserMap(List<DataTable> tables) {

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
@@ -3,12 +3,14 @@ package com.onedata.portal.agentapi.service;
 import com.onedata.portal.agentapi.dto.AgentDatasourceResolution;
 import com.onedata.portal.agentapi.dto.AgentReadQueryRequest;
 import com.onedata.portal.agentapi.dto.AgentReadQueryResponse;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import lombok.RequiredArgsConstructor;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -54,6 +56,8 @@ public class BackendAgentQueryService implements AgentQueryService {
         }
 
         validateReadOnlySql(sql);
+        AgentDataScopeContext.requireDatabaseNameAllowed(database);
+        validateSqlReferencesInScope(sql);
         int limit = normalizeLimit(request.getLimit());
         int timeoutSeconds = normalizeTimeout(request.getTimeoutSeconds());
         String preferredEngine = trimToLower(request.getPreferredEngine());
@@ -112,6 +116,44 @@ public class BackendAgentQueryService implements AgentQueryService {
         }
 
         return READ_ONLY_FALLBACK_KEYWORDS.contains(detectLeadingKeyword(sql));
+    }
+
+    private void validateSqlReferencesInScope(String sql) {
+        if (!AgentDataScopeContext.isActive()) {
+            return;
+        }
+        try {
+            Statement statement = CCJSqlParserUtil.parse(sql);
+            TablesNamesFinder finder = new TablesNamesFinder();
+            for (String tableName : finder.getTableList(statement)) {
+                String schema = schemaFromTableName(tableName);
+                if (StringUtils.hasText(schema)) {
+                    AgentDataScopeContext.requireSqlSchemaAllowed(schema);
+                }
+            }
+        } catch (JSQLParserException ignored) {
+            validateSqlReferencesInScopeLexically(sql);
+        }
+    }
+
+    private void validateSqlReferencesInScopeLexically(String sql) {
+        String normalizedSql = maskCommentsAndQuotedText(sql);
+        Matcher matcher = Pattern.compile("(?i)\\b(?:from|join|describe|desc)\\s+`?([A-Za-z0-9_]+)`?\\s*\\.").matcher(normalizedSql);
+        while (matcher.find()) {
+            AgentDataScopeContext.requireSqlSchemaAllowed(matcher.group(1));
+        }
+    }
+
+    private String schemaFromTableName(String tableName) {
+        if (!StringUtils.hasText(tableName)) {
+            return null;
+        }
+        String normalized = tableName.replace("`", "").trim();
+        int index = normalized.indexOf('.');
+        if (index <= 0) {
+            return null;
+        }
+        return normalized.substring(0, index).trim();
     }
 
     private void validateReadOnlySqlWithLexicalFallback(String sql) {

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.onedata.portal.agentapi;
 import com.onedata.portal.agentapi.dto.AgentDatasourceResolution;
 import com.onedata.portal.agentapi.dto.AgentReadQueryRequest;
 import com.onedata.portal.agentapi.dto.AgentReadQueryResponse;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import com.onedata.portal.agentapi.service.AgentJdbcExecutor;
 import com.onedata.portal.agentapi.service.AgentMetadataService;
 import com.onedata.portal.agentapi.service.BackendAgentQueryService;
@@ -195,6 +196,35 @@ class BackendAgentQueryServiceTest {
     @Test
     void readQueryRejectsMultipleStatements() {
         assertReadQueryRejected("SELECT 1; SELECT 2", "仅支持单条只读 SQL");
+    }
+
+    @Test
+    void readQueryRejectsDatabaseOutsideAgentDataScope() {
+        AgentDataScopeContext.setEncodedScope("eyJhbGxvd2VkX3Njb3BlcyI6W3siY2x1c3Rlcl9pZCI6MywiZGF0YWJhc2UiOiJhZHNfdXNlciIsInNvdXJjZV90eXBlIjoiRE9SSVMifV19");
+        try {
+            assertReadQueryRejected("SELECT 1", "数据范围限制: 未授权访问 database `opendataworks`");
+        } finally {
+            AgentDataScopeContext.clear();
+        }
+    }
+
+    @Test
+    void readQueryRejectsCrossSchemaReferencesOutsideAgentDataScope() {
+        AgentDataScopeContext.setEncodedScope("eyJhbGxvd2VkX3Njb3BlcyI6W3siY2x1c3Rlcl9pZCI6MywiZGF0YWJhc2UiOiJhZHNfdXNlciIsInNvdXJjZV90eXBlIjoiRE9SSVMifV19");
+        try {
+            AgentReadQueryRequest request = new AgentReadQueryRequest();
+            request.setDatabase("ads_user");
+            request.setSql("SELECT * FROM ads_user.profile p JOIN ods_user.orders o ON p.id = o.user_id");
+
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> backendAgentQueryService.readQuery(request)
+            );
+
+            assertEquals("数据范围限制: SQL 引用了未授权 schema `ods_user`", exception.getMessage());
+        } finally {
+            AgentDataScopeContext.clear();
+        }
     }
 
     @Test

--- a/dataagent/dataagent-backend/alembic/versions/20260522_000009_add_agent_data_scope.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260522_000009_add_agent_data_scope.py
@@ -1,0 +1,56 @@
+"""add data scope to agent profiles
+
+Revision ID: 20260522_000009
+Revises: 20260522_000008
+Create Date: 2026-05-22 15:00:00
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260522_000009"
+down_revision = "20260522_000008"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(column.get("name") == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if not _has_table("da_agent_profile"):
+        return
+    if not _has_column("da_agent_profile", "data_scope_json"):
+        op.add_column(
+            "da_agent_profile",
+            sa.Column("data_scope_json", sa.Text(), nullable=True),
+        )
+
+    empty_scope = json.dumps({"allowed_scopes": []}, ensure_ascii=False, sort_keys=True)
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            UPDATE da_agent_profile
+            SET data_scope_json = :empty_scope
+            WHERE data_scope_json IS NULL OR data_scope_json = ''
+            """
+        ),
+        {"empty_scope": empty_scope},
+    )
+
+
+def downgrade() -> None:
+    if _has_table("da_agent_profile") and _has_column("da_agent_profile", "data_scope_json"):
+        op.drop_column("da_agent_profile", "data_scope_json")

--- a/dataagent/dataagent-backend/api/admin_routes.py
+++ b/dataagent/dataagent-backend/api/admin_routes.py
@@ -7,6 +7,7 @@ from core.agent_profile_service import (
     create_agent_profile,
     delete_agent_profile,
     get_agent_profile,
+    list_data_scope_options,
     list_agent_profiles,
     skill_folders_from_documents,
     update_agent_profile,
@@ -30,6 +31,7 @@ from models.schemas import (
     AdminSettingsResponse,
     AdminSettingsUpdateRequest,
     AgentCapabilitiesResponse,
+    AgentDataScopeOption,
     AgentProfile,
     AgentProfileCreateRequest,
     AgentProfileUpdateRequest,
@@ -115,6 +117,11 @@ async def get_skill_documents():
 @skills_router.get("/agents/capabilities", response_model=AgentCapabilitiesResponse)
 async def get_agent_capabilities():
     return AgentCapabilitiesResponse.model_validate(agent_capabilities(list_documents()))
+
+
+@skills_router.get("/data-scope/options", response_model=list[AgentDataScopeOption])
+async def get_data_scope_options():
+    return [AgentDataScopeOption.model_validate(item) for item in list_data_scope_options()]
 
 
 @skills_router.get("/agents", response_model=list[AgentProfile])

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -166,6 +166,8 @@ async def api_create_topic(http_request: Request, request: CreateTopicRequest | 
     store = _get_store()
     context = _request_context(http_request)
     payload = request or CreateTopicRequest()
+    if context.get("source") == "widget" and not str(payload.agent_id or "").strip():
+        raise HTTPException(status_code=400, detail="agent_id is required for widget requests")
     profile = _require_agent_profile(payload.agent_id)
     topic = store.create_topic(
         title=str(payload.title or "").strip() or "新话题",

--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -12,6 +12,7 @@ from typing import Any
 import pymysql
 
 from config import get_settings
+from core.data_scope import normalize_data_scope
 
 DEFAULT_AGENT_ID = "agent_default"
 DEFAULT_AGENT_NAME = "通用智能体"
@@ -199,6 +200,7 @@ def normalize_agent_profile_payload(
     )
     max_turns = _validate_max_turns(data.get("max_turns", base.get("max_turns") or 0))
     env_vars = _validate_env_vars(data.get("env_vars", base.get("env_vars") or {}))
+    data_scope = normalize_data_scope(data.get("data_scope", base.get("data_scope") or {}))
 
     return {
         "name": name,
@@ -210,6 +212,7 @@ def normalize_agent_profile_payload(
         "skill_folders": skill_folders,
         "max_turns": max_turns,
         "env_vars": env_vars,
+        "data_scope": data_scope,
     }
 
 
@@ -225,6 +228,7 @@ def build_agent_snapshot(profile: dict[str, Any]) -> dict[str, Any]:
         "skill_folders": _dedupe_strings(profile.get("skill_folders")),
         "max_turns": int(profile.get("max_turns") or 0),
         "env_vars": _validate_env_vars(profile.get("env_vars") or {}),
+        "data_scope": normalize_data_scope(profile.get("data_scope") or {}),
         "is_default": bool(profile.get("is_default")),
         "is_builtin": bool(profile.get("is_builtin")),
     }
@@ -264,6 +268,7 @@ def default_agent_payload() -> dict[str, Any]:
         "skill_folders": [],
         "max_turns": 0,
         "env_vars": {},
+        "data_scope": {"allowed_scopes": []},
         "is_default": True,
         "is_builtin": True,
     }
@@ -281,6 +286,7 @@ def opendataworks_agent_payload() -> dict[str, Any]:
         "skill_folders": ["opendataworks-business-knowledge", "opendataworks-platform-tools"],
         "max_turns": 0,
         "env_vars": {},
+        "data_scope": {"allowed_scopes": []},
         "is_default": False,
         "is_builtin": True,
     }
@@ -356,6 +362,7 @@ class AgentProfileStore:
             "skill_folders": _dedupe_strings(_safe_json_load(row.get("skill_folders_json"), [])),
             "max_turns": int(row.get("max_turns") or 0),
             "env_vars": _validate_env_vars(_safe_json_load(row.get("env_vars_json"), {})),
+            "data_scope": normalize_data_scope(_safe_json_load(row.get("data_scope_json"), {})),
             "is_default": bool(row.get("is_default")),
             "is_builtin": bool(row.get("is_builtin")),
             "created_at": _to_iso(row.get("created_at")),
@@ -373,7 +380,7 @@ class AgentProfileStore:
                     """
                     SELECT agent_id, name, description, system_prompt, permission_mode,
                            allowed_tools_json, mcp_server_ids_json, skill_folders_json,
-                           max_turns, env_vars_json, is_default, is_builtin, created_at, updated_at
+                           max_turns, env_vars_json, data_scope_json, is_default, is_builtin, created_at, updated_at
                     FROM da_agent_profile
                     ORDER BY is_builtin DESC, is_default DESC, updated_at DESC, created_at DESC
                     """
@@ -392,7 +399,7 @@ class AgentProfileStore:
                     """
                     SELECT agent_id, name, description, system_prompt, permission_mode,
                            allowed_tools_json, mcp_server_ids_json, skill_folders_json,
-                           max_turns, env_vars_json, is_default, is_builtin, created_at, updated_at
+                           max_turns, env_vars_json, data_scope_json, is_default, is_builtin, created_at, updated_at
                     FROM da_agent_profile
                     WHERE agent_id = %s
                     LIMIT 1
@@ -419,8 +426,8 @@ class AgentProfileStore:
                     INSERT INTO da_agent_profile (
                         agent_id, name, description, system_prompt, permission_mode,
                         allowed_tools_json, mcp_server_ids_json, skill_folders_json,
-                        max_turns, env_vars_json, is_default, is_builtin
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        max_turns, env_vars_json, data_scope_json, is_default, is_builtin
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
                         name = VALUES(name),
                         description = VALUES(description),
@@ -431,6 +438,7 @@ class AgentProfileStore:
                         skill_folders_json = VALUES(skill_folders_json),
                         max_turns = VALUES(max_turns),
                         env_vars_json = VALUES(env_vars_json),
+                        data_scope_json = VALUES(data_scope_json),
                         is_default = VALUES(is_default),
                         is_builtin = VALUES(is_builtin),
                         updated_at = CURRENT_TIMESTAMP
@@ -446,6 +454,7 @@ class AgentProfileStore:
                         _json_dump(_dedupe_strings(profile.get("skill_folders"))),
                         int(profile.get("max_turns") or 0),
                         _json_dump(_validate_env_vars(profile.get("env_vars") or {})),
+                        _json_dump(normalize_data_scope(profile.get("data_scope") or {})),
                         1 if is_default else 0,
                         1 if is_builtin else 0,
                     ),
@@ -583,6 +592,7 @@ def update_agent_profile(
     )
     normalized["agent_id"] = existing["agent_id"]
     normalized["is_default"] = bool(existing.get("is_default"))
+    normalized["is_builtin"] = bool(existing.get("is_builtin"))
     return get_agent_profile_store().save_profile(normalized)
 
 
@@ -623,3 +633,74 @@ def skill_folders_from_documents(skill_documents: list[dict[str, Any]]) -> set[s
         if folder:
             folders.add(folder)
     return folders
+
+
+def list_data_scope_options() -> list[dict[str, Any]]:
+    cfg = get_settings()
+    metadata_schema = str(cfg.mysql_database or "opendataworks").strip() or "opendataworks"
+    rows: list[dict[str, Any]] = []
+    conn = pymysql.connect(
+        host=cfg.mysql_host,
+        port=cfg.mysql_port,
+        user=cfg.mysql_user,
+        password=cfg.mysql_password,
+        database=metadata_schema,
+        charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                    dt.cluster_id,
+                    COALESCE(dc.cluster_name, '') AS cluster_name,
+                    COALESCE(NULLIF(dc.source_type, ''), 'DORIS') AS source_type,
+                    dt.db_name AS database_name
+                FROM `{metadata_schema}`.`data_table` dt
+                LEFT JOIN `{metadata_schema}`.`doris_cluster` dc
+                    ON dc.id = dt.cluster_id
+                WHERE dt.deleted = 0
+                  AND (dt.status IS NULL OR dt.status <> 'deprecated')
+                  AND dt.db_name IS NOT NULL
+                  AND dt.db_name <> ''
+                GROUP BY dt.cluster_id, dc.cluster_name, dc.source_type, dt.db_name
+                ORDER BY dc.cluster_name ASC, dt.db_name ASC
+                """
+            )
+            rows.extend(dict(item) for item in (cur.fetchall() or []))
+    finally:
+        conn.close()
+
+    platform_database = str(cfg.mysql_database or "").strip()
+    if platform_database:
+        rows.append(
+            {
+                "cluster_id": None,
+                "cluster_name": "platform-mysql",
+                "source_type": "MYSQL",
+                "database_name": platform_database,
+            }
+        )
+
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[int | None, str]] = set()
+    for row in rows:
+        database = str(row.get("database_name") or row.get("database") or "").strip()
+        if not database:
+            continue
+        cluster_id = row.get("cluster_id")
+        cluster_id = int(cluster_id) if cluster_id not in (None, "") else None
+        key = (cluster_id, database)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(
+            {
+                "cluster_id": cluster_id,
+                "cluster_name": str(row.get("cluster_name") or ""),
+                "source_type": str(row.get("source_type") or "").upper(),
+                "database": database,
+            }
+        )
+    return result

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -13,6 +13,7 @@ from typing import Any
 from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
+from core.data_scope import encode_scope_header, normalize_data_scope
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
 from core.skill_discovery import (
     prepare_enabled_skills_project_cwd,
@@ -78,6 +79,17 @@ def _build_system_prompt(
     custom_prompt = str((agent_snapshot or {}).get("system_prompt") or "").strip()
     if custom_prompt:
         lines.extend(["", "# 智能体系统提示词", custom_prompt])
+    data_scope = normalize_data_scope((agent_snapshot or {}).get("data_scope") or {})
+    scope_items = data_scope.get("allowed_scopes", [])
+    if scope_items:
+        lines.extend(["", "# 已授权数据范围"])
+        for item in scope_items:
+            cluster_text = "null" if item.get("cluster_id") is None else str(item.get("cluster_id"))
+            lines.append(
+                f"- cluster_id={cluster_text}, source_type={item.get('source_type') or ''}, database={item.get('database') or ''}"
+            )
+    else:
+        lines.extend(["", "# 已授权数据范围", "- 无。未配置数据范围时禁止访问任何元数据或查询任何数据。"])
     if database_hint:
         lines.append(f"- 用户显式提供的 database hint: {database_hint}")
     return "\n".join(lines)
@@ -251,6 +263,11 @@ def _build_runtime_env(
             "DATAAGENT_SKILL_ROOT": str(skills_root),
             "DATAAGENT_ENABLED_SKILLS": ",".join(enabled_folders),
             "DATAAGENT_ENABLED_SKILL_ROOTS": json.dumps(enabled_roots, ensure_ascii=False),
+            "DATAAGENT_DATA_SCOPE_JSON": json.dumps(
+                normalize_data_scope((getattr(params, "agent_snapshot", None) or {}).get("data_scope") or {}),
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
             "VIRTUAL_ENV": str(python_bin.parent.parent),
             "PATH": runtime_path,
             "TZ": str(os.getenv("TZ") or "Asia/Shanghai"),
@@ -292,6 +309,7 @@ def _resolve_sdk_permission_mode(permission_mode: str | None = None) -> str:
 def _build_portal_mcp_servers(
     cfg: Any,
     mcp_server_ids: list[str] | tuple[str, ...] | None = None,
+    agent_snapshot: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     selected = _dedupe_strings(mcp_server_ids)
     if mcp_server_ids is not None and PORTAL_MCP_SERVER_NAME not in selected:
@@ -309,15 +327,19 @@ def _build_portal_mcp_servers(
         str(getattr(cfg, "dataagent_portal_mcp_token_header_name", "") or "").strip()
         or "X-Portal-MCP-Token"
     )
+    headers = {
+        header_name: token,
+    }
+    if agent_snapshot is not None:
+        headers["X-Agent-Data-Scope"] = encode_scope_header((agent_snapshot or {}).get("data_scope") or {})
+
     return {
         PORTAL_MCP_SERVER_NAME: {
             "type": "http",
             # portal-mcp is mounted as a Starlette sub-app; /mcp redirects to
             # /mcp/, and Streamable HTTP clients may not follow POST redirects.
             "url": raw_url.rstrip("/") + "/",
-            "headers": {
-                header_name: token,
-            },
+            "headers": headers,
         }
     }
 

--- a/dataagent/dataagent-backend/core/data_scope.py
+++ b/dataagent/dataagent-backend/core/data_scope.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from typing import Any
+
+
+def normalize_data_scope(value: Any) -> dict[str, list[dict[str, Any]]]:
+    payload = _safe_json_load(value)
+    scopes = payload.get("allowed_scopes") if isinstance(payload, dict) else []
+    if not isinstance(scopes, list):
+        scopes = []
+
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[int | None, str, str]] = set()
+    for item in scopes:
+        if not isinstance(item, dict):
+            continue
+        database = str(item.get("database") or "").strip()
+        if not database:
+            continue
+        cluster_id = _to_optional_int(item.get("cluster_id"))
+        source_type = str(item.get("source_type") or "").strip().upper()
+        key = (cluster_id, source_type, database)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(
+            {
+                "cluster_id": cluster_id,
+                "source_type": source_type,
+                "database": database,
+            }
+        )
+    return {"allowed_scopes": result}
+
+
+def scope_allows_database(scope: Any, database: str | None, cluster_id: int | None = None) -> bool:
+    db = str(database or "").strip()
+    if not db:
+        return False
+    normalized = normalize_data_scope(scope)
+    for item in normalized.get("allowed_scopes", []):
+        if str(item.get("database") or "") != db:
+            continue
+        item_cluster_id = item.get("cluster_id")
+        if cluster_id is None or item_cluster_id is None or int(item_cluster_id) == int(cluster_id):
+            return True
+    return False
+
+
+def allowed_databases(scope: Any) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in normalize_data_scope(scope).get("allowed_scopes", []):
+        database = str(item.get("database") or "").strip()
+        if database and database not in seen:
+            result.append(database)
+            seen.add(database)
+    return result
+
+
+def current_env_scope() -> dict[str, list[dict[str, Any]]]:
+    return normalize_data_scope(os.getenv("DATAAGENT_DATA_SCOPE_JSON") or {})
+
+
+def encode_scope_header(scope: Any) -> str:
+    payload = json.dumps(normalize_data_scope(scope), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _safe_json_load(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return json.loads(value)
+        except Exception:
+            return {}
+    return {}
+
+
+def _to_optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -844,7 +844,11 @@ async def execute_task_stream(
     permission_mode = _resolve_sdk_permission_mode(str((agent_snapshot or {}).get("permission_mode") or "inherit"))
     max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]
-    mcp_servers = _build_portal_mcp_servers(cfg, (agent_snapshot or {}).get("mcp_server_ids") if agent_snapshot else None)
+    mcp_servers = _build_portal_mcp_servers(
+        cfg,
+        (agent_snapshot or {}).get("mcp_server_ids") if agent_snapshot else None,
+        agent_snapshot=agent_snapshot,
+    )
     allowed_tools = _build_allowed_tools(mcp_servers, (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None)
     options_kwargs = dict(
         system_prompt=system_prompt,

--- a/dataagent/dataagent-backend/core/tool_runtime.py
+++ b/dataagent/dataagent-backend/core/tool_runtime.py
@@ -7,11 +7,13 @@ Tool Runtime（单一路径）
 """
 
 import logging
+import os
 import time
 from typing import Any
 
 import pymysql
 
+from core.data_scope import current_env_scope, scope_allows_database
 from core.datasource_resolver import (
     DatasourceResolutionError,
     resolve_engine_for_database,
@@ -63,6 +65,7 @@ def invoke_tool(tool_name: str, payload: dict[str, Any] | None = None) -> dict[s
 def run_query(sql: str, database: str | None = None, limit: int | None = None) -> dict[str, Any]:
     if not str(database or "").strip():
         raise ToolRuntimeError("database is required")
+    _ensure_database_in_scope(str(database or "").strip())
     try:
         engine = resolve_engine_for_database(database)
     except DatasourceResolutionError as e:
@@ -84,6 +87,7 @@ def _native_mysql_query(payload: dict[str, Any]) -> dict[str, Any]:
     _ensure_read_only(sql)
 
     database = str(payload.get("database") or "").strip()
+    _ensure_database_in_scope(database)
     params = payload.get("params") or []
     limit = _to_positive_int(payload.get("limit"))
     datasource = _resolve_datasource("mysql", database)
@@ -135,6 +139,7 @@ def _native_doris_query(payload: dict[str, Any]) -> dict[str, Any]:
     _ensure_read_only(sql)
 
     database = str(payload.get("database") or "").strip()
+    _ensure_database_in_scope(database)
     limit = _to_positive_int(payload.get("limit"))
     datasource = _resolve_datasource("doris", database)
 
@@ -194,3 +199,8 @@ def _resolve_datasource(engine: str, database: str) -> Any:
         return resolve_query_datasource(engine, database)
     except DatasourceResolutionError as e:
         raise ToolRuntimeError(str(e)) from e
+
+
+def _ensure_database_in_scope(database: str) -> None:
+    if "DATAAGENT_DATA_SCOPE_JSON" in os.environ and not scope_allows_database(current_env_scope(), database):
+        raise ToolRuntimeError(f"数据范围限制: 未授权访问 database `{str(database or '').strip()}`")

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -380,6 +380,7 @@ class AgentProfileBase(BaseModel):
     skill_folders: Optional[List[str]] = None
     max_turns: Optional[int] = None
     env_vars: Optional[Dict[str, str]] = None
+    data_scope: Optional[Dict[str, Any]] = None
 
 
 class AgentProfileCreateRequest(AgentProfileBase):
@@ -410,6 +411,13 @@ class AgentCapabilitiesResponse(BaseModel):
     permission_modes: List[str] = Field(default_factory=list)
 
 
+class AgentDataScopeOption(BaseModel):
+    cluster_id: Optional[int] = None
+    cluster_name: str = ""
+    source_type: str = ""
+    database: str = ""
+
+
 class AgentProfile(BaseModel):
     agent_id: str
     name: str
@@ -422,6 +430,7 @@ class AgentProfile(BaseModel):
     skill_folders: List[str] = Field(default_factory=list)
     max_turns: int = 0
     env_vars: Dict[str, str] = Field(default_factory=dict)
+    data_scope: Dict[str, Any] = Field(default_factory=lambda: {"allowed_scopes": []})
     is_default: bool = False
     is_builtin: bool = False
     created_at: str = ""

--- a/dataagent/dataagent-backend/tests/test_agent_profile_service.py
+++ b/dataagent/dataagent-backend/tests/test_agent_profile_service.py
@@ -49,6 +49,13 @@ def test_normalize_agent_profile_payload_accepts_scoped_runtime_config():
             "skill_folders": ["opendataworks-business-knowledge"],
             "max_turns": 12,
             "env_vars": {"AGENT_SCENE": "quality"},
+            "data_scope": {
+                "allowed_scopes": [
+                    {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"},
+                    {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"},
+                    {"cluster_id": None, "source_type": "MYSQL", "database": "opendataworks"},
+                ]
+            },
         },
         available_skill_folders={"opendataworks-business-knowledge", "opendataworks-platform-tools"},
         available_mcp_server_ids={"portal"},
@@ -61,6 +68,22 @@ def test_normalize_agent_profile_payload_accepts_scoped_runtime_config():
     assert payload["skill_folders"] == ["opendataworks-business-knowledge"]
     assert payload["max_turns"] == 12
     assert payload["env_vars"] == {"AGENT_SCENE": "quality"}
+    assert payload["data_scope"] == {
+        "allowed_scopes": [
+            {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"},
+            {"cluster_id": None, "source_type": "MYSQL", "database": "opendataworks"},
+        ]
+    }
+
+
+def test_normalize_agent_profile_payload_defaults_empty_data_scope_to_deny_all():
+    payload = agent_profile_service.normalize_agent_profile_payload(
+        {"name": "无数据授权智能体"},
+        available_skill_folders=set(),
+        available_mcp_server_ids=set(),
+    )
+
+    assert payload["data_scope"] == {"allowed_scopes": []}
 
 
 def test_normalize_agent_profile_payload_rejects_reserved_environment_keys():
@@ -88,6 +111,11 @@ def test_build_agent_snapshot_keeps_runtime_fields_without_timestamps():
             "skill_folders": ["opendataworks-business-knowledge"],
             "max_turns": 8,
             "env_vars": {"AGENT_SCENE": "quality"},
+            "data_scope": {
+                "allowed_scopes": [
+                    {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"},
+                ]
+            },
             "resolved_workdir": "/tmp/agent",
             "is_default": False,
             "is_builtin": False,
@@ -107,6 +135,11 @@ def test_build_agent_snapshot_keeps_runtime_fields_without_timestamps():
         "skill_folders": ["opendataworks-business-knowledge"],
         "max_turns": 8,
         "env_vars": {"AGENT_SCENE": "quality"},
+        "data_scope": {
+            "allowed_scopes": [
+                {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"},
+            ]
+        },
         "is_default": False,
         "is_builtin": False,
     }

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -127,15 +127,44 @@ def test_build_portal_mcp_servers_returns_http_config():
         dataagent_portal_mcp_token_header_name="X-Portal-MCP-Token",
     )
 
-    actual = agent_runtime._build_portal_mcp_servers(cfg)
+    actual = agent_runtime._build_portal_mcp_servers(
+        cfg,
+        agent_snapshot={
+            "data_scope": {
+                "allowed_scopes": [
+                    {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"}
+                ]
+            }
+        },
+    )
 
     assert actual == {
         "portal": {
             "type": "http",
             "url": "http://portal-mcp:8801/mcp/",
-            "headers": {"X-Portal-MCP-Token": "portal-token"},
+            "headers": {
+                "X-Portal-MCP-Token": "portal-token",
+                "X-Agent-Data-Scope": "eyJhbGxvd2VkX3Njb3BlcyI6W3siY2x1c3Rlcl9pZCI6MywiZGF0YWJhc2UiOiJhZHNfdXNlciIsInNvdXJjZV90eXBlIjoiRE9SSVMifV19",
+            },
         }
     }
+
+
+def test_build_system_prompt_includes_authorized_data_scope():
+    prompt = agent_runtime._build_system_prompt(
+        None,
+        {"enabled_folders": ["opendataworks-platform-tools"]},
+        {
+            "data_scope": {
+                "allowed_scopes": [
+                    {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"}
+                ]
+            }
+        },
+    )
+
+    assert "已授权数据范围" in prompt
+    assert "cluster_id=3, source_type=DORIS, database=ads_user" in prompt
 
 
 def test_build_portal_mcp_servers_returns_empty_when_disabled_or_incomplete():

--- a/dataagent/dataagent-backend/tests/test_sql_executor.py
+++ b/dataagent/dataagent-backend/tests/test_sql_executor.py
@@ -21,3 +21,14 @@ from core.sql_executor import execute_sql
 def test_execute_sql_requires_explicit_database():
     result = execute_sql("SELECT 1", database=None)
     assert result.error == "未提供目标 database，请让 Skill 或调用方显式指定库名"
+
+
+def test_execute_sql_rejects_database_outside_runtime_data_scope(monkeypatch):
+    monkeypatch.setenv(
+        "DATAAGENT_DATA_SCOPE_JSON",
+        '{"allowed_scopes":[{"cluster_id":3,"source_type":"DORIS","database":"ads_user"}]}',
+    )
+
+    result = execute_sql("SELECT 1", database="ods_user")
+
+    assert "数据范围限制" in result.error

--- a/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
+++ b/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
@@ -49,12 +49,12 @@ class FakeTopicStore:
     def init_schema(self):
         self.calls.append(("init_schema", None))
 
-    def create_topic(self, title="新话题", *, context=None):
-        self.calls.append(("create_topic", context))
+    def create_topic(self, title="新话题", *, agent_snapshot=None, context=None):
+        self.calls.append(("create_topic", context, agent_snapshot))
         return topic_payload("topic-created", title)
 
-    def list_topics(self, include_messages=False, *, context=None):
-        self.calls.append(("list_topics", context))
+    def list_topics(self, include_messages=False, *, context=None, agent_id=None):
+        self.calls.append(("list_topics", context, agent_id))
         return [topic_payload("topic-widget")]
 
     def get_topic(self, topic_id, *, context=None):
@@ -137,6 +137,28 @@ def install_widget_settings(monkeypatch):
     )
 
 
+def install_agent_profile(monkeypatch, agent_id="agent_widget"):
+    profile = {
+        "agent_id": agent_id,
+        "name": "Widget Agent",
+        "description": "",
+        "system_prompt": "",
+        "permission_mode": "inherit",
+        "allowed_tools": ["Read"],
+        "mcp_server_ids": [],
+        "skill_folders": [],
+        "max_turns": 0,
+        "env_vars": {},
+        "data_scope": {
+            "allowed_scopes": [
+                {"cluster_id": 3, "source_type": "DORIS", "database": "ads_user"}
+            ]
+        },
+    }
+    monkeypatch.setattr(routes, "get_agent_profile", lambda requested_agent_id: profile if requested_agent_id == agent_id else None)
+    return profile
+
+
 def widget_headers(user_id="u1", *, origin="https://host.example.com", visitor_id=""):
     headers = {
         "Origin": origin,
@@ -179,15 +201,66 @@ def test_widget_requests_pass_website_and_user_context_to_unified_routes(monkeyp
     assert context["visitor_id"] == ""
 
 
+def test_widget_topic_list_passes_agent_filter(monkeypatch):
+    install_widget_settings(monkeypatch)
+    store = install_fake_store(monkeypatch)
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/nl2sql/topics?agent_id=agent_widget",
+        headers=widget_headers("user-123"),
+    )
+
+    assert response.status_code == 200
+    assert store.calls[-1][0] == "list_topics"
+    assert store.calls[-1][2] == "agent_widget"
+
+
+def test_widget_topic_create_requires_explicit_agent_id(monkeypatch):
+    install_widget_settings(monkeypatch)
+    install_agent_profile(monkeypatch)
+    install_fake_store(monkeypatch)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/nl2sql/topics",
+        headers=widget_headers("user-123"),
+        json={"title": "Widget 会话"},
+    )
+
+    assert response.status_code == 400
+    assert "agent_id" in response.json()["detail"]
+
+
+def test_widget_topic_create_uses_requested_agent_snapshot(monkeypatch):
+    install_widget_settings(monkeypatch)
+    profile = install_agent_profile(monkeypatch, "agent_widget")
+    store = install_fake_store(monkeypatch)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/nl2sql/topics",
+        headers=widget_headers("user-123"),
+        json={"title": "Widget 会话", "agent_id": "agent_widget"},
+    )
+
+    assert response.status_code == 200
+    assert store.calls[-1][0] == "create_topic"
+    agent_snapshot = store.calls[-1][2]
+    assert agent_snapshot["agent_id"] == profile["agent_id"]
+    assert agent_snapshot["data_scope"]["allowed_scopes"] == profile["data_scope"]["allowed_scopes"]
+
+
 def test_widget_requests_fall_back_to_visitor_context_without_user_id(monkeypatch):
     install_widget_settings(monkeypatch)
+    install_agent_profile(monkeypatch)
     store = install_fake_store(monkeypatch)
     client = TestClient(app)
 
     response = client.post(
         "/api/v1/nl2sql/topics",
         headers=widget_headers("", visitor_id="visitor-abc"),
-        json={"title": "匿名访客"},
+        json={"title": "匿名访客", "agent_id": "agent_widget"},
     )
 
     assert response.status_code == 200

--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -11,6 +11,7 @@ from starlette.routing import Mount, Route
 
 from .backend_client import BackendApiClient
 from .config import Settings, load_settings
+from .scope_context import set_data_scope_header
 from .service import PortalToolService
 
 
@@ -105,7 +106,11 @@ class FrontDoorTokenMiddleware:
             await _send_json(scope, receive, send, 401, {"success": False, "message": "portal mcp token 无效"})
             return
 
-        await self.app(scope, receive, send)
+        reset_scope = set_data_scope_header(headers.get("x-agent-data-scope", ""))
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_scope()
 
 
 def build_mcp_server(service: PortalToolService) -> FastMCP:

--- a/dataagent/portal-mcp/portal_mcp/backend_client.py
+++ b/dataagent/portal-mcp/portal_mcp/backend_client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 
 from .config import Settings
+from .scope_context import get_data_scope_header
 
 
 class BackendApiError(RuntimeError):
@@ -48,6 +49,9 @@ class BackendApiClient:
             "Accept": "application/json",
             self.settings.backend_token_header_name: self.settings.backend_service_token,
         }
+        data_scope = get_data_scope_header()
+        if data_scope:
+            headers["X-Agent-Data-Scope"] = data_scope
         timeout = httpx.Timeout(self.settings.backend_timeout_seconds)
         async with httpx.AsyncClient(timeout=timeout) as client:
             try:

--- a/dataagent/portal-mcp/portal_mcp/scope_context.py
+++ b/dataagent/portal-mcp/portal_mcp/scope_context.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Callable
+
+
+_data_scope_header: ContextVar[str] = ContextVar("data_scope_header", default="")
+
+
+def get_data_scope_header() -> str:
+    return _data_scope_header.get("")
+
+
+def set_data_scope_header(value: str | None) -> Callable[[], None]:
+    token = _data_scope_header.set(str(value or "").strip())
+
+    def reset() -> None:
+        _data_scope_header.reset(token)
+
+    return reset

--- a/dataagent/portal-mcp/tests/test_backend_client.py
+++ b/dataagent/portal-mcp/tests/test_backend_client.py
@@ -12,6 +12,7 @@ if str(SERVICE_ROOT) not in sys.path:
 
 from portal_mcp.backend_client import BackendApiClient, BackendApiError
 from portal_mcp.config import Settings
+from portal_mcp.scope_context import set_data_scope_header
 
 
 def _settings() -> Settings:
@@ -40,6 +41,7 @@ class _FakeAsyncClient:
         return False
 
     async def request(self, *args, **kwargs):
+        self.last_kwargs = kwargs
         if self._error is not None:
             raise self._error
         return self._response
@@ -105,3 +107,19 @@ async def test_backend_client_maps_request_error(monkeypatch):
 
     with pytest.raises(BackendApiError, match="backend agent api 不可达"):
         await client.inspect(database="dw")
+
+
+@pytest.mark.anyio
+async def test_backend_client_forwards_agent_data_scope_header(monkeypatch):
+    fake_client = _FakeAsyncClient(response=_response(200, json_payload={"ok": True}))
+    monkeypatch.setattr(
+        "portal_mcp.backend_client.httpx.AsyncClient",
+        lambda **kwargs: fake_client,
+    )
+    reset = set_data_scope_header("encoded-scope")
+    try:
+        await BackendApiClient(_settings()).inspect(database="dw")
+    finally:
+        reset()
+
+    assert fake_client.last_kwargs["headers"]["X-Agent-Data-Scope"] == "encoded-scope"

--- a/docs/design/2026-04-29-intelligent-query-widget-design.md
+++ b/docs/design/2026-04-29-intelligent-query-widget-design.md
@@ -16,6 +16,7 @@ External Vue + Spring Boot projects need to embed intelligent query with a singl
   src="https://odw.example.com/widget/opendataworks-widget.bundle.js"
   data-display-mode="floating"
   data-website-id="your-project"
+  data-agent-id="agent_widget"
   data-user-id="USER_123"
   data-project-name="Your Project"
   data-project-color="#4A90A4"
@@ -34,6 +35,7 @@ Some host systems also need to place intelligent query inside a normal applicati
   data-display-mode="inline"
   data-container-id="odw-intelligent-query"
   data-website-id="your-project"
+  data-agent-id="agent_widget"
   data-user-id="USER_123"
   data-project-name="Your Project"
   data-project-color="#4A90A4"
@@ -95,6 +97,8 @@ Widget calls add these headers:
 - `X-ODW-Website-Id: <website_id>`
 - `X-ODW-User-Id: <business_user_id>`
 - `X-ODW-Visitor-Id: <generated_visitor_id>` when no user id is provided
+
+Widget runtime payloads also include `agent_id` from the embedding script's `data-agent-id`. Widget topic creation requires this value so the selected DataAgent profile snapshot, including its `data_scope`, is stored on the topic. Widget topic listing and message delivery pass the same `agent_id` to keep history filtering and task validation aligned with the selected agent.
 
 Portal calls send no widget headers and remain `source=portal`.
 

--- a/docs/design/2026-05-22-agent-data-scope-design.md
+++ b/docs/design/2026-05-22-agent-data-scope-design.md
@@ -1,0 +1,55 @@
+# Agent Data Scope Design
+
+**Date:** 2026-05-22
+**Goal:** Add strong per-agent data access boundaries for DataAgent metadata and read-only query paths.
+
+## Current State
+
+Agent profiles currently scope prompts, tools, skills, MCP services, max turns, and environment variables. They do not scope data access. Portal MCP and local SQL tools can resolve metadata or execute read-only SQL for any database reachable through the platform metadata and configured credentials.
+
+## Problem
+
+Administrators need each agent to have an explicit allowed data range. The range must be enforced by runtime and backend boundaries, not just by prompt instructions. An empty range must deny access.
+
+## Solution
+
+Add `data_scope_json` to `da_agent_profile`. The API field is `data_scope`:
+
+```json
+{
+  "allowed_scopes": [
+    {
+      "cluster_id": 3,
+      "source_type": "DORIS",
+      "database": "ads_user"
+    }
+  ]
+}
+```
+
+The first version supports datasource/schema scope only. Empty or missing `allowed_scopes` means no data is authorized. The profile snapshot copied to topics and tasks includes the same scope so historical conversations keep their original authorization.
+
+DataAgent injects scope into runtime context and Portal MCP HTTP headers. Portal MCP forwards the scope header to the Java Agent API. Java Agent API parses the scope from a request-scoped context and applies it to metadata lookup, datasource resolution, and read-only query execution.
+
+Non-portal entrypoints must bind to an explicit agent before they can reach data. The embeddable widget reads `data-agent-id` from the script tag and sends that `agent_id` when creating topics, listing agent-scoped topics, and delivering messages. Online evaluation runners require `--agent-id` or `DATAAGENT_EVAL_AGENT_ID` for non-dry-run executions and include it in topic/task payloads.
+
+## Interfaces
+
+- `GET /api/v1/dataagent/data-scope/options`: returns selectable datasource/schema options for the Agent detail UI.
+- Agent profile create/update/list/detail responses include `data_scope`.
+- Widget script config includes required `data-agent-id`; widget payloads include `agent_id`.
+- Evaluation runners expose required non-dry-run `--agent-id` and `DATAAGENT_EVAL_AGENT_ID`.
+- Portal MCP forwards `X-Agent-Data-Scope`, a base64url-encoded JSON `data_scope` payload.
+- Local tool runtime reads `DATAAGENT_DATA_SCOPE_JSON` and denies databases not present in `allowed_scopes`.
+
+## Enforcement
+
+- Metadata search, export, DDL, lineage, datasource resolution, and query execution must require a non-empty allowed scope.
+- Global metadata search with no database is narrowed to the allowed scopes.
+- Query execution rejects request databases outside the scope before datasource resolution.
+- SQL parsing rejects explicit references to schemas outside the allowed set.
+- Prompt text lists authorized scopes only as user-visible guidance; it is not trusted for enforcement.
+
+## Verification
+
+Focused pytest, Vitest, and Maven tests cover profile normalization, runtime header injection, local SQL rejection, Portal MCP forwarding, frontend scope editing, and Java query scope rejection.

--- a/docs/plans/2026-05-22-agent-data-scope-plan.md
+++ b/docs/plans/2026-05-22-agent-data-scope-plan.md
@@ -1,0 +1,33 @@
+# Agent Data Scope Implementation Plan
+
+**Goal:** Enforce per-agent datasource/schema authorization across DataAgent local tools, Portal MCP, Java Agent API metadata, and read-only query paths.
+
+## Tasks
+
+1. Add DataAgent `data_scope` validation, persistence, snapshotting, and Alembic migration for `da_agent_profile.data_scope_json`.
+2. Add `GET /api/v1/dataagent/data-scope/options` to return distinct platform datasource/schema options.
+3. Propagate scope into runtime env, system prompt, and Portal MCP `X-Agent-Data-Scope` header.
+4. Make local SQL execution reject databases outside `DATAAGENT_DATA_SCOPE_JSON`.
+5. Add Portal MCP request scope context and forward `X-Agent-Data-Scope` to backend Agent API.
+6. Add Java Agent API request scope context and enforce it in metadata and query services.
+7. Add Agent detail/list UI for selectable data scopes and persist `data_scope`.
+8. Require explicit agent binding for widget and online evaluation entrypoints so they cannot accidentally run through an empty-scope default agent.
+9. Run focused backend, portal-mcp, frontend, Java, widget, and evaluation tests; report any unavailable end-to-end smoke coverage.
+
+## Verification Commands
+
+```bash
+cd dataagent/dataagent-backend
+./.venv-py313/bin/python -m pytest tests/test_agent_profile_service.py tests/test_agent_runtime.py tests/test_sql_executor.py tests/test_admin_routes.py -q
+
+cd dataagent/portal-mcp
+python -m pytest tests/test_backend_client.py tests/test_app.py -q
+
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use
+npm --prefix frontend run test -- AgentDetailView AgentStudio
+npm --prefix frontend run test -- widget
+
+python -m pytest tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py -q
+
+mvn -f backend/pom.xml -Dtest=BackendAgentQueryServiceTest,BackendAgentMetadataServiceTest test
+```

--- a/frontend/src/api/dataagent.js
+++ b/frontend/src/api/dataagent.js
@@ -87,5 +87,9 @@ export const dataagentApi = {
 
   getAgentCapabilities() {
     return dataagentRequest.get('/v1/dataagent/agents/capabilities')
+  },
+
+  listDataScopeOptions() {
+    return dataagentRequest.get('/v1/dataagent/data-scope/options')
   }
 }

--- a/frontend/src/views/intelligence/AgentDetailView.vue
+++ b/frontend/src/views/intelligence/AgentDetailView.vue
@@ -82,6 +82,31 @@
           <el-input v-model="envVarsText" type="textarea" :rows="6" />
         </el-form-item>
       </section>
+
+      <section class="agent-section">
+        <h3>数据范围</h3>
+        <el-form-item label="允许访问的 Schema">
+          <el-select
+            v-model="scopeSelection"
+            multiple
+            filterable
+            collapse-tags
+            collapse-tags-tooltip
+            placeholder="选择数据源 Schema"
+          >
+            <el-option
+              v-for="option in dataScopeOptions"
+              :key="scopeKey(option)"
+              :label="scopeLabel(option)"
+              :value="scopeKey(option)"
+            />
+          </el-select>
+        </el-form-item>
+        <div v-if="!scopeSelection.length" class="scope-empty">无可访问数据范围</div>
+        <div v-else class="scope-list">
+          <span v-for="key in scopeSelection" :key="key">{{ scopeLabel(scopeOptionByKey[key]) }}</span>
+        </div>
+      </section>
     </el-form>
   </section>
 </template>
@@ -98,6 +123,8 @@ const router = useRouter()
 const loading = ref(false)
 const saving = ref(false)
 const envVarsText = ref('{}')
+const dataScopeOptions = ref([])
+const scopeSelection = ref([])
 
 const capabilities = reactive({
   tools: [],
@@ -118,10 +145,29 @@ const form = reactive({
   skill_folders: [],
   max_turns: 0,
   env_vars: {},
+  data_scope: { allowed_scopes: [] },
   is_default: false
 })
 
 const agentId = computed(() => String(route.params.agentId || ''))
+const scopeOptionByKey = computed(() => {
+  const map = {}
+  for (const option of dataScopeOptions.value) {
+    map[scopeKey(option)] = option
+  }
+  for (const item of form.data_scope?.allowed_scopes || []) {
+    map[scopeKey(item)] = map[scopeKey(item)] || item
+  }
+  return map
+})
+
+const scopeKey = (scope) => `${scope?.cluster_id ?? 'platform'}::${scope?.database || ''}`
+const scopeLabel = (scope) => {
+  if (!scope) return ''
+  const cluster = scope.cluster_name || (scope.cluster_id == null ? 'platform-mysql' : `cluster_id=${scope.cluster_id}`)
+  const source = scope.source_type || '-'
+  return `${cluster} / ${source} / ${scope.database || ''}`
+}
 
 const applyAgent = (agent) => {
   Object.assign(form, {
@@ -136,17 +182,22 @@ const applyAgent = (agent) => {
     skill_folders: Array.isArray(agent?.skill_folders) ? [...agent.skill_folders] : [],
     max_turns: Number(agent?.max_turns || 0),
     env_vars: agent?.env_vars && typeof agent.env_vars === 'object' ? { ...agent.env_vars } : {},
+    data_scope: agent?.data_scope && typeof agent.data_scope === 'object'
+      ? { allowed_scopes: Array.isArray(agent.data_scope.allowed_scopes) ? [...agent.data_scope.allowed_scopes] : [] }
+      : { allowed_scopes: [] },
     is_default: Boolean(agent?.is_default)
   })
   envVarsText.value = JSON.stringify(form.env_vars || {}, null, 2)
+  scopeSelection.value = (form.data_scope.allowed_scopes || []).map(scopeKey)
 }
 
 const loadDetail = async () => {
   loading.value = true
   try {
-    const [agent, caps] = await Promise.all([
+    const [agent, caps, scopeOptions] = await Promise.all([
       dataagentApi.getAgent(agentId.value),
-      dataagentApi.getAgentCapabilities()
+      dataagentApi.getAgentCapabilities(),
+      dataagentApi.listDataScopeOptions()
     ])
     Object.assign(capabilities, {
       tools: caps?.tools || [],
@@ -154,6 +205,7 @@ const loadDetail = async () => {
       skills: caps?.skills || [],
       permission_modes: caps?.permission_modes || capabilities.permission_modes
     })
+    dataScopeOptions.value = Array.isArray(scopeOptions) ? scopeOptions : []
     applyAgent(agent)
   } finally {
     loading.value = false
@@ -179,7 +231,17 @@ const buildPayload = () => {
     mcp_server_ids: [...form.mcp_server_ids],
     skill_folders: [...form.skill_folders],
     max_turns: Number(form.max_turns || 0),
-    env_vars: envVars
+    env_vars: envVars,
+    data_scope: {
+      allowed_scopes: scopeSelection.value
+        .map((key) => scopeOptionByKey.value[key])
+        .filter(Boolean)
+        .map((scope) => ({
+          cluster_id: scope.cluster_id ?? null,
+          source_type: scope.source_type || '',
+          database: scope.database || ''
+        }))
+    }
   }
 }
 
@@ -265,6 +327,25 @@ onMounted(loadDetail)
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 6px 12px;
+}
+
+.scope-empty {
+  color: #b42318;
+  font-size: 13px;
+}
+
+.scope-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.scope-list span {
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: #eef4ff;
+  color: #344054;
+  font-size: 12px;
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/views/intelligence/AgentStudio.vue
+++ b/frontend/src/views/intelligence/AgentStudio.vue
@@ -31,6 +31,7 @@
           <span>{{ agent.skill_folders?.length || 0 }} Skills</span>
           <span>{{ agent.allowed_tools?.length || 0 }} 工具</span>
           <span>{{ agent.mcp_server_ids?.length || 0 }} MCP</span>
+          <span>{{ agent.data_scope?.allowed_scopes?.length || 0 }} Schema</span>
         </div>
 
         <div class="agent-workdir">{{ agent.resolved_workdir || '-' }}</div>
@@ -88,7 +89,8 @@ const handleCreate = async () => {
       mcp_server_ids: [],
       skill_folders: [],
       max_turns: 0,
-      env_vars: {}
+      env_vars: {},
+      data_scope: { allowed_scopes: [] }
     })
     await router.push({
       name: 'IntelligentQueryAgentDetail',

--- a/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
@@ -8,6 +8,7 @@ const routeState = vi.hoisted(() => ({
 const dataagentApi = vi.hoisted(() => ({
   getAgent: vi.fn(),
   getAgentCapabilities: vi.fn(),
+  listDataScopeOptions: vi.fn(),
   updateAgent: vi.fn()
 }))
 
@@ -91,8 +92,15 @@ describe('AgentDetailView', () => {
       skill_folders: ['marketing-insights'],
       max_turns: 12,
       env_vars: { SAFE_FLAG: '1' },
+      data_scope: {
+        allowed_scopes: [{ cluster_id: 3, source_type: 'DORIS', database: 'ads_user' }]
+      },
       is_default: false
     })
+    dataagentApi.listDataScopeOptions.mockResolvedValue([
+      { cluster_id: 3, cluster_name: 'cluster-a', source_type: 'DORIS', database: 'ads_user' },
+      { cluster_id: 4, cluster_name: 'cluster-b', source_type: 'DORIS', database: 'ods_user' }
+    ])
     dataagentApi.getAgentCapabilities.mockResolvedValue({
       tools: ['Skill', 'Read', 'Bash'],
       mcp_servers: [{ id: 'portal', name: 'Portal MCP', enabled: true, tool_names: [] }],
@@ -123,8 +131,23 @@ describe('AgentDetailView', () => {
       'agent_1',
       expect.objectContaining({
         name: '营销分析 Plus',
-        env_vars: { SAFE_FLAG: '1' }
+        env_vars: { SAFE_FLAG: '1' },
+        data_scope: {
+          allowed_scopes: [{ cluster_id: 3, source_type: 'DORIS', database: 'ads_user' }]
+        }
       })
     )
+  })
+
+  it('loads data scope options and renders current authorization', async () => {
+    const wrapper = shallowMount(AgentDetailView, { global: { stubs } })
+
+    await flushPromises()
+
+    expect(dataagentApi.listDataScopeOptions).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.scopeSelection).toEqual(['3::ads_user'])
+    expect(wrapper.vm.buildPayload().data_scope.allowed_scopes).toEqual([
+      { cluster_id: 3, source_type: 'DORIS', database: 'ads_user' }
+    ])
   })
 })

--- a/frontend/src/views/intelligence/__tests__/AgentStudio.spec.js
+++ b/frontend/src/views/intelligence/__tests__/AgentStudio.spec.js
@@ -49,6 +49,7 @@ describe('AgentStudio', () => {
         allowed_tools: ['Skill', 'Read'],
         mcp_server_ids: ['portal'],
         skill_folders: ['dataagent-nl2sql'],
+        data_scope: { allowed_scopes: [{ cluster_id: 3, database: 'ads_user', source_type: 'DORIS' }] },
         is_default: true,
         is_builtin: true
       }
@@ -64,6 +65,7 @@ describe('AgentStudio', () => {
     expect(wrapper.text()).toContain('默认智能问数助手')
     expect(wrapper.text()).toContain('/tmp/default')
     expect(wrapper.text()).toContain('1 Skills')
+    expect(wrapper.text()).toContain('1 Schema')
     expect(wrapper.text()).toContain('内置')
   })
 

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -15,7 +15,7 @@
           <div class="query-brand">智能问数</div>
           <div class="query-brand-meta">数据分析</div>
         </div>
-        <button class="query-btn-new" type="button" data-testid="new-conversation" :disabled="isBusy" @click="newConversation">
+        <button class="query-btn-new" type="button" data-testid="new-conversation" :disabled="isBusy || !hasAgentId" @click="newConversation">
           新建
         </button>
       </div>
@@ -78,7 +78,7 @@
                 :key="suggestion"
                 class="query-suggestion"
                 type="button"
-                :disabled="isBusy"
+                :disabled="isBusy || !hasAgentId"
                 @click="handleSuggestion(suggestion)"
               >
                 {{ suggestion }}
@@ -171,7 +171,7 @@
               v-model="inputText"
               class="query-textarea"
               rows="1"
-              :disabled="!providers.length || !availableModels.length"
+              :disabled="!hasAgentId || !providers.length || !availableModels.length"
               placeholder="例如：查询最近 30 天工作流发布次数趋势"
               @keydown.ctrl.enter.prevent="send"
               @keydown.meta.enter.prevent="send"
@@ -282,10 +282,13 @@ const providers = ref([])
 const selectedProvider = ref('')
 const selectedModel = ref('')
 const hydratedTopicIds = new Set()
+const missingAgentMessage = 'Widget 缺少 data-agent-id 配置'
 
 const isInline = computed(() => props.config.displayMode === 'inline')
 const historyVisible = computed(() => isInline.value || Boolean(props.state.historyOpen))
 const isBusy = computed(() => isSubmitting.value || Boolean(activeTaskId.value))
+const agentId = computed(() => String(props.config.agentId || '').trim())
+const hasAgentId = computed(() => Boolean(agentId.value))
 const activeTopic = computed(() => topics.value.find((topic) => topic.topic_id === topicId.value) || null)
 const activeProviderConfig = computed(() => (
   providers.value.find((provider) => provider.provider_id === selectedProvider.value)
@@ -302,6 +305,7 @@ const availableModels = computed(() => {
 const canSend = computed(() => (
   Boolean(inputText.value.trim())
   && !isBusy.value
+  && hasAgentId.value
   && Boolean(selectedProvider.value)
   && Boolean(selectedModel.value)
 ))
@@ -422,8 +426,15 @@ const loadTopicMessages = async (targetTopicId) => {
 }
 
 const loadTopics = async () => {
+  if (!hasAgentId.value) {
+    errorText.value = missingAgentMessage
+    emit('event', { name: 'error', payload: errorText.value })
+    topics.value = []
+    messages.value = []
+    return
+  }
   try {
-    const list = await api.topicApi.listTopics()
+    const list = await api.topicApi.listTopics({ agent_id: agentId.value })
     topics.value = (Array.isArray(list) ? list : []).map(normalizeTopic).filter((topic) => topic.topic_id)
     sortTopics()
     const nextTopicId = topicId.value || topics.value[0]?.topic_id || ''
@@ -433,6 +444,13 @@ const loadTopics = async () => {
     topics.value = []
     messages.value = []
   }
+}
+
+const ensureAgentConfigured = () => {
+  if (hasAgentId.value) return true
+  errorText.value = missingAgentMessage
+  emit('event', { name: 'error', payload: errorText.value })
+  return false
 }
 
 const guardIdle = () => {
@@ -455,10 +473,11 @@ const selectTopic = async (targetTopicId) => {
 }
 
 const newConversation = async () => {
+  if (!ensureAgentConfigured()) return
   if (!guardIdle()) return
   errorText.value = ''
   searchKeyword.value = ''
-  const topic = normalizeTopic(await api.topicApi.createTopic('Widget 会话'))
+  const topic = normalizeTopic(await api.topicApi.createTopic('Widget 会话', { agent_id: agentId.value }))
   if (!topic.topic_id) return
   topics.value = [topic, ...topics.value.filter((item) => item.topic_id !== topic.topic_id)]
   topicId.value = topic.topic_id
@@ -479,8 +498,9 @@ const deleteConversation = async (targetTopicId) => {
 }
 
 const ensureTopic = async (title) => {
+  if (!ensureAgentConfigured()) return ''
   if (topicId.value) return topicId.value
-  const topic = normalizeTopic(await api.topicApi.createTopic(title || 'Widget 会话'))
+  const topic = normalizeTopic(await api.topicApi.createTopic(title || 'Widget 会话', { agent_id: agentId.value }))
   if (!topic.topic_id) return ''
   topics.value = [topic, ...topics.value.filter((item) => item.topic_id !== topic.topic_id)]
   topicId.value = topic.topic_id
@@ -566,6 +586,7 @@ const updateActiveTopicAfterSend = (text, taskId) => {
 const send = async () => {
   const text = inputText.value.trim()
   if (!text || isBusy.value) return
+  if (!ensureAgentConfigured()) return
   isSubmitting.value = true
   inputText.value = ''
   errorText.value = ''
@@ -579,6 +600,7 @@ const send = async () => {
       content: text,
       provider_id: selectedProvider.value,
       model: selectedModel.value,
+      agent_id: agentId.value,
       debug: false,
       execution_mode: 'auto'
     })

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -30,6 +30,7 @@ vi.mock('@/api/nl2sql', () => ({
 const baseConfig = {
   displayMode: 'floating',
   projectColor: '#4A90A4',
+  agentId: 'agent_widget',
   headers: {
     'X-ODW-Client': 'widget',
     'X-ODW-Website-Id': 'demo',
@@ -135,6 +136,7 @@ describe('WidgetChat history conversations', () => {
     expect(apiMocks.createClient).toHaveBeenCalledWith(expect.objectContaining({
       defaultHeaders: baseConfig.headers
     }))
+    expect(apiMocks.topicApi.listTopics).toHaveBeenCalledWith({ agent_id: 'agent_widget' })
     expect(apiMocks.topicApi.getTopicMessages).toHaveBeenCalledWith('topic-1', { page: 1, page_size: 200, order: 'asc' })
   })
 
@@ -152,10 +154,21 @@ describe('WidgetChat history conversations', () => {
 
     await wrapper.get('[data-testid="new-conversation"]').trigger('click')
     await flushPromises()
-    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('Widget 会话')
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('Widget 会话', { agent_id: 'agent_widget' })
     expect(wrapper.text()).toContain('Widget 会话')
     expect(wrapper.text()).toContain('请输入你的数据问题')
     expect(apiMocks.topicApi.deleteTopic).not.toHaveBeenCalled()
+  })
+
+  it('shows a configuration error when the embedding script omits agent id', async () => {
+    const { wrapper } = mountChat({ config: { agentId: '', displayMode: 'inline' } })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Widget 缺少 data-agent-id 配置')
+    expect(wrapper.get('[data-testid="new-conversation"]').attributes('disabled')).toBeDefined()
+    expect(apiMocks.topicApi.listTopics).not.toHaveBeenCalled()
+    expect(apiMocks.topicApi.createTopic).not.toHaveBeenCalled()
   })
 
   it('renders floating as a compact portal-style panel with a history drawer and no delete actions', async () => {
@@ -201,5 +214,8 @@ describe('WidgetChat history conversations', () => {
     await flushPromises()
 
     expect(wrapper.findAll('.query-main-text').some((item) => item.text().includes('smoke-ok'))).toBe(true)
+    expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledWith(expect.objectContaining({
+      agent_id: 'agent_widget'
+    }))
   })
 })

--- a/frontend/src/widget/__tests__/config.spec.js
+++ b/frontend/src/widget/__tests__/config.spec.js
@@ -11,11 +11,13 @@ describe('parseWidgetConfig', () => {
     script.dataset.projectName = 'Demo Project'
     script.dataset.projectColor = '#4A90A4'
     script.dataset.apiBaseUrl = 'https://odw.example.com/'
+    script.dataset.agentId = 'agent_widget'
 
     const config = parseWidgetConfig(script)
 
     expect(config.websiteId).toBe('demo')
     expect(config.userId).toBe('user-123')
+    expect(config.agentId).toBe('agent_widget')
     expect(config.projectName).toBe('Demo Project')
     expect(config.projectColor).toBe('#4A90A4')
     expect(config.apiBaseUrl).toBe('https://odw.example.com')

--- a/frontend/src/widget/config.js
+++ b/frontend/src/widget/config.js
@@ -36,6 +36,7 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
   const dataset = script?.dataset || {}
   const websiteId = String(dataset.websiteId || '').trim()
   const userId = String(dataset.userId || '').trim()
+  const agentId = String(dataset.agentId || '').trim()
   const visitorId = userId ? '' : resolveVisitorId(websiteId)
   const apiBaseUrl = trimTrailingSlash(dataset.apiBaseUrl || (script?.src ? new URL(script.src, window.location.href).origin : ''))
   const projectName = String(dataset.projectName || DEFAULT_PROJECT_NAME).trim() || DEFAULT_PROJECT_NAME
@@ -57,6 +58,7 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
   return {
     websiteId,
     userId,
+    agentId,
     visitorId,
     projectName,
     projectColor,

--- a/scripts/run-dataagent-deepeval-evals.sh
+++ b/scripts/run-dataagent-deepeval-evals.sh
@@ -18,6 +18,7 @@ Common options are passed through to the container:
   --dataset <path>       Required private JSONL dataset path
   --output-dir <path>
   --case <case_id>
+  --agent-id <agent_id> Required for non-dry-run evaluation
   --provider-id <provider_id>
   --model <model>
   --timeout-seconds <seconds>
@@ -36,6 +37,7 @@ Environment:
   DATAAGENT_EVAL_JUDGE_MODEL
   DATAAGENT_EVAL_JUDGE_MAX_TOKENS
   DATAAGENT_EVAL_DATASET
+  DATAAGENT_EVAL_AGENT_ID
   DATAAGENT_DEEPEVAL_RUN_LOCAL=1  Run local Python instead of Docker/Podman.
 EOF
 }
@@ -82,6 +84,7 @@ exec "$CONTAINER_CMD" run --rm \
     -e DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS="${DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS:-120}" \
     -e DATAAGENT_EVAL_JUDGE_MAX_TOKENS="${DATAAGENT_EVAL_JUDGE_MAX_TOKENS:-4096}" \
     -e DATAAGENT_EVAL_DATASET="${DATAAGENT_EVAL_DATASET:-}" \
+    -e DATAAGENT_EVAL_AGENT_ID="${DATAAGENT_EVAL_AGENT_ID:-}" \
     "${VOLUMES[@]}" \
     -w /workspace \
     "$IMAGE" "$@"

--- a/scripts/run-dataagent-evals.sh
+++ b/scripts/run-dataagent-evals.sh
@@ -18,6 +18,7 @@ Common options are passed through to the container:
   --dataset <path>       Required private JSONL dataset path
   --output-dir <path>
   --case <case_id>
+  --agent-id <agent_id> Required for non-dry-run evaluation
   --provider-id <provider_id>
   --model <model>
   --timeout-seconds <seconds>
@@ -36,6 +37,7 @@ Environment:
   DATAAGENT_EVAL_JUDGE_MODEL
   DATAAGENT_EVAL_JUDGE_MAX_TOKENS
   DATAAGENT_EVAL_DATASET
+  DATAAGENT_EVAL_AGENT_ID
   DATAAGENT_BUILTIN_RUN_LOCAL=1  Run local Python instead of Docker/Podman.
 EOF
 }
@@ -82,6 +84,7 @@ exec "$CONTAINER_CMD" run --rm \
     -e DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS="${DATAAGENT_EVAL_JUDGE_TIMEOUT_SECONDS:-300}" \
     -e DATAAGENT_EVAL_JUDGE_MAX_TOKENS="${DATAAGENT_EVAL_JUDGE_MAX_TOKENS:-4096}" \
     -e DATAAGENT_EVAL_DATASET="${DATAAGENT_EVAL_DATASET:-}" \
+    -e DATAAGENT_EVAL_AGENT_ID="${DATAAGENT_EVAL_AGENT_ID:-}" \
     "${VOLUMES[@]}" \
     -w /workspace \
     "$IMAGE" "$@"

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -171,6 +171,64 @@ def test_deepeval_apply_judges_uses_shared_results_when_metric_is_copied(monkeyp
     assert updated[0]["case_passed"] is True
 
 
+def test_deepeval_agent_id_can_default_from_environment(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    monkeypatch.setenv("DATAAGENT_EVAL_AGENT_ID", "agent_eval")
+
+    args = runner.parse_args(["--dry-run", "--dataset", "cases.jsonl"])
+
+    assert args.agent_id == "agent_eval"
+
+
+def test_deepeval_non_dry_run_requires_agent_id(tmp_path, capsys, monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    dataset = tmp_path / "cases.jsonl"
+    dataset.write_text(json.dumps(_sample_case(), ensure_ascii=False) + "\n", encoding="utf-8")
+
+    code = runner.main(
+        [
+            "--dataset",
+            str(dataset),
+            "--output-dir",
+            str(tmp_path),
+            "--judge-base-url",
+            "http://judge",
+            "--judge-token",
+            "token",
+            "--judge-model",
+            "model",
+        ]
+    )
+
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "--agent-id" in captured.err
+
+
+def test_deepeval_topic_and_task_requests_include_agent_id(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    calls = []
+
+    def fake_http_json(method, url, payload=None, **kwargs):
+        calls.append({"method": method, "url": url, "payload": payload, "kwargs": kwargs})
+        if url.endswith("/topics"):
+            return {"topic_id": "topic-1"}
+        return {"task_id": "task-1"}
+
+    monkeypatch.setattr(runner, "http_json", fake_http_json)
+    args = types.SimpleNamespace(provider_id="", model="", agent_id="agent_eval")
+
+    topic_id = runner._create_topic("http://dataagent", _sample_case(), args.agent_id)
+    task_id = runner._submit_task("http://dataagent", topic_id, _sample_case(), args)
+
+    assert task_id == "task-1"
+    assert calls[0]["payload"]["agent_id"] == "agent_eval"
+    assert calls[1]["payload"]["agent_id"] == "agent_eval"
+
+
 def test_deepeval_evaluate_error_without_all_judges_raises_runner_error(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
@@ -467,6 +525,8 @@ def test_deepeval_runner_drives_dataagent_and_writes_case_outputs(tmp_path, monk
                 str(dataset),
                 "--output-dir",
                 str(output_dir),
+                "--agent-id",
+                "agent_eval",
                 "--judge-base-url",
                 "http://judge",
                 "--judge-token",

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -84,6 +84,60 @@ def test_missing_dataset_argument_returns_exit_2(tmp_path, capsys):
     assert "--dataset" in captured.err
 
 
+def test_non_dry_run_requires_agent_id(tmp_path, capsys):
+    runner = _load_runner()
+    dataset = _write_dataset(tmp_path / "cases.jsonl")
+
+    code = runner.main(
+        [
+            "--dataset",
+            str(dataset),
+            "--output-dir",
+            str(tmp_path),
+            "--judge-base-url",
+            "http://judge",
+            "--judge-token",
+            "token",
+            "--judge-model",
+            "model",
+        ]
+    )
+
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "--agent-id" in captured.err
+
+
+def test_agent_id_can_default_from_environment(monkeypatch):
+    runner = _load_runner()
+    monkeypatch.setenv("DATAAGENT_EVAL_AGENT_ID", "agent_eval")
+
+    args = runner.parse_args(["--dry-run", "--dataset", "cases.jsonl"])
+
+    assert args.agent_id == "agent_eval"
+
+
+def test_topic_and_task_requests_include_agent_id(monkeypatch):
+    runner = _load_runner()
+    calls = []
+
+    def fake_http_json(method, url, payload=None, **kwargs):
+        calls.append({"method": method, "url": url, "payload": payload, "kwargs": kwargs})
+        if url.endswith("/topics"):
+            return {"topic_id": "topic-1"}
+        return {"task_id": "task-1"}
+
+    monkeypatch.setattr(runner, "http_json", fake_http_json)
+    args = types.SimpleNamespace(provider_id="", model="", agent_id="agent_eval")
+
+    topic_id = runner._create_topic("http://dataagent", _sample_case(), args.agent_id)
+    task_id = runner._submit_task("http://dataagent", topic_id, _sample_case(), args)
+
+    assert task_id == "task-1"
+    assert calls[0]["payload"]["agent_id"] == "agent_eval"
+    assert calls[1]["payload"]["agent_id"] == "agent_eval"
+
+
 def test_default_output_root_prefers_mounted_workspace(tmp_path, monkeypatch):
     runner = _load_runner()
     workspace = tmp_path / "workspace"
@@ -671,6 +725,8 @@ def _run_fake_scenario(tmp_path, scenario: str, *extra_args: str):
                 str(dataset),
                 "--output-dir",
                 str(tmp_path),
+                "--agent-id",
+                "agent_eval",
                 "--judge-base-url",
                 judge_url,
                 "--judge-token",

--- a/tools/dataagent-evals/builtin/README.md
+++ b/tools/dataagent-evals/builtin/README.md
@@ -8,13 +8,15 @@ It is intentionally separate from the DataAgent backend runtime. DataAgent is on
 
 Datasets are private deployment assets and are not committed with this tool. Pass the JSONL file explicitly with `--dataset` or set `DATAAGENT_EVAL_DATASET`.
 
+Non-dry-run evaluation must also choose the DataAgent profile to execute with. Pass `--agent-id` or set `DATAAGENT_EVAL_AGENT_ID`. The selected agent's `data_scope` is snapshotted on each eval topic and enforces metadata/query access.
+
 ## Run With Docker
 
 ```bash
 DATAAGENT_EVAL_JUDGE_BASE_URL=https://api.example.com \
 DATAAGENT_EVAL_JUDGE_TOKEN=... \
 DATAAGENT_EVAL_JUDGE_MODEL=claude-opus-4-6 \
-bash scripts/run-dataagent-evals.sh --base-url http://127.0.0.1:8900 --dataset /path/to/private-cases.jsonl
+bash scripts/run-dataagent-evals.sh --base-url http://127.0.0.1:8900 --agent-id agent_eval --dataset /path/to/private-cases.jsonl
 ```
 
 The wrapper runs `opendataworks-dataagent-evals-builtin:latest` by default. Override with:

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -117,6 +117,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--output-dir", default=str(default_output_dir(root)), help="Report output directory.")
     parser.add_argument("--case", action="append", dest="case_ids", default=[], help="Case ID to run. Can be repeated.")
+    parser.add_argument("--agent-id", default=os.environ.get("DATAAGENT_EVAL_AGENT_ID", ""), help="Required DataAgent agent_id for non-dry-run evaluation tasks.")
     parser.add_argument("--provider-id", default="", help="Override DataAgent execution provider for evaluated tasks.")
     parser.add_argument("--model", default="", help="Override DataAgent execution model for evaluated tasks.")
     parser.add_argument("--timeout-seconds", type=int, default=900, help="Maximum wait per case.")
@@ -524,8 +525,12 @@ def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
     return str((candidates[-1] if candidates else {}).get("content") or "").strip()
 
 
-def _create_topic(base_url: str, case: dict[str, Any]) -> str:
-    topic = http_json("POST", f"{base_url}/api/v1/nl2sql/topics", {"title": f"Eval {case['case_id']}"})
+def _create_topic(base_url: str, case: dict[str, Any], agent_id: str) -> str:
+    topic = http_json(
+        "POST",
+        f"{base_url}/api/v1/nl2sql/topics",
+        {"title": f"Eval {case['case_id']}", "agent_id": agent_id},
+    )
     topic_id = str(topic.get("topic_id") or "").strip()
     if not topic_id:
         raise EvalRunnerError("topic creation response did not include topic_id")
@@ -536,6 +541,7 @@ def _submit_task(base_url: str, topic_id: str, case: dict[str, Any], args: argpa
     payload: dict[str, Any] = {
         "topic_id": topic_id,
         "content": str(case.get("question") or ""),
+        "agent_id": str(args.agent_id or "").strip(),
         "execution_mode": "background",
     }
     if args.provider_id:
@@ -810,7 +816,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     messages: dict[str, Any] = {}
     final_answer = ""
     try:
-        topic_id = _create_topic(base_url, case)
+        topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
         task, events, poll_errors = _poll_task(base_url, task_id, case_timeout)
@@ -866,6 +872,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
         "case_id": case.get("case_id"),
         "category": case.get("category"),
         "question": case.get("question"),
+        "agent_id": str(args.agent_id or "").strip(),
         "topic_id": topic_id,
         "task_id": task_id,
         "task_status": str(task.get("task_status") or ""),
@@ -900,6 +907,7 @@ def _run_cases(base_url: str, cases: list[dict[str, Any]], args: argparse.Namesp
                     "case_id": case.get("case_id"),
                     "category": case.get("category"),
                     "question": case.get("question"),
+                    "agent_id": str(getattr(args, "agent_id", "") or "").strip(),
                     "task_status": "runner_error",
                     "final_answer": "",
                     "tool_names": [],
@@ -1018,6 +1026,7 @@ def render_report(summary: dict[str, Any], results: list[dict[str, Any]]) -> str
         "# DataAgent 在线评测报告",
         "",
         f"- 数据集: `{summary.get('dataset_path', '')}`",
+        f"- Agent: `{summary.get('agent_id', '')}`",
         f"- 用例数: {summary.get('total_cases', 0)}",
         f"- 结论: {summary.get('recommendation', '')}",
         "",
@@ -1077,6 +1086,9 @@ def main(argv: list[str] | None = None) -> int:
     if not str(args.dataset or "").strip():
         print("--dataset is required and must point to the private evaluation JSONL file", file=sys.stderr)
         return 2
+    if not args.dry_run and not str(args.agent_id or "").strip():
+        print("--agent-id is required for non-dry-run evaluation", file=sys.stderr)
+        return 2
     root = _repo_or_package_root()
     dataset_path = Path(args.dataset)
     if not dataset_path.is_absolute():
@@ -1097,6 +1109,7 @@ def main(argv: list[str] | None = None) -> int:
         judge_config = _judge_config_from_args(args)
         preflight_payload = preflight(base_url)
         dataset_stats["preflight"] = preflight_payload
+        dataset_stats["agent_id"] = str(args.agent_id or "").strip()
         results = _run_cases(base_url, cases, args, judge_config)
         summary = build_summary(results, dataset_stats)
         write_outputs(output_dir, results, summary)

--- a/tools/dataagent-evals/deepeval/README.md
+++ b/tools/dataagent-evals/deepeval/README.md
@@ -8,13 +8,15 @@ It is intentionally separate from the DataAgent backend runtime. DataAgent is on
 
 Datasets are private deployment assets and are not committed with this tool. Pass the JSONL file explicitly with `--dataset` or set `DATAAGENT_EVAL_DATASET`. The JSONL schema matches the builtin runner dataset so both engines can be compared case by case.
 
+Non-dry-run evaluation must also choose the DataAgent profile to execute with. Pass `--agent-id` or set `DATAAGENT_EVAL_AGENT_ID`. The selected agent's `data_scope` is snapshotted on each eval topic and enforces metadata/query access.
+
 ## Run With Docker
 
 ```bash
 DATAAGENT_EVAL_JUDGE_BASE_URL=https://api.example.com \
 DATAAGENT_EVAL_JUDGE_TOKEN=... \
 DATAAGENT_EVAL_JUDGE_MODEL=claude-opus-4-6 \
-bash scripts/run-dataagent-deepeval-evals.sh --base-url http://127.0.0.1:8900 --dataset /path/to/private-cases.jsonl
+bash scripts/run-dataagent-deepeval-evals.sh --base-url http://127.0.0.1:8900 --agent-id agent_eval --dataset /path/to/private-cases.jsonl
 ```
 
 The wrapper runs `opendataworks-dataagent-evals-deepeval:latest` by default. Override with:

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -119,6 +119,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--output-dir", default=str(default_output_dir(root)), help="Report output directory.")
     parser.add_argument("--case", action="append", dest="case_ids", default=[], help="Case ID to run. Can be repeated.")
+    parser.add_argument("--agent-id", default=os.environ.get("DATAAGENT_EVAL_AGENT_ID", ""), help="Required DataAgent agent_id for non-dry-run evaluation tasks.")
     parser.add_argument("--provider-id", default="", help="Override DataAgent execution provider for evaluated tasks.")
     parser.add_argument("--model", default="", help="Override DataAgent execution model for evaluated tasks.")
     parser.add_argument("--timeout-seconds", type=int, default=900, help="Maximum wait per case.")
@@ -411,8 +412,12 @@ def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
     return str((candidates[-1] if candidates else {}).get("content") or "").strip()
 
 
-def _create_topic(base_url: str, case: dict[str, Any]) -> str:
-    topic = http_json("POST", f"{base_url}/api/v1/nl2sql/topics", {"title": f"DeepEval {case['case_id']}"})
+def _create_topic(base_url: str, case: dict[str, Any], agent_id: str) -> str:
+    topic = http_json(
+        "POST",
+        f"{base_url}/api/v1/nl2sql/topics",
+        {"title": f"DeepEval {case['case_id']}", "agent_id": agent_id},
+    )
     topic_id = str(topic.get("topic_id") or "").strip()
     if not topic_id:
         raise EvalRunnerError("topic creation response did not include topic_id")
@@ -423,6 +428,7 @@ def _submit_task(base_url: str, topic_id: str, case: dict[str, Any], args: argpa
     payload: dict[str, Any] = {
         "topic_id": topic_id,
         "content": str(case.get("question") or ""),
+        "agent_id": str(args.agent_id or "").strip(),
         "execution_mode": "background",
     }
     if args.provider_id:
@@ -486,7 +492,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
     messages: dict[str, Any] = {}
     final_answer = ""
     try:
-        topic_id = _create_topic(base_url, case)
+        topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
         task, events, poll_errors = _poll_task(base_url, task_id, case_timeout)
@@ -512,6 +518,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
         "case_id": case.get("case_id"),
         "category": case.get("category"),
         "question": case.get("question"),
+        "agent_id": str(args.agent_id or "").strip(),
         "topic_id": topic_id,
         "task_id": task_id,
         "task_status": str(task.get("task_status") or ""),
@@ -546,6 +553,7 @@ def _run_cases(base_url: str, cases: list[dict[str, Any]], args: argparse.Namesp
                     "case_id": case.get("case_id"),
                     "category": case.get("category"),
                     "question": case.get("question"),
+                    "agent_id": str(getattr(args, "agent_id", "") or "").strip(),
                     "task_status": "runner_error",
                     "final_answer": "",
                     "tool_names": [],
@@ -950,6 +958,7 @@ def render_report(summary: dict[str, Any], results: list[dict[str, Any]]) -> str
         "",
         f"- 引擎: `{summary.get('engine', 'deepeval')}`",
         f"- 数据集: `{summary.get('dataset_path', '')}`",
+        f"- Agent: `{summary.get('agent_id', '')}`",
         f"- 用例数: {summary.get('total_cases', 0)}",
         f"- 结论: {summary.get('recommendation', '')}",
         "",
@@ -1040,6 +1049,9 @@ def main(argv: list[str] | None = None) -> int:
     if not str(args.dataset or "").strip():
         print("--dataset is required and must point to the private evaluation JSONL file", file=sys.stderr)
         return 2
+    if not args.dry_run and not str(args.agent_id or "").strip():
+        print("--agent-id is required for non-dry-run evaluation", file=sys.stderr)
+        return 2
     root = _repo_or_package_root()
     dataset_path = Path(args.dataset)
     if not dataset_path.is_absolute():
@@ -1061,6 +1073,7 @@ def main(argv: list[str] | None = None) -> int:
         base_url = str(args.base_url or "").rstrip("/")
         preflight_payload = preflight(base_url)
         dataset_stats["preflight"] = preflight_payload
+        dataset_stats["agent_id"] = str(args.agent_id or "").strip()
         results = _run_cases(base_url, cases, args)
         metric = DataAgentEvaluationMetric(judge_config)
         test_cases = [to_deepeval_test_case(case, result) for case, result in zip(cases, results)]


### PR DESCRIPTION
## Summary
- Add per-agent datasource/schema data_scope persistence, snapshots, runtime injection, local SQL enforcement, Portal MCP scope forwarding, and Java Agent API metadata/query checks.
- Add Agent detail/list UI for configuring allowed schemas and expose data-scope options.
- Require explicit agent binding for widget and evaluation entrypoints so non-portal traffic uses the selected agent snapshot and data_scope.

## Validation
- `./.venv-py313/bin/python -m pytest tests/test_agent_profile_service.py tests/test_agent_runtime.py tests/test_sql_executor.py tests/test_admin_routes.py tests/test_widget_runtime_routes.py -q`
- `../dataagent-backend/.venv-py313/bin/python -m pytest tests/test_backend_client.py tests/test_app.py -q`
- `python -m pytest tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py -q`
- `npm --prefix frontend run test -- AgentDetailView AgentStudio widget` after `nvm use`
- `mvn -f backend/pom.xml -Dtest=AgentMetadataControllerTest,AgentQueryControllerTest,BackendAgentQueryServiceTest,BackendAgentMetadataServiceTest test`
- `bash scripts/run-dataagent-evals.sh --help`
- `bash scripts/run-dataagent-deepeval-evals.sh --help`
- `git diff --check`
