### PR TITLE
feat: increase followup turn budget and add eval task recovery

### DIFF
--- a/dataagent/dataagent-backend/core/followup_suggestions.py
+++ b/dataagent/dataagent-backend/core/followup_suggestions.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 MAX_SUGGESTIONS = 3
 MAX_SUGGESTION_LENGTH = 64
 DEFAULT_TIMEOUT_SECONDS = 20
-DEFAULT_MAX_TURNS = 2
+DEFAULT_MAX_TURNS = 10
 
 ModelRunner = Callable[..., Awaitable[str]]
 

--- a/dataagent/dataagent-backend/tests/test_followup_suggestions.py
+++ b/dataagent/dataagent-backend/tests/test_followup_suggestions.py
@@ -14,7 +14,7 @@ from core import followup_suggestions
 from core.followup_suggestions import generate_followup_suggestions
 
 
-def test_default_model_runner_uses_bounded_two_turn_budget(monkeypatch, tmp_path):
+def test_default_model_runner_uses_bounded_ten_turn_budget(monkeypatch, tmp_path):
     class FakeOptions:
         last_kwargs = None
 
@@ -63,7 +63,7 @@ def test_default_model_runner_uses_bounded_two_turn_budget(monkeypatch, tmp_path
     result = anyio.run(run)
 
     assert result == '{"suggestions":["查看异常波动对应的明细"]}'
-    assert FakeOptions.last_kwargs["max_turns"] == 2
+    assert FakeOptions.last_kwargs["max_turns"] == 10
 
 
 def test_generate_followup_suggestions_parses_and_normalizes_model_json():

--- a/docs/design/2026-05-26-followup-suggestions-design.md
+++ b/docs/design/2026-05-26-followup-suggestions-design.md
@@ -23,7 +23,7 @@ Add an independent follow-up suggestion endpoint:
 
 The endpoint validates that the target message belongs to the topic, is visible, is an assistant message, is finished, and has non-empty visible answer content. It then locates the previous user message in the same topic and asks a lightweight generator for 2-3 Chinese follow-up questions.
 
-The generator uses the same provider/model recorded on the original task, disables tools, uses a bounded 2-turn SDK budget, and applies a short timeout. Model output is parsed as JSON and normalized by trimming bullets, removing duplicates, limiting length, and filtering the original question. If generation fails, the endpoint returns backend fallback suggestions or an empty list with a non-error source.
+The generator uses the same provider/model recorded on the original task, disables tools, uses a bounded 10-turn SDK budget, and applies a short timeout. Model output is parsed as JSON and normalized by trimming bullets, removing duplicates, limiting length, and filtering the original question. If generation fails, the endpoint returns backend fallback suggestions or an empty list with a non-error source.
 
 ## Interfaces
 

--- a/docs/plans/2026-05-26-followup-suggestions-plan.md
+++ b/docs/plans/2026-05-26-followup-suggestions-plan.md
@@ -7,7 +7,7 @@ Replace frontend keyword-based "猜你想问" suggestions with an additive backe
 ## Backend Tasks
 
 1. Add a `FollowupSuggestionsResponse` schema with `topic_id`, `message_id`, `suggestions`, and `source`.
-2. Add `core/followup_suggestions.py` to build the prompt, run a bounded 2-turn no-tool model call, parse JSON suggestions, normalize output, and return fallback or empty results on failure.
+2. Add `core/followup_suggestions.py` to build the prompt, run a bounded 10-turn no-tool model call, parse JSON suggestions, normalize output, and return fallback or empty results on failure.
 3. Add `POST /topics/{topic_id}/messages/{message_id}/followup-suggestions`.
 4. Validate topic ownership, assistant sender type, finished status, visible message state, and non-empty answer content before calling the generator.
 5. Reuse the original task provider/model for generation.

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -346,6 +346,58 @@ def test_deepeval_poll_task_retries_transient_event_error(monkeypatch):
     assert errors == []
 
 
+def test_deepeval_run_case_uses_recovered_task_answer(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+
+    def fake_http_json(method, url, payload=None, **kwargs):
+        if url.endswith("/api/v1/nl2sql/topics") and method == "POST":
+            return {"topic_id": "topic_1"}
+        if url.endswith("/api/v1/nl2sql/tasks/deliver-message"):
+            return {"task_id": "task_1", "accepted": True}
+        if url == "http://dataagent/api/v1/nl2sql/tasks/task_1":
+            return {
+                "task_id": "task_1",
+                "topic_id": "topic_1",
+                "task_status": "suspended",
+                "error": {"code": "task_recovered", "message": "任务租约已过期，已转移到 task_2"},
+            }
+        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_1/events"):
+            return {"task_id": "task_1", "task_status": "suspended", "next_after_seq": 0, "events": []}
+        if url == "http://dataagent/api/v1/nl2sql/topics/topic_1":
+            return {"topic_id": "topic_1", "current_task_id": "task_2", "current_task_status": "finished"}
+        if url == "http://dataagent/api/v1/nl2sql/tasks/task_2":
+            return {"task_id": "task_2", "topic_id": "topic_1", "task_status": "finished"}
+        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_2/events"):
+            return {
+                "task_id": "task_2",
+                "task_status": "finished",
+                "next_after_seq": 1,
+                "events": [{"seq_id": 1, "data": {"tool_name": "run_sql"}}],
+            }
+        if url.startswith("http://dataagent/api/v1/nl2sql/topics/topic_1/messages"):
+            return {
+                "items": [
+                    {"sender_type": "assistant", "task_id": "task_1", "content": ""},
+                    {"sender_type": "assistant", "task_id": "task_2", "content": "recovered answer"},
+                ]
+            }
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    monkeypatch.setattr(runner, "http_json", fake_http_json)
+
+    result = runner.run_case(
+        "http://dataagent",
+        _sample_case(),
+        types.SimpleNamespace(agent_id="agent_eval", provider_id="", model="", timeout_seconds=5),
+    )
+
+    assert result["task_id"] == "task_2"
+    assert result["task_status"] == "finished"
+    assert result["final_answer"] == "recovered answer"
+    assert result["errors"] == []
+
+
 def test_deepeval_auto_rule_check_adds_generic_failure_attribution(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -520,16 +520,57 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
         if self.path == "/api/v1/nl2sql-admin/settings":
             self._send(200, {"provider_id": "openrouter", "model": "anthropic/claude-sonnet-4.5"})
             return
+        if self.path == "/api/v1/nl2sql/topics/topic-1":
+            self._send(
+                200,
+                {
+                    "topic_id": "topic-1",
+                    "title": "eval",
+                    "chat_topic_id": "chat-1",
+                    "chat_conversation_id": "conv-1",
+                    "current_task_id": "task-2" if self.scenario == "recovered" else "task-1",
+                    "current_task_status": "success" if self.scenario == "recovered" else "running",
+                },
+            )
+            return
+        if self.path.startswith("/api/v1/nl2sql/tasks/task-2/events"):
+            self._send(
+                200,
+                {
+                    "task_id": "task-2",
+                    "task_status": "success",
+                    "after_seq": 0,
+                    "next_after_seq": 1,
+                    "has_more": False,
+                    "events": [
+                        {
+                            "record_type": "event",
+                            "seq_id": 1,
+                            "event_type": "AFTER_TOOL_CALL",
+                            "data": {
+                                "tool_name": "run_sql",
+                                "output": {
+                                    "rows": [{"cnt": 1}],
+                                    "sql": "select count(1) from opendataworks.workflow_publish_record",
+                                },
+                            },
+                        },
+                    ],
+                },
+            )
+            return
         if self.path.startswith("/api/v1/nl2sql/tasks/task-1/events"):
             self._send(
                 200,
                 {
                     "task_id": "task-1",
-                    "task_status": "success",
+                    "task_status": "suspended" if self.scenario == "recovered" else "success",
                     "after_seq": 0,
-                    "next_after_seq": 2,
+                    "next_after_seq": 0 if self.scenario == "recovered" else 2,
                     "has_more": False,
-                    "events": [
+                    "events": []
+                    if self.scenario == "recovered"
+                    else [
                         {
                             "record_type": "event",
                             "seq_id": 1,
@@ -562,9 +603,57 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
                     },
                 )
                 return
+            if self.scenario == "recovered":
+                self._send(
+                    200,
+                    {
+                        "task_id": "task-1",
+                        "topic_id": "topic-1",
+                        "task_status": "suspended",
+                        "error": {"code": "task_recovered", "message": "任务租约已过期，已转移到 task-2"},
+                    },
+                )
+                return
             self._send(200, {"task_id": "task-1", "topic_id": "topic-1", "task_status": "success", "usage": {"input_tokens": 1}})
             return
+        if self.path == "/api/v1/nl2sql/tasks/task-2":
+            self._send(200, {"task_id": "task-2", "topic_id": "topic-1", "task_status": "success", "usage": {"input_tokens": 1}})
+            return
         if self.path.startswith("/api/v1/nl2sql/topics/topic-1/messages"):
+            if self.scenario == "recovered":
+                self._send(
+                    200,
+                    {
+                        "topic_id": "topic-1",
+                        "page": 1,
+                        "page_size": 200,
+                        "order": "asc",
+                        "total": 3,
+                        "items": [
+                            {"message_id": "m1", "topic_id": "topic-1", "sender_type": "user", "type": "chat", "status": "success", "content": "q"},
+                            {
+                                "message_id": "m2",
+                                "topic_id": "topic-1",
+                                "task_id": "task-1",
+                                "sender_type": "assistant",
+                                "type": "assistant",
+                                "status": "suspended",
+                                "content": "",
+                            },
+                            {
+                                "message_id": "m3",
+                                "topic_id": "topic-1",
+                                "task_id": "task-2",
+                                "sender_type": "assistant",
+                                "type": "assistant",
+                                "status": "success",
+                                "content": "answer with opendataworks.workflow_publish_record",
+                                "usage": {"input_tokens": 1, "output_tokens": 2},
+                            },
+                        ],
+                    },
+                )
+                return
             self._send(
                 200,
                 {
@@ -758,6 +847,17 @@ def test_task_failure_generates_report_and_exit_1(tmp_path):
     result = json.loads((tmp_path / "cases.jsonl").read_text(encoding="utf-8").splitlines()[0])
     assert result["case_passed"] is False
     assert result["task_status"] == "failed"
+
+
+def test_recovered_task_follows_replacement_and_scores_final_answer(tmp_path):
+    code = _run_fake_scenario(tmp_path, "recovered")
+
+    assert code == 0
+    result = json.loads((tmp_path / "cases.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert result["task_id"] == "task-2"
+    assert result["task_status"] == "success"
+    assert result["final_answer"] == "answer with opendataworks.workflow_publish_record"
+    assert result["errors"] == []
 
 
 def test_timeout_generates_case_error_and_exit_1(tmp_path):

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -555,8 +555,44 @@ def _submit_task(base_url: str, topic_id: str, case: dict[str, Any], args: argpa
     return task_id
 
 
-def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+def _is_recovered_task(task: dict[str, Any]) -> bool:
+    error = task.get("error") if isinstance(task.get("error"), dict) else {}
+    return str(task.get("task_status") or "").lower() == "suspended" and str(error.get("code") or "") == "task_recovered"
+
+
+def _task_id_from_recovery_message(task: dict[str, Any]) -> str:
+    error = task.get("error") if isinstance(task.get("error"), dict) else {}
+    message = str(error.get("message") or "")
+    match = re.search(r"\btask[-_][A-Za-z0-9]+\b", message)
+    return match.group(0) if match else ""
+
+
+def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any]) -> str:
+    parent_task_id = str(task.get("task_id") or "").strip()
+    if topic_id:
+        try:
+            topic = http_json("GET", f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}", timeout=30)
+        except EvalRunnerError:
+            topic = {}
+        current_task_id = str(topic.get("current_task_id") or "").strip()
+        if current_task_id and current_task_id != parent_task_id:
+            return current_task_id
+    recovered_task_id = _task_id_from_recovery_message(task)
+    if recovered_task_id and recovered_task_id != parent_task_id:
+        return recovered_task_id
+    return ""
+
+
+def _poll_task(
+    base_url: str,
+    task_id: str,
+    timeout_seconds: int,
+    *,
+    topic_id: str = "",
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
     deadline = time.time() + max(1, timeout_seconds)
+    current_task_id = task_id
+    seen_task_ids = {task_id}
     after_seq = 0
     all_events: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -564,7 +600,7 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
     last_poll_error = ""
     while time.time() < deadline:
         try:
-            last_task = http_json("GET", f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}", timeout=30)
+            last_task = http_json("GET", f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}", timeout=30)
         except EvalRunnerError as exc:
             last_poll_error = str(exc)
             time.sleep(1.0)
@@ -574,7 +610,7 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
         try:
             page = http_json(
                 "GET",
-                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/events?after_seq={after_seq}&limit=1000",
+                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}/events?after_seq={after_seq}&limit=1000",
                 timeout=60,
             )
             events = [item for item in page.get("events") or [] if isinstance(item, dict)]
@@ -585,13 +621,20 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
             last_poll_error = str(exc)
 
         if status in TERMINAL_STATUSES:
+            if _is_recovered_task(last_task):
+                recovered_task_id = _resolve_recovered_task_id(base_url, topic_id, last_task)
+                if recovered_task_id and recovered_task_id not in seen_task_ids:
+                    current_task_id = recovered_task_id
+                    seen_task_ids.add(recovered_task_id)
+                    after_seq = 0
+                    continue
             return last_task, all_events, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
         errors.append({"code": "poll_error", "message": last_poll_error})
     if not last_task:
-        last_task = {"task_id": task_id, "task_status": "timeout"}
+        last_task = {"task_id": current_task_id, "task_status": "timeout"}
     else:
         last_task = dict(last_task)
         last_task["task_status"] = str(last_task.get("task_status") or "timeout")
@@ -819,14 +862,15 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout)
+        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
+        final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
             "GET",
             f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}/messages?page=1&page_size=200&order=asc",
             timeout=30,
         )
-        final_answer = _final_assistant_answer(messages, task_id)
+        final_answer = _final_assistant_answer(messages, final_task_id)
         status = str(task.get("task_status") or "").lower()
         if status and status not in SUCCESS_STATUSES:
             errors.append({"code": status, "message": json.dumps(task.get("error") or {}, ensure_ascii=False)})
@@ -874,7 +918,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
         "question": case.get("question"),
         "agent_id": str(args.agent_id or "").strip(),
         "topic_id": topic_id,
-        "task_id": task_id,
+        "task_id": str(task.get("task_id") or task_id),
         "task_status": str(task.get("task_status") or ""),
         "final_answer": final_answer,
         "tool_names": tool_names,

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -442,8 +442,44 @@ def _submit_task(base_url: str, topic_id: str, case: dict[str, Any], args: argpa
     return task_id
 
 
-def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+def _is_recovered_task(task: dict[str, Any]) -> bool:
+    error = task.get("error") if isinstance(task.get("error"), dict) else {}
+    return str(task.get("task_status") or "").lower() == "suspended" and str(error.get("code") or "") == "task_recovered"
+
+
+def _task_id_from_recovery_message(task: dict[str, Any]) -> str:
+    error = task.get("error") if isinstance(task.get("error"), dict) else {}
+    message = str(error.get("message") or "")
+    match = re.search(r"\btask[-_][A-Za-z0-9]+\b", message)
+    return match.group(0) if match else ""
+
+
+def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any]) -> str:
+    parent_task_id = str(task.get("task_id") or "").strip()
+    if topic_id:
+        try:
+            topic = http_json("GET", f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}", timeout=30)
+        except EvalRunnerError:
+            topic = {}
+        current_task_id = str(topic.get("current_task_id") or "").strip()
+        if current_task_id and current_task_id != parent_task_id:
+            return current_task_id
+    recovered_task_id = _task_id_from_recovery_message(task)
+    if recovered_task_id and recovered_task_id != parent_task_id:
+        return recovered_task_id
+    return ""
+
+
+def _poll_task(
+    base_url: str,
+    task_id: str,
+    timeout_seconds: int,
+    *,
+    topic_id: str = "",
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
     deadline = time.time() + max(1, timeout_seconds)
+    current_task_id = task_id
+    seen_task_ids = {task_id}
     after_seq = 0
     all_events: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
@@ -451,7 +487,7 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
     last_poll_error = ""
     while time.time() < deadline:
         try:
-            last_task = http_json("GET", f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}", timeout=30)
+            last_task = http_json("GET", f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}", timeout=30)
         except EvalRunnerError as exc:
             last_poll_error = str(exc)
             time.sleep(1.0)
@@ -461,7 +497,7 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
         try:
             page = http_json(
                 "GET",
-                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/events?after_seq={after_seq}&limit=1000",
+                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}/events?after_seq={after_seq}&limit=1000",
                 timeout=60,
             )
             events = [item for item in page.get("events") or [] if isinstance(item, dict)]
@@ -472,12 +508,19 @@ def _poll_task(base_url: str, task_id: str, timeout_seconds: int) -> tuple[dict[
             last_poll_error = str(exc)
 
         if status in TERMINAL_STATUSES:
+            if _is_recovered_task(last_task):
+                recovered_task_id = _resolve_recovered_task_id(base_url, topic_id, last_task)
+                if recovered_task_id and recovered_task_id not in seen_task_ids:
+                    current_task_id = recovered_task_id
+                    seen_task_ids.add(recovered_task_id)
+                    after_seq = 0
+                    continue
             return last_task, all_events, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
         errors.append({"code": "poll_error", "message": last_poll_error})
-    last_task = dict(last_task or {"task_id": task_id})
+    last_task = dict(last_task or {"task_id": current_task_id})
     last_task["task_status"] = str(last_task.get("task_status") or "timeout")
     return last_task, all_events, errors
 
@@ -495,14 +538,15 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout)
+        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
+        final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
             "GET",
             f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}/messages?page=1&page_size=200&order=asc",
             timeout=30,
         )
-        final_answer = _final_assistant_answer(messages, task_id)
+        final_answer = _final_assistant_answer(messages, final_task_id)
         status = str(task.get("task_status") or "").lower()
         if status and status not in SUCCESS_STATUSES:
             errors.append({"code": status, "message": json.dumps(task.get("error") or {}, ensure_ascii=False)})
@@ -520,7 +564,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
         "question": case.get("question"),
         "agent_id": str(args.agent_id or "").strip(),
         "topic_id": topic_id,
-        "task_id": task_id,
+        "task_id": str(task.get("task_id") or task_id),
         "task_status": str(task.get("task_status") or ""),
         "final_answer": final_answer,
         "tool_names": tool_names,


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_MAX_TURNS` from 2 to 10 for more robust followup suggestions
- Add task recovery support to both builtin and deepeval eval runners — when a task is suspended with `task_recovered` error, the runner now follows the replacement task and scores its final answer
- Add tests for recovered task flow

## Test plan
- [x] Unit tests pass for followup suggestions
- [x] Eval runner tests pass for task recovery scenario
- [ ] Smoke test with real NL2SQL flow (if backend available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)