### PR TITLE
fix(dataagent): normalize follow-up suggestion output

### DIFF
--- a/dataagent/dataagent-backend/core/followup_suggestions.py
+++ b/dataagent/dataagent-backend/core/followup_suggestions.py
@@ -23,6 +23,7 @@ DEFAULT_TIMEOUT_SECONDS = 20
 DEFAULT_MAX_TURNS = 10
 SUGGESTION_TEXT_KEYS = ("question", "text", "content", "title", "value", "label")
 FOLLOWUP_SCHEMA_EXAMPLE = '{"suggestions":["问题1","问题2"]}'
+JSON_STRUCTURE_KEYS = {"suggestions", *SUGGESTION_TEXT_KEYS, "items", "item", "kind", "type"}
 
 ModelRunner = Callable[..., Awaitable[str]]
 
@@ -55,8 +56,43 @@ def _parse_json_like_value(value: str) -> Any | None:
         return None
 
 
+def _quoted_text_candidates(value: str) -> list[str]:
+    candidates: list[str] = []
+    index = 0
+    while index < len(value):
+        start = value.find('"', index)
+        if start < 0:
+            break
+        raw_parts: list[str] = []
+        pos = start + 1
+        closed = False
+        while pos < len(value):
+            char = value[pos]
+            if char == "\\" and pos + 1 < len(value):
+                raw_parts.append(value[pos : pos + 2])
+                pos += 2
+                continue
+            if char == '"':
+                closed = True
+                break
+            raw_parts.append(char)
+            pos += 1
+        raw = "".join(raw_parts)
+        try:
+            text = json.loads(f'"{raw}"')
+        except Exception:
+            text = raw.replace('\\"', '"').replace("\\n", "\n")
+        text = str(text or "").strip()
+        if not text or text.lower() in JSON_STRUCTURE_KEYS:
+            index = pos + 1 if closed else len(value)
+            continue
+        candidates.append(text)
+        index = pos + 1 if closed else len(value)
+    return candidates
+
+
 def _suggestion_text_candidates(value: Any, *, depth: int = 0) -> list[Any]:
-    if depth > 4 or value is None:
+    if depth > 8 or value is None:
         return []
     if isinstance(value, dict):
         if "suggestions" in value:
@@ -71,9 +107,12 @@ def _suggestion_text_candidates(value: Any, *, depth: int = 0) -> list[Any]:
             candidates.extend(_suggestion_text_candidates(item, depth=depth + 1))
         return candidates
     if isinstance(value, str):
+        text = _strip_code_fence(value)
         parsed = _parse_json_like_value(value)
         if parsed is not None:
             return _suggestion_text_candidates(parsed, depth=depth + 1)
+        if text.startswith(("{", "[")):
+            return _quoted_text_candidates(text)
         return [line for line in value.splitlines() if line.strip()]
     return [value]
 
@@ -127,6 +166,9 @@ def _parse_strict_model_suggestions(raw: str, *, previous_question: str) -> tupl
     if not all(isinstance(value, str) for value in values):
         return [], "suggestions 数组中的每一项必须是字符串"
 
+    if any(str(value or "").strip().startswith(("{", "[")) for value in values):
+        return [], "suggestions 数组项不能是 JSON 字符串"
+
     suggestions = _normalize_suggestions(values, previous_question=previous_question)
     if not suggestions:
         return [], "suggestions 中没有可用的问题文本"
