### PR TITLE
feat: persist message feedback with like/dislike buttons for intelligent query UI

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260525_000010_add_message_feedback.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260525_000010_add_message_feedback.py
@@ -1,0 +1,41 @@
+"""add feedback to agent messages
+
+Revision ID: 20260525_000010
+Revises: 20260522_000009
+Create Date: 2026-05-25 11:55:00
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260525_000010"
+down_revision = "20260522_000009"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(column.get("name") == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if not _has_table("da_agent_message"):
+        return
+    if not _has_column("da_agent_message", "feedback"):
+        op.add_column(
+            "da_agent_message",
+            sa.Column("feedback", sa.String(length=16), nullable=False, server_default=""),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("da_agent_message") and _has_column("da_agent_message", "feedback"):
+        op.drop_column("da_agent_message", "feedback")

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -37,8 +37,10 @@ from models.schemas import (
     TaskStatusResponse,
     TaskSubmissionResponse,
     TopicDetail,
+    TopicMessage,
     TopicMessagePageResponse,
     TopicSummary,
+    UpdateMessageFeedbackRequest,
     UpdateTopicRequest,
 )
 
@@ -224,6 +226,33 @@ async def api_list_topic_messages(
     _require_topic(topic_id, context)
     payload = _get_store().list_topic_messages_page(topic_id=topic_id, page=page, page_size=page_size, order=order, context=context)
     return TopicMessagePageResponse.model_validate(payload)
+
+
+@topic_router.put("/{topic_id}/messages/{message_id}/feedback", response_model=TopicMessage)
+async def api_update_message_feedback(
+    topic_id: str,
+    message_id: str,
+    payload: UpdateMessageFeedbackRequest,
+    request: Request,
+):
+    context = _request_context(request)
+    _require_topic(topic_id, context)
+
+    feedback = str(payload.feedback or "").strip().lower()
+    if feedback not in {"", "like", "dislike"}:
+        raise HTTPException(status_code=400, detail="feedback must be like, dislike, or empty")
+
+    store = _get_store()
+    message = store.get_message(message_id)
+    if not message or str(message.get("topic_id") or "") != topic_id or not message.get("show_in_ui", True):
+        raise HTTPException(status_code=404, detail="Message not found")
+    if str(message.get("sender_type") or "") != "assistant":
+        raise HTTPException(status_code=400, detail="feedback is only supported for assistant messages")
+
+    updated = store.update_message_feedback(topic_id=topic_id, message_id=message_id, feedback=feedback, context=context)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return TopicMessage.model_validate(updated)
 
 
 @task_router.post("/deliver-message", response_model=TaskSubmissionResponse)

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -533,7 +533,7 @@ class TopicTaskStore:
                     """
                     SELECT message_id, topic_id, task_id, sender_type, type, status, content, event,
                            steps_json, tool_json, seq_id, correlation_id, parent_correlation_id,
-                           content_type, usage_json, error_json, show_in_ui, created_at, updated_at
+                           content_type, usage_json, feedback, error_json, show_in_ui, created_at, updated_at
                     FROM da_agent_message
                     WHERE topic_id = %s AND show_in_ui = 1
                     ORDER BY seq_id ASC, created_at ASC
@@ -585,7 +585,7 @@ class TopicTaskStore:
                     f"""
                     SELECT message_id, topic_id, task_id, sender_type, type, status, content, event,
                            steps_json, tool_json, seq_id, correlation_id, parent_correlation_id,
-                           content_type, usage_json, error_json, show_in_ui, created_at, updated_at
+                           content_type, usage_json, feedback, error_json, show_in_ui, created_at, updated_at
                     FROM da_agent_message
                     WHERE topic_id = %s AND show_in_ui = 1
                     ORDER BY seq_id {sort_direction}, created_at {sort_direction}
@@ -716,7 +716,7 @@ class TopicTaskStore:
                     """
                     SELECT message_id, topic_id, task_id, sender_type, type, status, content, event,
                            steps_json, tool_json, seq_id, correlation_id, parent_correlation_id,
-                           content_type, usage_json, error_json, show_in_ui, created_at, updated_at
+                           content_type, usage_json, feedback, error_json, show_in_ui, created_at, updated_at
                     FROM da_agent_message
                     WHERE task_id = %s AND sender_type = 'assistant' AND show_in_ui = 1
                     ORDER BY seq_id ASC
