### PR TITLE
fix: polish intelligent query demo mocks

### DIFF
--- a/frontend/src/api/__tests__/demoNl2sqlIntegration.spec.js
+++ b/frontend/src/api/__tests__/demoNl2sqlIntegration.spec.js
@@ -25,5 +25,6 @@ describe('demo nl2sql client integration', () => {
         name: '通用数据问答'
       })
     ]))
+    await expect(client.agentApi.listAgents()).resolves.toHaveLength(1)
   })
 })

--- a/frontend/src/demo/__tests__/mockServerIntelligentQuery.spec.js
+++ b/frontend/src/demo/__tests__/mockServerIntelligentQuery.spec.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { demoAdapter } from '../mockServer'
+
+const request = async (method, url, options = {}) => {
+  const response = await demoAdapter({
+    method,
+    url,
+    baseURL: options.baseURL ?? '',
+    params: options.params || {},
+    data: options.data
+  })
+  return response.data
+}
+
+describe('demoAdapter intelligent query admin endpoints', () => {
+  it('keeps the agent list focused on the default demo agent', async () => {
+    await expect(request('get', '/api/v1/dataagent/agents')).resolves.toMatchObject({
+      code: 200,
+      data: [
+        expect.objectContaining({
+          agent_id: 'agent_default',
+          name: '通用数据问答',
+          is_default: true
+        })
+      ]
+    })
+  })
+
+  it('returns complete Skill document detail data for the detail editor', async () => {
+    await expect(request('get', '/api/v1/dataagent/skills/documents/skill-doc-1')).resolves.toMatchObject({
+      code: 200,
+      data: expect.objectContaining({
+        id: 'skill-doc-1',
+        content_type: 'markdown',
+        current_content: expect.stringContaining('dataagent-nl2sql'),
+        versions: [
+          expect.objectContaining({
+            is_current: true,
+            version_no: 1
+          })
+        ]
+      })
+    })
+  })
+
+  it('returns a visible demo model provider for model management', async () => {
+    await expect(request('get', '/api/v1/nl2sql-admin/settings')).resolves.toMatchObject({
+      code: 200,
+      data: expect.objectContaining({
+        provider_id: 'demo-provider',
+        model: 'demo-nl2sql',
+        providers: [
+          expect.objectContaining({
+            provider_id: 'demo-provider',
+            display_name: 'Demo 模型',
+            models: ['demo-nl2sql'],
+            supported_models: ['demo-nl2sql']
+          })
+        ]
+      })
+    })
+  })
+})

--- a/frontend/src/demo/mockServer.js
+++ b/frontend/src/demo/mockServer.js
@@ -1131,26 +1131,6 @@ const demoAgents = [
     resolved_workdir: '/demo/opendataworks',
     is_default: true,
     is_builtin: true
-  },
-  {
-    agent_id: 'agent_lineage',
-    name: '血缘分析助手',
-    description: '用于解释样例表上下游链路与任务关系。',
-    system_prompt: '你专注于数据血缘分析。',
-    permission_mode: 'inherit',
-    allowed_tools: ['Skill', 'Read'],
-    mcp_server_ids: [],
-    skill_folders: ['dataagent-nl2sql'],
-    max_turns: 0,
-    env_vars: {},
-    data_scope: {
-      allowed_scopes: [
-        { cluster_id: DEMO_CLUSTER_ID, source_type: 'DORIS', database: DEMO_DATABASE }
-      ]
-    },
-    resolved_workdir: '/demo/opendataworks',
-    is_default: false,
-    is_builtin: true
   }
 ]
 
@@ -1161,13 +1141,24 @@ const demoSkillDocuments = [
     file_name: 'SKILL.md',
     relative_path: 'SKILL.md',
     category: 'root',
+    content_type: 'markdown',
     source: 'bundled',
     enabled: true,
     editable: false,
     content: '# dataagent-nl2sql\n\n演示模式下使用前端内置数据回答样例问题。',
+    current_content: '# dataagent-nl2sql\n\n演示模式下使用前端内置数据回答样例问题。\n\n## 可回答范围\n\n- 样例表结构、DDL 与预览数据\n- demo_order_detail 的上下游血缘\n- 最近订单、门店销售等演示问数场景',
     updated_at: '2026-05-22T00:00:00+08:00',
     version_count: 1,
-    versions: []
+    versions: [
+      {
+        id: 'skill-doc-1-v1',
+        version_no: 1,
+        is_current: true,
+        change_source: 'demo',
+        change_summary: '初始化演示 Skill',
+        created_at: '2026-05-22T00:00:00+08:00'
+      }
+    ]
   },
   {
     id: 'skill-doc-2',
@@ -1175,13 +1166,24 @@ const demoSkillDocuments = [
     file_name: 'question-routing.md',
     relative_path: 'reference/question-routing.md',
     category: 'reference',
+    content_type: 'markdown',
     source: 'bundled',
     enabled: true,
     editable: false,
     content: '优先识别血缘、趋势、表结构和查询类问题。',
+    current_content: '# 问题路由\n\n优先识别血缘、趋势、表结构和查询类问题；演示模式下只返回前端内置样例数据。',
     updated_at: '2026-05-22T00:00:00+08:00',
     version_count: 1,
-    versions: []
+    versions: [
+      {
+        id: 'skill-doc-2-v1',
+        version_no: 1,
+        is_current: true,
+        change_source: 'demo',
+        change_summary: '初始化演示路由说明',
+        created_at: '2026-05-22T00:00:00+08:00'
+      }
+    ]
   }
 ]
 
@@ -2166,6 +2168,7 @@ export const demoAdapter = async (config) => {
     const document = demoSkillDocuments.find((item) => String(item.id) === documentId)
     if (!document) return createRejectedResponse(config, 'Skill 文档不存在', 404)
     document.content = String(body.content || document.content || '')
+    document.current_content = document.content
     document.updated_at = demoNow()
     return createResponse(config, clone(document))
   }


### PR DESCRIPTION
## Summary
- Keep the demo intelligent-agent page focused on one default built-in agent.
- Fill Skill detail mock payloads with current_content, content_type, and version history so the editor and history table render real demo data.
- Add regression coverage for intelligent-query demo admin mocks, including visible model-management settings.

## Validation
- npm --prefix frontend test -- src/demo/__tests__/mockServerIntelligentQuery.spec.js src/demo/__tests__/mockServerDatastudio.spec.js src/api/__tests__/nl2sqlClient.spec.js src/api/__tests__/dataagentClient.spec.js src/api/__tests__/demoNl2sqlIntegration.spec.js src/views/settings/__tests__/SkillStudio.spec.js src/views/settings/__tests__/SkillDetailView.spec.js src/views/settings/__tests__/DataAgentConfig.spec.js src/views/intelligence/__tests__/AgentStudio.spec.js
- npm --prefix frontend run build:demo
- Local Vite preview smoke: agents shows one default agent, Skill detail renders markdown and V1 history, model management shows Demo 模型/demo-nl2sql; console has no errors.