### PR TITLE
feat: add floating AI assistant panel to main frontend layout

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260529_000012_sdk_block_records.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260529_000012_sdk_block_records.py
@@ -1,0 +1,44 @@
+"""add da_agent_sdk_record table for native SDK block stream
+
+Revision ID: 20260529_000012
+Revises: 20260525_000011
+Create Date: 2026-05-29 00:00:00
+"""
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260529_000012"
+down_revision = "20260525_000011"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def upgrade() -> None:
+    if _has_table("da_agent_sdk_record"):
+        return
+    op.execute(
+        """
+        CREATE TABLE da_agent_sdk_record (
+            id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+            topic_id    VARCHAR(64) NOT NULL,
+            task_id     VARCHAR(64) NOT NULL,
+            turn_index  SMALLINT NOT NULL DEFAULT 0,
+            record_type VARCHAR(32) NOT NULL,
+            event_type  VARCHAR(64) DEFAULT NULL,
+            data        JSON NOT NULL,
+            created_at  DATETIME(3) DEFAULT NOW(3),
+            KEY idx_sdk_record_task_id (task_id, id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS da_agent_sdk_record")

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -34,6 +34,8 @@ from models.schemas import (
     MessageScheduleUpsertRequest,
     RuntimeConfigResponse,
     RuntimeProviderConfig,
+    SdkEventPageResponse,
+    SdkEventRecord,
     TaskEventPageResponse,
     TaskEventRecord,
     TaskStatusResponse,
@@ -453,6 +455,81 @@ async def api_stream_task_events(task_id: str, request: Request, after_seq: int 
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@task_router.get("/{task_id}/sdk-events", response_model=SdkEventPageResponse)
+async def api_list_sdk_events(
+    task_id: str,
+    request: Request,
+    after_id: int = Query(default=0, ge=0),
+    limit: int = Query(default=200, ge=1, le=500),
+):
+    store = _get_store()
+    context = _request_context(request)
+    task = store.get_task(task_id, context=context)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    records = store.list_sdk_records(task_id=task_id, after_id=after_id, limit=limit + 1)
+    has_more = len(records) > limit
+    page = records[:limit]
+    next_after_id = int(page[-1]["seq_id"]) if page else after_id
+    return SdkEventPageResponse(
+        task_id=task_id,
+        task_status=str(task.get("task_status") or "waiting"),
+        after_id=after_id,
+        next_after_id=next_after_id,
+        has_more=has_more,
+        records=[SdkEventRecord.model_validate(r) for r in page],
+    )
+
+
+@task_router.get("/{task_id}/sdk-events/stream")
+async def api_stream_sdk_events(task_id: str, request: Request, after_id: int = Query(default=0, ge=0)):
+    store = _get_store()
+    context = _request_context(request)
+    task = store.get_task(task_id, context=context)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return StreamingResponse(
+        _stream_sdk_events(task_id=task_id, after_id=after_id, context=context),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _stream_sdk_events(task_id: str, after_id: int, context: dict[str, str] | None = None) -> AsyncIterator[str]:
+    cfg = get_settings()
+    poll_interval = max(1, int(cfg.run_events_stream_poll_interval_seconds or 1))
+    ping_seconds = max(5, int(cfg.run_events_stream_ping_seconds or 10))
+    next_after_id = max(0, after_id)
+    since_ping = 0
+    store = _get_store()
+
+    while True:
+        records = store.list_sdk_records(task_id=task_id, after_id=next_after_id, limit=200)
+        for rec in records:
+            next_after_id = max(next_after_id, int(rec.get("seq_id") or 0))
+            yield encode_sse(rec)
+        if records:
+            since_ping = 0
+        else:
+            since_ping += poll_interval
+            if since_ping >= ping_seconds:
+                yield ": ping\n\n"
+                since_ping = 0
+
+        task = store.get_task(task_id, context=context)
+        if not task:
+            break
+        # Stop when: task is terminal AND we've delivered all SDK records (look for 'done'/'error')
+        if str(task.get("task_status") or "") in TERMINAL_TASK_STATUSES and not records:
+            # Check if we've already yielded a done/error record
+            break
+        await anyio.sleep(poll_interval)
 
 
 @task_router.post("/{task_id}/cancel", response_model=CancelTaskResponse)

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -1,0 +1,96 @@
+"""Parallel SDK block writer — records native Claude SDK messages to da_agent_sdk_record.
+
+Runs alongside ClaudeToMagicAdapter without touching the existing magic-event path.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SdkBlockWriter:
+    """Writes raw Claude SDK messages into da_agent_sdk_record for the v2 stream endpoint."""
+
+    def __init__(self, store: Any, task_id: str, topic_id: str) -> None:
+        self._store = store
+        self._task_id = task_id
+        self._topic_id = topic_id
+        self._turn_index = 0
+
+    def ingest(self, msg: Any) -> None:
+        """Process one SDK message from the claude_query() stream."""
+        try:
+            self._ingest_safe(msg)
+        except Exception:
+            logger.exception("sdk_block_writer: failed to ingest message type=%s", type(msg).__name__)
+
+    def _ingest_safe(self, msg: Any) -> None:
+        type_name = type(msg).__name__
+
+        if type_name == "StreamEvent":
+            evt = getattr(msg, "event", None) or {}
+            etype = str(evt.get("type") or "")
+            if etype == "message_start":
+                self._turn_index += 1
+            self._store.append_sdk_record(
+                task_id=self._task_id,
+                topic_id=self._topic_id,
+                turn_index=self._turn_index,
+                record_type="stream",
+                event_type=etype or None,
+                data=evt,
+            )
+
+        elif type_name == "UserMessage":
+            content = getattr(msg, "content", None) or []
+            for block in content:
+                tool_use_id = getattr(block, "tool_use_id", None)
+                if not tool_use_id:
+                    continue
+                raw_content = getattr(block, "content", None)
+                # Normalise content to a JSON-serialisable form
+                if hasattr(raw_content, "__iter__") and not isinstance(raw_content, str):
+                    serialised = _serialise_blocks(raw_content)
+                else:
+                    serialised = raw_content
+                self._store.append_sdk_record(
+                    task_id=self._task_id,
+                    topic_id=self._topic_id,
+                    turn_index=self._turn_index,
+                    record_type="tool_result",
+                    event_type=None,
+                    data={
+                        "tool_use_id": str(tool_use_id),
+                        "content": serialised,
+                        "is_error": bool(getattr(block, "is_error", False)),
+                    },
+                )
+
+        elif type_name == "ResultMessage":
+            self._store.append_sdk_record(
+                task_id=self._task_id,
+                topic_id=self._topic_id,
+                turn_index=self._turn_index,
+                record_type="done",
+                event_type=None,
+                data={
+                    "is_error": bool(getattr(msg, "is_error", False)),
+                    "subtype": str(getattr(msg, "subtype", "") or ""),
+                },
+            )
+
+
+def _serialise_blocks(blocks: Any) -> Any:
+    """Convert SDK block objects into plain dicts for JSON storage."""
+    result = []
+    for b in blocks:
+        if isinstance(b, dict):
+            result.append(b)
+        elif hasattr(b, "__dict__"):
+            result.append({k: v for k, v in vars(b).items() if not k.startswith("_")})
+        else:
+            result.append(str(b))
+    return result

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -39,6 +39,8 @@ from core.agent_runtime import (
     resolve_runtime_provider_selection,
 )
 from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, resolved_agent_workdir
+from core.sdk_block_writer import SdkBlockWriter
+from core.topic_task_store import get_topic_task_store
 
 logger = logging.getLogger(__name__)
 
@@ -765,6 +767,7 @@ async def execute_task_stream(
         model = _default_model_for_provider(provider_id)
 
     adapter = ClaudeToMagicAdapter(params, provider_id=provider_id, model=model)
+    sdk_writer = SdkBlockWriter(get_topic_task_store(), params.task_id, params.topic_id)
 
     prompt = str(params.question or "").strip() if params.resume_session_id else _build_prompt(params.history, params.question)
     agent_snapshot = normalize_agent_snapshot(params.agent_snapshot) if params.agent_snapshot else None
@@ -937,6 +940,7 @@ async def execute_task_stream(
                         session_id=adapter.session_id,
                     )
                 await _emit_records(emit, adapter.ingest_sdk_message(msg))
+                sdk_writer.ingest(msg)
     except Exception as exc:
         reason = _format_exception_reason(exc)
         partial = adapter._current_answer_text().strip()

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -1423,6 +1423,80 @@ class TopicTaskStore:
             "events": page,
         }
 
+    def append_sdk_record(
+        self,
+        *,
+        task_id: str,
+        topic_id: str,
+        turn_index: int,
+        record_type: str,
+        event_type: str | None,
+        data: dict[str, Any],
+    ) -> None:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO da_agent_sdk_record (topic_id, task_id, turn_index, record_type, event_type, data)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        topic_id,
+                        task_id,
+                        int(turn_index),
+                        record_type,
+                        event_type,
+                        json.dumps(data, ensure_ascii=False, default=_json_default),
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_sdk_records(
+        self,
+        *,
+        task_id: str,
+        after_id: int = 0,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, turn_index, record_type, event_type, data, created_at
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s AND id > %s
+                    ORDER BY id ASC
+                    LIMIT %s
+                    """,
+                    (task_id, max(0, after_id), max(1, limit)),
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+        result = []
+        for row in rows:
+            raw_data = row.get("data")
+            if isinstance(raw_data, str):
+                try:
+                    raw_data = json.loads(raw_data)
+                except Exception:
+                    raw_data = {}
+            result.append({
+                "seq_id": int(row.get("id") or 0),
+                "turn_index": int(row.get("turn_index") or 0),
+                "record_type": str(row.get("record_type") or ""),
+                "event_type": row.get("event_type"),
+                "data": raw_data or {},
+                "created_at": _to_iso(row["created_at"]) if row.get("created_at") else None,
+            })
+        return result
+
     def get_message_queue(self, queue_id: str, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
         self._ensure_ready()
         context_sql, context_params = self._topic_context_predicate(context, alias="t")

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -640,4 +640,22 @@ class MessageScheduleLogPageResponse(BaseModel):
     list: List[MessageScheduleLogRecord] = Field(default_factory=list)
 
 
+class SdkEventRecord(BaseModel):
+    seq_id: int
+    turn_index: int = 0
+    record_type: str
+    event_type: Optional[str] = None
+    data: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[str] = None
+
+
+class SdkEventPageResponse(BaseModel):
+    task_id: str
+    task_status: str
+    after_id: int
+    next_after_id: int
+    has_more: bool
+    records: List[SdkEventRecord] = Field(default_factory=list)
+
+
 TableMeta.model_rebuild()

--- a/frontend/src/api/nl2sql.js
+++ b/frontend/src/api/nl2sql.js
@@ -209,6 +209,36 @@ export function createNl2SqlApiClient(options = {}) {
       if (buffer.trim()) {
         parseSseChunk(`${buffer}\n\n`, onEvent)
       }
+    },
+
+    async streamSdkEvents(taskId, options = {}) {
+      const { onRecord, signal, afterId = 0 } = options
+      const response = await fetch(
+        buildUrl(baseURL, `${RUNTIME_PREFIX}/tasks/${taskId}/sdk-events/stream?after_id=${encodeURIComponent(afterId)}`),
+        {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream', ...defaultHeaders },
+          signal
+        }
+      )
+      if (!response.ok) {
+        throw new Error(await extractHttpError(response))
+      }
+      if (!response.body) {
+        throw new Error('SSE stream body is empty')
+      }
+      const decoder = new TextDecoder('utf-8')
+      const reader = response.body.getReader()
+      let buffer = ''
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        buffer = parseSseChunk(buffer, onRecord)
+      }
+      if (buffer.trim()) {
+        parseSseChunk(`${buffer}\n\n`, onRecord)
+      }
     }
   }
 

--- a/frontend/src/components/FloatingAssistant.vue
+++ b/frontend/src/components/FloatingAssistant.vue
@@ -1,0 +1,219 @@
+<template>
+  <Teleport to="body">
+    <button
+      v-if="!isOpen"
+      class="fa-fab"
+      type="button"
+      aria-label="打开 AI 助手"
+      @click="openPanel"
+    >
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        <circle cx="9" cy="10" r="0.5" fill="currentColor" stroke="none" />
+        <circle cx="12" cy="10" r="0.5" fill="currentColor" stroke="none" />
+        <circle cx="15" cy="10" r="0.5" fill="currentColor" stroke="none" />
+      </svg>
+    </button>
+
+    <Transition name="fa-slide">
+      <div v-if="isOpen" class="fa-panel" role="dialog" aria-label="AI 助手">
+        <header class="fa-panel-header">
+          <svg class="fa-panel-logo" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2V4" />
+            <rect x="4" y="6" width="16" height="12" rx="2" />
+            <circle cx="9" cy="12" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="15" cy="12" r="1.5" fill="currentColor" stroke="none" />
+            <path d="M9 16c1.5 1 4.5 1 6 0" />
+          </svg>
+          <span class="fa-panel-title">AI 助手</span>
+          <div class="fa-panel-actions">
+            <button class="fa-icon-btn" type="button" title="新建对话" aria-label="新建对话" @click="handleNewTopic">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+            <a class="fa-icon-btn" href="/intelligent-query" title="在完整界面中打开" aria-label="在完整界面中打开">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M15 3h6v6" />
+                <path d="M10 14L21 3" />
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              </svg>
+            </a>
+            <button class="fa-icon-btn" type="button" title="关闭" aria-label="关闭面板" @click="isOpen = false">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </header>
+        <div class="fa-panel-body">
+          <NL2SqlChat v-if="chatMounted" ref="chatRef" mode="panel" />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue'
+import NL2SqlChat from '@/views/intelligence/NL2SqlChat.vue'
+
+const isOpen = ref(false)
+const chatMounted = ref(false)
+const chatRef = ref(null)
+
+const openPanel = () => {
+  isOpen.value = true
+  chatMounted.value = true
+}
+
+const handleNewTopic = () => {
+  chatRef.value?.handleNewTopic()
+}
+
+const onKeydown = (e) => {
+  if (e.key === 'Escape' && isOpen.value) {
+    isOpen.value = false
+  }
+}
+
+document.addEventListener('keydown', onKeydown)
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<style scoped>
+.fa-fab {
+  position: fixed;
+  bottom: 28px;
+  right: 28px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: #fff;
+  box-shadow: 0 4px 20px rgba(44, 82, 130, 0.35);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--odw-transition), box-shadow var(--odw-transition);
+}
+
+.fa-fab:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 28px rgba(44, 82, 130, 0.45);
+}
+
+.fa-fab:active {
+  transform: scale(0.96);
+}
+
+.fa-panel {
+  position: fixed;
+  bottom: 28px;
+  right: 28px;
+  width: 480px;
+  height: min(680px, calc(100vh - 100px));
+  border-radius: var(--odw-radius-lg);
+  background: #ffffff;
+  box-shadow: 0 12px 48px rgba(15, 23, 42, 0.18), 0 2px 8px rgba(15, 23, 42, 0.08);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.fa-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  height: 52px;
+  flex-shrink: 0;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: var(--odw-text-on-dark);
+  border-radius: var(--odw-radius-lg) var(--odw-radius-lg) 0 0;
+}
+
+.fa-panel-logo {
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+
+.fa-panel-title {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: var(--odw-text-on-dark);
+}
+
+.fa-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.fa-icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--odw-radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--odw-text-on-dark-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--odw-transition), color var(--odw-transition);
+  text-decoration: none;
+}
+
+.fa-icon-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--odw-text-on-dark);
+}
+
+.fa-icon-btn:active {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.fa-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.fa-slide-enter-active {
+  transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.22s ease;
+}
+
+.fa-slide-leave-active {
+  transition: transform 0.22s ease, opacity 0.18s ease;
+}
+
+.fa-slide-enter-from,
+.fa-slide-leave-to {
+  transform: translateY(24px);
+  opacity: 0;
+}
+
+@media (max-width: 768px) {
+  .fa-fab {
+    bottom: 16px;
+    right: 16px;
+  }
+
+  .fa-panel {
+    bottom: 16px;
+    right: 16px;
+    width: calc(100vw - 32px);
+  }
+}
+</style>

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -33,6 +33,8 @@
     <el-main>
       <router-view />
     </el-main>
+
+    <FloatingAssistant />
   </el-container>
 </template>
 
@@ -42,6 +44,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { DataBoard, DataLine, Connection, Collection, Warning, Setting, Share, Link, ChatDotRound } from '@element-plus/icons-vue'
 import { isDemoMode } from '@/demo/runtime'
 import { preloadRouteComponents, scheduleRouteWarmup } from '@/router/routeWarmup'
+import FloatingAssistant from '@/components/FloatingAssistant.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -18,6 +18,10 @@
           <el-icon><User /></el-icon>
           <span>智能体</span>
         </el-menu-item>
+        <el-menu-item index="chat-v2">
+          <el-icon><MagicStick /></el-icon>
+          <span>Chat V2</span>
+        </el-menu-item>
         <el-menu-item index="models">
           <el-icon><Cpu /></el-icon>
           <span>模型管理</span>
@@ -25,12 +29,13 @@
       </el-menu>
     </aside>
 
-    <main class="intelligent-query-content" :class="{ 'is-chat': activeMenu === 'chat' }">
+    <main class="intelligent-query-content" :class="{ 'is-chat': activeMenu === 'chat' || activeMenu === 'chat-v2' }">
       <SkillDetailView v-if="isSkillDetailRoute" />
       <AgentDetailView v-else-if="isAgentDetailRoute" />
       <AgentStudio v-else-if="activeTab === 'agents'" />
       <SkillStudio v-else-if="activeTab === 'skills'" />
       <DataAgentConfig v-else-if="activeTab === 'models'" />
+      <NL2SqlChatV2 v-else-if="activeTab === 'chat-v2'" />
       <NL2SqlChat v-else />
     </main>
   </div>
@@ -39,8 +44,9 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChatDotRound, Collection, Cpu, User } from '@element-plus/icons-vue'
+import { ChatDotRound, Collection, Cpu, MagicStick, User } from '@element-plus/icons-vue'
 import NL2SqlChat from './NL2SqlChat.vue'
+import NL2SqlChatV2 from './NL2SqlChatV2.vue'
 import AgentStudio from './AgentStudio.vue'
 import AgentDetailView from './AgentDetailView.vue'
 import SkillStudio from '../settings/SkillStudio.vue'
@@ -49,7 +55,7 @@ import SkillDetailView from '../settings/SkillDetailView.vue'
 
 const route = useRoute()
 const router = useRouter()
-const validTabs = new Set(['chat', 'skills', 'agents', 'models'])
+const validTabs = new Set(['chat', 'chat-v2', 'skills', 'agents', 'models'])
 
 const isSkillDetailRoute = computed(() => (
   route.name === 'IntelligentQuerySkillDetail' || route.path.startsWith('/intelligent-query/skills/')
@@ -82,6 +88,7 @@ const handleMenuSelect = (index) => {
     path: '/intelligent-query',
     query: tab === 'chat' ? {} : { tab }
   })
+
 }
 </script>
 

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="query-workbench">
-    <aside class="query-sidebar">
+  <div class="query-workbench" :class="{ 'is-panel': isPanelMode }">
+    <aside v-if="!isPanelMode" class="query-sidebar">
       <div class="query-sidebar-head">
         <el-select
           v-model="agentSelectValue"
@@ -60,7 +60,7 @@
     </aside>
 
     <main class="query-main">
-      <div class="query-main-top-bar">
+      <div v-if="!isPanelMode" class="query-main-top-bar">
         <div class="query-topic-info">
           <h4 class="query-topic-title">{{ activeTopic ? activeTopic.title : '开始一次新的数据分析' }}</h4>
         </div>
@@ -379,6 +379,11 @@ import {
 } from './messageStream'
 
 marked.setOptions({ breaks: true, gfm: true })
+
+const props = defineProps({
+  mode: { type: String, default: 'page' }
+})
+const isPanelMode = computed(() => props.mode === 'panel')
 
 const api = createNl2SqlApiClient({ timeout: 300000 })
 const { topicApi, taskApi, adminApi, agentApi } = api
@@ -1462,7 +1467,7 @@ const loadAgents = async () => {
     agents.value = normalized.length
       ? normalized
       : [{ agent_id: 'agent_default', name: '默认助手', description: '', is_default: true, is_builtin: true }]
-    const routeAgentId = String(route.query.agent_id || '').trim()
+    const routeAgentId = isPanelMode.value ? '' : String(route.query.agent_id || '').trim()
     if (routeAgentId && agents.value.some((agent) => agent.agent_id === routeAgentId)) {
       selectedAgentId.value = routeAgentId
     } else if (!agents.value.some((agent) => agent.agent_id === selectedAgentId.value)) {
@@ -1476,6 +1481,7 @@ const loadAgents = async () => {
 }
 
 const persistSelectedAgentInRoute = (agentId) => {
+  if (isPanelMode.value) return
   const value = String(agentId || '').trim()
   if (String(route.query.agent_id || '').trim() === value) return
 
@@ -1804,6 +1810,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   stopAllTaskSubscriptions()
 })
+
+defineExpose({ handleNewTopic })
 </script>
 
 <style scoped>
@@ -3419,5 +3427,18 @@ onBeforeUnmount(() => {
   .query-composer-input-row {
     align-items: flex-end;
   }
+}
+
+.query-workbench.is-panel {
+  grid-template-columns: 1fr;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  --content-max-width: 100%;
+}
+
+.query-workbench.is-panel .query-messages-inner,
+.query-workbench.is-panel .query-composer {
+  max-width: 100%;
 }
 </style>

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1,0 +1,967 @@
+<template>
+  <div class="v2-workbench">
+    <!-- Sidebar: topic list + agent selector -->
+    <aside class="v2-sidebar">
+      <div class="v2-sidebar-head">
+        <el-select
+          v-model="agentSelectValue"
+          class="v2-agent-select"
+          :disabled="!agents.length"
+          @change="handleAgentChange"
+        >
+          <template #prefix>
+            <svg class="v2-agent-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 2V4" />
+              <rect x="4" y="6" width="16" height="12" rx="2" />
+              <circle cx="9" cy="12" r="1.5" fill="currentColor" stroke="none" />
+              <circle cx="15" cy="12" r="1.5" fill="currentColor" stroke="none" />
+              <path d="M9 16c1.5 1 4.5 1 6 0" />
+            </svg>
+          </template>
+          <el-option v-for="a in agents" :key="a.agent_id" :label="a.name" :value="a.agent_id" />
+        </el-select>
+        <button class="v2-btn-new" @click="handleNewTopic">新建</button>
+      </div>
+
+      <div class="v2-sidebar-search">
+        <input v-model="searchKeyword" class="v2-search-input" type="text" placeholder="搜索话题">
+      </div>
+
+      <el-scrollbar class="v2-session-scroll">
+        <div class="v2-session-list">
+          <button
+            v-for="topic in filteredTopics"
+            :key="topic.topic_id"
+            class="v2-session-item"
+            :class="{ active: topic.topic_id === activeTopicId }"
+            @click="handleSelectTopic(topic.topic_id)"
+          >
+            <span class="v2-session-title">{{ topic.title || '新话题' }}</span>
+            <span class="v2-session-meta">{{ formatTime(topic.updated_at || topic.created_at) }}</span>
+          </button>
+          <div v-if="!filteredTopics.length" class="v2-empty-sessions">暂无话题</div>
+        </div>
+      </el-scrollbar>
+    </aside>
+
+    <!-- Main chat area -->
+    <main class="v2-main">
+      <div class="v2-main-top-bar">
+        <h4 class="v2-topic-title">{{ activeTopic?.title || '开始一次新的数据分析' }}</h4>
+        <span class="v2-badge">SDK Native</span>
+      </div>
+
+      <el-scrollbar ref="messagesScrollbarRef" class="v2-messages" @scroll="handleScroll">
+        <div class="v2-messages-inner">
+          <div v-if="!settings.providers.length" class="v2-config-empty">
+            <div class="v2-config-empty-title">还没有可用的模型</div>
+            <div class="v2-config-empty-text">请先完成模型配置。</div>
+          </div>
+
+          <div v-if="!messages.length" class="v2-welcome">
+            <div class="v2-welcome-mark">AI</div>
+            <div class="v2-welcome-title">SDK Native Chat</div>
+            <div class="v2-welcome-sub">原生展示思考过程、工具调用与结论</div>
+          </div>
+
+          <!-- Message loop -->
+          <template v-for="msg in messages" :key="msg.id">
+            <!-- User message -->
+            <div v-if="msg.role === 'user'" class="v2-msg-row v2-msg-user">
+              <div class="v2-user-shell">
+                <div class="v2-user-bubble">{{ msg.content }}</div>
+                <div class="v2-msg-footer">
+                  <span v-if="msg.created_at" class="v2-msg-time">{{ formatMessageTime(msg.created_at) }}</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Assistant message -->
+            <div v-else class="v2-msg-row v2-msg-assistant">
+              <div class="v2-assistant-body">
+                <!-- Streaming: render turns from v2 state -->
+                <template v-if="msg._v2state">
+                  <template v-for="(turn, ti) in msg._v2state.turns" :key="ti">
+                    <template v-for="block in turn.blocks" :key="block.blockIndex + '-' + ti">
+                      <!-- Thinking block -->
+                      <div v-if="block.type === 'thinking'" class="v2-process-panel">
+                        <button
+                          class="v2-process-summary"
+                          type="button"
+                          @click="toggleThinking(msg.id + '-' + ti + '-' + block.blockIndex)"
+                        >
+                          <span class="v2-process-label">
+                            <span v-if="block.status === 'streaming'" class="v2-badge-dot" />
+                            深度思考
+                          </span>
+                          <span v-if="!thinkingExpanded[msg.id + '-' + ti + '-' + block.blockIndex]" class="v2-process-preview">
+                            {{ block.content.slice(0, 80) }}
+                          </span>
+                          <svg class="v2-chevron" :class="{ expanded: thinkingExpanded[msg.id + '-' + ti + '-' + block.blockIndex] }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6" /></svg>
+                        </button>
+                        <el-scrollbar v-if="thinkingExpanded[msg.id + '-' + ti + '-' + block.blockIndex]" class="v2-process-content">
+                          <div class="v2-process-thought" v-html="renderMarkdown(block.content)" />
+                          <span v-if="block.status === 'streaming'" class="v2-cursor">|</span>
+                        </el-scrollbar>
+                      </div>
+
+                      <!-- Tool use block -->
+                      <div v-else-if="block.type === 'tool_use'" class="v2-tool-row">
+                        <ToolOutputRenderer :tool="blockToToolProp(block)" />
+                      </div>
+
+                      <!-- Text block -->
+                      <div v-else-if="block.type === 'text' && block.content" class="v2-text-block">
+                        <div v-html="renderMarkdown(block.content)" />
+                        <span v-if="block.status === 'streaming'" class="v2-cursor">|</span>
+                      </div>
+                    </template>
+                  </template>
+
+                  <!-- Error from stream -->
+                  <div v-if="msg._v2state.status === 'error'" class="v2-error-card">
+                    <span class="v2-error-label">错误</span>
+                    {{ msg._v2state.errorText || '流式处理出错' }}
+                  </div>
+                </template>
+
+                <!-- Hydrated from history -->
+                <template v-else>
+                  <div v-if="msg.thinkingText" class="v2-process-panel">
+                    <button class="v2-process-summary" type="button" @click="toggleThinking('hist-' + msg.id)">
+                      <span class="v2-process-label">深度思考</span>
+                      <span v-if="!thinkingExpanded['hist-' + msg.id]" class="v2-process-preview">{{ msg.thinkingText.slice(0, 80) }}</span>
+                      <svg class="v2-chevron" :class="{ expanded: thinkingExpanded['hist-' + msg.id] }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6" /></svg>
+                    </button>
+                    <el-scrollbar v-if="thinkingExpanded['hist-' + msg.id]" class="v2-process-content">
+                      <div class="v2-process-thought" v-html="renderMarkdown(msg.thinkingText)" />
+                    </el-scrollbar>
+                  </div>
+                  <div v-if="msg.content" class="v2-text-block" v-html="renderMarkdown(msg.content)" />
+                </template>
+
+                <!-- Message footer -->
+                <div class="v2-msg-footer">
+                  <span v-if="msg.created_at" class="v2-msg-time">{{ formatMessageTime(msg.created_at) }}</span>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </el-scrollbar>
+
+      <!-- Composer -->
+      <div class="v2-composer-wrap">
+        <div class="v2-composer">
+          <div class="v2-composer-textarea-wrap">
+            <textarea
+              ref="textareaRef"
+              v-model="inputText"
+              class="v2-textarea"
+              :placeholder="isStreaming ? '正在回复中…' : '输入数据问题…'"
+              :disabled="isStreaming"
+              rows="1"
+              @keydown.enter.exact.prevent="handleSend"
+              @input="autoResize"
+            />
+          </div>
+          <div class="v2-composer-actions">
+            <el-dropdown trigger="click" @command="handleModelCommand">
+              <button type="button" class="v2-model-btn" title="切换模型">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M12 2V4" /><rect x="4" y="6" width="16" height="12" rx="2" /><circle cx="9" cy="12" r="1.5" fill="currentColor" stroke="none" /><circle cx="15" cy="12" r="1.5" fill="currentColor" stroke="none" /></svg>
+                <span class="v2-model-label">{{ selectedModel || '默认' }}</span>
+              </button>
+              <template #dropdown>
+                <el-dropdown-menu>
+                  <template v-for="provider in settings.providers" :key="provider.provider_id">
+                    <el-dropdown-item
+                      v-for="model in provider.models"
+                      :key="model"
+                      :command="provider.provider_id + '::' + model"
+                      :class="{ active: selectedProvider === provider.provider_id && selectedModel === model }"
+                    >
+                      {{ model }}
+                    </el-dropdown-item>
+                  </template>
+                </el-dropdown-menu>
+              </template>
+            </el-dropdown>
+
+            <button
+              type="button"
+              class="v2-send-btn"
+              :class="{ 'v2-cancel-btn': isStreaming }"
+              :disabled="!isStreaming && !inputText.trim()"
+              @click="isStreaming ? handleCancel() : handleSend()"
+            >
+              <svg v-if="isStreaming" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><rect x="8" y="8" width="8" height="8" rx="1.5" /></svg>
+              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" /></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { marked } from 'marked'
+import { ElMessage } from 'element-plus'
+import { createNl2SqlApiClient } from '@/api/nl2sql'
+import ToolOutputRenderer from './ToolOutputRenderer.vue'
+import { blockToToolProp, createChatState, processV2Record } from './v2StreamParser'
+
+marked.setOptions({ breaks: true, gfm: true })
+
+const api = createNl2SqlApiClient({ timeout: 300000 })
+const { topicApi, taskApi, adminApi, agentApi } = api
+
+// ── State ────────────────────────────────────────────────────────────────────
+const topics = ref([])
+const agents = ref([])
+const activeTopicId = ref('')
+const messages = ref([])
+const settings = reactive({ providers: [], default_provider_id: '', default_model: '' })
+const selectedProvider = ref('')
+const selectedModel = ref('')
+const agentSelectValue = ref('')
+const searchKeyword = ref('')
+const inputText = ref('')
+const isStreaming = ref(false)
+const autoScroll = ref(true)
+const thinkingExpanded = reactive({})
+const messagesScrollbarRef = ref(null)
+const textareaRef = ref(null)
+
+let abortController = null
+
+// ── Computed ─────────────────────────────────────────────────────────────────
+const filteredTopics = computed(() => {
+  const kw = searchKeyword.value.trim().toLowerCase()
+  return kw
+    ? topics.value.filter((t) => (t.title || '').toLowerCase().includes(kw))
+    : topics.value
+})
+
+const activeTopic = computed(() => topics.value.find((t) => t.topic_id === activeTopicId.value) || null)
+
+const agentSelectOptions = computed(() => agents.value.map((a) => ({ label: a.name, value: a.agent_id })))
+
+// ── Markdown ──────────────────────────────────────────────────────────────────
+function renderMarkdown(text) {
+  if (!text) return ''
+  try {
+    return marked.parse(String(text))
+  } catch {
+    return String(text)
+  }
+}
+
+// ── Thinking toggle ────────────────────────────────────────────────────────
+function toggleThinking(key) {
+  thinkingExpanded[key] = !thinkingExpanded[key]
+}
+
+// ── Time formatting ────────────────────────────────────────────────────────
+function formatTime(dateStr) {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return ''
+  const now = new Date()
+  if (d.toDateString() === now.toDateString()) {
+    return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+  }
+  return d.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' })
+}
+
+function formatMessageTime(dateStr) {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+}
+
+// ── Auto-resize textarea ───────────────────────────────────────────────────
+function autoResize() {
+  const el = textareaRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+}
+
+// ── Scroll ─────────────────────────────────────────────────────────────────
+function scrollToBottom(force = false) {
+  if (!force && !autoScroll.value) return
+  nextTick(() => {
+    const sb = messagesScrollbarRef.value
+    if (sb?.setScrollTop) {
+      sb.setScrollTop(999999)
+    }
+  })
+}
+
+function handleScroll({ scrollTop, scrollHeight, clientHeight }) {
+  autoScroll.value = scrollHeight - scrollTop - clientHeight < 60
+}
+
+// ── Data loading ───────────────────────────────────────────────────────────
+async function loadSettings() {
+  try {
+    const data = await adminApi.getSettings()
+    settings.providers = Array.isArray(data?.providers) ? data.providers : []
+    settings.default_provider_id = String(data?.default_provider_id || '')
+    settings.default_model = String(data?.default_model || '')
+    if (!selectedModel.value) {
+      selectedProvider.value = settings.default_provider_id
+      selectedModel.value = settings.default_model
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
+async function loadAgents() {
+  try {
+    const list = await agentApi.listAgents()
+    const normalized = (Array.isArray(list) ? list : []).map((a) => ({
+      agent_id: String(a?.agent_id || ''),
+      name: String(a?.name || '默认助手'),
+      is_default: Boolean(a?.is_default),
+    })).filter((a) => a.agent_id)
+    agents.value = normalized.length
+      ? normalized
+      : [{ agent_id: 'agent_default', name: '默认助手', is_default: true }]
+    if (!agentSelectValue.value) {
+      const def = agents.value.find((a) => a.is_default) || agents.value[0]
+      agentSelectValue.value = def?.agent_id || ''
+    }
+  } catch {
+    agents.value = [{ agent_id: 'agent_default', name: '默认助手', is_default: true }]
+    agentSelectValue.value = 'agent_default'
+  }
+}
+
+async function loadTopics() {
+  try {
+    const data = await topicApi.listTopics({ page: 1, page_size: 50 })
+    topics.value = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
+    if (topics.value.length && !activeTopicId.value) {
+      await selectTopic(topics.value[0].topic_id)
+    }
+  } catch {
+    // non-fatal
+  }
+}
+
+async function selectTopic(topicId) {
+  activeTopicId.value = topicId
+  try {
+    const data = await topicApi.getTopicMessages(topicId, { page: 1, page_size: 50 })
+    const list = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
+    messages.value = list.map((m) => hydrateHistoryMessage(m))
+    scrollToBottom(true)
+  } catch {
+    messages.value = []
+  }
+}
+
+function hydrateHistoryMessage(m) {
+  const role = String(m?.role || m?.sender_type || 'user')
+  const content = String(m?.content || '')
+  // Extract thinking text from stored blocks if present
+  let thinkingText = ''
+  const blocks = Array.isArray(m?.blocks) ? m.blocks : []
+  for (const b of blocks) {
+    if (String(b?.kind || b?.type || '') === 'thinking' && b?.text) {
+      thinkingText += b.text
+    }
+  }
+  return {
+    id: String(m?.message_id || m?.id || Math.random()),
+    role: role === 'assistant' ? 'assistant' : 'user',
+    content,
+    thinkingText,
+    created_at: m?.created_at || null,
+    _v2state: null,
+  }
+}
+
+// ── Topic management ───────────────────────────────────────────────────────
+async function handleNewTopic() {
+  if (isStreaming.value) return
+  activeTopicId.value = ''
+  messages.value = []
+  searchKeyword.value = ''
+}
+
+async function handleSelectTopic(topicId) {
+  if (topicId === activeTopicId.value) return
+  if (isStreaming.value) handleCancel()
+  await selectTopic(topicId)
+}
+
+function handleAgentChange(agentId) {
+  agentSelectValue.value = agentId
+}
+
+function handleModelCommand(command) {
+  const [providerId, model] = String(command || '').split('::')
+  if (providerId && model) {
+    selectedProvider.value = providerId
+    selectedModel.value = model
+  }
+}
+
+// ── Send message ───────────────────────────────────────────────────────────
+async function handleSend() {
+  const text = inputText.value.trim()
+  if (!text || isStreaming.value) return
+
+  inputText.value = ''
+  autoResize()
+
+  let topicId = activeTopicId.value
+  if (!topicId) {
+    try {
+      const topic = await topicApi.createTopic(text.slice(0, 60))
+      topicId = topic.topic_id
+      activeTopicId.value = topicId
+      topics.value.unshift(topic)
+    } catch (err) {
+      ElMessage.error('创建话题失败: ' + String(err?.message || err))
+      return
+    }
+  }
+
+  // Append user message locally
+  messages.value.push({
+    id: 'user-' + Date.now(),
+    role: 'user',
+    content: text,
+    created_at: new Date().toISOString(),
+    _v2state: null,
+  })
+  scrollToBottom(true)
+
+  // Prepare assistant placeholder
+  const v2state = reactive(createChatState())
+  const assistantMsg = reactive({
+    id: 'asst-' + Date.now(),
+    role: 'assistant',
+    content: '',
+    thinkingText: '',
+    created_at: new Date().toISOString(),
+    _v2state: v2state,
+  })
+  messages.value.push(assistantMsg)
+
+  isStreaming.value = true
+  abortController = new AbortController()
+
+  try {
+    // Deliver message (creates task)
+    const taskResp = await taskApi.deliverMessage({
+      topic_id: topicId,
+      content: text,
+      provider_id: selectedProvider.value || undefined,
+      model: selectedModel.value || undefined,
+      agent_id: agentSelectValue.value || undefined,
+    })
+    const taskId = taskResp?.task_id
+    if (!taskId) throw new Error('任务创建失败，未获取到 task_id')
+
+    // Stream SDK events
+    await taskApi.streamSdkEvents(taskId, {
+      signal: abortController.signal,
+      afterId: 0,
+      onRecord: (record) => {
+        processV2Record(v2state, record)
+        scrollToBottom()
+      },
+    })
+  } catch (err) {
+    if (err?.name !== 'AbortError') {
+      v2state.status = 'error'
+      v2state.errorText = String(err?.message || '请求失败')
+      ElMessage.error('请求失败: ' + String(err?.message || err))
+    }
+  } finally {
+    isStreaming.value = false
+    abortController = null
+    // Refresh topic list to update title
+    loadTopics()
+    scrollToBottom(true)
+  }
+}
+
+function handleCancel() {
+  abortController?.abort()
+  isStreaming.value = false
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+onMounted(async () => {
+  await Promise.all([loadSettings(), loadAgents()])
+  await loadTopics()
+})
+
+onBeforeUnmount(() => {
+  abortController?.abort()
+})
+</script>
+
+<style scoped>
+/* ── Root layout ─────────────────────────────────────────────────────────── */
+.v2-workbench {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  border: 1px solid #E5EAF1;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #F4F5F7;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.035);
+  font-family: 'IBM Plex Sans', 'PingFang SC', 'Hiragino Sans GB', sans-serif;
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────────────────── */
+.v2-sidebar {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 16px 12px;
+  background: #ffffff;
+  border-right: 1px solid #E5EAF1;
+}
+
+.v2-sidebar-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 16px;
+}
+
+.v2-agent-select {
+  flex: 1;
+  min-width: 0;
+}
+
+.v2-agent-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.v2-btn-new {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 6px;
+  background: var(--odw-primary);
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background var(--odw-transition);
+}
+
+.v2-btn-new:hover { background: var(--odw-primary-light); }
+
+.v2-sidebar-search { padding: 0 8px 12px; }
+
+.v2-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  border: 1px solid #dbe3ef;
+  border-radius: 6px;
+  font-size: 13px;
+  outline: none;
+  background: #f9fafc;
+}
+
+.v2-search-input:focus { border-color: var(--odw-primary); }
+
+.v2-session-scroll { flex: 1; min-height: 0; }
+
+.v2-session-list { display: flex; flex-direction: column; gap: 2px; padding: 0 8px 8px; }
+
+.v2-session-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--odw-transition);
+}
+
+.v2-session-item:hover { background: #f0f3f8; }
+.v2-session-item.active { background: #e8eef8; }
+
+.v2-session-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: #1F1F1F;
+}
+
+.v2-session-meta { flex-shrink: 0; font-size: 11px; color: #8C8C8C; }
+
+.v2-empty-sessions { padding: 16px 10px; font-size: 13px; color: #8C8C8C; text-align: center; }
+
+/* ── Main ────────────────────────────────────────────────────────────────── */
+.v2-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: #ffffff;
+}
+
+.v2-main-top-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 24px 12px;
+  border-bottom: 1px solid #eef1f5;
+  flex-shrink: 0;
+}
+
+.v2-topic-title {
+  flex: 1;
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #162131;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+/* ── Messages ────────────────────────────────────────────────────────────── */
+.v2-messages { flex: 1; min-height: 0; }
+
+.v2-messages-inner {
+  padding: 24px 32px 32px;
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.v2-config-empty,
+.v2-welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+  gap: 12px;
+  color: #8C8C8C;
+}
+
+.v2-welcome-mark {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.v2-welcome-title { font-size: 17px; font-weight: 600; color: #334155; }
+.v2-welcome-sub { font-size: 14px; color: #8C8C8C; }
+.v2-config-empty-title { font-size: 15px; font-weight: 600; color: #334155; }
+.v2-config-empty-text { font-size: 13px; }
+
+/* ── Message rows ────────────────────────────────────────────────────────── */
+.v2-msg-row { display: flex; }
+
+.v2-msg-user { justify-content: flex-end; }
+
+.v2-user-shell { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; max-width: 72%; }
+
+.v2-user-bubble {
+  padding: 10px 16px;
+  border-radius: 16px 16px 4px 16px;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.v2-msg-assistant { justify-content: flex-start; }
+
+.v2-assistant-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 88%;
+}
+
+.v2-msg-footer { display: flex; gap: 8px; align-items: center; padding: 2px 0; }
+.v2-msg-time { font-size: 11px; color: #A0AABF; }
+
+/* ── Thinking (深度思考) panel ────────────────────────────────────────────── */
+.v2-process-panel {
+  border: 1px solid #dbe3ef;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #f9fafc;
+}
+
+.v2-process-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  color: #334155;
+  font-weight: 500;
+  text-align: left;
+  transition: background var(--odw-transition);
+}
+
+.v2-process-summary:hover { background: #eff1f5; }
+
+.v2-process-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.v2-badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--odw-primary);
+  animation: v2-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes v2-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}
+
+.v2-process-preview {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: #8C8C8C;
+  font-weight: 400;
+}
+
+.v2-chevron {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: #8C8C8C;
+  transition: transform var(--odw-transition);
+}
+
+.v2-chevron.expanded { transform: rotate(180deg); }
+
+.v2-process-content { max-height: min(360px, 50vh); }
+
+.v2-process-thought {
+  padding: 12px 16px;
+  font-size: 13px;
+  line-height: 1.65;
+  color: #595959;
+}
+
+.v2-process-thought :deep(p) { margin: 0 0 8px; }
+.v2-process-thought :deep(p:last-child) { margin: 0; }
+
+/* ── Tool output row ─────────────────────────────────────────────────────── */
+.v2-tool-row { border-radius: 10px; overflow: hidden; }
+
+/* ── Text block ──────────────────────────────────────────────────────────── */
+.v2-text-block {
+  font-size: 14px;
+  line-height: 1.65;
+  color: #162131;
+}
+
+.v2-text-block :deep(p) { margin: 0 0 10px; }
+.v2-text-block :deep(p:last-child) { margin: 0; }
+.v2-text-block :deep(pre) {
+  background: #f3f7fb;
+  border-radius: 8px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  font-size: 13px;
+}
+.v2-text-block :deep(code) { font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 13px; }
+.v2-text-block :deep(table) { border-collapse: collapse; width: 100%; margin: 10px 0; }
+.v2-text-block :deep(th), .v2-text-block :deep(td) { border: 1px solid #dbe3ef; padding: 6px 12px; font-size: 13px; }
+.v2-text-block :deep(th) { background: #f4f7fb; font-weight: 600; }
+
+/* ── Error card ──────────────────────────────────────────────────────────── */
+.v2-error-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(254, 242, 242, 0.9);
+  border: 1px solid rgba(252, 165, 165, 0.5);
+  font-size: 13px;
+  color: #7f1d1d;
+}
+
+.v2-error-label {
+  flex-shrink: 0;
+  font-weight: 600;
+  color: #b91c1c;
+}
+
+/* ── Cursor ──────────────────────────────────────────────────────────────── */
+.v2-cursor {
+  display: inline-block;
+  color: var(--odw-primary);
+  font-weight: 700;
+  animation: v2-blink 1s step-end infinite;
+  margin-left: 2px;
+}
+
+@keyframes v2-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ── Composer ────────────────────────────────────────────────────────────── */
+.v2-composer-wrap {
+  padding: 12px 16px 16px;
+  border-top: 1px solid #eef1f5;
+  flex-shrink: 0;
+  background: #ffffff;
+}
+
+.v2-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid #dbe3ef;
+  border-radius: 14px;
+  background: #fafbfc;
+  transition: border-color var(--odw-transition);
+}
+
+.v2-composer:focus-within { border-color: var(--odw-primary); }
+
+.v2-composer-textarea-wrap { flex: 1; min-width: 0; }
+
+.v2-textarea {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  resize: none;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #162131;
+  font-family: inherit;
+  min-height: 22px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.v2-textarea::placeholder { color: #A0AABF; }
+
+.v2-composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.v2-model-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #fff;
+  color: #595959;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color var(--odw-transition), background var(--odw-transition);
+  max-width: 140px;
+  overflow: hidden;
+}
+
+.v2-model-btn:hover { border-color: var(--odw-primary); background: #f4f7fb; }
+
+.v2-model-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-send-btn {
+  width: 34px;
+  height: 34px;
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--odw-primary) 0%, var(--odw-primary-dark) 100%);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: opacity var(--odw-transition), transform var(--odw-transition);
+}
+
+.v2-send-btn:disabled { opacity: 0.4; cursor: default; }
+.v2-send-btn:not(:disabled):hover { transform: scale(1.05); }
+.v2-send-btn:active { transform: scale(0.96); }
+
+.v2-cancel-btn {
+  background: linear-gradient(135deg, #7f1d1d 0%, #b91c1c 100%) !important;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .v2-workbench { grid-template-columns: 1fr; }
+  .v2-sidebar { display: none; }
+  .v2-messages-inner { max-width: 100%; }
+}
+</style>

--- a/frontend/src/views/intelligence/v2StreamParser.js
+++ b/frontend/src/views/intelligence/v2StreamParser.js
@@ -1,0 +1,153 @@
+/**
+ * v2StreamParser — parses native Anthropic SDK block events from the /sdk-events/stream endpoint.
+ *
+ * The backend writes StreamEvent.event dicts directly, so the frontend receives the Anthropic
+ * streaming protocol without any intermediate "magic event" transformation:
+ *
+ *   message_start → content_block_start → content_block_delta… → content_block_stop
+ *   → message_delta → message_stop
+ *   tool_result record (after each UserMessage with tool results)
+ *   done record (after ResultMessage)
+ */
+
+/**
+ * Create a fresh chat state for one assistant message.
+ * One state object maps to one user question + all AI reply turns.
+ */
+export function createChatState() {
+  return {
+    /** All turns in this response (one turn = one message_start…message_stop cycle). */
+    turns: [],
+    /** Flat list of all blocks across all turns — convenient for looking up by id. */
+    blocks: [],
+    /** Final stream status: 'idle' | 'streaming' | 'done' | 'error' */
+    status: 'idle',
+    /** Token usage from the last message_delta. */
+    usage: null,
+    /** Error text if record_type === 'error'. */
+    errorText: null,
+  }
+}
+
+/**
+ * Process one record from the /sdk-events/stream endpoint into the given state.
+ * Mutates state in place (designed for Vue reactivity via reactive() or ref()).
+ *
+ * @param {object} state  Created by createChatState()
+ * @param {object} record Raw SSE record parsed from JSON
+ */
+export function processV2Record(state, record) {
+  if (record.record_type === 'stream') {
+    _handleStreamEvent(state, record.data || {})
+  } else if (record.record_type === 'tool_result') {
+    _handleToolResult(state, record.data || {})
+  } else if (record.record_type === 'done') {
+    state.status = (record.data || {}).is_error ? 'error' : 'done'
+  } else if (record.record_type === 'error') {
+    state.status = 'error'
+    state.errorText = String((record.data || {}).message || '未知错误')
+  }
+}
+
+function _handleStreamEvent(state, evt) {
+  const etype = evt.type
+  if (!etype) return
+
+  if (etype === 'message_start') {
+    state.status = 'streaming'
+    state.turns.push({ turnIndex: state.turns.length, blocks: [], status: 'streaming' })
+    return
+  }
+
+  const currentTurn = state.turns.at(-1)
+  if (!currentTurn) return
+
+  if (etype === 'content_block_start') {
+    const cb = evt.content_block || {}
+    const block = {
+      turnIndex: currentTurn.turnIndex,
+      blockIndex: typeof evt.index === 'number' ? evt.index : currentTurn.blocks.length,
+      type: cb.type || 'text',   // 'thinking' | 'text' | 'tool_use'
+      content: '',
+      status: 'streaming',
+      // tool_use fields
+      id: cb.id || null,
+      name: cb.name || null,
+      inputJson: '',
+      input: null,
+      output: null,
+      is_error: false,
+    }
+    currentTurn.blocks.push(block)
+    state.blocks.push(block)
+    return
+  }
+
+  if (etype === 'content_block_delta') {
+    const block = _findBlock(currentTurn, evt.index)
+    if (!block) return
+    const d = evt.delta || {}
+    if (d.type === 'thinking_delta') {
+      block.content += d.thinking || ''
+    } else if (d.type === 'text_delta') {
+      block.content += d.text || ''
+    } else if (d.type === 'input_json_delta') {
+      block.inputJson += d.partial_json || ''
+    }
+    return
+  }
+
+  if (etype === 'content_block_stop') {
+    const block = _findBlock(currentTurn, evt.index)
+    if (!block) return
+    block.status = 'done'
+    if (block.type === 'tool_use' && block.inputJson) {
+      try {
+        block.input = JSON.parse(block.inputJson)
+      } catch {
+        block.input = block.inputJson
+      }
+    }
+    return
+  }
+
+  if (etype === 'message_delta') {
+    if (evt.usage) state.usage = evt.usage
+    return
+  }
+
+  if (etype === 'message_stop') {
+    currentTurn.status = 'done'
+  }
+}
+
+function _handleToolResult(state, data) {
+  const toolUseId = data.tool_use_id
+  if (!toolUseId) return
+  const block = state.blocks.find((b) => b.type === 'tool_use' && b.id === toolUseId)
+  if (!block) return
+  block.output = data.content
+  block.is_error = Boolean(data.is_error)
+}
+
+function _findBlock(turn, index) {
+  if (typeof index !== 'number') return turn.blocks.at(-1) || null
+  return turn.blocks.find((b) => b.blockIndex === index) || null
+}
+
+/**
+ * Convert a v2 tool_use block to the prop shape expected by ToolOutputRenderer.
+ */
+export function blockToToolProp(block) {
+  const hasOutput = block.output != null
+  return {
+    name: block.name,
+    input: block.input,
+    output: block.output,
+    status: hasOutput ? (block.is_error ? 'failed' : 'success') : (block.status === 'done' ? 'pending' : 'streaming'),
+    id: block.id,
+    _callComplete: block.status === 'done',
+    _runtimeStarted: hasOutput,
+    _startedAt: null,
+  }
+}


### PR DESCRIPTION
Embeds the intelligent query assistant as a fixed bottom-right FAB +
sliding panel available on every page, reusing NL2SqlChat's streaming,
deep-thinking, and tool-output rendering without duplication.

- FloatingAssistant.vue: 56px FAB launcher → 480×680px slide-in panel
  with gradient header matching the nav bar; Escape to close; lazy-mounts
  NL2SqlChat on first open to preserve state across toggles
- NL2SqlChat.vue: adds mode='panel' prop that hides the sidebar and
  top-bar, collapses grid to single column, and guards the two
  route-navigation calls so the panel never changes the browser URL
- Layout.vue: registers FloatingAssistant globally (Teleport to body)

The standalone widget bundle (vite.widget.config.js / entry.js) is
unchanged; external JS embedding capability is fully preserved.

https://claude.ai/code/session_01WYgfzWmr2PB4cykwSqc4dL