@@ -739,7 +739,7 @@ class TopicTaskStore:
                     """
                     SELECT message_id, topic_id, task_id, sender_type, type, status, content, event,
                            steps_json, tool_json, seq_id, correlation_id, parent_correlation_id,
-                           content_type, usage_json, error_json, show_in_ui, created_at, updated_at
+                           content_type, usage_json, feedback, error_json, show_in_ui, created_at, updated_at
                     FROM da_agent_message
                     WHERE message_id = %s
                     LIMIT 1
@@ -761,6 +761,59 @@ class TopicTaskStore:
             if row
             else None
         )
+
+    def update_message_feedback(
+        self,
+        *,
+        topic_id: str,
+        message_id: str,
+        feedback: str,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        self._ensure_ready()
+        safe_feedback = str(feedback or "").strip()
+        if safe_feedback not in {"", "like", "dislike"}:
+            raise ValueError("feedback must be like, dislike, or empty")
+
+        context_sql, context_params = self._topic_context_predicate(context, alias="t")
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT m.message_id
+                    FROM da_agent_message m
+                    JOIN da_agent_topic t ON t.topic_id = m.topic_id
+                    WHERE m.topic_id = %s
+                      AND m.message_id = %s
+                      AND m.sender_type = 'assistant'
+                      AND m.show_in_ui = 1
+                      AND {context_sql}
+                    LIMIT 1
+                    """,
+                    [topic_id, message_id, *context_params],
+                )
+                if not cur.fetchone():
+                    conn.commit()
+                    return None
+
+                cur.execute(
+                    """
+                    UPDATE da_agent_message
+                    SET feedback = %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE topic_id = %s
+                      AND message_id = %s
+                      AND sender_type = 'assistant'
+                      AND show_in_ui = 1
+                    LIMIT 1
+                    """,
+                    (safe_feedback, topic_id, message_id),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        return self.get_message(message_id)
 
     def create_task(
         self,
@@ -2168,6 +2221,7 @@ class TopicTaskStore:
             "parent_correlation_id": str(row.get("parent_correlation_id") or "") or None,
             "content_type": str(row.get("content_type") or "") or None,
             "usage": _safe_json_load(row.get("usage_json")),
+            "feedback": str(row.get("feedback") or ""),
             "show_in_ui": bool(row.get("show_in_ui")),
             "error": _safe_json_load(row.get("error_json")),
             "created_at": _to_iso(row.get("created_at")),

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -456,6 +456,7 @@ class TopicMessage(BaseModel):
     blocks: Optional[List[Dict[str, Any]]] = None
     resume_after_seq: int = 0
     show_in_ui: bool = True
+    feedback: str = ""
     error: Optional[Dict[str, Any]] = None
     created_at: str = ""
     updated_at: str = ""
@@ -496,6 +497,10 @@ class TopicMessagePageResponse(BaseModel):
     order: str = "asc"
     total: int = 0
     items: List[TopicMessage] = Field(default_factory=list)
+
+
+class UpdateMessageFeedbackRequest(BaseModel):
+    feedback: str = ""
 
 
 class TaskSubmissionResponse(BaseModel):

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -228,6 +228,7 @@ class _FakeStore:
             "parent_correlation_id": None,
             "content_type": None,
             "usage": None,
+            "feedback": "",
             "show_in_ui": True,
             "error": None,
             "created_at": _now(),
@@ -260,6 +261,7 @@ class _FakeStore:
             "usage": None,
             "blocks": [],
             "resume_after_seq": 0,
+            "feedback": "",
             "show_in_ui": True,
             "error": None,
             "created_at": _now(),
@@ -273,6 +275,21 @@ class _FakeStore:
             for message in messages:
                 if message["task_id"] == task_id and message["sender_type"] == "assistant":
                     return message
+        return None
+
+    def get_message(self, message_id: str, context=None):
+        for messages in self.topic_messages.values():
+            for message in messages:
+                if message["message_id"] == message_id:
+                    return dict(message)
+        return None
+
+    def update_message_feedback(self, *, topic_id: str, message_id: str, feedback: str, context=None):
+        for message in self.topic_messages.get(topic_id, []):
+            if message["message_id"] == message_id and message.get("sender_type") == "assistant" and message.get("show_in_ui", True):
+                message["feedback"] = feedback
+                message["updated_at"] = _now()
+                return dict(message)
         return None
 
     def get_task(self, task_id: str, context=None):
@@ -586,6 +603,39 @@ def test_topics_tasks_and_legacy_routes(monkeypatch):
         assert history.json()["items"][1]["sender_type"] == "assistant"
         assert history.json()["items"][1]["blocks"] == []
         assert history.json()["items"][1]["resume_after_seq"] == 0
+        assistant_message_id = history.json()["items"][1]["message_id"]
+
+        feedback = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/feedback",
+            json={"feedback": "like"},
+        )
+        assert feedback.status_code == 200
+        assert feedback.json()["message_id"] == assistant_message_id
+        assert feedback.json()["feedback"] == "like"
+
+        hydrated_feedback = client.get(f"/api/v1/nl2sql/topics/{topic_id}/messages", params={"page": 1, "page_size": 50, "order": "asc"})
+        assert hydrated_feedback.status_code == 200
+        assert hydrated_feedback.json()["items"][1]["feedback"] == "like"
+
+        clear_feedback = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/feedback",
+            json={"feedback": ""},
+        )
+        assert clear_feedback.status_code == 200
+        assert clear_feedback.json()["feedback"] == ""
+
+        invalid_feedback = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/feedback",
+            json={"feedback": "star"},
+        )
+        assert invalid_feedback.status_code == 400
+
+        user_message_id = history.json()["items"][0]["message_id"]
+        user_feedback = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}/messages/{user_message_id}/feedback",
+            json={"feedback": "like"},
+        )
+        assert user_feedback.status_code == 400
 
         created_task = client.post(
             "/api/v1/nl2sql/tasks",

--- a/dataagent/dataagent-backend/tests/test_topic_task_store.py
+++ b/dataagent/dataagent-backend/tests/test_topic_task_store.py
@@ -141,6 +141,7 @@ def test_normalize_message_row_only_attaches_history_to_assistant():
             "parent_correlation_id": None,
             "content_type": None,
             "usage_json": None,
+            "feedback": "like",
             "error_json": None,
             "show_in_ui": 1,
             "created_at": None,
@@ -175,5 +176,7 @@ def test_normalize_message_row_only_attaches_history_to_assistant():
 
     assert assistant["blocks"][0]["type"] == "main_text"
     assert assistant["resume_after_seq"] == 12
+    assert assistant["feedback"] == "like"
     assert "blocks" not in user
     assert "resume_after_seq" not in user
+    assert user["feedback"] == ""

--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -51,7 +51,9 @@
   - 复制按钮：点击将消息文本拷贝到剪贴板，使用 SVG 复制图标。
 - **AI 回复特有动作**：
   - 点赞/点踩按钮：双态（选中与未选中），选中时激活高亮。
-  - 本期先作为前端本地交互状态，不持久化到后端；刷新页面或重新 hydrate 后状态重置。后续如果要用于反馈闭环，需要单独设计反馈 API、数据表和权限规则。
+  - 点赞/点踩状态需要持久化到 DataAgent 后端，刷新页面或重新 hydrate 后继续显示上次反馈。
+  - 反馈只绑定 assistant 消息，允许值为 `like`、`dislike` 或空字符串。再次点击同一按钮清空反馈，点击另一按钮切换反馈。
+  - 前端乐观更新按钮状态；若后端保存失败，回滚到点击前状态并提示错误。
 - **暂缓动作**：
   - “编辑最后一条用户消息并重新发送”本期不实现。原因是该能力涉及前端消息截断、后端持久化历史、任务事件流取消和刷新后一致性，单纯前端截断会产生状态不一致风险。
   - 本期消息工具栏不展示编辑入口；后续如需实现，必须先补充 DataAgent 后端消息裁剪接口和端到端 smoke 验证。
@@ -79,7 +81,12 @@
 ## 3. 技术设计与状态管理
 - **键盘事件劫持**：在 `<textarea>` 绑定 `@keydown.enter.exact.prevent` 触发发送，配合 `@keydown.shift.enter` 维持默认的换行逻辑。
 - **复制交互状态**：优先使用 `navigator.clipboard.writeText`；失败时降级提示“复制失败，请手动复制”，不引入额外依赖。
-- **点赞/点踩状态**：本期挂载在消息对象的本地字段（如 `msg.feedback = 'like' | 'dislike' | ''`），不写入后端。
+- **点赞/点踩状态**：前端仍使用消息对象上的 `msg.feedback = 'like' | 'dislike' | ''` 驱动按钮选中态，但该字段来自后端消息响应，并通过反馈接口写回后端。
+- **点赞/点踩持久化**：
+  - DataAgent 在 `da_agent_message` 增加 `feedback VARCHAR(16) NOT NULL DEFAULT ''` 字段。
+  - `GET /api/v1/nl2sql/topics/{topic_id}/messages` 返回每条消息的 `feedback` 字段；用户消息固定为空字符串。
+  - 新增 `PUT /api/v1/nl2sql/topics/{topic_id}/messages/{message_id}/feedback`，请求体为 `{ "feedback": "like" | "dislike" | "" }`，响应返回更新后的 `TopicMessage`。
+  - 后端必须先按当前 request context 校验 topic 归属，再校验 message 属于该 topic，且只允许更新 `sender_type='assistant'` 且 `show_in_ui=1` 的消息。非法反馈值返回 400，消息不存在或不属于当前上下文返回 404，非 assistant 消息返回 400。
 - **Token 用量状态**：新增 `latestAssistantUsage` / `contextWindowUsage` 计算属性，读取 `activeMessages` 中最新 assistant 消息的 `usage`，并基于 `selectedModel` 推断上下文上限。
 - **样式方案**：继续在 `<style scoped>` 中编写纯粹的 CSS / Sass 样式。配合弹性布局与 Hover 触发器，提供平滑的过度动画。
 
@@ -91,3 +98,4 @@
 - **图表渲染性能**：外置图表直接在对话区域渲染，随着历史消息变多，页面中的 ECharts 实例可能增多。须确保每个 `ToolOutputRenderer` 实例在销毁（`onBeforeUnmount`）时能够正确释放 ECharts 内存。
 - **快捷键行为变化风险**：从 `Ctrl/Meta + Enter` 发送改为 `Enter` 发送会改变既有用户肌肉记忆。需要保留 `Shift + Enter` 换行，并在测试中覆盖空输入、禁用态和运行中任务的 Enter 行为。
 - **空态与异常数据风险**：usage 缺失、provider/model 未配置、消息缺少 `created_at`、剪贴板权限被拒绝时，UI 必须优雅降级，不阻塞发送主链路。
+- **反馈持久化失败风险**：点赞/点踩保存失败时，前端需要回滚乐观状态，避免 UI 显示与后端历史不一致。反馈接口不影响发送、流式事件或任务取消主链路。

--- a/docs/plans/2026-05-25-intelligent-query-ui-optimization-plan.md
+++ b/docs/plans/2026-05-25-intelligent-query-ui-optimization-plan.md
@@ -45,9 +45,32 @@
   2. 样式上使用 `opacity: 0` 隐藏，当 `.query-message-row:hover` 时设为 `opacity: 1` 渐显。
   3. 增加 `formatMessageTime(value)`，复用现有 `parseDisplayDate` 与 `formatInShanghai`，输出 `YYYY-MM-DD HH:mm`；无时间时隐藏时间文本。
   4. 渲染一键复制图标与复制函数 `handleCopyMessage(msg)`。复制内容优先使用 `msg.content`，assistant 消息为空时拼接 `main_text` block 的可见文本；调用 `navigator.clipboard.writeText`，失败时 `ElMessage.error('复制失败，请手动复制')`。
-  5. 对于 AI 消息，展示点赞和点踩按钮，绑定响应动作改变 `msg.feedback`：再次点击同一按钮清空，点击另一按钮切换。该状态仅本地保存，不持久化。
+  5. 对于 AI 消息，展示点赞和点踩按钮，绑定响应动作改变 `msg.feedback`：再次点击同一按钮清空，点击另一按钮切换。状态通过 DataAgent 反馈接口持久化；保存失败时回滚到点击前状态并提示。
   6. 不实现“编辑最后一条用户消息并重新发送”：不展示编辑按钮，不新增 `editingMessageId` / `editingMessageText`，不截断前端消息，也不调用重发逻辑。
   7. 若后续恢复该能力，先新增 DataAgent 后端“从指定 message_id 裁剪话题消息”接口和对应测试，再补前端交互。
+
+### 1.5.1 消息反馈持久化
+- **修改文件**：
+  - `dataagent/dataagent-backend/alembic/versions/20260525_000010_add_message_feedback.py`
+  - `dataagent/dataagent-backend/models/schemas.py`
+  - `dataagent/dataagent-backend/core/topic_task_store.py`
+  - `dataagent/dataagent-backend/api/routes.py`
+  - `dataagent/dataagent-backend/tests/test_routes_contract.py`
+  - `dataagent/dataagent-backend/tests/test_topic_task_store.py`
+  - `frontend/src/api/nl2sql.js`
+  - `frontend/src/demo/mockServer.js`
+  - `frontend/src/views/intelligence/NL2SqlChat.vue`
+  - `frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js`
+- **步骤**：
+  1. 新增 Alembic migration，在 `da_agent_message` 上增加 `feedback VARCHAR(16) NOT NULL DEFAULT ''`；降级时删除该字段。
+  2. 在 `TopicMessage` schema 增加 `feedback: str = ""`，并在消息归一化、列表查询、单条查询中返回该字段。
+  3. 在 `TopicTaskStore` 增加 `update_message_feedback(topic_id, message_id, feedback, context=None)`：只更新当前上下文可访问话题下的 `assistant` + `show_in_ui=1` 消息，返回更新后的消息；无匹配返回 `None`，非法消息类型由路由转换为 400。
+  4. 新增 `UpdateMessageFeedbackRequest`，校验反馈值只允许 `like`、`dislike`、空字符串。
+  5. 新增 `PUT /api/v1/nl2sql/topics/{topic_id}/messages/{message_id}/feedback`，先 `_require_topic(topic_id, context)`，再校验消息存在、属于该 topic、为 assistant 消息，最后调用 store 更新并返回 `TopicMessage`。
+  6. 前端 `topicApi` 增加 `updateMessageFeedback(topicId, messageId, feedback)`。
+  7. `toggleMessageFeedback` 改为异步乐观更新：计算 next feedback，先更新 UI，再调用 API；失败时恢复 previous feedback 并 `ElMessage.error('反馈保存失败，请稍后重试')`。
+  8. demo adapter 支持同一反馈接口，更新 `demoTopics[].messages[].feedback` 后返回消息，避免演示模式下点击反馈失败。
+  9. 按 TDD 先补失败测试，再实现后端和前端逻辑。
 
 ### 1.6 猜你想问 (Follow-up Suggestions)
 - **修改文件**：`frontend/src/views/intelligence/NL2SqlChat.vue`
@@ -75,7 +98,7 @@
 - **步骤**：
   1. 增加 Context Ring 用例：hydrate 一条 assistant 消息，`usage: { input_tokens: 1000, output_tokens: 200 }`，断言圆环或 Tooltip 文案包含 `1,200` 和模型上限。
   2. 增加 Enter 发送用例：输入文本后触发 textarea 的 `keydown.enter`，断言 `taskApi.deliverMessage` 调用一次；触发 `keydown.shift.enter` 时不调用发送。
-  3. 增加消息工具栏用例：断言用户和 assistant 消息 footer 存在，复制按钮调用 clipboard，点赞/点踩会切换本地状态。
+  3. 增加消息工具栏用例：断言用户和 assistant 消息 footer 存在，复制按钮调用 clipboard，点赞/点踩会调用反馈持久化 API 并切换状态。
   4. 增加消息工具栏不含编辑入口用例：最后一条用户消息 footer 只展示时间与复制，不展示编辑按钮。
   5. 增加智能体选择器用例：断言顶部栏渲染 Element Plus select，切换 `selectedAgentId` 后会清空当前话题并调用 `topicApi.listTopics({ agent_id })`。
 
@@ -106,8 +129,8 @@
 7. 对话完成后，检查对话底部是否出现「猜你想问」气泡，点击是否能直接提交。
 
 ### 2.4 智能问数本地 Smoke 边界
-- 本次计划默认只改 `frontend/src/views/intelligence/NL2SqlChat.vue` 和前端测试，不改变 DataAgent 后端 API、任务协调、持久化或部署行为时，可不强制运行完整 DataAgent smoke。
-- 如果实施过程中新增后端消息裁剪 API、修改 `/tasks/deliver-message` 请求/响应、修改事件流处理协议，必须按仓库 AGENTS 规则补充本地智能问数 smoke，至少覆盖：
+- 本次新增消息反馈字段和反馈接口，不改变任务协调、`/tasks/deliver-message` 请求/响应或事件流处理协议。验证以后端路由/存储测试、前端 API/组件测试和前端构建为主。
+- 如果实施过程中进一步新增后端消息裁剪 API、修改 `/tasks/deliver-message` 请求/响应、修改事件流处理协议，必须按仓库 AGENTS 规则补充本地智能问数 smoke，至少覆盖：
   1. `POST /api/v1/nl2sql/tasks/deliver-message` 返回 `accepted=true` 和 `task_id`。
   2. 任务状态从 `waiting -> running -> success|failed|suspended`。
   3. `/api/v1/nl2sql/tasks/{task_id}/events/stream` 能消费终态事件。

--- a/frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -87,4 +87,15 @@ describe('createNl2SqlApiClient', () => {
 
     expect(clients[0].get).toHaveBeenCalledWith('/runtime-config')
   })
+
+  it('updates assistant message feedback through the topic API', () => {
+    const client = createNl2SqlApiClient()
+
+    client.topicApi.updateMessageFeedback('topic-1', 'message-1', 'like')
+
+    expect(clients[0].put).toHaveBeenCalledWith(
+      '/topics/topic-1/messages/message-1/feedback',
+      { feedback: 'like' }
+    )
+  })
 })

