### PR TITLE
ci: build anonymously to avoid Docker Hub 429 rate limits

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,13 +77,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -102,22 +95,44 @@ jobs:
           chmod +x opendataagent/scripts/sync-root-skills.sh
           opendataagent/scripts/sync-root-skills.sh
 
-      - name: Build and push
+      - name: Build
         id: build
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
           build-args: ${{ matrix.service.build_args }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ runner.os }}-buildx-${{ matrix.service.name }}
           cache-to: type=gha,mode=max,scope=${{ runner.os }}-buildx-${{ matrix.service.name }},sharing=locked
 
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Push
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: ${{ matrix.service.build_args }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ runner.os }}-buildx-${{ matrix.service.name }}
+
       - name: Image digest
-        run: echo "Image digest ${{ steps.build.outputs.digest }}"
+        if: github.event_name != 'pull_request'
+        run: echo "Image digest ${{ steps.push.outputs.digest }}"
 
   create-release:
     needs: build-and-push


### PR DESCRIPTION
## Summary
将 Docker build 和 push 拆成两步：
- Build 阶段用**匿名**拉取基础镜像（按 IP 限流，多个 runner 互不干扰，总配额高）
- Push 阶段才登录 Docker Hub（只上传，不消耗拉取配额）

## Root cause
PR 构建不登录 Docker Hub，匿名配额 100次/6h/IP，8个 service 跑在不同 runner，有效配额高。
Main 构建登录后配额按账号算 200次/6h，所有 service 共用一个配额池，8×2个平台构建
很容易超限触发 HTTP 429。

## Fix
1. build（push: false → 匿名拉取基础镜像）
2. Login to Docker Hub（仅 push 前）
3. push（push: true → 复用 buildx 缓存，不重新拉取，只上传）

## Test plan
- [ ] PR 构建通过（匿名拉取 + 不推送）
- [ ] 合并到 main 后验证 push 成功且不再 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)