### PR TITLE
fix: use correct 'items' field from TopicMessagePageResponse in Chat …

### DIFF
--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -359,7 +359,7 @@ async function loadTopics() {
 async function selectTopic(topicId) {
   activeTopicId.value = topicId
   try {
-    const data = await topicApi.getTopicMessages(topicId, { page: 1, page_size: 50 })
+    const data = await topicApi.getTopicMessages(topicId, { page: 1, page_size: 500, order: 'asc' })
     const list = Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : [])
     messages.value = list.map((m) => hydrateHistoryMessage(m))
     scrollToBottom(true)

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -360,7 +360,7 @@ async function selectTopic(topicId) {
   activeTopicId.value = topicId
   try {
     const data = await topicApi.getTopicMessages(topicId, { page: 1, page_size: 50 })
-    const list = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
+    const list = Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : [])
     messages.value = list.map((m) => hydrateHistoryMessage(m))
     scrollToBottom(true)
   } catch {


### PR DESCRIPTION
…V2 history

The API returns TopicMessagePageResponse.items but selectTopic was reading data.list (always undefined), causing history to always render empty.

https://claude.ai/code/session_01WYgfzWmr2PB4cykwSqc4dL