--- a/frontend/src/api/nl2sql.js
+++ b/frontend/src/api/nl2sql.js
@@ -143,6 +143,9 @@ export function createNl2SqlApiClient(options = {}) {
     },
     getTopicMessages(topicId, params = {}) {
       return runtimeRequest.get(`/topics/${topicId}/messages`, { params })
+    },
+    updateMessageFeedback(topicId, messageId, feedback = '') {
+      return runtimeRequest.put(`/topics/${topicId}/messages/${messageId}/feedback`, { feedback })
     }
   }
 

--- a/frontend/src/demo/mockServer.js
+++ b/frontend/src/demo/mockServer.js
@@ -1213,6 +1213,7 @@ const demoTopics = [
         role: 'assistant',
         content: 'demo_order_detail 上游来自 demo_order_event_raw 与 demo_member_profile，下游产出 demo_store_sales_daily 和 demo_order_risk_alert。',
         status: 'finished',
+        feedback: '',
         blocks: [
           {
             block_id: 'main-text',
@@ -2257,6 +2258,25 @@ export const demoAdapter = async (config) => {
     })
   }
 
+  if (method === 'put' && pathname.match(/^\/v1\/nl2sql\/topics\/[^/]+\/messages\/[^/]+\/feedback$/)) {
+    const parts = pathname.split('/')
+    const topicId = decodeURIComponent(parts[4])
+    const messageId = decodeURIComponent(parts[6])
+    const feedback = String(body.feedback || '').trim()
+    if (!['', 'like', 'dislike'].includes(feedback)) {
+      return createRejectedResponse(config, 'feedback must be like, dislike, or empty', 400)
+    }
+    const topic = findDemoTopic(topicId)
+    const message = topic?.messages?.find((item) => String(item.message_id) === messageId)
+    if (!message) return createRejectedResponse(config, '消息不存在', 404)
+    if (String(message.sender_type || message.role || '') !== 'assistant') {
+      return createRejectedResponse(config, '仅支持反馈 AI 消息', 400)
+    }
+    message.feedback = feedback
+    topic.updated_at = demoNow()
+    return createResponse(config, clone(message))
+  }
+
   if (method === 'post' && pathname === '/v1/nl2sql/tasks/deliver-message') {
     const topic = findDemoTopic(body.topic_id)
     const now = demoNow()
@@ -2276,6 +2296,7 @@ export const demoAdapter = async (config) => {
         role: 'assistant',
         content: '',
         status: 'waiting',
+        feedback: '',
         task_id: taskId,
         created_at: now
       })

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -825,9 +825,27 @@ const handleCopyMessage = async (msg) => {
   }
 }
 
