### PR TITLE
fix: persist intelligent query agent selection

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260522_000008_add_builtin_agent_profiles.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260522_000008_add_builtin_agent_profiles.py
@@ -23,7 +23,7 @@ OPENDATAWORKS_AGENT_ID = "agent_opendataworks"
 
 GENERAL_AGENT_SNAPSHOT = {
     "agent_id": DEFAULT_AGENT_ID,
-    "name": "通用智能体",
+    "name": "默认助手",
     "description": "通用对话与分析入口，不预置 OpenDataWorks 专属 Skills。",
     "system_prompt": "",
     "permission_mode": "default",

--- a/dataagent/dataagent-backend/alembic/versions/20260525_000011_rename_default_agent.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260525_000011_rename_default_agent.py
@@ -1,0 +1,78 @@
+"""rename default agent display name
+
+Revision ID: 20260525_000011
+Revises: 20260525_000010
+Create Date: 2026-05-25 16:40:00
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260525_000011"
+down_revision = "20260525_000010"
+branch_labels = None
+depends_on = None
+
+DEFAULT_AGENT_ID = "agent_default"
+OLD_DEFAULT_AGENT_NAME = "通用智能体"
+NEW_DEFAULT_AGENT_NAME = "默认助手"
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(column.get("name") == column_name for column in inspector.get_columns(table_name))
+
+
+def _rename_profile_name(old_name: str, new_name: str) -> None:
+    bind = op.get_bind()
+    if _has_table("da_agent_profile") and _has_column("da_agent_profile", "name"):
+        bind.execute(
+            sa.text(
+                """
+                UPDATE da_agent_profile
+                SET name = :new_name
+                WHERE agent_id = :agent_id
+                  AND name = :old_name
+                """
+            ),
+            {
+                "agent_id": DEFAULT_AGENT_ID,
+                "old_name": old_name,
+                "new_name": new_name,
+            },
+        )
+
+    for table_name in ("da_agent_topic", "da_agent_task"):
+        if not _has_table(table_name) or not _has_column(table_name, "agent_snapshot_json"):
+            continue
+        bind.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET agent_snapshot_json = JSON_SET(agent_snapshot_json, '$.name', :new_name)
+                WHERE agent_id = :agent_id
+                  AND JSON_VALID(agent_snapshot_json)
+                  AND JSON_UNQUOTE(JSON_EXTRACT(agent_snapshot_json, '$.name')) = :old_name
+                """
+            ),
+            {
+                "agent_id": DEFAULT_AGENT_ID,
+                "old_name": old_name,
+                "new_name": new_name,
+            },
+        )
+
+
+def upgrade() -> None:
+    _rename_profile_name(OLD_DEFAULT_AGENT_NAME, NEW_DEFAULT_AGENT_NAME)
+
+
+def downgrade() -> None:
+    _rename_profile_name(NEW_DEFAULT_AGENT_NAME, OLD_DEFAULT_AGENT_NAME)

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -359,7 +359,7 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, triggerRef, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { marked } from 'marked'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
@@ -377,6 +377,7 @@ marked.setOptions({ breaks: true, gfm: true })
 const api = createNl2SqlApiClient({ timeout: 300000 })
 const { topicApi, taskApi, adminApi, agentApi } = api
 const route = useRoute()
+const router = useRouter()
 
 const topics = ref([])
 const agents = ref([])
