### PR TITLE
fix(ci): rewrite Gitee release body with attachment download links

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -211,18 +211,24 @@ jobs:
       - name: Sync release artifacts to Gitee
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_REPO: ${{ secrets.GITEE_REPO }}
         run: |
           set -euo pipefail
           TAG="${{ github.ref_name }}"
           NAME="OpenDataWorks ${TAG}"
-          GITEE_API="https://gitee.com/api/v5/repos/${{ secrets.GITEE_REPO }}"
+          GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
           existing=$(curl -sS --retry 3 -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/tags/${TAG}" || echo '{}')
           existing_id=$(echo "${existing}" | jq -r '.id // empty')
           if [ -n "${existing_id}" ] && [ "${existing_id}" != "null" ]; then
             echo "Deleting existing Gitee release id=${existing_id}"
-            curl -sS -X DELETE -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/${existing_id}"
+            curl -fsS -X DELETE -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/${existing_id}"
           fi
-          body_json=$(jq -Rs '.' release_body.md)
+          {
+            echo "## ${NAME}"
+            echo ""
+            echo "Gitee 附件上传中，完成后会自动回写下载链接。"
+          } > gitee_release_body.pending.md
+          body_json=$(jq -Rs '.' gitee_release_body.pending.md)
           response=$(curl -sS --retry 3 -X POST \
             -H "Authorization: token ${GITEE_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -234,17 +240,30 @@ jobs:
             exit 1
           fi
           echo "Created Gitee release id=${release_id}"
+          : > gitee_attach_files.jsonl
           for f in "$PACKAGE_PATH" "$PACKAGE_SHA" "$ODA_PACKAGE_PATH" "$ODA_PACKAGE_SHA"; do
             if [ -f "$f" ]; then
               echo "Uploading ${f} ..."
-              curl -sS --retry 3 -X POST \
+              upload_response=$(curl -fsS --retry 3 -X POST \
                 -H "Authorization: token ${GITEE_TOKEN}" \
                 -F "file=@${f}" \
-                "${GITEE_API}/releases/${release_id}/attach_files"
+                "${GITEE_API}/releases/${release_id}/attach_files")
+              echo "${upload_response}" | jq -e '.id' >/dev/null
+              echo "${upload_response}" >> gitee_attach_files.jsonl
               echo ""
             fi
           done
-          echo "Synced to https://gitee.com/${{ secrets.GITEE_REPO }}/releases/tag/${TAG}"
+          bash scripts/release/render-gitee-release-body.sh \
+            release_body.md \
+            gitee_attach_files.jsonl \
+            "${GITEE_REPO}" > gitee_release_body.md
+          gitee_body_json=$(jq -Rs '.' gitee_release_body.md)
+          curl -fsS --retry 3 -X PATCH \
+            -H "Authorization: token ${GITEE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\":${gitee_body_json}}" \
+            "${GITEE_API}/releases/${release_id}" >/dev/null
+          echo "Synced to https://gitee.com/${GITEE_REPO}/releases/tag/${TAG}"
 
   create-latest-release:
     needs: build-and-push
@@ -359,18 +378,24 @@ jobs:
       - name: Sync latest release artifacts to Gitee
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_REPO: ${{ secrets.GITEE_REPO }}
         run: |
           set -euo pipefail
           TAG="${RELEASE_TAG}"
           NAME="${RELEASE_NAME}"
-          GITEE_API="https://gitee.com/api/v5/repos/${{ secrets.GITEE_REPO }}"
+          GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
           existing=$(curl -sS --retry 3 -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/tags/${TAG}" || echo '{}')
           existing_id=$(echo "${existing}" | jq -r '.id // empty')
           if [ -n "${existing_id}" ] && [ "${existing_id}" != "null" ]; then
             echo "Deleting existing Gitee release id=${existing_id}"
-            curl -sS -X DELETE -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/${existing_id}"
+            curl -fsS -X DELETE -H "Authorization: token ${GITEE_TOKEN}" "${GITEE_API}/releases/${existing_id}"
           fi
-          body_json=$(jq -Rs '.' latest_release_body.md)
+          {
+            echo "## ${NAME}"
+            echo ""
+            echo "Gitee 附件上传中，完成后会自动回写下载链接。"
+          } > gitee_release_body.pending.md
+          body_json=$(jq -Rs '.' gitee_release_body.pending.md)
           response=$(curl -sS --retry 3 -X POST \
             -H "Authorization: token ${GITEE_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -382,17 +407,30 @@ jobs:
             exit 1
           fi
           echo "Created Gitee release id=${release_id}"
+          : > gitee_attach_files.jsonl
           for f in "$PACKAGE_PATH" "$PACKAGE_SHA" "$ODA_PACKAGE_PATH" "$ODA_PACKAGE_SHA"; do
             if [ -f "$f" ]; then
               echo "Uploading ${f} ..."
-              curl -sS --retry 3 -X POST \
+              upload_response=$(curl -fsS --retry 3 -X POST \
                 -H "Authorization: token ${GITEE_TOKEN}" \
                 -F "file=@${f}" \
-                "${GITEE_API}/releases/${release_id}/attach_files"
+                "${GITEE_API}/releases/${release_id}/attach_files")
+              echo "${upload_response}" | jq -e '.id' >/dev/null
+              echo "${upload_response}" >> gitee_attach_files.jsonl
               echo ""
             fi
           done
-          echo "Synced to https://gitee.com/${{ secrets.GITEE_REPO }}/releases/tag/${TAG}"
+          bash scripts/release/render-gitee-release-body.sh \
+            latest_release_body.md \
+            gitee_attach_files.jsonl \
+            "${GITEE_REPO}" > gitee_release_body.md
+          gitee_body_json=$(jq -Rs '.' gitee_release_body.md)
+          curl -fsS --retry 3 -X PATCH \
+            -H "Authorization: token ${GITEE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"body\":${gitee_body_json}}" \
+            "${GITEE_API}/releases/${release_id}" >/dev/null
+          echo "Synced to https://gitee.com/${GITEE_REPO}/releases/tag/${TAG}"
 
   summary:
     needs: build-and-push

--- a/docs/handbook/release-process.md
+++ b/docs/handbook/release-process.md
@@ -88,6 +88,7 @@ git push origin v1.0.0
 2. **生成离线部署包**：调用 `scripts/create-offline-package.sh --tag 1.0.0`
 3. **生成 Opendataagent 离线部署包**：调用 `opendataagent/scripts/create-offline-package.sh --tag 1.0.0`
 4. **创建 GitHub Release**：上传两份离线包为 Release 附件，并自动生成 Release Notes（含提交记录）
+5. **同步 Gitee Release**：上传同一组离线包附件，并在附件上传完成后用 Gitee 附件 id 回写下载链接
 
 ---
 
@@ -115,6 +116,8 @@ GitHub Release 中应包含：
   - 可选：`opendataworks-deployment-1.0.0.tar.gz.sha256`（校验和）
   - 可选：`opendataagent-deployment-1.0.0.tar.gz.sha256`（校验和）
 
+Gitee Release 复用同一组离线包附件，但不能复用 GitHub 下载 URL。同步步骤会先创建占位正文，上传附件后根据 Gitee 返回的 `attach_files/{id}/download` 地址生成最终正文并 PATCH 回 Release。
+
 ### 4.3 用户下载方式
 
 1. **Docker 镜像**：
@@ -136,6 +139,7 @@ GitHub Release 中应包含：
 
 - [ ] 在 GitHub Releases 页面检查附件是否上传成功
 - [ ] 验证 Release Notes 中的下载链接可用
+- [ ] 在 Gitee Releases 页面检查附件是否上传成功，并确认正文下载链接指向 `gitee.com/.../attach_files/.../download`
 - [ ] 如有文档站，更新「最新版本」等说明
 
 ---

--- a/scripts/release/render-gitee-release-body.sh
+++ b/scripts/release/render-gitee-release-body.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <release-body.md> <gitee-attachments.jsonl> <gitee-owner/repo>" >&2
+  exit 2
+fi
+
+release_body_file="$1"
+attachments_file="$2"
+gitee_repo="${3#/}"
+gitee_repo="${gitee_repo%/}"
+
+if [ ! -f "$release_body_file" ]; then
+  echo "Release body file not found: $release_body_file" >&2
+  exit 1
+fi
+
+if [ ! -f "$attachments_file" ]; then
+  echo "Gitee attachments file not found: $attachments_file" >&2
+  exit 1
+fi
+
+if [ -z "$gitee_repo" ]; then
+  echo "Gitee repository must be owner/repo" >&2
+  exit 1
+fi
+
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT
+cp "$release_body_file" "$rendered"
+
+while IFS= read -r attachment_json || [ -n "$attachment_json" ]; do
+  if [ -z "$attachment_json" ]; then
+    continue
+  fi
+
+  attachment_id="$(jq -r '.id // .attach_file_id // .attachFileId // empty' <<<"$attachment_json")"
+  attachment_name="$(jq -r '.name // .filename // .file_name // .fileName // .path // empty' <<<"$attachment_json")"
+
+  if [ -z "$attachment_id" ] || [ "$attachment_id" = "null" ]; then
+    echo "Gitee attachment response is missing id: $attachment_json" >&2
+    exit 1
+  fi
+
+  if [ -z "$attachment_name" ] || [ "$attachment_name" = "null" ]; then
+    echo "Gitee attachment response is missing filename: $attachment_json" >&2
+    exit 1
+  fi
+
+  escaped_name="$(printf '%s' "$attachment_name" | perl -pe 's/([\\\/.^$|(){}\[\]*+?])/\\$1/g')"
+  gitee_download_url="https://gitee.com/${gitee_repo}/attach_files/${attachment_id}/download"
+  escaped_url="$(printf '%s' "$gitee_download_url" | perl -pe 's/[\\&]/\\$&/g')"
+
+  perl -0pi -e \
+    "s#https://github\\.com/[^)\\s]+/releases/download/[^)\\s]+/${escaped_name}(?=[)\\s]|$)#${escaped_url}#g" \
+    "$rendered"
+done < "$attachments_file"
+
+if grep -Eq 'https://github\.com/[^)[:space:]]+/releases/download/' "$rendered"; then
+  echo "Rendered Gitee release body still contains GitHub release download links" >&2
+  exit 1
+fi
+
+cat "$rendered"

--- a/tests/test_gitee_release_sync.py
+++ b/tests/test_gitee_release_sync.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RENDER_SCRIPT = REPO_ROOT / "scripts" / "release" / "render-gitee-release-body.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docker-build.yml"
+
+
+def test_gitee_release_body_uses_uploaded_attachment_links(tmp_path):
+    release_body = tmp_path / "release_body.md"
+    attachments = tmp_path / "gitee_attach_files.jsonl"
+
+    release_body.write_text(
+        "\n".join(
+            [
+                "## OpenDataWorks v1.2.3",
+                "",
+                "### 离线部署包 (Offline Deployment Package)",
+                "- **[opendataworks-deployment-1.2.3.tar.gz](https://github.com/MingkeVan/opendataworks/releases/download/v1.2.3/opendataworks-deployment-1.2.3.tar.gz)** - 适用于无外网环境",
+                "- 校验和: `opendataworks-deployment-1.2.3.tar.gz.sha256`",
+                "- **[opendataagent-deployment-1.2.3.tar.gz](https://github.com/MingkeVan/opendataworks/releases/download/v1.2.3/opendataagent-deployment-1.2.3.tar.gz)** - 独立 `opendataagent` 离线部署包",
+                "- [Frontend](https://hub.docker.com/r/example/opendataworks-frontend/tags?name=1.2.3)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    attachments.write_text(
+        "\n".join(
+            [
+                '{"id":1001,"name":"opendataworks-deployment-1.2.3.tar.gz"}',
+                '{"id":1002,"name":"opendataagent-deployment-1.2.3.tar.gz"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(RENDER_SCRIPT), str(release_body), str(attachments), "opendata-lab/opendataworks"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "https://github.com/MingkeVan/opendataworks/releases/download" not in result.stdout
+    assert (
+        "https://gitee.com/opendata-lab/opendataworks/attach_files/1001/download"
+        in result.stdout
+    )
+    assert (
+        "https://gitee.com/opendata-lab/opendataworks/attach_files/1002/download"
+        in result.stdout
+    )
+    assert "https://hub.docker.com/r/example/opendataworks-frontend/tags?name=1.2.3" in result.stdout
+
+
+def test_gitee_sync_workflow_patches_release_body_after_upload():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow.count("render-gitee-release-body.sh") == 2
+    assert workflow.count(": > gitee_attach_files.jsonl") == 2
+    assert workflow.count(">> gitee_attach_files.jsonl") == 2
+    assert workflow.count("-X PATCH") >= 2


### PR DESCRIPTION
## Summary

- Gitee Release 同步不再直接复用 GitHub Release 正文里的 `releases/download/...` 链接；先创建占位说明，上传离线包附件后收集 API 返回的附件 id，再用 `scripts/release/render-gitee-release-body.sh` 将正文中的 GitHub 下载链接替换为 `https://gitee.com/{owner}/{repo}/attach_files/{id}/download`，并通过 PATCH 写回 Release。
- CI 中对 Gitee 删除/上传/更新步骤改用 `curl -fsS`，上传响应校验 `jq -e '.id'`，避免静默失败。
- 更新 `docs/handbook/release-process.md` 中的发布检查项，并新增回归测试覆盖渲染脚本与 workflow 关键步骤。

## Test plan

- [x] `python3 -m pytest tests/test_gitee_release_sync.py -q`（2 passed）
- [ ] 下次打 tag 发布时，在 Gitee Releases 页面确认附件可下载且正文链接指向 `attach_files/.../download`


Made with [Cursor](https://cursor.com)