### PR TITLE
[codex] Update context usage while streaming

### DIFF
--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -534,6 +534,24 @@ const parseTokenNumber = (value) => {
 
 const formatTokenCount = (value) => tokenFormatter.format(Math.max(0, Math.round(Number(value) || 0)))
 
+const estimateTextTokens = (value) => {
+  const text = String(value || '').trim()
+  if (!text) return 0
+  return Math.max(1, Math.ceil(text.length / 4))
+}
+
+const estimateAssistantOutputTokens = (msg) => {
+  if (!msg) return 0
+  const directText = `${String(msg.thinkingText || '')}${String(msg.mainText || '')}`.trim()
+  if (directText) return estimateTextTokens(directText)
+  if (!Array.isArray(msg.renderBlocks)) return 0
+  const blockText = msg.renderBlocks
+    .filter((block) => block && ['thinking', 'main_text'].includes(block.kind))
+    .map((block) => String(block.text || ''))
+    .join('')
+  return estimateTextTokens(blockText)
+}
+
 const getContextWindowLimit = (model) => {
   const text = String(model || '').toLowerCase()
   if (text.includes('claude-3') || text.includes('claude-opus') || text.includes('claude-sonnet') || text.includes('claude-haiku')) {
@@ -545,16 +563,23 @@ const getContextWindowLimit = (model) => {
 }
 
 const contextWindowUsage = computed(() => {
-  const usage = latestAssistantMessage.value?.usage || latestAssistantMessage.value?.token_usage || null
+  const message = latestAssistantMessage.value
+  const usage = message?.usage || message?.token_usage || null
   const inputTokens = parseTokenNumber(usage?.input_tokens)
-  const outputTokens = parseTokenNumber(usage?.output_tokens)
-  const totalTokens = inputTokens + outputTokens || parseTokenNumber(usage?.total_tokens)
-  const limitTokens = getContextWindowLimit(selectedModel.value || latestAssistantMessage.value?.model || settings.default_model)
+  const actualOutputTokens = parseTokenNumber(usage?.output_tokens)
+  const estimatedOutputTokens = actualOutputTokens ? 0 : estimateAssistantOutputTokens(message)
+  const outputTokens = actualOutputTokens || estimatedOutputTokens
+  const outputEstimated = !actualOutputTokens && estimatedOutputTokens > 0
+  const summedTokens = inputTokens + outputTokens
+  const reportedTotalTokens = parseTokenNumber(usage?.total_tokens)
+  const totalTokens = Math.max(summedTokens, reportedTotalTokens)
+  const limitTokens = getContextWindowLimit(selectedModel.value || message?.model || settings.default_model)
   if (!totalTokens) {
     return {
       available: false,
       inputTokens,
       outputTokens,
+      outputEstimated: false,
       totalTokens: 0,
       limitTokens,
       percentage: 0,
@@ -569,6 +594,7 @@ const contextWindowUsage = computed(() => {
     available: true,
     inputTokens,
     outputTokens,
+    outputEstimated,
     totalTokens,
     limitTokens,
     percentage,
@@ -590,7 +616,9 @@ const contextWindowTooltip = computed(() => {
   const usage = contextWindowUsage.value
   if (!usage.available) return '暂无 Token 用量'
   const inputText = usage.inputTokens ? formatTokenCount(usage.inputTokens) : '未知'
-  const outputText = usage.outputTokens ? formatTokenCount(usage.outputTokens) : '未知'
+  const outputText = usage.outputTokens
+    ? `${usage.outputEstimated ? '约 ' : ''}${formatTokenCount(usage.outputTokens)}`
+    : '未知'
   return `上下文窗口使用情况：${formatTokenCount(usage.totalTokens)} / ${formatTokenCount(usage.limitTokens)} Tokens；输入：${inputText}；输出：${outputText}；占比：${usage.percentLabel}`
 })
 

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -901,6 +901,27 @@ describe('NL2SqlChat', () => {
 
   it('estimates context window usage while assistant text is streaming', async () => {
     const streamHold = deferred()
+    apiMocks.topicApi.getTopicMessages.mockResolvedValue({
+      topic_id: 'topic-1',
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 1,
+      items: [
+        {
+          message_id: 'a1',
+          topic_id: 'topic-1',
+          task_id: 'task-1',
+          sender_type: 'assistant',
+          type: 'assistant',
+          status: 'running',
+          content: '',
+          resume_after_seq: 12,
+          blocks: [],
+          created_at: '2026-03-10T02:00:00Z'
+        }
+      ]
+    })
     apiMocks.taskApi.streamTaskEvents.mockImplementation(async (_taskId, options = {}) => {
       options.onEvent?.({
         seq_id: 13,


### PR DESCRIPTION
## Summary

- Estimate assistant output token usage from streamed thinking and answer text while provider `output_tokens` is still unavailable.
- Keep provider-reported usage authoritative once it arrives, including reported totals.
- Add a regression test covering context-window updates during an active stream.

## Why

The context-window ring previously updated output usage only after the final provider usage payload arrived, so it appeared stale while the assistant was actively streaming text.

## Validation

- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/views/intelligence/__tests__/NL2SqlChat.spec.js` — 20 tests passed.
- `git diff --check -- frontend/src/views/intelligence/NL2SqlChat.vue frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js` — passed.

## Risk / Rollback

Risk is limited to the intelligent-query context usage indicator. Rollback by reverting commit `a46fa43`.
