### PR TITLE
fix: handle demo agent detail capabilities route

### DIFF
--- a/frontend/src/demo/__tests__/mockServerIntelligentQuery.spec.js
+++ b/frontend/src/demo/__tests__/mockServerIntelligentQuery.spec.js
@@ -26,6 +26,28 @@ describe('demoAdapter intelligent query admin endpoints', () => {
     })
   })
 
+  it('serves agent detail dependencies without treating capabilities as an agent id', async () => {
+    await expect(request('get', '/api/v1/dataagent/agents/agent_default')).resolves.toMatchObject({
+      code: 200,
+      data: expect.objectContaining({
+        agent_id: 'agent_default',
+        name: '通用数据问答'
+      })
+    })
+
+    await expect(request('get', '/api/v1/dataagent/agents/capabilities')).resolves.toMatchObject({
+      code: 200,
+      data: expect.objectContaining({
+        tools: expect.arrayContaining(['Skill', 'Read']),
+        skills: [
+          expect.objectContaining({
+            folder: 'dataagent-nl2sql'
+          })
+        ]
+      })
+    })
+  })
+
   it('returns complete Skill document detail data for the detail editor', async () => {
     await expect(request('get', '/api/v1/dataagent/skills/documents/skill-doc-1')).resolves.toMatchObject({
       code: 200,

--- a/frontend/src/demo/mockServer.js
+++ b/frontend/src/demo/mockServer.js
@@ -2096,6 +2096,17 @@ export const demoAdapter = async (config) => {
     return createResponse(config, clone(demoAgents))
   }
 
+  if (method === 'get' && pathname === '/v1/dataagent/agents/capabilities') {
+    return createResponse(config, {
+      tools: ['Skill', 'Read', 'Grep', 'Bash'],
+      mcp_servers: [],
+      skills: demoSkillDocuments
+        .filter((item) => item.file_name === 'SKILL.md')
+        .map((item) => ({ folder: item.folder, name: item.folder, enabled: item.enabled })),
+      permission_modes: ['inherit', 'allow_all', 'restricted']
+    })
+  }
+
   if (method === 'get' && pathname.match(/^\/v1\/dataagent\/agents\/[^/]+$/)) {
     const agentId = decodeURIComponent(pathname.split('/').pop())
     const agent = demoAgents.find((item) => item.agent_id === agentId)
@@ -2127,17 +2138,6 @@ export const demoAdapter = async (config) => {
 
   if (method === 'delete' && pathname.match(/^\/v1\/dataagent\/agents\/[^/]+$/)) {
     return createResponse(config, { status: 'ok' })
-  }
-
-  if (method === 'get' && pathname === '/v1/dataagent/agents/capabilities') {
-    return createResponse(config, {
-      tools: ['Skill', 'Read', 'Grep', 'Bash'],
-      mcp_servers: [],
-      skills: demoSkillDocuments
-        .filter((item) => item.file_name === 'SKILL.md')
-        .map((item) => ({ folder: item.folder, name: item.folder, enabled: item.enabled })),
-      permission_modes: ['inherit', 'allow_all', 'restricted']
-    })
   }
 
   if (method === 'get' && pathname === '/v1/dataagent/data-scope/options') {


### PR DESCRIPTION
## Summary
- Move the demo agent capabilities mock before the dynamic /agents/:id matcher so agent detail no longer treats capabilities as an agent id.
- Add regression coverage for loading the default demo agent detail and its capabilities dependency.

## Validation
- npm --prefix frontend test -- src/demo/__tests__/mockServerIntelligentQuery.spec.js src/views/intelligence/__tests__/AgentDetailView.spec.js
- npm --prefix frontend run build:demo
- Local Vite preview smoke: /intelligent-query/agents/agent_default renders detail content and console has no errors.