@@ -1275,7 +1276,7 @@ const loadSettings = async () => {
 
 const normalizeAgent = (agent) => ({
   agent_id: String(agent?.agent_id || ''),
-  name: String(agent?.name || '通用智能体'),
+  name: String(agent?.name || '默认助手'),
   description: String(agent?.description || ''),
   is_default: Boolean(agent?.is_default),
   is_builtin: Boolean(agent?.is_builtin)
@@ -1287,7 +1288,7 @@ const loadAgents = async () => {
     const normalized = (Array.isArray(list) ? list : []).map(normalizeAgent).filter((agent) => agent.agent_id)
     agents.value = normalized.length
       ? normalized
-      : [{ agent_id: 'agent_default', name: '通用智能体', description: '', is_default: true, is_builtin: true }]
+      : [{ agent_id: 'agent_default', name: '默认助手', description: '', is_default: true, is_builtin: true }]
     const routeAgentId = String(route.query.agent_id || '').trim()
     if (routeAgentId && agents.value.some((agent) => agent.agent_id === routeAgentId)) {
       selectedAgentId.value = routeAgentId
@@ -1296,8 +1297,28 @@ const loadAgents = async () => {
     }
   } catch (error) {
     console.warn('load agents failed', error)
-    agents.value = [{ agent_id: 'agent_default', name: '通用智能体', description: '', is_default: true, is_builtin: true }]
+    agents.value = [{ agent_id: 'agent_default', name: '默认助手', description: '', is_default: true, is_builtin: true }]
     selectedAgentId.value = selectedAgentId.value || 'agent_default'
+  }
+}
+
+const persistSelectedAgentInRoute = (agentId) => {
+  const value = String(agentId || '').trim()
+  if (String(route.query.agent_id || '').trim() === value) return
+
+  const query = { ...route.query }
+  if (value) {
+    query.agent_id = value
+  } else {
+    delete query.agent_id
+  }
+
+  const navigation = router.replace({
+    path: '/intelligent-query',
+    query
+  })
+  if (navigation && typeof navigation.catch === 'function') {
+    navigation.catch(() => {})
   }
 }
 
@@ -1557,6 +1578,7 @@ const handleAgentChange = async (nextValue) => {
         type: 'info'
       }
     ).then(async () => {
+      persistSelectedAgentInRoute(nextValue)
       selectedAgentId.value = nextValue
       await handleNewTopic()
     }).catch(() => {
@@ -1566,6 +1588,7 @@ const handleAgentChange = async (nextValue) => {
   } else {
     // Delete the old empty topic to avoid leaving clutter
     const oldTopicId = activeTopicId.value
+    persistSelectedAgentInRoute(nextValue)
     selectedAgentId.value = nextValue
     await handleNewTopic()
     if (oldTopicId) {

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -48,13 +48,23 @@ const apiMocks = vi.hoisted(() => ({
   },
   health: vi.fn()
 }))
+const routeState = vi.hoisted(() => ({
+  query: {},
+  params: {},
+  path: '/intelligent-query',
+  name: 'IntelligentQuery'
+}))
+const routerReplace = vi.hoisted(() => vi.fn())
 
 vi.mock('@/api/nl2sql', () => ({
   createNl2SqlApiClient: () => apiMocks
 }))
 
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ query: {}, params: {}, path: '/intelligent-query', name: 'IntelligentQuery' })
+  useRoute: () => routeState,
+  useRouter: () => ({
+    replace: routerReplace
+  })
 }))
 
 vi.mock('element-plus', () => ({
@@ -201,6 +211,11 @@ describe('NL2SqlChat', () => {
     Object.values(apiMocks.adminApi).forEach((fn) => fn.mockReset())
     Object.values(apiMocks.agentApi).forEach((fn) => fn.mockReset())
     apiMocks.health.mockReset()
+    routerReplace.mockReset()
+    routeState.query = {}
+    routeState.params = {}
+    routeState.path = '/intelligent-query'
+    routeState.name = 'IntelligentQuery'
 
     apiMocks.adminApi.getSettings.mockResolvedValue({
       provider_id: 'anyrouter',
@@ -383,6 +398,49 @@ describe('NL2SqlChat', () => {
     await flushPromises()
 
     expect(apiMocks.topicApi.listTopics).toHaveBeenCalledWith({ agent_id: 'agent_sales' })
+  })
+
+  it('persists the selected agent id in the route query for refresh recovery', async () => {
+    apiMocks.agentApi.listAgents.mockResolvedValue([
+      {
+        agent_id: 'agent_default',
+        name: '默认智能问数助手',
+        description: '默认描述',
+        is_default: true
+      },
+      {
+        agent_id: 'agent_sales',
+        name: '销售分析助手',
+        description: '销售分析',
+        is_default: false
+      }
+    ])
+    apiMocks.topicApi.getTopicMessages.mockResolvedValue({
+      topic_id: 'topic-1',
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 0,
+      items: []
+    })
+    apiMocks.topicApi.deleteTopic.mockResolvedValue({})
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await flushPromises()
+
+    apiMocks.topicApi.listTopics.mockClear()
+    apiMocks.topicApi.listTopics.mockResolvedValue([])
+
+    await wrapper.find('.query-main-top-bar .el-select-stub.query-agent-select').trigger('click')
+    await flushPromises()
+    await flushPromises()
+
+    expect(routerReplace).toHaveBeenCalledWith({
+      path: '/intelligent-query',
+      query: { agent_id: 'agent_sales' }
+    })
   })
 
   it('keeps streamed main text visible while tools are still running', async () => {
@@ -839,6 +897,45 @@ describe('NL2SqlChat', () => {
     expect(ring.attributes('aria-label')).toContain('1,200 / 200,000')
     expect(ring.attributes('aria-label')).toContain('输入：1,000')
     expect(ring.attributes('aria-label')).toContain('输出：200')
+  })
+
+  it('estimates context window usage while assistant text is streaming', async () => {
+    const streamHold = deferred()
+    apiMocks.taskApi.streamTaskEvents.mockImplementation(async (_taskId, options = {}) => {
+      options.onEvent?.({
+        seq_id: 13,
+        type: 'message_start',
+        message: { id: 'stream-a1', usage: { input_tokens: 1000 } }
+      })
+      options.onEvent?.({
+        seq_id: 14,
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' }
+      })
+      options.onEvent?.({
+        seq_id: 15,
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'abcdefghijklmnopqrst' }
+      })
+      await streamHold.promise
+    })
+
+    const wrapper = mountChat()
+
+    try {
+      await flushPromises()
+      await flushPromises()
+
+      const ring = wrapper.find('.query-context-ring-wrap')
+      expect(ring.attributes('aria-label')).toContain('1,005 / 200,000')
+      expect(ring.attributes('aria-label')).toContain('输入：1,000')
+      expect(ring.attributes('aria-label')).toContain('输出：约 5')
+    } finally {
+      streamHold.resolve()
+      wrapper.unmount()
+    }
   })
 
   it('shows message footer actions without an edit resend entry', async () => {


### PR DESCRIPTION
## Summary
- Keep the intelligent-query page on the selected agent after refresh by persisting the active `agent_id` in the route query.
- Rename the default built-in agent display name from `通用智能体` to `默认助手`, including seed data and existing DataAgent snapshots.

## What Changed

### Behavior Changes
- Selecting an agent in the intelligent-query chat updates `/intelligent-query?agent_id=...`, so refresh restores the same agent instead of falling back to the default.
- The default assistant label now appears as `默认助手` in frontend fallback states and DataAgent seeded profile data.
- Added a DataAgent Alembic migration that renames existing `agent_default` profile rows and topic/task agent snapshots from `通用智能体` to `默认助手`.

### Key Files
- `frontend/src/views/intelligence/NL2SqlChat.vue`: syncs selected agent id into the route and updates default display fallback.
- `frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js`: covers route persistence when switching agents.
- `dataagent/dataagent-backend/alembic/versions/20260522_000008_add_builtin_agent_profiles.py`: updates fresh seed data.
- `dataagent/dataagent-backend/alembic/versions/20260525_000011_rename_default_agent.py`: migrates existing profile and snapshot names.

## Validation
- [x] `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_agent_profile_service.py dataagent/dataagent-backend/tests/test_routes_contract.py -q`
  - Result: 9 passed.
- [x] `npm --prefix frontend test -- src/views/intelligence/__tests__/NL2SqlChat.spec.js`
  - Result: 19 passed.
- [x] `PYTHONDONTWRITEBYTECODE=1 dataagent/dataagent-backend/.venv-py313/bin/python - <<'PY' ... py_compile.compile(...) ... PY`
  - Result: migration compile check passed.

## Risks
- Risk: route query synchronization could affect chat agent switching behavior, covered by the focused NL2SqlChat regression test.

## Rollback
- Rollback: revert this PR and run the Alembic downgrade for `20260525_000011` if the default assistant label migration must be undone.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Migration/config updates completed where required.
