### PR TITLE
feat: add follow-up suggestions API

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import json
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 import anyio
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, build_agent_snapshot, get_agent_profile
+from core.followup_suggestions import generate_followup_suggestions
 from core.magic_events import TERMINAL_TASK_STATUSES, encode_sse
 from core.skill_admin_service import resolved_chat_settings_payload
 from core.task_coordinator import get_task_coordinator
@@ -20,6 +21,7 @@ from models.schemas import (
     CreateTaskRequest,
     CreateTopicRequest,
     DeliverMessageRequest,
+    FollowupSuggestionsResponse,
     MessageQueuePageResponse,
     MessageQueueQueryRequest,
     MessageQueueRecord,
@@ -46,6 +48,8 @@ from models.schemas import (
 
 logger = logging.getLogger(__name__)
 
+SUCCESS_MESSAGE_STATUSES = {"finished", "success", "completed"}
+
 router = APIRouter(prefix="/api/v1/nl2sql")
 topic_router = APIRouter(prefix="/topics")
 task_router = APIRouter(prefix="/tasks")
@@ -58,6 +62,52 @@ def _clean_header(value: str | None, max_length: int = 255) -> str:
     if len(text) > max_length:
         return text[:max_length]
     return text
+
+
+def _message_answer_text(message: dict[str, Any]) -> str:
+    blocks = message.get("blocks")
+    if isinstance(blocks, list):
+        parts = [
+            str(block.get("text") or "").strip()
+            for block in blocks
+            if isinstance(block, dict) and str(block.get("type") or "") == "main_text" and str(block.get("text") or "").strip()
+        ]
+        if parts:
+            return "\n\n".join(parts).strip()
+    return str(message.get("content") or "").strip()
+
+
+def _message_result_summary(message: dict[str, Any]) -> str:
+    blocks = message.get("blocks")
+    if not isinstance(blocks, list):
+        return ""
+    summaries: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = str(block.get("type") or "").strip()
+        if block_type not in {"tool", "chart_spec"}:
+            continue
+        output = block.get("output")
+        if output is None and isinstance(block.get("payload"), dict):
+            output = block["payload"].get("output") or block["payload"].get("content")
+        text = str(output or "").strip()
+        if text:
+            summaries.append(text[:500])
+    return "\n\n".join(summaries)[:1200]
+
+
+def _previous_user_question(messages: list[dict[str, Any]], assistant_message: dict[str, Any]) -> str:
+    assistant_seq = int(assistant_message.get("seq_id") or 0)
+    for message in reversed(messages):
+        if str(message.get("sender_type") or "") != "user":
+            continue
+        if assistant_seq and int(message.get("seq_id") or 0) >= assistant_seq:
+            continue
+        content = str(message.get("content") or "").strip()
+        if content:
+            return content
+    return ""
 
 
 def _allowed_widget_sites() -> list[dict]:
@@ -253,6 +303,44 @@ async def api_update_message_feedback(
     if not updated:
         raise HTTPException(status_code=404, detail="Message not found")
     return TopicMessage.model_validate(updated)
+
+
+@topic_router.post("/{topic_id}/messages/{message_id}/followup-suggestions", response_model=FollowupSuggestionsResponse)
+async def api_generate_followup_suggestions(topic_id: str, message_id: str, request: Request):
+    context = _request_context(request)
+    _require_topic(topic_id, context)
+    store = _get_store()
+    message = store.get_message(message_id, context=context)
+    if not message or str(message.get("topic_id") or "") != topic_id or not bool(message.get("show_in_ui", True)):
+        raise HTTPException(status_code=404, detail="Message not found")
+    if str(message.get("sender_type") or "") != "assistant":
+        raise HTTPException(status_code=400, detail="follow-up suggestions are only supported for assistant messages")
+    if str(message.get("status") or "").strip().lower() not in SUCCESS_MESSAGE_STATUSES:
+        raise HTTPException(status_code=400, detail="follow-up suggestions require a finished assistant message")
+
+    answer_text = _message_answer_text(message)
+    if not answer_text:
+        raise HTTPException(status_code=400, detail="assistant message content is empty")
+
+    topic_messages = store.list_topic_messages(topic_id)
+    previous_question = _previous_user_question(topic_messages, message)
+    task = store.get_task(str(message.get("task_id") or ""), context=context) if message.get("task_id") else {}
+    generated = await generate_followup_suggestions(
+        previous_question=previous_question,
+        answer_text=answer_text,
+        result_summary=_message_result_summary(message),
+        provider_id=str((task or {}).get("provider_id") or ""),
+        model=str((task or {}).get("model") or ""),
+        timeout_seconds=int(getattr(get_settings(), "followup_suggestions_timeout_seconds", 20) or 20),
+    )
+    return FollowupSuggestionsResponse.model_validate(
+        {
+            "topic_id": topic_id,
+            "message_id": message_id,
+            "suggestions": list(generated.get("suggestions") or []),
+            "source": str(generated.get("source") or "empty"),
+        }
+    )
 
 
 @task_router.post("/deliver-message", response_model=TaskSubmissionResponse)

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     agent_interactive_sql_read_timeout_seconds: int = 300
     agent_background_sql_read_timeout_seconds: int = 900
     agent_sql_write_timeout_seconds: int = 60
+    followup_suggestions_timeout_seconds: int = 20
     run_events_stream_poll_interval_seconds: int = 1
     run_events_stream_ping_seconds: int = 10
     task_max_concurrency: int = 4

--- a/dataagent/dataagent-backend/core/followup_suggestions.py
+++ b/dataagent/dataagent-backend/core/followup_suggestions.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import anyio
+
+from config import get_settings
+from core.provider_runtime import build_provider_env, normalize_provider_id, safe_base_url_for_log
+from core.skill_admin_service import resolve_runtime_provider_selection
+from core.skill_discovery import resolve_agent_project_cwd
+from core.claude_cli import resolve_claude_cli_path
+
+logger = logging.getLogger(__name__)
+
+MAX_SUGGESTIONS = 3
+MAX_SUGGESTION_LENGTH = 64
+DEFAULT_TIMEOUT_SECONDS = 20
+
+ModelRunner = Callable[..., Awaitable[str]]
+
+
+def _strip_code_fence(text: str) -> str:
+    value = str(text or "").strip()
+    if value.startswith("```"):
+        value = re.sub(r"^```(?:json)?\s*", "", value, flags=re.IGNORECASE)
+        value = re.sub(r"\s*```$", "", value)
+    return value.strip()
+
+
+def _clean_suggestion(value: Any) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"^\s*[-*•]\s*", "", text)
+    text = re.sub(r"^\s*\d+[.)、]\s*", "", text)
+    text = re.sub(r"\s+", " ", text).strip(" \t\r\n\"'`")
+    if len(text) > MAX_SUGGESTION_LENGTH:
+        text = text[:MAX_SUGGESTION_LENGTH].rstrip()
+    return text
+
+
+def _normalize_suggestions(values: Any, *, previous_question: str) -> list[str]:
+    if isinstance(values, dict):
+        values = values.get("suggestions")
+    if isinstance(values, str):
+        values = [line for line in values.splitlines() if line.strip()]
+    if not isinstance(values, list):
+        return []
+
+    previous = str(previous_question or "").strip()
+    previous_key = previous.lower()
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _clean_suggestion(value)
+        if not text:
+            continue
+        key = text.lower()
+        if key == previous_key or key in seen:
+            continue
+        seen.add(key)
+        result.append(text)
+        if len(result) >= MAX_SUGGESTIONS:
+            break
+    return result
+
+
+def _parse_model_suggestions(raw: str, *, previous_question: str) -> list[str]:
+    text = _strip_code_fence(raw)
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = text
+    return _normalize_suggestions(parsed, previous_question=previous_question)
+
+
+def _fallback_suggestions(answer_text: str, *, previous_question: str) -> list[str]:
+    text = str(answer_text or "")
+    if not text.strip():
+        return []
+    if re.search(r"\b(sql|select|from|where)\b", text, flags=re.IGNORECASE):
+        values = [
+            "解释一下这个 SQL 的逻辑",
+            "这个查询还能按哪些维度继续分析？",
+            "帮我检查这个 SQL 是否有优化空间",
+        ]
+    elif re.search(r"图表|趋势|chart|折线|柱状|饼图", text, flags=re.IGNORECASE):
+        values = [
+            "对图表展现的趋势做个深度解读",
+            "按业务维度拆解这个趋势",
+            "查看异常波动对应的明细",
+        ]
+    else:
+        values = [
+            "按核心维度做进一步对比",
+            "查看这个结果的明细数据",
+            "总结一下可能的业务原因",
+        ]
+    return _normalize_suggestions(values, previous_question=previous_question)
+
+
+def _build_prompt(*, previous_question: str, answer_text: str, result_summary: str) -> str:
+    sections = [
+        "请基于上一轮问答，生成 2-3 条用户最可能继续追问的问题。",
+        "要求：只输出 JSON；格式为 {\"suggestions\":[\"问题1\",\"问题2\"]}；不要输出 Markdown、编号或解释。",
+        "追问必须贴合当前回答中的事实、指标、SQL、图表或异常点，避免重复原问题。",
+        f"上一轮用户问题：{previous_question}",
+        f"上一轮助手回答：{answer_text}",
+    ]
+    if str(result_summary or "").strip():
+        sections.append(f"结果摘要：{result_summary}")
+    return "\n\n".join(sections)
+
+
+def _extract_sdk_text(message: Any) -> str:
+    type_name = type(message).__name__
+    if type_name == "ResultMessage":
+        return str(getattr(message, "result", "") or "")
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict):
+            value = block.get("text") or block.get("content")
+        else:
+            value = getattr(block, "text", None)
+        if value:
+            parts.append(str(value))
+    return "\n".join(parts)
+
+
+async def _default_model_runner(
+    *,
+    prompt: str,
+    provider_id: str,
+    model: str,
+    timeout_seconds: int,
+) -> str:
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, query as claude_query
+    except ImportError as exc:
+        raise RuntimeError(f"claude-agent-sdk 未安装: {exc}") from exc
+
+    cfg = get_settings()
+    runtime_target = resolve_runtime_provider_selection(provider_id, model)
+    resolved_provider_id = normalize_provider_id(runtime_target.get("provider_id"), runtime_target.get("base_url"))
+    resolved_model = str(runtime_target.get("model") or "").strip()
+    provider_env = build_provider_env(
+        resolved_provider_id,
+        api_key=str(runtime_target.get("api_key") or ""),
+        auth_token=str(runtime_target.get("auth_token") or ""),
+        base_url=str(runtime_target.get("base_url") or ""),
+    )
+    runtime_env = dict(os.environ)
+    runtime_env.update(provider_env)
+
+    options_kwargs = {
+        "system_prompt": "你是 OpenDataWorks 智能问数的追问建议生成器。只输出符合要求的 JSON。",
+        "model": resolved_model,
+        "cwd": str(resolve_agent_project_cwd()),
+        "setting_sources": ["project"],
+        "max_turns": 1,
+        "allowed_tools": [],
+        "mcp_servers": {},
+        "include_partial_messages": bool(runtime_target.get("supports_partial_messages", True)),
+        "env": runtime_env,
+        "stderr": lambda line: logger.error(
+            "followup_suggestions.stderr provider=%s model=%s %s",
+            resolved_provider_id,
+            resolved_model,
+            str(line or "").rstrip(),
+        ),
+    }
+    cli_path = resolve_claude_cli_path(cfg)
+    if cli_path:
+        options_kwargs["cli_path"] = cli_path
+
+    logger.info(
+        "followup_suggestions.start provider=%s model=%s base_url=%s",
+        resolved_provider_id,
+        resolved_model,
+        safe_base_url_for_log(str(runtime_target.get("base_url") or "")),
+    )
+
+    chunks: list[str] = []
+    options = ClaudeAgentOptions(**options_kwargs)
+    with anyio.fail_after(max(3, int(timeout_seconds or DEFAULT_TIMEOUT_SECONDS))):
+        async for message in claude_query(prompt=prompt, options=options):
+            text = _extract_sdk_text(message)
+            if text:
+                chunks.append(text)
+    return "\n".join(chunks).strip()
+
+
+async def generate_followup_suggestions(
+    *,
+    previous_question: str,
+    answer_text: str,
+    result_summary: str = "",
+    provider_id: str = "",
+    model: str = "",
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    model_runner: ModelRunner | None = None,
+) -> dict[str, Any]:
+    prompt = _build_prompt(
+        previous_question=previous_question,
+        answer_text=answer_text,
+        result_summary=result_summary,
+    )
+    runner = model_runner or _default_model_runner
+    try:
+        raw = await runner(
+            prompt=prompt,
+            provider_id=provider_id,
+            model=model,
+            timeout_seconds=timeout_seconds,
+        )
+        suggestions = _parse_model_suggestions(raw, previous_question=previous_question)
+        if suggestions:
+            return {"suggestions": suggestions, "source": "generated"}
+    except Exception as exc:
+        logger.warning("followup_suggestions.failed error=%s", exc)
+
+    fallback = _fallback_suggestions(answer_text, previous_question=previous_question)
+    if fallback:
+        return {"suggestions": fallback, "source": "fallback"}
+    return {"suggestions": [], "source": "empty"}

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -503,6 +503,13 @@ class UpdateMessageFeedbackRequest(BaseModel):
     feedback: str = ""
 
 
+class FollowupSuggestionsResponse(BaseModel):
+    topic_id: str
+    message_id: str
+    suggestions: List[str] = Field(default_factory=list)
+    source: str = "empty"
+
+
 class TaskSubmissionResponse(BaseModel):
     accepted: bool = True
     topic_id: str

--- a/dataagent/dataagent-backend/tests/test_followup_suggestions.py
+++ b/dataagent/dataagent-backend/tests/test_followup_suggestions.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import anyio
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from core.followup_suggestions import generate_followup_suggestions
+
+
+def test_generate_followup_suggestions_parses_and_normalizes_model_json():
+    async def fake_runner(**_kwargs):
+        return """
+        ```json
+        {
+          "suggestions": [
+            "最近 30 天工作流发布次数趋势",
+            " 查看异常峰值对应的工作流明细 ",
+            "查看异常峰值对应的工作流明细",
+            "按发布操作类型拆解这段趋势"
+          ]
+        }
+        ```
+        """
+
+    async def run():
+        return await generate_followup_suggestions(
+            previous_question="最近 30 天工作流发布次数趋势",
+            answer_text="最近 30 天发布次数上升，5 月 20 日出现异常峰值。",
+            result_summary="",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            model_runner=fake_runner,
+        )
+
+    result = anyio.run(run)
+
+    assert result == {
+        "suggestions": ["查看异常峰值对应的工作流明细", "按发布操作类型拆解这段趋势"],
+        "source": "generated",
+    }
+
+
+def test_generate_followup_suggestions_returns_fallback_when_model_fails():
+    async def failing_runner(**_kwargs):
+        raise TimeoutError("model timed out")
+
+    async def run():
+        return await generate_followup_suggestions(
+            previous_question="最近 30 天工作流发布次数趋势",
+            answer_text="SQL 查询如下：select count(*) from workflow_publish_record;",
+            result_summary="",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            model_runner=failing_runner,
+        )
+
+    result = anyio.run(run)
+
+    assert result["source"] == "fallback"
+    assert result["suggestions"] == [
+        "解释一下这个 SQL 的逻辑",
+        "这个查询还能按哪些维度继续分析？",
+        "帮我检查这个 SQL 是否有优化空间",
+    ]

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -679,6 +679,88 @@ def test_topics_tasks_and_legacy_routes(monkeypatch):
         assert store.get_topic(topic_id) is None
 
 
+def test_followup_suggestions_route_generates_without_changing_message_contract(monkeypatch):
+    client, store, _coordinator, _submit_calls = _build_client(monkeypatch)
+    captured: dict = {}
+
+    async def fake_generate_followup_suggestions(**kwargs):
+        captured.update(kwargs)
+        return {
+            "suggestions": ["查看异常波动对应的明细", "按业务维度拆解这个趋势"],
+            "source": "generated",
+        }
+
+    monkeypatch.setattr(routes, "generate_followup_suggestions", fake_generate_followup_suggestions, raising=False)
+
+    with client:
+        topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "追问测试"}).json()["topic_id"]
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={
+                "topic_id": topic_id,
+                "content": "最近 30 天工作流发布次数趋势",
+                "provider_id": "openrouter",
+                "model": "anthropic/claude-sonnet-4.5",
+            },
+        )
+        task_id = delivered.json()["task_id"]
+        assistant_message_id = delivered.json()["assistant_message_id"]
+
+        assistant = store.get_assistant_message(task_id)
+        assistant["status"] = "finished"
+        assistant["content"] = "最近 30 天工作流发布次数整体上升，5 月 20 日出现异常峰值。"
+
+        response = client.post(f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/followup-suggestions")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "topic_id": topic_id,
+            "message_id": assistant_message_id,
+            "suggestions": ["查看异常波动对应的明细", "按业务维度拆解这个趋势"],
+            "source": "generated",
+        }
+        assert captured["previous_question"] == "最近 30 天工作流发布次数趋势"
+        assert captured["answer_text"] == "最近 30 天工作流发布次数整体上升，5 月 20 日出现异常峰值。"
+        assert captured["provider_id"] == "openrouter"
+        assert captured["model"] == "anthropic/claude-sonnet-4.5"
+
+        history = client.get(f"/api/v1/nl2sql/topics/{topic_id}/messages", params={"page": 1, "page_size": 50, "order": "asc"})
+        assert history.status_code == 200
+        assert "followup_suggestions" not in history.json()["items"][1]
+
+
+def test_followup_suggestions_route_rejects_invalid_message_states(monkeypatch):
+    client, store, _coordinator, _submit_calls = _build_client(monkeypatch)
+    calls = []
+
+    async def fake_generate_followup_suggestions(**kwargs):
+        calls.append(kwargs)
+        return {"suggestions": ["不应生成"], "source": "generated"}
+
+    monkeypatch.setattr(routes, "generate_followup_suggestions", fake_generate_followup_suggestions, raising=False)
+
+    with client:
+        topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "追问校验"}).json()["topic_id"]
+        other_topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "其他话题"}).json()["topic_id"]
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={"topic_id": topic_id, "content": "各数据层表数量对比"},
+        )
+        user_message_id = delivered.json()["user_message_id"]
+        assistant_message_id = delivered.json()["assistant_message_id"]
+
+        assert client.post(f"/api/v1/nl2sql/topics/{topic_id}/messages/missing/followup-suggestions").status_code == 404
+        assert client.post(f"/api/v1/nl2sql/topics/{other_topic_id}/messages/{assistant_message_id}/followup-suggestions").status_code == 404
+        assert client.post(f"/api/v1/nl2sql/topics/{topic_id}/messages/{user_message_id}/followup-suggestions").status_code == 400
+        assert client.post(f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/followup-suggestions").status_code == 400
+
+        assistant = store.get_assistant_message(delivered.json()["task_id"])
+        assistant["status"] = "finished"
+        assistant["content"] = ""
+        assert client.post(f"/api/v1/nl2sql/topics/{topic_id}/messages/{assistant_message_id}/followup-suggestions").status_code == 400
+        assert calls == []
+
+
 def test_message_queue_and_schedule_routes(monkeypatch):
     client, store, _coordinator, submit_calls = _build_client(monkeypatch)
     with client:

--- a/docs/design/2026-05-26-followup-suggestions-design.md
+++ b/docs/design/2026-05-26-followup-suggestions-design.md
@@ -1,0 +1,55 @@
+# Follow-up Suggestions Design
+
+## Current State
+
+The intelligent-query chat UI renders the "猜你想问" area from frontend-only keyword rules in `NL2SqlChat.vue`. The rules inspect the latest successful assistant answer for SQL or chart-related keywords and then show fixed suggestions.
+
+This produces stable UI behavior but does not actually infer the next question from the previous answer. It also puts answer-understanding logic in the frontend, where it cannot use the configured DataAgent provider or the conversation/task context.
+
+## Problem
+
+Follow-up suggestions should be derived from the previous user question and the latest assistant answer, while preserving the existing chat contracts:
+
+- Do not change topic message response fields.
+- Do not change task status responses.
+- Do not add SSE events.
+- Do not add database tables or columns in v1.
+
+## Solution
+
+Add an independent follow-up suggestion endpoint:
+
+`POST /api/v1/nl2sql/topics/{topic_id}/messages/{message_id}/followup-suggestions`
+
+The endpoint validates that the target message belongs to the topic, is visible, is an assistant message, is finished, and has non-empty visible answer content. It then locates the previous user message in the same topic and asks a lightweight generator for 2-3 Chinese follow-up questions.
+
+The generator uses the same provider/model recorded on the original task, disables tools, uses `max_turns=1`, and applies a short timeout. Model output is parsed as JSON and normalized by trimming bullets, removing duplicates, limiting length, and filtering the original question. If generation fails, the endpoint returns backend fallback suggestions or an empty list with a non-error source.
+
+## Interfaces
+
+Response shape:
+
+```json
+{
+  "topic_id": "topic_x",
+  "message_id": "msg_x",
+  "suggestions": ["查看异常波动对应的明细", "按业务维度拆解这个趋势"],
+  "source": "generated"
+}
+```
+
+`source` values:
+
+- `generated`: model-generated and normalized suggestions.
+- `fallback`: backend fallback suggestions after generation failure or unusable model output.
+- `empty`: no suggestions available.
+
+Existing topic, message, task, and SSE interfaces remain unchanged.
+
+## Frontend Behavior
+
+`NL2SqlChat.vue` requests suggestions only for the latest successful assistant message. Suggestions are cached in component state by message id for the current page lifetime. Empty or failed responses render no "猜你想问" block. Clicking a suggestion continues to use the existing `handleSuggestion -> deliverMessage` flow.
+
+## Tradeoffs
+
+This v1 intentionally avoids server-side persistence. Refreshing the page can regenerate suggestions for the same message, and suggestions may vary slightly between calls. That is acceptable for the first version because it keeps the change additive and avoids schema or migration risk.

--- a/docs/plans/2026-05-26-followup-suggestions-plan.md
+++ b/docs/plans/2026-05-26-followup-suggestions-plan.md
@@ -1,0 +1,43 @@
+# Follow-up Suggestions Implementation Plan
+
+## Goal
+
+Replace frontend keyword-based "猜你想问" suggestions with an additive backend follow-up suggestion API, without changing existing message, task, SSE, or database contracts.
+
+## Backend Tasks
+
+1. Add a `FollowupSuggestionsResponse` schema with `topic_id`, `message_id`, `suggestions`, and `source`.
+2. Add `core/followup_suggestions.py` to build the prompt, run a one-turn no-tool model call, parse JSON suggestions, normalize output, and return fallback or empty results on failure.
+3. Add `POST /topics/{topic_id}/messages/{message_id}/followup-suggestions`.
+4. Validate topic ownership, assistant sender type, finished status, visible message state, and non-empty answer content before calling the generator.
+5. Reuse the original task provider/model for generation.
+
+## Frontend Tasks
+
+1. Add `topicApi.generateFollowupSuggestions(topicId, messageId)`.
+2. Replace the `NL2SqlChat.vue` local regex suggestion rules with message-scoped API state.
+3. Load suggestions only for the latest successful assistant message.
+4. Cache loaded/empty/error states by message id for the current page lifetime.
+5. Keep suggestion clicks on the existing send path.
+
+## Tests
+
+1. Backend route contract tests cover generated suggestions and invalid message states.
+2. Backend generator tests cover JSON parsing, dedupe, original-question filtering, and fallback behavior.
+3. Frontend API client tests cover the additive endpoint path.
+4. Frontend chat tests cover API-driven rendering, empty responses, and click-to-send behavior.
+
+## Verification
+
+Run focused backend tests with the DataAgent virtualenv:
+
+```bash
+dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_followup_suggestions.py dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_generates_without_changing_message_contract dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_rejects_invalid_message_states -q
+```
+
+Run focused frontend tests after `nvm use`:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use
+cd frontend && npm test -- src/api/__tests__/nl2sqlClient.spec.js src/views/intelligence/__tests__/NL2SqlChat.spec.js
+```

--- a/frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -98,4 +98,15 @@ describe('createNl2SqlApiClient', () => {
       { feedback: 'like' }
     )
   })
+
+  it('requests follow-up suggestions through the additive topic API', () => {
+    const client = createNl2SqlApiClient()
+
+    client.topicApi.generateFollowupSuggestions('topic-1', 'message-1')
+
+    expect(clients[0].post).toHaveBeenCalledWith(
+      '/topics/topic-1/messages/message-1/followup-suggestions',
+      {}
+    )
+  })
 })

--- a/frontend/src/api/nl2sql.js
+++ b/frontend/src/api/nl2sql.js
@@ -146,6 +146,9 @@ export function createNl2SqlApiClient(options = {}) {
     },
     updateMessageFeedback(topicId, messageId, feedback = '') {
       return runtimeRequest.put(`/topics/${topicId}/messages/${messageId}/feedback`, { feedback })
+    },
+    generateFollowupSuggestions(topicId, messageId) {
+      return runtimeRequest.post(`/topics/${topicId}/messages/${messageId}/followup-suggestions`, {})
     }
   }
 

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -390,6 +390,8 @@ const autoScroll = ref(true)
 const hydratedIds = new Set()
 const taskSubscriptions = new Map()
 const pendingSubmitKeys = ref(new Set())
+const followupSuggestionsByMessage = ref({})
+const followupSuggestionStateByMessage = ref({})
 
 const settings = reactive({
   default_provider_id: '',
@@ -912,31 +914,56 @@ const latestSuccessfulAssistantMessage = computed(() => {
   return latest
 })
 
+const followupMessageKey = (msg) => String(msg?.message_id || msg?.id || '').trim()
+
+const normalizeFollowupSuggestions = (values) => {
+  if (!Array.isArray(values)) return []
+  const seen = new Set()
+  return values
+    .map((value) => String(value || '').trim())
+    .filter((value) => {
+      if (!value || seen.has(value)) return false
+      seen.add(value)
+      return true
+    })
+    .slice(0, 3)
+}
+
+const setFollowupSuggestionState = (messageKey, state, suggestions = []) => {
+  if (!messageKey) return
+  followupSuggestionStateByMessage.value = {
+    ...followupSuggestionStateByMessage.value,
+    [messageKey]: state
+  }
+  followupSuggestionsByMessage.value = {
+    ...followupSuggestionsByMessage.value,
+    [messageKey]: suggestions
+  }
+}
+
+const loadFollowupSuggestionsForMessage = async (msg) => {
+  const messageKey = followupMessageKey(msg)
+  const topicId = String(activeTopicId.value || '').trim()
+  if (!topicId || !messageKey) return
+  const currentState = followupSuggestionStateByMessage.value[messageKey]
+  if (currentState === 'loading' || currentState === 'loaded') return
+  setFollowupSuggestionState(messageKey, 'loading', [])
+  try {
+    const response = await topicApi.generateFollowupSuggestions(topicId, messageKey)
+    setFollowupSuggestionState(
+      messageKey,
+      'loaded',
+      normalizeFollowupSuggestions(response?.suggestions)
+    )
+  } catch (_error) {
+    setFollowupSuggestionState(messageKey, 'error', [])
+  }
+}
+
 const followupSuggestions = computed(() => {
   const msg = latestSuccessfulAssistantMessage.value
-  if (!msg) return []
-  const text = visibleMessageText(msg)
-  if (!text.trim()) return []
-  if (/错误|失败|error/i.test(text)) return []
-  if (/sql|select|from|where/i.test(text)) {
-    return [
-      '解释一下这个 SQL 的逻辑',
-      '这个查询还能按哪些维度继续分析？',
-      '帮我检查这个 SQL 是否有优化空间'
-    ]
-  }
-  if (/图表|趋势|chart|折线|柱状|饼图/i.test(text)) {
-    return [
-      '对图表展现的趋势做个深度解读',
-      '按业务维度拆解这个趋势',
-      '查看异常波动对应的明细'
-    ]
-  }
-  return [
-    '按核心维度做进一步对比',
-    '查看这个结果的明细数据',
-    '总结一下可能的业务原因'
-  ]
+  const messageKey = followupMessageKey(msg)
+  return messageKey ? (followupSuggestionsByMessage.value[messageKey] || []) : []
 })
 
 const shouldShowFollowupForMessage = (msg) => latestSuccessfulAssistantMessage.value === msg && followupSuggestions.value.length > 0
@@ -1656,6 +1683,19 @@ watch(selectedAgentId, async (next, prev) => {
   activeTopicId.value = ''
   await loadTopics()
 })
+
+watch(
+  () => [
+    activeTopicId.value,
+    followupMessageKey(latestSuccessfulAssistantMessage.value),
+    latestSuccessfulAssistantMessage.value?.status
+  ],
+  () => {
+    const msg = latestSuccessfulAssistantMessage.value
+    if (!msg) return
+    void loadFollowupSuggestionsForMessage(msg)
+  }
+)
 
 onMounted(async () => {
   await loadSettings()

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -9,7 +9,8 @@ const apiMocks = vi.hoisted(() => ({
     updateTopic: vi.fn(),
     deleteTopic: vi.fn(),
     getTopicMessages: vi.fn(),
-    updateMessageFeedback: vi.fn()
+    updateMessageFeedback: vi.fn(),
+    generateFollowupSuggestions: vi.fn()
   },
   taskApi: {
     deliverMessage: vi.fn(),
@@ -245,6 +246,12 @@ describe('NL2SqlChat', () => {
     ])
     apiMocks.topicApi.getTopic.mockImplementation(async (topicId) => makeTopicDetail(topicId, topicId === 'topic-1' ? '流式话题' : '新话题'))
     apiMocks.topicApi.updateTopic.mockImplementation(async (topicId, data) => makeTopicDetail(topicId, data?.title || '新话题'))
+    apiMocks.topicApi.generateFollowupSuggestions.mockResolvedValue({
+      topic_id: 'topic-1',
+      message_id: 'a1',
+      suggestions: [],
+      source: 'empty'
+    })
     apiMocks.topicApi.getTopicMessages.mockResolvedValue({
       topic_id: 'topic-1',
       page: 1,
@@ -1049,7 +1056,7 @@ describe('NL2SqlChat', () => {
     expect(wrapper.find('.query-message-feedback-dislike').classes()).toContain('active')
   })
 
-  it('renders follow-up suggestions for the latest successful assistant answer and submits one when clicked', async () => {
+  it('renders API follow-up suggestions for the latest successful assistant answer and submits one when clicked', async () => {
     apiMocks.topicApi.getTopicMessages.mockResolvedValue({
       topic_id: 'topic-1',
       page: 1,
@@ -1085,15 +1092,23 @@ describe('NL2SqlChat', () => {
       user_message_id: 'u-new',
       assistant_message_id: 'a-new'
     })
+    apiMocks.topicApi.generateFollowupSuggestions.mockResolvedValue({
+      topic_id: 'topic-1',
+      message_id: 'a1',
+      suggestions: ['查看异常峰值对应的明细', '按发布操作类型拆解这个趋势'],
+      source: 'generated'
+    })
 
     const wrapper = mountChat()
 
     await flushPromises()
     await flushPromises()
+    await flushPromises()
 
+    expect(apiMocks.topicApi.generateFollowupSuggestions).toHaveBeenCalledWith('topic-1', 'a1')
     const suggestions = wrapper.findAll('.query-followup-suggestion')
-    expect(suggestions.length).toBeGreaterThanOrEqual(2)
-    expect(suggestions[0].text()).toContain('SQL')
+    expect(suggestions).toHaveLength(2)
+    expect(suggestions[0].text()).toBe('查看异常峰值对应的明细')
 
     await suggestions[0].trigger('click')
     await flushPromises()
@@ -1103,6 +1118,51 @@ describe('NL2SqlChat', () => {
       topic_id: 'topic-1',
       content: suggestions[0].text()
     }))
+  })
+
+  it('does not render follow-up suggestions when the API returns an empty list', async () => {
+    apiMocks.topicApi.getTopicMessages.mockResolvedValue({
+      topic_id: 'topic-1',
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 1,
+      items: [
+        {
+          message_id: 'a1',
+          topic_id: 'topic-1',
+          task_id: 'task-1',
+          sender_type: 'assistant',
+          type: 'assistant',
+          status: 'finished',
+          content: '最近 30 天共发布 4 次。',
+          blocks: [
+            {
+              block_id: 'main-1',
+              type: 'main_text',
+              status: 'success',
+              text: '最近 30 天共发布 4 次。'
+            }
+          ],
+          created_at: '2026-03-10T02:01:00Z'
+        }
+      ]
+    })
+    apiMocks.topicApi.generateFollowupSuggestions.mockResolvedValue({
+      topic_id: 'topic-1',
+      message_id: 'a1',
+      suggestions: [],
+      source: 'empty'
+    })
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await flushPromises()
+    await flushPromises()
+
+    expect(apiMocks.topicApi.generateFollowupSuggestions).toHaveBeenCalledWith('topic-1', 'a1')
+    expect(wrapper.find('.query-followup-suggestion').exists()).toBe(false)
   })
 
   it('renders tool chart_spec blocks in the conclusion area instead of the process panel', async () => {


### PR DESCRIPTION
## Summary
- Add an independent DataAgent follow-up suggestions endpoint for finished assistant messages without changing existing message, task, SSE, or database contracts.
- Generate suggestions with a one-turn no-tool model call, normalize JSON output, and fall back safely on generation errors.
- Update the intelligent-query chat UI to load API-driven follow-up suggestions per message and keep click-to-send behavior unchanged.

## Validation
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_followup_suggestions.py dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_generates_without_changing_message_contract dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_rejects_invalid_message_states -q` (4 passed, 5 warnings)
- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && cd frontend && npm test -- src/api/__tests__/nl2sqlClient.spec.js src/views/intelligence/__tests__/NL2SqlChat.spec.js` (26 passed)

## Risk / Rollback
Risk is limited to the new additive follow-up endpoint and the chat UI suggestion loader; rollback by reverting this PR restores the previous frontend-local suggestion rules.