### PR TITLE
fix: forward agent data scope to query runtime

### DIFF
--- a/dataagent/.claude/skills/opendataworks-platform-tools/bin/odw-cli
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/bin/odw-cli
@@ -5,6 +5,7 @@ BASE_URL="${ODW_BACKEND_BASE_URL:-}"
 SERVICE_TOKEN="${ODW_AGENT_SERVICE_TOKEN:-}"
 TIMEOUT_SECONDS="${ODW_BACKEND_TIMEOUT_SECONDS:-30}"
 TOKEN_HEADER_NAME="${ODW_AGENT_SERVICE_TOKEN_HEADER_NAME:-X-Agent-Service-Token}"
+DATA_SCOPE_HEADER="${ODW_AGENT_DATA_SCOPE_HEADER:-${DATAAGENT_DATA_SCOPE_HEADER:-}}"
 AI_BASE_URL=""
 METADATA_BASE_URL=""
 
@@ -76,12 +77,22 @@ run_get_request() {
   body_file="$(mktemp)"
   trap 'rm -f "$body_file"' EXIT INT TERM
 
-  http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
-    -H "Accept: application/json" \
-    -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
-    --max-time "$TIMEOUT_SECONDS" \
-    -G "${base_url%/}/${endpoint}" \
-    "$@")"
+  if [ -n "$DATA_SCOPE_HEADER" ]; then
+    http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+      -H "Accept: application/json" \
+      -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
+      -H "X-Agent-Data-Scope: ${DATA_SCOPE_HEADER}" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -G "${base_url%/}/${endpoint}" \
+      "$@")"
+  else
+    http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+      -H "Accept: application/json" \
+      -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -G "${base_url%/}/${endpoint}" \
+      "$@")"
+  fi
 
   handle_response "$body_file" "$http_code"
 }
@@ -94,13 +105,24 @@ run_post_json() {
   body_file="$(mktemp)"
   trap 'rm -f "$body_file"' EXIT INT TERM
 
-  http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
-    -H "Accept: application/json" \
-    -H "Content-Type: application/json" \
-    -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
-    --max-time "$TIMEOUT_SECONDS" \
-    -X POST "${base_url%/}/${endpoint}" \
-    --data-binary "$payload")"
+  if [ -n "$DATA_SCOPE_HEADER" ]; then
+    http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
+      -H "X-Agent-Data-Scope: ${DATA_SCOPE_HEADER}" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -X POST "${base_url%/}/${endpoint}" \
+      --data-binary "$payload")"
+  else
+    http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "${TOKEN_HEADER_NAME}: ${SERVICE_TOKEN}" \
+      --max-time "$TIMEOUT_SECONDS" \
+      -X POST "${base_url%/}/${endpoint}" \
+      --data-binary "$payload")"
+  fi
 
   handle_response "$body_file" "$http_code"
 }

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -64,6 +65,26 @@ def metadata_cli_command(subcommand: str, **options: Any) -> list[str]:
     return command
 
 
+def runtime_data_scope_header() -> str:
+    configured = str(
+        os.getenv("ODW_AGENT_DATA_SCOPE_HEADER")
+        or os.getenv("DATAAGENT_DATA_SCOPE_HEADER")
+        or ""
+    ).strip()
+    if configured:
+        return configured
+
+    raw_scope = str(os.getenv("DATAAGENT_DATA_SCOPE_JSON") or "").strip()
+    if not raw_scope:
+        return ""
+    try:
+        parsed = json.loads(raw_scope)
+    except json.JSONDecodeError:
+        return ""
+    payload = json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
 def serializable_value(value: Any) -> Any:
     if value is None or isinstance(value, (int, float, str, bool)):
         return value
@@ -105,6 +126,11 @@ def ensure_read_only(sql: str):
 def call_metadata_cli(subcommand: str, **options: Any) -> Any:
     command = metadata_cli_command(subcommand, **options)
     cli_path = metadata_cli_bin()
+    scope_header = runtime_data_scope_header()
+    cli_env = None
+    if scope_header:
+        cli_env = dict(os.environ)
+        cli_env["ODW_AGENT_DATA_SCOPE_HEADER"] = scope_header
 
     try:
         completed = subprocess.run(
@@ -112,6 +138,7 @@ def call_metadata_cli(subcommand: str, **options: Any) -> Any:
             check=False,
             capture_output=True,
             text=True,
+            env=cli_env,
         )
     except PermissionError as exc:
         # 离线部署包常见场景是文件保留了 +x，但挂载介质本身是 noexec；
@@ -125,6 +152,7 @@ def call_metadata_cli(subcommand: str, **options: Any) -> Any:
             check=False,
             capture_output=True,
             text=True,
+            env=cli_env,
         )
 
     if completed.returncode != 0:

--- a/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
+++ b/dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py
@@ -158,11 +158,36 @@ def test_query_readonly_uses_backend_cli(monkeypatch):
     assert result["duration_ms"] == 12
 
 
