### PR TITLE
fix: add widget origin debug logs and improve judge model JSON output

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -157,12 +157,17 @@ def _request_context(request: Request) -> dict[str, str]:
             matched_site = site
             break
     if not matched_site:
+        allowed_ids = [str(s.get("website_id") or "") for s in _allowed_widget_sites()]
+        logger.warning(f"Widget site rejected: website_id={website_id!r} allowed={allowed_ids!r}")
         raise HTTPException(status_code=403, detail="Widget site is not allowed")
 
     allowed_origins = matched_site.get("allowed_origins") or []
     if not isinstance(allowed_origins, list):
+        logger.warning(f"Widget config error: allowed_origins is not a list: {allowed_origins!r}")
         allowed_origins = []
-    if not _origin_allowed(request.headers.get("Origin") or "", allowed_origins):
+    req_origin = request.headers.get("Origin") or ""
+    if not _origin_allowed(req_origin, allowed_origins):
+        logger.warning(f"Widget origin rejected: origin={req_origin!r} allowed={allowed_origins!r}")
         raise HTTPException(status_code=403, detail="Widget origin is not allowed")
 
     return {

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -821,24 +821,32 @@ def call_judge_model(config: JudgeConfig, payload: dict[str, Any]) -> dict[str, 
         "x-api-key": config.token,
         "Authorization": f"Bearer {config.token}",
     }
-    for attempt in range(2):
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        if attempt > 0:
+            time.sleep(1)
+        messages: list[dict[str, str]] = [
+            {"role": "user", "content": _judge_message_content(judge_payload, repair=attempt > 0, previous_output=raw_output)},
+            {"role": "assistant", "content": "{"},
+        ]
         body = {
             "model": config.model,
             "max_tokens": config.max_tokens,
             "temperature": 0,
-            "messages": [{"role": "user", "content": _judge_message_content(judge_payload, repair=attempt > 0, previous_output=raw_output)}],
+            "messages": messages,
         }
         try:
             response = http_json("POST", _anthropic_messages_url(config.base_url), body, timeout=config.timeout_seconds, headers=headers)
-            raw_output = _extract_message_text(response)
+            raw_output = "{" + _extract_message_text(response)
             parsed = json.loads(_json_object_text(raw_output))
             if not isinstance(parsed, dict):
                 raise ValueError("judge output is not a JSON object")
             return _normalize_judge_payload(parsed, raw_output=raw_output)
         except EvalRunnerError as exc:
-            return _failed_judge(str(exc), raw_output=raw_output, attribution=["judge_failed", "judge_http_error"])
+            if attempt == max_attempts - 1:
+                return _failed_judge(str(exc), raw_output=raw_output, attribution=["judge_failed", "judge_http_error"])
         except Exception as exc:
-            if attempt == 1:
+            if attempt == max_attempts - 1:
                 return _failed_judge(f"裁判模型未返回合法 JSON: {exc}", raw_output=raw_output)
     return _failed_judge("裁判模型未返回合法 JSON", raw_output=raw_output)
 

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -811,22 +811,32 @@ def call_judge_model(config: JudgeConfig, payload: dict[str, Any]) -> dict[str, 
         "x-api-key": config.token,
         "Authorization": f"Bearer {config.token}",
     }
-    for attempt in range(2):
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        if attempt > 0:
+            time.sleep(1)
+        messages: list[dict[str, str]] = [
+            {"role": "user", "content": _judge_message_content(payload, repair=attempt > 0, previous_output=raw_output)},
+            {"role": "assistant", "content": "{"},
+        ]
         body = {
             "model": config.model,
             "max_tokens": config.max_tokens,
             "temperature": 0,
-            "messages": [{"role": "user", "content": _judge_message_content(payload, repair=attempt > 0, previous_output=raw_output)}],
+            "messages": messages,
         }
         try:
             response = http_json("POST", _anthropic_messages_url(config.base_url), body, timeout=config.timeout_seconds, headers=headers)
-            raw_output = _extract_message_text(response)
+            raw_output = "{" + _extract_message_text(response)
             parsed = json.loads(_json_object_text(raw_output))
             if not isinstance(parsed, dict):
                 raise ValueError("judge output is not a JSON object")
             return normalize_judge_payload(parsed, raw_output=raw_output)
+        except EvalRunnerError as exc:
+            if attempt == max_attempts - 1:
+                return failed_judge(str(exc), raw_output=raw_output, attribution=["judge_failed", "judge_http_error"])
         except Exception as exc:
-            if attempt == 1:
+            if attempt == max_attempts - 1:
                 return failed_judge(f"裁判模型未返回合法 JSON: {exc}", raw_output=raw_output)
     return failed_judge("裁判模型未返回合法 JSON", raw_output=raw_output)
 


### PR DESCRIPTION
## Summary
- Add diagnostic logging for widget site/origin rejection to help debugging
- Force judge model JSON output with assistant prefill (`{`) to avoid parsing issues
- Increase max retry attempts from 2 to 3 with 1s sleep between retries
- Fix `EvalRunnerError` exception handling — previously fell through to generic catch

## Test plan
- [x] Judge model tested with real DeepSeek API — returns valid JSON with scores
- [x] Widget origin logging verified in code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)