### PR TITLE
fix: relative session time + auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,41 @@
+name: Auto Merge PR
+
+on:
+  workflow_run:
+    workflows: ["Build and Release"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Auto merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          echo "Build succeeded for branch: ${HEAD_BRANCH}"
+
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${HEAD_BRANCH}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No open PR found for branch ${HEAD_BRANCH}, nothing to merge."
+            exit 0
+          fi
+
+          echo "Merging PR #${PR_NUMBER} (${HEAD_BRANCH} -> ${{ github.event.workflow_run.head_repository.owner.login == github.repository_owner && 'main' || github.event.workflow_run.head_branch }})"
+
+          gh pr merge "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" \
+            --merge \
+            --delete-branch

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -634,9 +634,27 @@ const formatTime = (value) => {
   const dateKey = formatInShanghai(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
   const nowKey = formatInShanghai(now, { year: 'numeric', month: '2-digit', day: '2-digit' })
   if (dateKey === nowKey) {
+    const diffMs = now.getTime() - date.getTime()
+    const diffSeconds = Math.floor(diffMs / 1000)
+    const diffMinutes = Math.floor(diffSeconds / 60)
+    if (diffSeconds < 60) return '刚刚'
+    if (diffMinutes < 60) return `${diffMinutes}分钟前`
     return formatInShanghai(date, { hour: '2-digit', minute: '2-digit', hour12: false })
   }
-  return formatInShanghai(date, { month: '2-digit', day: '2-digit' })
+
+  const [y, m, d] = dateKey.split('/').map(Number)
+  const [ny, nm, nd] = nowKey.split('/').map(Number)
+  const diffDays = Math.floor((new Date(ny, nm - 1, nd) - new Date(y, m - 1, d)) / 86400000)
+
+  if (diffDays === 1) return '1天前'
+  if (diffDays <= 7) return `${diffDays}天前`
+
+  const dateYear = formatInShanghai(date, { year: 'numeric' })
+  const nowYear = formatInShanghai(now, { year: 'numeric' })
+  if (dateYear === nowYear) {
+    return formatInShanghai(date, { month: '2-digit', day: '2-digit' })
+  }
+  return formatInShanghai(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
 }
 
 const formatMessageTime = (value) => {

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -365,13 +365,34 @@ const truncate = (value, max) => {
 const formatTime = (value) => {
   const date = value ? new Date(value) : null
   if (!date || Number.isNaN(date.getTime())) return ''
-  return date.toLocaleString('zh-CN', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  })
+
+  const fmtDate = (d, options) => d.toLocaleString('zh-CN', { hour12: false, ...options })
+  const now = new Date()
+  const dateKey = fmtDate(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
+  const nowKey = fmtDate(now, { year: 'numeric', month: '2-digit', day: '2-digit' })
+
+  if (dateKey === nowKey) {
+    const diffMs = now.getTime() - date.getTime()
+    const diffSeconds = Math.floor(diffMs / 1000)
+    const diffMinutes = Math.floor(diffSeconds / 60)
+    if (diffSeconds < 60) return '刚刚'
+    if (diffMinutes < 60) return `${diffMinutes}分钟前`
+    return fmtDate(date, { hour: '2-digit', minute: '2-digit' })
+  }
+
+  const [y, m, d] = dateKey.split('/').map(Number)
+  const [ny, nm, nd] = nowKey.split('/').map(Number)
+  const diffDays = Math.floor((new Date(ny, nm - 1, nd) - new Date(y, m - 1, d)) / 86400000)
+
+  if (diffDays === 1) return '1天前'
+  if (diffDays <= 7) return `${diffDays}天前`
+
+  const dateYear = fmtDate(date, { year: 'numeric' })
+  const nowYear = fmtDate(now, { year: 'numeric' })
+  if (dateYear === nowYear) {
+    return fmtDate(date, { month: '2-digit', day: '2-digit' })
+  }
+  return fmtDate(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
 }
 
 const normalizeTopic = (topic) => ({


### PR DESCRIPTION
## Summary
- 智能问数左侧会话列表时间改为相对时间展示（刚刚、X分钟前、X天前、MM-DD、YYYY/MM/DD）
- Widget 组件同步更新
- 新增 auto-merge workflow：docker-build 通过后自动 merge PR

## Test plan
- [ ] 前端构建通过
- [ ] 验证不同时间的会话显示正确（今天、昨天、3天前、跨年等）
- [ ] auto-merge 流程需合并到 main 后验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)