### PR TITLE
fix: allow empty Origin for same-origin widget requests

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -129,7 +129,8 @@ def _origin_allowed(origin: str, allowed_origins: list[str]) -> bool:
     if "*" in normalized_allowed:
         return True
     if not normalized_origin:
-        return False
+        # 同源请求 / 非浏览器客户端不会发送 Origin 头，放行
+        return True
     return normalized_origin in normalized_allowed
 
 


### PR DESCRIPTION
## Summary
Allow empty Origin header in widget origin check. When widget is tested locally via Vite proxy or accessed same-origin, the browser does not send an `Origin` header. Previously this was rejected; now it is allowed since same-origin requests are inherently safe.

## Test plan
- [x] Verified locally via Vite dev proxy — widget requests succeed
- [x] Cross-origin widget requests still require matching `allowed_origins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)