### PR TITLE
fix: isolate DataAgent agent workspaces

### DIFF
--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -15,7 +15,7 @@ from config import get_settings
 from core.data_scope import normalize_data_scope
 
 DEFAULT_AGENT_ID = "agent_default"
-DEFAULT_AGENT_NAME = "通用智能体"
+DEFAULT_AGENT_NAME = "默认助手"
 OPENDATAWORKS_AGENT_ID = "agent_opendataworks"
 OPENDATAWORKS_AGENT_NAME = "OpenDataWorks助手智能体"
 PERMISSION_MODES = {"inherit", "default", "bypassPermissions"}
@@ -305,10 +305,10 @@ def _runtime_root() -> Path:
 
 
 def resolved_agent_workdir(agent_id: str, *, is_default: bool = False) -> str:
-    if is_default:
-        return str(_runtime_root())
     safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(agent_id or "").strip()) or "agent"
-    return str((_runtime_root().parent / "agents" / safe_id).resolve())
+    if is_default and not str(agent_id or "").strip():
+        safe_id = DEFAULT_AGENT_ID
+    return str((_runtime_root().parent / "workspaces" / safe_id).resolve())
 
 
 def _new_agent_id() -> str:

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -6,8 +6,11 @@ Shared DataAgent Claude runtime helpers.
 
 import json
 import os
+import re
+import shlex
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from core.provider_runtime import build_provider_env as _build_provider_env
@@ -33,6 +36,14 @@ PORTAL_MCP_TOOL_NAMES = [
 ]
 PLATFORM_TOOLS_SKILL_FOLDER = "opendataworks-platform-tools"
 SYSTEM_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "data_agent_system_prompt.md"
+_FILE_BOUNDARY_PATH_KEYS = {
+    "Read": ("file_path", "path"),
+    "LS": ("path",),
+    "Glob": ("path", "pattern"),
+    "Grep": ("path", "glob"),
+}
+_BASH_PARENT_SEGMENT_RE = re.compile(r"(^|[\s;&|()])\.\.(?=$|[/\s;&|()])")
+_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 
 
 def _build_prompt(history: list[dict[str, str]], question: str) -> str:
@@ -66,6 +77,159 @@ def _dedupe_strings(values: Any) -> list[str]:
         result.append(text)
         seen.add(text)
     return result
