### PR TITLE
[codex] Fix context ring usage during follow-up

### DIFF
--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -587,8 +587,7 @@ const getContextWindowLimit = (model) => {
   return 128000
 }
 
-const contextWindowUsage = computed(() => {
-  const message = latestAssistantMessage.value
+const buildContextWindowUsage = (message) => {
   const usage = message?.usage || message?.token_usage || null
   const inputTokens = parseTokenNumber(usage?.input_tokens)
   const actualOutputTokens = parseTokenNumber(usage?.output_tokens)
@@ -625,6 +624,20 @@ const contextWindowUsage = computed(() => {
     percentage,
     percentLabel
   }
+}
+
+const contextWindowUsage = computed(() => {
+  const assistantMessages = [...activeMessages.value]
+    .reverse()
+    .filter((msg) => msg?.role === 'assistant')
+  const fallback = assistantMessages[0] || latestAssistantMessage.value
+
+  for (const message of assistantMessages) {
+    const usage = buildContextWindowUsage(message)
+    if (usage.available) return usage
+  }
+
+  return buildContextWindowUsage(fallback)
 })
 
 const contextRingDashArray = computed(() => `${contextWindowUsage.value.available ? contextWindowUsage.value.percentage : 0} 100`)

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -70,6 +70,7 @@ vi.mock('vue-router', () => ({
 
 vi.mock('element-plus', () => ({
   ElMessage: {
+    success: vi.fn(),
     error: vi.fn()
   },
   ElScrollbar: {
@@ -930,6 +931,78 @@ describe('NL2SqlChat', () => {
     expect(ring.attributes('aria-label')).toContain('输出：200')
   })
 
+  it('keeps previous context window usage while a follow-up question is queued', async () => {
+    const deliverPending = deferred()
+    apiMocks.topicApi.getTopicMessages.mockResolvedValue({
+      topic_id: 'topic-1',
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 2,
+      items: [
+        {
+          message_id: 'u1',
+          topic_id: 'topic-1',
+          sender_type: 'user',
+          content: '最近 30 天工作流发布次数趋势',
+          created_at: '2026-03-10T02:00:00Z'
+        },
+        {
+          message_id: 'a1',
+          topic_id: 'topic-1',
+          task_id: 'task-1',
+          sender_type: 'assistant',
+          type: 'assistant',
+          status: 'finished',
+          content: '最近 30 天共发布 4 次。',
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 200
+          },
+          blocks: [
+            {
+              block_id: 'main-1',
+              type: 'main_text',
+              status: 'success',
+              text: '最近 30 天共发布 4 次。'
+            }
+          ],
+          created_at: '2026-03-10T02:01:00Z'
+        }
+      ]
+    })
+    apiMocks.taskApi.deliverMessage.mockImplementation(() => deliverPending.promise)
+
+    const wrapper = mountChat()
+
+    try {
+      await flushPromises()
+      await flushPromises()
+
+      expect(wrapper.find('.query-context-ring-wrap').attributes('aria-label')).toContain('1,200 / 200,000')
+
+      await wrapper.find('.query-textarea').setValue('继续追问同比情况')
+      await wrapper.find('.query-btn-send').trigger('click')
+      await flushPromises()
+
+      const ring = wrapper.find('.query-context-ring-wrap')
+      expect(ring.attributes('aria-label')).toContain('1,200 / 200,000')
+      expect(ring.attributes('aria-label')).toContain('输入：1,000')
+      expect(ring.attributes('aria-label')).toContain('输出：200')
+    } finally {
+      deliverPending.resolve({
+        accepted: true,
+        topic_id: 'topic-1',
+        task_id: 'task-new',
+        task_status: 'waiting',
+        user_message_id: 'u-new',
+        assistant_message_id: 'a-new'
+      })
+      await flushPromises()
+      wrapper.unmount()
+    }
+  })
+
   it('estimates context window usage while assistant text is streaming', async () => {
     const streamHold = deferred()
     apiMocks.topicApi.getTopicMessages.mockResolvedValue({
@@ -995,6 +1068,10 @@ describe('NL2SqlChat', () => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: { writeText }
+    })
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true
     })
 
     apiMocks.topicApi.getTopicMessages.mockResolvedValue({


### PR DESCRIPTION
## Summary

Fix the intelligent-query context window ring so it does not clear token usage while the user sends a follow-up question in the same conversation.

## Root Cause

The composer appends a queued assistant placeholder immediately after a follow-up question is submitted. The ring previously read only the latest assistant message, so it switched to the placeholder before usage metadata or streamed text was available.

## Changes

- Reuse the existing token usage calculation across assistant messages.
- Select the newest assistant message with available context-window usage, falling back to the latest assistant only when no usage is available.
- Add a regression test covering follow-up submission while the task acceptance request is still pending.
- Tighten the clipboard test setup so it explicitly exercises the secure clipboard branch it asserts.

## Validation

- `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/views/intelligence/__tests__/NL2SqlChat.spec.js` -> 22 tests passed
- `git diff --check` -> passed

## Risk

Low. The change is limited to the context ring display selection logic and a focused component test.

## Rollback

Revert commit `6a674b2` to restore the previous latest-assistant-only ring behavior.
