### PR TITLE
ci: remove Docker login from offline-package jobs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,12 +142,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
       - name: Create offline deployment package
         run: |
           VERSION=${GITHUB_REF_NAME#v}
@@ -294,12 +288,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Create latest offline deployment package
         run: |


### PR DESCRIPTION
The create-release and create-latest-release jobs pull images that were just pushed to Docker Hub. Login is unnecessary for pulling public images, and anonymous pulls use per-IP quota instead of the shared per-account 200/6hr limit, avoiding 429 rate limit errors.