+
+
+def _path_has_parent_segment(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return any(part == ".." for part in text.replace("\\", "/").split("/"))
+
+
+def _resolve_workspace_candidate(raw: Any, workspace: Path) -> Path:
+    text = os.path.expandvars(str(raw or "").strip())
+    path = Path(text).expanduser()
+    if not path.is_absolute():
+        path = workspace / path
+    return path.resolve(strict=False)
+
+
+def _path_is_under(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def _path_is_allowed(path: Path, allowed_roots: list[Path]) -> bool:
+    return any(_path_is_under(path, root) for root in allowed_roots)
+
+
+def _build_workspace_allowed_roots(project_cwd: str | Path, skill_runtime: dict[str, Any] | None) -> list[Path]:
+    roots = [Path(project_cwd).expanduser().resolve(strict=False)]
+    enabled_folders = set(_dedupe_strings((skill_runtime or {}).get("enabled_folders")))
+    enabled_roots = dict((skill_runtime or {}).get("enabled_roots") or {})
+    for root in enabled_roots.values():
+        if str(root or "").strip():
+            roots.append(Path(str(root)).expanduser().resolve(strict=False))
+
+    primary_root = str((skill_runtime or {}).get("primary_root") or "").strip()
+    if enabled_folders and primary_root:
+        roots.append(Path(primary_root).expanduser().resolve(strict=False))
+
+    if PLATFORM_TOOLS_SKILL_FOLDER in enabled_folders and primary_root:
+        sibling_platform_root = Path(primary_root).expanduser().resolve(strict=False).parent / PLATFORM_TOOLS_SKILL_FOLDER
+        if sibling_platform_root.exists():
+            roots.append(sibling_platform_root.resolve(strict=False))
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        key = str(root)
+        if key in seen:
+            continue
+        deduped.append(root)
+        seen.add(key)
+    return deduped
+
+
+def _iter_tool_path_inputs(tool_name: str, tool_input: dict[str, Any]) -> list[tuple[str, str]]:
+    keys = _FILE_BOUNDARY_PATH_KEYS.get(tool_name, ())
+    results: list[tuple[str, str]] = []
+    for key in keys:
+        value = tool_input.get(key)
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)):
+            results.extend((key, str(item)) for item in value if str(item or "").strip())
+        else:
+            text = str(value or "").strip()
+            if text:
+                results.append((key, text))
+    return results
+
+
+def _normalize_bash_token(token: str) -> str:
+    return str(token or "").strip().strip("'\"").rstrip(",;")
+
+
+def _validate_bash_workspace_boundary(
+    command: str,
+    allowed_roots: list[Path],
+    runtime_env: dict[str, str] | None,
+) -> str | None:
+    if _BASH_PARENT_SEGMENT_RE.search(command.replace("\\", "/")):
+        return "Bash command uses a parent directory segment; stay inside the current agent workspace."
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    python_bin = str((runtime_env or {}).get("DATAAGENT_PYTHON_BIN") or "").strip()
+    allowed_executable = Path(python_bin).expanduser().resolve(strict=False) if python_bin else None
+    for token in tokens:
+        normalized = _normalize_bash_token(token)
+        if not normalized or normalized.startswith("$") or _URL_SCHEME_RE.match(normalized):
+            continue
+        if _path_has_parent_segment(normalized):
+            return "Bash command uses a parent directory segment; stay inside the current agent workspace."
+        if not normalized.startswith("/"):
+            continue
+        candidate = Path(normalized).expanduser().resolve(strict=False)
+        if allowed_executable and candidate == allowed_executable:
+            continue
+        if not _path_is_allowed(candidate, allowed_roots):
+            return f"Bash command references absolute path outside workspace: {normalized}"
+    return None
+
+
+def _validate_workspace_tool_boundary(
+    tool_name: str,
+    tool_input: dict[str, Any] | None,
+    project_cwd: str | Path,
+    allowed_roots: list[Path],
+    runtime_env: dict[str, str] | None,
+) -> str | None:
+    normalized_tool = str(tool_name or "").strip()
+    input_payload = tool_input or {}
+    workspace = Path(project_cwd).expanduser().resolve(strict=False)
+    if normalized_tool == "Bash":
+        command = str(input_payload.get("command") or "").strip()
+        if command:
+            return _validate_bash_workspace_boundary(command, allowed_roots, runtime_env)
+        return None
+
+    for key, value in _iter_tool_path_inputs(normalized_tool, input_payload):
+        if _path_has_parent_segment(value):
+            return f"{normalized_tool} {key} uses a parent directory segment; stay inside the current agent workspace."
+        candidate = _resolve_workspace_candidate(value, workspace)
+        if not _path_is_allowed(candidate, allowed_roots):
+            return f"{normalized_tool} {key} is outside workspace or enabled Skill roots: {value}"
+    return None
+
+
+def _build_workspace_boundary_hooks(
+    project_cwd: str | Path,
+    skill_runtime: dict[str, Any] | None,
+    runtime_env: dict[str, str] | None,
+) -> dict[str, list[Any]]:
+    workspace = Path(project_cwd).expanduser().resolve(strict=False)
+    allowed_roots = _build_workspace_allowed_roots(workspace, skill_runtime)
+
+    async def _pre_tool_use(input_data: dict[str, Any], tool_use_id: str | None, context: dict[str, Any]) -> dict[str, Any]:
+        tool_name = str((input_data or {}).get("tool_name") or "")
+        tool_input = (input_data or {}).get("tool_input") or {}
+        reason = _validate_workspace_tool_boundary(tool_name, tool_input, workspace, allowed_roots, runtime_env)
+        if not reason:
+            return {"continue_": True, "suppressOutput": True}
+        return {
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            },
+        }
+
+    return {"PreToolUse": [SimpleNamespace(matcher=None, hooks=[_pre_tool_use])]}
 
 
 def _build_system_prompt(

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -20,6 +20,7 @@ from core.agent_runtime import (
     _build_provider_env,
     _build_runtime_env,
     _build_system_prompt,
+    _build_workspace_boundary_hooks,
     _clip_text,
     _default_model_for_provider,
     _extract_block,
@@ -860,6 +861,7 @@ async def execute_task_stream(
         mcp_servers=mcp_servers,
         include_partial_messages=supports_partial_messages,
         env=runtime_env,
+        hooks=_build_workspace_boundary_hooks(project_cwd, skill_runtime, runtime_env),
         stderr=lambda line: logger.error(
             "sdk.stderr task_id=%s provider=%s model=%s %s",
             params.task_id,

--- a/dataagent/dataagent-backend/tests/test_admin_routes.py
+++ b/dataagent/dataagent-backend/tests/test_admin_routes.py
@@ -329,7 +329,7 @@ def test_agent_profile_routes_contract(monkeypatch):
         "agent_id": "agent_1",
         "name": "营销分析智能体",
         "description": "营销场景",
-        "resolved_workdir": "/tmp/dataagent/agents/agent_1",
+        "resolved_workdir": "/tmp/dataagent/workspaces/agent_1",
         "system_prompt": "只回答营销问题",
         "permission_mode": "inherit",
         "allowed_tools": ["Skill", "Read"],
@@ -405,7 +405,7 @@ def test_agent_profile_routes_contract(monkeypatch):
 
     detail = client.get("/api/v1/dataagent/agents/agent_1")
     assert detail.status_code == 200
-    assert detail.json()["resolved_workdir"] == "/tmp/dataagent/agents/agent_1"
+    assert detail.json()["resolved_workdir"] == "/tmp/dataagent/workspaces/agent_1"
 
     updated = client.put("/api/v1/dataagent/agents/agent_1", json={"description": "更新后"})
     assert updated.status_code == 200

--- a/dataagent/dataagent-backend/tests/test_agent_profile_service.py
+++ b/dataagent/dataagent-backend/tests/test_agent_profile_service.py
@@ -9,6 +9,7 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
+from config import get_settings, update_settings
 from core import agent_profile_service
 
 
@@ -16,7 +17,7 @@ def test_default_agent_payload_is_general_builtin_agent():
     payload = agent_profile_service.default_agent_payload()
 
     assert payload["agent_id"] == "agent_default"
-    assert payload["name"] == "通用智能体"
+    assert payload["name"] == "默认助手"
     assert payload["description"] == "通用对话与分析入口，不预置 OpenDataWorks 专属 Skills。"
     assert payload["allowed_tools"] == ["Read", "LS", "Glob", "Grep"]
     assert payload["mcp_server_ids"] == []
@@ -35,6 +36,21 @@ def test_opendataworks_agent_payload_is_builtin_with_platform_capabilities():
     assert payload["skill_folders"] == ["opendataworks-business-knowledge", "opendataworks-platform-tools"]
     assert payload["is_default"] is False
     assert payload["is_builtin"] is True
+
+
+def test_resolved_agent_workdir_uses_managed_workspace_root_for_all_profiles(monkeypatch, tmp_path: Path):
+    original_runtime_cwd = get_settings().dataagent_runtime_project_cwd
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    update_settings({"dataagent_runtime_project_cwd": ""})
+    try:
+        default_workdir = agent_profile_service.resolved_agent_workdir("agent_default", is_default=True)
+        custom_workdir = agent_profile_service.resolved_agent_workdir("agent unsafe/id", is_default=False)
+    finally:
+        update_settings({"dataagent_runtime_project_cwd": original_runtime_cwd})
+
+    runtime_root = tmp_path / "home" / ".dataagent" / "runtime"
+    assert default_workdir == str(runtime_root / "workspaces" / "agent_default")
+    assert custom_workdir == str(runtime_root / "workspaces" / "agent-unsafe-id")
 
 
 def test_normalize_agent_profile_payload_accepts_scoped_runtime_config():

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -211,6 +212,101 @@ def test_build_allowed_tools_includes_portal_mcp_tools_once():
     assert "mcp__portal__portal_search_tables" in allowed_tools
     assert "mcp__portal__portal_query_readonly" in allowed_tools
     assert len(allowed_tools) == len(set(allowed_tools))
+
+
+def test_workspace_boundary_denies_parent_directory_file_lookup(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Read",
+        {"file_path": "../secret.md"},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "parent directory" in denial
+
+
+def test_workspace_boundary_allows_workspace_and_enabled_skill_roots(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_opendataworks"
+    workspace.mkdir(parents=True)
+    local_doc = workspace / "notes.md"
+    local_doc.write_text("ok", encoding="utf-8")
+    skill_root = tmp_path / "skills" / "opendataworks-platform-tools"
+    skill_root.mkdir(parents=True)
+    skill_doc = skill_root / "SKILL.md"
+    skill_doc.write_text("# skill\n", encoding="utf-8")
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(
+        workspace,
+        {"enabled_roots": {"opendataworks-platform-tools": str(skill_root)}},
+    )
+
+    assert agent_runtime._validate_workspace_tool_boundary(
+        "Read",
+        {"file_path": str(local_doc)},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    ) is None
+    assert agent_runtime._validate_workspace_tool_boundary(
+        "Read",
+        {"file_path": str(skill_doc)},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    ) is None
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Read",
+        {"file_path": str(tmp_path / "outside.md")},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+    assert denial is not None
+    assert "outside workspace" in denial
+
+
+def test_workspace_boundary_denies_bash_parent_directory_lookup(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Bash",
+        {"command": "find .. -name '*.md'"},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "parent directory" in denial
+
+
+def test_workspace_boundary_hook_returns_pretooluse_denial(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    hooks = agent_runtime._build_workspace_boundary_hooks(
+        workspace,
+        {"enabled_roots": {}},
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+    hook = hooks["PreToolUse"][0].hooks[0]
+
+    result = asyncio.run(
+        hook(
+            {"tool_name": "Read", "tool_input": {"path": "../secret.md"}},
+            "tool-read-1",
+            {"signal": None},
+        )
+    )
+
+    assert result["decision"] == "block"
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 def test_system_prompt_template_is_markdown_file():

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -17,7 +17,7 @@ import main
 
 DEFAULT_AGENT = {
     "agent_id": "agent_default",
-    "name": "通用智能体",
+    "name": "默认助手",
     "description": "default",
     "system_prompt": "",
     "permission_mode": "default",
@@ -28,7 +28,7 @@ DEFAULT_AGENT = {
     "env_vars": {},
     "is_default": True,
     "is_builtin": True,
-    "resolved_workdir": "/tmp/dataagent/default",
+    "resolved_workdir": "/tmp/dataagent/workspaces/agent_default",
     "created_at": "",
     "updated_at": "",
 }

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -290,7 +290,7 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
         },
     )
     _patch_skill_runtime(monkeypatch, tmp_path)
-    agent_cwd = tmp_path / "agents" / "agent_1"
+    agent_cwd = tmp_path / "workspaces" / "agent_1"
     captured: dict[str, object] = {}
 
     def fake_prepare_enabled_skills_project_cwd(folders, **kwargs):
@@ -335,6 +335,17 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     assert ClaudeAgentOptions.last_kwargs["permission_mode"] == "default"
     assert ClaudeAgentOptions.last_kwargs["env"]["SAFE_FLAG"] == "1"
     assert "只返回自定义智能体结果。" in ClaudeAgentOptions.last_kwargs["system_prompt"]
+    assert "PreToolUse" in ClaudeAgentOptions.last_kwargs["hooks"]
+    hook = ClaudeAgentOptions.last_kwargs["hooks"]["PreToolUse"][0].hooks[0]
+    blocked = asyncio.run(
+        hook(
+            {"tool_name": "Read", "tool_input": {"file_path": "../secret.md"}},
+            "tool-read-escape",
+            {"signal": None},
+        )
+    )
+    assert blocked["decision"] == "block"
+    assert blocked["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 def test_execute_task_stream_buffers_partial_text_until_turn_end(monkeypatch, tmp_path: Path):

--- a/docs/design/2026-05-21-dataagent-agent-profiles-design.md
+++ b/docs/design/2026-05-21-dataagent-agent-profiles-design.md
@@ -61,7 +61,7 @@ Add `da_agent_profile` in the DataAgent session schema. Each profile stores:
 - `is_builtin`
 - timestamps
 
-The backend resolves `resolved_workdir` from runtime configuration instead of storing arbitrary paths. The default profile is the built-in `通用智能体`, which has no skills or MCP services and uses only a minimal read-only tool set. The built-in `OpenDataWorks助手智能体` preserves the OpenDataWorks-specific intelligent-query behavior by enabling the OpenDataWorks skill folders, safe tool set, and Portal MCP service. User-created profiles use a managed cwd under the DataAgent runtime home.
+The backend resolves `resolved_workdir` from runtime configuration instead of storing arbitrary paths. The default profile is the built-in `默认助手`, which has no skills or MCP services and uses only a minimal read-only tool set. The built-in `OpenDataWorks助手智能体` preserves the OpenDataWorks-specific intelligent-query behavior by enabling the OpenDataWorks skill folders, safe tool set, and Portal MCP service. Each profile uses a managed workspace under the DataAgent runtime home.
 
 ### Topic And Task Binding
 
@@ -81,7 +81,7 @@ Existing topics are backfilled to the default general agent. Existing tasks can 
 - MCP servers = only selected existing MCP services; v1 includes current `portal`
 - max turns = agent `max_turns` when positive, otherwise existing interactive/background defaults
 - env vars = validated agent env merged after provider/runtime env, excluding reserved runtime keys
-- cwd = default agent uses existing enabled-skills cwd; custom agents use managed per-agent cwd
+- cwd = every agent profile uses a managed per-agent workspace with its own `.claude/skills`
 
 Root execution still downgrades `bypassPermissions` to SDK-compatible default behavior.
 
@@ -104,7 +104,7 @@ The chat view adds an agent selector in the upper-left. Selecting an agent reloa
 
 Two profiles are owned by the system:
 
-- `agent_default` / `通用智能体`: default selector target and backfill target for records that had no agent before profiles existed. It is intentionally broad but not all-powerful: no skill folders, no MCP services, and only `Read`, `LS`, `Glob`, and `Grep` tools.
+- `agent_default` / `默认助手`: default selector target and backfill target for records that had no agent before profiles existed. It is intentionally broad but not all-powerful: no skill folders, no MCP services, and only `Read`, `LS`, `Glob`, and `Grep` tools.
 - `agent_opendataworks` / `OpenDataWorks助手智能体`: OpenDataWorks-specific assistant with the current business-knowledge and platform-tools skill folders, the safe tool set, and Portal MCP.
 
 Both built-in agents are visible and can start chats. They cannot be deleted. User-created agents are always non-built-in.

--- a/docs/design/2026-05-25-dataagent-agent-workspace-isolation-design.md
+++ b/docs/design/2026-05-25-dataagent-agent-workspace-isolation-design.md
@@ -1,0 +1,92 @@
+# DataAgent Agent Workspace Isolation Design
+
+## Current State
+
+DataAgent profile execution already passes a managed `cwd` to Claude Agent SDK and generates enabled Skill symlinks under `<cwd>/.claude/skills`.
+
+The current profile cwd layout is inconsistent:
+
+- the default profile uses `HOME/.dataagent/runtime/enabled-skills`
+- custom profiles use `HOME/.dataagent/runtime/agents/<agent_id>`
+
+That `agents` directory name is easy to confuse with Claude subagents. More importantly, the SDK receives only `cwd`, allowed tool names, and permission mode. The runtime does not currently enforce that file-oriented tools stay inside the current profile cwd.
+
+## Problem
+
+Different intelligent-query agents should work in separate profile workspaces. During a run, an agent must not search upward into parent directories or inspect sibling profile state.
+
+Relying only on Claude SDK `cwd` is not enough. Tools such as `Read`, `LS`, `Glob`, `Grep`, and `Bash` can receive relative paths, absolute paths, or commands that refer to `..` or another directory outside the run workspace.
+
+## Scope
+
+In scope:
+
+- DataAgent managed workspace path resolution for agent profiles.
+- SDK runtime options for enforcing tool filesystem boundaries.
+- Regression tests for workspace paths and parent-directory denial.
+- Documentation for the new runtime layout.
+
+Out of scope:
+
+- Database schema changes.
+- Arbitrary administrator-supplied filesystem workspaces.
+- Changing Skill storage or Skill editing APIs.
+- Container-level sandboxing or OS namespace isolation.
+
+## Solution
+
+Use one workspace layout for every DataAgent profile:
+
+```text
+HOME/.dataagent/runtime/
+  workspaces/
+    agent_default/
+      .claude/
+        skills/
+    agent_opendataworks/
+      .claude/
+        skills/
+    <custom_agent_id>/
+      .claude/
+        skills/
+```
+
+The backend continues to expose `resolved_workdir` for API compatibility, but its value becomes the profile workspace path.
+
+For each task:
+
+1. Resolve the selected profile workspace from the profile `agent_id`.
+2. Generate the enabled Skill symlinks under `<workspace>/.claude/skills`.
+3. Pass the workspace as SDK `cwd`.
+4. Register a `PreToolUse` runtime hook that denies filesystem escape attempts:
+   - deny any `Read`, `LS`, `Glob`, or `Grep` path input containing a parent-directory segment
+   - deny any resolved file path outside the current workspace and explicitly enabled Skill roots
+   - deny `Bash` commands that include parent-directory path segments
+   - deny absolute paths in `Bash` unless they are inside an allowed root or are the configured DataAgent Python executable
+
+Enabled Skill roots are allowed because the workspace exposes them through symlinks under `.claude/skills`; the hook still resolves symlinks and only allows roots for Skills enabled for the current profile.
+
+## Interfaces
+
+No public API shape changes are required.
+
+- `resolved_workdir` remains in agent profile responses.
+- The visible path changes from `.../runtime/agents/<agent_id>` to `.../runtime/workspaces/<agent_id>`.
+- Runtime logs continue to report the SDK `cwd`.
+
+## Tradeoffs
+
+The SDK session project path changes for profile runs because `cwd` changes. Existing historical topics still keep their DataAgent topic/task records, but Claude SDK local resume files tied to the old cwd path may not be reused.
+
+The runtime hook is an application-level guard, not a container sandbox. It prevents normal SDK tool calls from escaping the workspace, but it does not replace OS-level hardening. Container deployments should still run the DataAgent backend as a non-root user with a narrow writable home volume.
+
+The Bash validation is intentionally conservative for parent-directory segments and absolute paths. This matches the intelligent-query contract, where platform scripts must be invoked through `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/<name>.py" ...` instead of probing arbitrary filesystem locations.
+
+## Verification
+
+- Unit tests for profile workspace path resolution.
+- Unit tests for file tool parent-directory and outside-root denial.
+- Unit tests for allowed workspace and enabled Skill access.
+- Task executor test proving SDK options include workspace boundary hooks.
+- Targeted pytest for `test_agent_profile_service.py`, `test_agent_runtime.py`, and `test_task_executor.py`.
+

--- a/docs/plans/2026-05-21-dataagent-agent-profiles-plan.md
+++ b/docs/plans/2026-05-21-dataagent-agent-profiles-plan.md
@@ -17,7 +17,7 @@
 3. Add backend profile store/service with default bootstrap, validation, snapshot creation, delete guards, and capability discovery.
 4. Add agent profile API routes under `/api/v1/dataagent/agents`.
 5. Extend topic/task store and submission flow so topics and tasks carry immutable agent snapshots.
-6. Extend runtime helpers and task execution to apply agent prompt, tools, MCP services, skills, max turns, env vars, and managed cwd.
+6. Extend runtime helpers and task execution to apply agent prompt, tools, MCP services, skills, max turns, env vars, and managed workspace cwd.
 7. Add frontend API helpers for agents.
 8. Add `AgentStudio.vue` and `AgentDetailView.vue`; register intelligent-query routes and menu item.
 9. Update `NL2SqlChat.vue` to load/select agents, filter topics by `agent_id`, create topics with active agent, and submit `agent_id`.
@@ -29,7 +29,7 @@
 This follow-up keeps the profile architecture from the original plan and adjusts the built-in seed data:
 
 1. Add `is_builtin` to `da_agent_profile` with a new Alembic migration.
-2. Treat `agent_default` as `通用智能体`; it is `is_default=true`, `is_builtin=true`, has no skills/MCP services, and uses the minimal read-only tool set.
+2. Treat `agent_default` as `默认助手`; it is `is_default=true`, `is_builtin=true`, has no skills/MCP services, and uses the minimal read-only tool set.
 3. Add `agent_opendataworks` as `OpenDataWorks助手智能体`; it is `is_default=false`, `is_builtin=true`, and carries the OpenDataWorks skills, safe tools, and Portal MCP.
 4. Backfill only missing topic/task agent bindings to `agent_default` so old records without an agent map to the general agent.
 5. Expose `is_builtin` in agent summaries and profiles; hide delete actions for built-in profiles in the frontend.

--- a/docs/plans/2026-05-25-dataagent-agent-workspace-isolation-plan.md
+++ b/docs/plans/2026-05-25-dataagent-agent-workspace-isolation-plan.md
@@ -1,0 +1,43 @@
+# DataAgent Agent Workspace Isolation Plan
+
+## Goal
+
+Give every intelligent-query profile an independent managed workspace and prevent runtime tool calls from searching parent directories or sibling profile state.
+
+## Tasks
+
+1. Add path-resolution regression coverage.
+   - Assert every profile, including `agent_default`, resolves under `HOME/.dataagent/runtime/workspaces/<agent_id>`.
+   - Assert custom agent IDs are sanitized before path use.
+
+2. Add runtime boundary regression coverage.
+   - Deny `Read` with `../secret.md`.
+   - Deny absolute paths outside the current workspace and enabled Skill roots.
+   - Allow paths inside the workspace.
+   - Allow paths inside an enabled Skill root.
+   - Deny `Bash` commands that reference `..`.
+
+3. Update workspace path resolution.
+   - Keep the API field `resolved_workdir`.
+   - Change its value to the managed workspace path.
+   - Keep legacy no-profile fallback execution on the existing global enabled-Skill cwd.
+
+4. Add SDK PreToolUse boundary hooks.
+   - Build allowed roots from the resolved workspace and enabled Skill roots.
+   - Add the hook to `ClaudeAgentOptions`.
+   - Keep existing allowed tool, MCP, permission mode, and env behavior unchanged.
+
+5. Refresh focused docs and UI copy if touched.
+   - Keep design and plan files in sync.
+   - Prefer “工作空间” wording for visible profile workspace text.
+
+6. Verify.
+   - Run `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_agent_profile_service.py dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py -q`.
+   - If frontend copy changes, run `nvm use` and the smallest relevant Vitest target.
+
+## Backout
+
+- Revert `resolved_workdir` to the previous `runtime/agents/<agent_id>` and default enabled-Skill cwd behavior.
+- Remove the SDK hook wiring and boundary helper tests.
+- Keep the documentation change reverted together with code so deployment notes match runtime behavior.
+

--- a/frontend/src/demo/mockServer.js
+++ b/frontend/src/demo/mockServer.js
@@ -1128,7 +1128,7 @@ const demoAgents = [
         { cluster_id: DEMO_CLUSTER_ID, source_type: 'DORIS', database: DEMO_DATABASE }
       ]
     },
-    resolved_workdir: '/demo/opendataworks',
+    resolved_workdir: '/demo/workspaces/opendataworks',
     is_default: true,
     is_builtin: true
   }
@@ -2123,7 +2123,7 @@ export const demoAdapter = async (config) => {
       agent_id: `agent_demo_${demoAgents.length + 1}`,
       is_default: false,
       is_builtin: false,
-      resolved_workdir: '/demo/opendataworks'
+      resolved_workdir: '/demo/workspaces/opendataworks'
     }
     demoAgents.push(next)
     return createResponse(config, clone(next))

--- a/frontend/src/views/intelligence/AgentDetailView.vue
+++ b/frontend/src/views/intelligence/AgentDetailView.vue
@@ -7,7 +7,7 @@
           返回智能体
         </el-button>
         <h2>{{ form.name || '智能体详情' }}</h2>
-        <p class="agent-detail-workdir">{{ form.resolved_workdir || '托管工作目录将在保存后生成' }}</p>
+        <p class="agent-detail-workdir">{{ form.resolved_workdir || '托管工作空间将在保存后生成' }}</p>
       </div>
       <div class="agent-detail-actions">
         <el-button :icon="ChatLineRound" @click="openChat">开启对话</el-button>

--- a/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/AgentDetailView.spec.js
@@ -65,7 +65,7 @@ describe('AgentDetailView', () => {
       agent_id: 'agent_1',
       name: '营销分析',
       description: '营销场景',
-      resolved_workdir: '/tmp/agents/agent_1',
+      resolved_workdir: '/tmp/workspaces/agent_1',
       system_prompt: '只做营销分析',
       permission_mode: 'inherit',
       allowed_tools: ['Skill', 'Read'],
@@ -90,7 +90,7 @@ describe('AgentDetailView', () => {
     })
     dataagentApi.updateAgent.mockImplementation(async (_agentId, data) => ({
       agent_id: 'agent_1',
-      resolved_workdir: '/tmp/agents/agent_1',
+      resolved_workdir: '/tmp/workspaces/agent_1',
       is_default: false,
       ...data
     }))


### PR DESCRIPTION
## Summary
- Move managed DataAgent profile runtime paths to per-agent `runtime/workspaces/<agent_id>` directories.
- Add Claude SDK `PreToolUse` boundary hooks to block parent-directory and outside-root file/Bash access while still allowing enabled Skill roots.
- Document the workspace isolation design/plan and update focused backend/frontend contract tests.

## Validation
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_agent_profile_service.py dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py dataagent/dataagent-backend/tests/test_admin_routes.py dataagent/dataagent-backend/tests/test_routes_contract.py dataagent/dataagent-backend/tests/test_skill_discovery.py -q` — 53 passed
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend run test -- AgentDetailView mockServerIntelligentQuery` — 6 passed
- `git diff --check` — passed

## Risk
- Existing Claude SDK local resume files keyed by the previous cwd path may not be reused after the workspace path change.

## Rollback
- Revert this PR to restore the previous runtime cwd layout and remove the SDK boundary hook.