-const toggleMessageFeedback = (msg, value) => {
+const toggleMessageFeedback = async (msg, value) => {
   if (!msg || typeof msg !== 'object') return
-  msg.feedback = msg.feedback === value ? '' : value
+  const previousFeedback = String(msg.feedback || '')
+  const nextFeedback = previousFeedback === value ? '' : value
+  const topicId = String(msg.topic_id || activeTopicId.value || '')
+  const messageId = String(msg.message_id || msg.id || '')
+
+  msg.feedback = nextFeedback
+  if (!topicId || !messageId) {
+    msg.feedback = previousFeedback
+    ElMessage.error('反馈保存失败，请稍后重试')
+    return
+  }
+
+  try {
+    const updated = await topicApi.updateMessageFeedback(topicId, messageId, nextFeedback)
+    msg.feedback = String(updated?.feedback ?? nextFeedback)
+  } catch (_error) {
+    msg.feedback = previousFeedback
+    ElMessage.error('反馈保存失败，请稍后重试')
+  }
 }
 
 const assistantAgentName = (msg) => String(

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -8,7 +8,8 @@ const apiMocks = vi.hoisted(() => ({
     getTopic: vi.fn(),
     updateTopic: vi.fn(),
     deleteTopic: vi.fn(),
-    getTopicMessages: vi.fn()
+    getTopicMessages: vi.fn(),
+    updateMessageFeedback: vi.fn()
   },
   taskApi: {
     deliverMessage: vi.fn(),
@@ -765,6 +766,7 @@ describe('NL2SqlChat', () => {
           type: 'assistant',
           status: 'finished',
           content: '最近 30 天共发布 4 次。',
+          feedback: '',
           blocks: [
             {
               block_id: 'main-1',
@@ -897,10 +899,34 @@ describe('NL2SqlChat', () => {
     expect(likeButton.exists()).toBe(true)
     expect(dislikeButton.exists()).toBe(true)
 
+    apiMocks.topicApi.updateMessageFeedback.mockResolvedValue({
+      topic_id: 'topic-1',
+      message_id: 'a1',
+      sender_type: 'assistant',
+      type: 'assistant',
+      status: 'finished',
+      content: '最近 30 天共发布 4 次。',
+      feedback: 'like'
+    })
+
     await likeButton.trigger('click')
+    await flushPromises()
+    expect(apiMocks.topicApi.updateMessageFeedback).toHaveBeenCalledWith('topic-1', 'a1', 'like')
     expect(wrapper.find('.query-message-feedback-like').classes()).toContain('active')
 
+    apiMocks.topicApi.updateMessageFeedback.mockResolvedValue({
+      topic_id: 'topic-1',
+      message_id: 'a1',
+      sender_type: 'assistant',
+      type: 'assistant',
+      status: 'finished',
+      content: '最近 30 天共发布 4 次。',
+      feedback: 'dislike'
+    })
+
     await dislikeButton.trigger('click')
+    await flushPromises()
+    expect(apiMocks.topicApi.updateMessageFeedback).toHaveBeenLastCalledWith('topic-1', 'a1', 'dislike')
     expect(wrapper.find('.query-message-feedback-like').classes()).not.toContain('active')
     expect(wrapper.find('.query-message-feedback-dislike').classes()).toContain('active')
   })

--- a/frontend/src/views/intelligence/messageStream.js
+++ b/frontend/src/views/intelligence/messageStream.js
@@ -261,6 +261,7 @@ export const createAssistantMessageState = (seed = {}) => ({
   stop_reason: textOrEmpty(seed.stop_reason),
   stop_sequence: textOrEmpty(seed.stop_sequence),
   usage: isPlainObject(seed.usage) ? { ...seed.usage } : null,
+  feedback: textOrEmpty(seed.feedback),
   provider_id: seed.provider_id || null,
   model: seed.model || null,
   created_at: seed.created_at || new Date().toISOString(),
@@ -287,6 +288,7 @@ export const hydrateAssistantMessageState = (message) => {
     provider_id: message?.provider_id || null,
     model: message?.model || null,
     usage: isPlainObject(message?.usage) ? message.usage : null,
+    feedback: textOrEmpty(message?.feedback),
     resume_after_seq: Number(message?.resume_after_seq || 0)
   })
 


### PR DESCRIPTION
## Summary

- Add message feedback (like/dislike) persistence for assistant messages in the intelligent query chat UI
- Backend: new `feedback` column on `da_agent_message`, new `PUT /api/v1/nl2sql/topics/{topic_id}/messages/{message_id}/feedback` endpoint, schema and store updates
- Frontend: `toggleMessageFeedback` uses optimistic update with rollback on API failure; demo mock server supports the feedback endpoint
- Tests: contract tests for the new endpoint, store test for feedback field, client test for `updateMessageFeedback`, component test for async feedback toggle
- Docs: updated design and plan documents to reflect feedback persistence instead of local-only state

## Test plan
- [x] Backend route contract tests cover feedback put/clear/invalid/non-assistant cases
- [x] Store test verifies `feedback` field in message normalization
- [x] Frontend API client test for `updateMessageFeedback`
- [x] Frontend component test for like/dislike click calls API and toggles active state
- [ ] Local full-flow smoke not run (feedback endpoint does not change task coordination or streaming protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)