@@ -170,20 +212,6 @@ def _build_prompt(*, previous_question: str, answer_text: str, result_summary: s
     if str(result_summary or "").strip():
         sections.append(f"结果摘要：{result_summary}")
     return "\n\n".join(sections)
-
-
-def _build_format_retry_prompt(*, original_prompt: str, raw: str, error: str) -> str:
-    return "\n\n".join(
-        [
-            "上一次输出不符合格式要求。",
-            f"格式错误：{error}",
-            f"必须只输出合法 JSON，且格式严格为 {FOLLOWUP_SCHEMA_EXAMPLE}。",
-            "suggestions 数组中的每一项必须是字符串，禁止对象、嵌套数组、JSON 字符串、Markdown、编号、解释或额外字段。",
-            "请基于下面的原始任务重新输出：",
-            original_prompt,
-            f"上一次错误输出：{str(raw or '').strip()[:1200]}",
-        ]
-    )
 
 
 def _extract_sdk_text(message: Any) -> str:
@@ -294,15 +322,6 @@ async def generate_followup_suggestions(
         )
         suggestions, schema_error = _parse_strict_model_suggestions(raw, previous_question=previous_question)
         if not suggestions and schema_error:
-            retry_prompt = _build_format_retry_prompt(original_prompt=prompt, raw=raw, error=schema_error)
-            raw = await runner(
-                prompt=retry_prompt,
-                provider_id=provider_id,
-                model=model,
-                timeout_seconds=timeout_seconds,
-            )
-            suggestions, schema_error = _parse_strict_model_suggestions(raw, previous_question=previous_question)
-        if not suggestions:
             suggestions = _parse_model_suggestions(raw, previous_question=previous_question)
         if suggestions:
             return {"suggestions": suggestions, "source": "generated"}

--- a/dataagent/dataagent-backend/tests/test_followup_suggestions.py
+++ b/dataagent/dataagent-backend/tests/test_followup_suggestions.py
@@ -99,8 +99,12 @@ def test_generate_followup_suggestions_parses_and_normalizes_model_json():
     }
 
 
-def test_generate_followup_suggestions_extracts_text_from_structured_items():
+def test_generate_followup_suggestions_extracts_text_from_structured_items_without_retry():
+    calls = 0
+
     async def fake_runner(**_kwargs):