+def test_call_metadata_cli_exports_runtime_data_scope_header(monkeypatch):
+    runtime = _load_runtime_module()
+    _bind_existing_cli(monkeypatch, runtime)
+    captured = {}
+    monkeypatch.setenv(
+        "DATAAGENT_DATA_SCOPE_JSON",
+        '{"allowed_scopes":[{"cluster_id":3,"source_type":"DORIS","database":"ads_user"}]}',
+    )
+    monkeypatch.delenv("ODW_AGENT_DATA_SCOPE_HEADER", raising=False)
+
+    def fake_run(command, check, capture_output, text, env=None):
+        captured["scope_header"] = (env or {}).get("ODW_AGENT_DATA_SCOPE_HEADER")
+        return SimpleNamespace(returncode=0, stdout='{"kind":"ok"}', stderr="")
+
+    monkeypatch.setattr(runtime.subprocess, "run", fake_run)
+
+    runtime.call_metadata_cli("query-readonly", database="ads_user", sql="SELECT 1")
+
+    assert (
+        captured["scope_header"]
+        == "eyJhbGxvd2VkX3Njb3BlcyI6W3siY2x1c3Rlcl9pZCI6MywiZGF0YWJhc2UiOiJhZHNfdXNlciIsInNvdXJjZV90eXBlIjoiRE9SSVMifV19"
+    )
+    assert os.environ.get("ODW_AGENT_DATA_SCOPE_HEADER") is None
+
+
 def test_call_metadata_cli_rejects_invalid_json(monkeypatch):
     runtime = _load_runtime_module()
     _bind_existing_cli(monkeypatch, runtime)
 
-    def fake_run(command, check, capture_output, text):
+    def fake_run(command, check, capture_output, text, env=None):
         return SimpleNamespace(returncode=0, stdout="not-json", stderr="")
 
     monkeypatch.setattr(runtime.subprocess, "run", fake_run)
@@ -175,7 +200,7 @@ def test_call_metadata_cli_surfaces_non_zero_exit(monkeypatch):
     runtime = _load_runtime_module()
     _bind_existing_cli(monkeypatch, runtime)
 
-    def fake_run(command, check, capture_output, text):
+    def fake_run(command, check, capture_output, text, env=None):
         return SimpleNamespace(returncode=22, stdout="", stderr="agent api token 无效")
 
     monkeypatch.setattr(runtime.subprocess, "run", fake_run)
@@ -220,7 +245,7 @@ def test_call_metadata_cli_non_executable_bin_falls_back_to_sh(monkeypatch):
             return False
         return os.access(path, mode)
 
-    def fake_run(command, check, capture_output, text):
+    def fake_run(command, check, capture_output, text, env=None):
         captured["command"] = command
         return SimpleNamespace(returncode=0, stdout='{"kind":"ok"}', stderr="")
 
@@ -240,7 +265,7 @@ def test_call_metadata_cli_permission_denied_falls_back_to_sh(monkeypatch):
     cli_path = Path(runtime.metadata_cli_bin())
     captured = {"calls": 0}
 
-    def fake_run(command, check, capture_output, text):
+    def fake_run(command, check, capture_output, text, env=None):
         captured["calls"] += 1
         captured["command"] = command
         if captured["calls"] == 1:

--- a/dataagent/dataagent-backend/tests/test_odw_cli.py
+++ b/dataagent/dataagent-backend/tests/test_odw_cli.py
@@ -148,6 +148,31 @@ def test_odw_cli_query_readonly_uses_query_endpoint_for_legacy_metadata_base_url
     }
 
 
+def test_odw_cli_query_readonly_forwards_agent_data_scope_header(tmp_path: Path):
+    env = _base_env(tmp_path, "http://backend:8080/api/v1/ai")
+    env["ODW_AGENT_DATA_SCOPE_HEADER"] = "encoded-scope"
+
+    completed = subprocess.run(
+        [
+            "sh",
+            str(ODW_CLI),
+            "query-readonly",
+            "--database",
+            "ads_user",
+            "--sql",
+            "SELECT 1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0
+    args = (tmp_path / "curl-args.txt").read_text(encoding="utf-8").splitlines()
+    assert "X-Agent-Data-Scope: encoded-scope" in args
+
+
 def test_odw_cli_ddl_uses_metadata_ddl_endpoint(tmp_path: Path):
     env = _base_env(tmp_path, "http://backend:8080/api/v1/ai")
 


### PR DESCRIPTION
## Summary
Forward the agent's authorized data scope from the DataAgent runtime into the backend query request path so SQL execution no longer reports unauthorized access when the scope is already assigned.

## Changes
- Encode the runtime data scope into `ODW_AGENT_DATA_SCOPE_HEADER` before invoking the platform-tools metadata/query CLI bridge.
- Forward `X-Agent-Data-Scope` from `odw-cli` to backend GET and POST requests.
- Add regression tests covering both the Python bridge and the shell CLI header propagation.

## Validation
- `dataagent/dataagent-backend/.venv-py313/bin/pytest dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py dataagent/dataagent-backend/tests/test_odw_cli.py dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_sql_executor.py` -> 52 passed
- `mvn -pl backend -am -Dtest=BackendAgentQueryServiceTest,AgentQueryControllerTest -DfailIfNoTests=false test` -> 20 tests passed, build success

## Risk
This only touches the agent metadata/query path and header propagation. Rolling back the commit restores the previous behavior.