+        nonlocal calls
+        calls += 1
         return """
         {
           "suggestions": [
@@ -123,22 +127,23 @@ def test_generate_followup_suggestions_extracts_text_from_structured_items():
 
     result = anyio.run(run)
 
+    assert calls == 1
     assert result == {
         "suggestions": ["查看异常峰值对应的工作流明细", "按发布操作类型拆解这段趋势", "查看失败任务明细"],
         "source": "generated",
     }
 
 
-def test_generate_followup_suggestions_retries_once_when_model_schema_is_invalid():
-    prompts: list[str] = []
-    responses = [
-        '{"suggestions":[{"question":"查看异常峰值对应的工作流明细"}]}',
-        '{"suggestions":["查看异常峰值对应的工作流明细","按发布操作类型拆解这段趋势"]}',
-    ]
+def test_generate_followup_suggestions_uses_local_extraction_when_first_schema_is_invalid():
+    calls = 0
 
-    async def fake_runner(**kwargs):
-        prompts.append(kwargs["prompt"])
-        return responses[len(prompts) - 1]
+    async def fake_runner(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return (
+            '{"suggestions":[{"question":"查看异常峰值对应的工作流明细"},'
+            '{"question":"按发布操作类型拆解这段趋势"}]}'
+        )
 
     async def run():
         return await generate_followup_suggestions(
@@ -152,13 +157,100 @@ def test_generate_followup_suggestions_retries_once_when_model_schema_is_invalid
 
     result = anyio.run(run)
 
+    assert calls == 1
     assert result == {
         "suggestions": ["查看异常峰值对应的工作流明细", "按发布操作类型拆解这段趋势"],
         "source": "generated",
     }
-    assert len(prompts) == 2
-    assert "上一次输出不符合格式要求" in prompts[1]
-    assert "suggestions 数组中的每一项必须是字符串" in prompts[1]
+
+
+def test_generate_followup_suggestions_extracts_items_from_json_string_without_retry():
+    calls = 0
+
+    async def fake_runner(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return (
+            '{"suggestions":["{\\"suggestions\\":[\\"分级保障等级具体有哪些取值？\\",'
+            '\\"各等级分别代表什么含义？\\"]}"]}'
+        )
+
+    async def run():
+        return await generate_followup_suggestions(
+            previous_question="所有分级保障组件都是普通组件吗？",
+            answer_text="所有分级保障组件都是普通组件，但不是所有普通组件都是分级保障组件。",
+            result_summary="",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            model_runner=fake_runner,
+        )
+
+    result = anyio.run(run)
+
+    assert calls == 1
+    assert result == {
+        "suggestions": ["分级保障等级具体有哪些取值？", "各等级分别代表什么含义？"],
+        "source": "generated",
+    }
+
+
+def test_generate_followup_suggestions_extracts_items_from_truncated_json_string_without_retry():
+    calls = 0
+
+    async def fake_runner(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return (
+            '{"suggestions":["{\\"suggestions\\":[\\"分级保障等级具体有哪些级别？\\",'
+            '\\"保障策略具体包含哪些内容？\\",\\"如何查询一个普通组件是否具备"]}'
+        )
+
+    async def run():
+        return await generate_followup_suggestions(
+            previous_question="所有分级保障组件都是普通组件吗？",
+            answer_text="简言之：所有分级保障组件都是普通组件，但不是所有普通组件都是分级保障组件。",
+            result_summary="",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            model_runner=fake_runner,
+        )
+
+    result = anyio.run(run)
+
+    assert calls == 1
+    assert result == {
+        "suggestions": ["分级保障等级具体有哪些级别？", "保障策略具体包含哪些内容？", "如何查询一个普通组件是否具备"],
+        "source": "generated",
+    }
+
+
+def test_generate_followup_suggestions_returns_fallback_when_local_extraction_finds_nothing():
+    calls = 0
+
+    async def fake_runner(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return '{"items":[{"kind":"metadata"}]}'
+
+    async def run():
+        return await generate_followup_suggestions(
+            previous_question="所有分级保障组件都是普通组件吗？",
+            answer_text="简言之：所有分级保障组件都是普通组件，但不是所有普通组件都是分级保障组件。",
+            result_summary="",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            model_runner=fake_runner,
+        )
+
+    result = anyio.run(run)
+
+    assert calls == 1
+    assert result["source"] == "fallback"
+    assert result["suggestions"] == [
+        "按核心维度做进一步对比",
+        "查看这个结果的明细数据",
+        "总结一下可能的业务原因",
+    ]
 
 
 def test_generate_followup_suggestions_returns_fallback_when_model_fails():


### PR DESCRIPTION
## Summary
- Prevent follow-up suggestions from rendering raw model JSON by normalizing model output into plain suggestion strings.
- The backend now extracts usable question text from strict JSON, structured objects, nested JSON strings, and partially truncated JSON-like model output before falling back.

## What Changed

### Behavior Changes
- Keep the public `followup-suggestions` response contract as `suggestions: string[]`.
- Parse model responses like `{"suggestions":[{"question":"..."}]}` into plain strings.
- Parse nested JSON-string responses like `{"suggestions":["{\"suggestions\":[\"...\"]}"]}` into plain strings.
- Extract quoted suggestion text from truncated JSON-like strings when the useful question text is still recoverable.
- Use fallback suggestions only when local extraction cannot find usable question text or model execution fails.

### Key Files
- `dataagent/dataagent-backend/core/followup_suggestions.py`: adds resilient local extraction and removes the model-retry correction path.
- `dataagent/dataagent-backend/tests/test_followup_suggestions.py`: covers structured items, nested JSON strings, truncated JSON-like strings, and fallback behavior.

## Validation
- [x] `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_followup_suggestions.py dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_generates_without_changing_message_contract dataagent/dataagent-backend/tests/test_routes_contract.py::test_followup_suggestions_route_rejects_invalid_message_states -q`
  - Result: pass, `10 passed`.
- [x] `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use && npm --prefix frontend test -- src/views/intelligence/__tests__/NL2SqlChat.spec.js`
  - Result: pass, `23 passed`.
- [x] Real HTTP smoke against local `dataagent-backend` with `anthropic_compatible / deepseek-v4-pro`
  - Result: `POST /api/v1/nl2sql/topics/{topic_id}/messages/{message_id}/followup-suggestions` returned `source=generated` and `suggestions` as plain strings, with no JSON-string suggestions.
- [x] `git diff --check`
  - Result: pass.

## Risks
- Risk: malformed model text could still produce a poor suggestion if it contains quoted non-question text; fallback remains available when nothing useful is extracted.

## Rollback
- Rollback: revert `d38148d` to restore the previous strict/fallback parsing behavior.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updates not required for this backend-only contract-preserving fix.
