### PR TITLE
fix(widgetchat): 修复 Enter 发送、问候语、会话区字体间距及深度思考面板样式

### DIFF
--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -95,7 +95,7 @@
                             深度思考
                           </span>
                           <svg class="query-process-chevron" :class="{ open: isThinkingExpanded(msg.id + '-' + ti + '-' + block.blockIndex) }" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 18l6-6-6-6" />
                           </svg>
                         </button>
                         <div v-if="isThinkingExpanded(msg.id + '-' + ti + '-' + block.blockIndex)" class="query-process-content">
@@ -149,17 +149,18 @@
               <div class="query-config-empty-title">还没有可用的模型</div>
               <div class="query-config-empty-text">请先完成模型配置。</div>
             </div>
-            <div class="query-landing-greeting">您好，我是智能数据助手。</div>
+            <div class="query-landing-greeting">您好，我是{{ agentName }}。</div>
           </template>
 
           <!-- Input pill -->
-          <div class="query-composer" @keydown.ctrl.enter.prevent="send" @keydown.meta.enter.prevent="send">
+          <div class="query-composer">
             <textarea
               v-model="inputText"
               class="query-textarea"
               rows="1"
               :disabled="!providers.length || !availableModels.length"
               placeholder="输入数据问题…"
+              @keydown.enter.exact.prevent="send"
               @input="autoResizeTextarea"
             />
             <button
@@ -249,6 +250,7 @@ const DEFAULT_SUGGESTIONS = [
 ]
 
 const agentPresetQuestions = ref([])
+const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
 
 const inputText = ref('')
@@ -882,6 +884,7 @@ onMounted(async () => {
   if (agentId.value && agentId.value !== 'demo') {
     try {
       const agentProfile = await api.agentApi.getAgent(agentId.value)
+      if (agentProfile?.name) agentName.value = String(agentProfile.name)
       const questions = Array.isArray(agentProfile?.preset_questions) ? agentProfile.preset_questions.filter(Boolean) : []
       agentPresetQuestions.value = questions.slice(0, 3)
     } catch {

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -605,7 +605,7 @@ export const WIDGET_STYLES = `
   background: var(--accent);
   color: #fff;
   font-size: 14px;
-  line-height: 1.7;
+  line-height: 1.65;
   white-space: pre-wrap;
   transition: transform 0.15s ease;
 }
@@ -617,9 +617,11 @@ export const WIDGET_STYLES = `
 .query-assistant-body {
   width: min(860px, 92%);
   color: var(--text);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.query-process-panel,
 .query-error-card {
   border: 1px solid var(--line-soft);
   border-radius: 16px;
@@ -631,7 +633,7 @@ export const WIDGET_STYLES = `
   padding: 2px 0;
   color: var(--text);
   font-size: 14px;
-  line-height: 1.8;
+  line-height: 1.65;
 }
 
 .query-main-text p,
@@ -680,21 +682,30 @@ export const WIDGET_STYLES = `
 
 .query-process-panel {
   width: 100%;
-  margin-bottom: 12px;
   overflow: hidden;
+  border: 1px solid #dbe3ef;
+  border-radius: 10px;
+  background: #f9fafc;
 }
 
 .query-process-summary {
   width: 100%;
-  min-height: 42px;
   border: none;
-  padding: 0 14px;
+  padding: 10px 14px;
   display: flex;
   align-items: center;
-  gap: 10px;
-  background: #fff;
-  color: var(--text-muted);
+  gap: 8px;
+  background: transparent;
+  color: #334155;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.query-process-summary:hover {
+  background: rgba(0, 0, 0, 0.03);
 }
 
 .query-process-summary-label {
@@ -730,7 +741,7 @@ export const WIDGET_STYLES = `
 }
 
 .query-process-chevron.open {
-  transform: rotate(180deg);
+  transform: rotate(90deg);
 }
 
 .query-process-content {
@@ -750,9 +761,9 @@ export const WIDGET_STYLES = `
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
-  font-size: 12px;
-  font-weight: 500;
-  color: #8c96a8;
+  font-size: 13px;
+  font-weight: 600;
+  color: #334155;
 }
 
 .query-process-thought {


### PR DESCRIPTION
- 为 textarea 添加 @keydown.enter.exact.prevent="send"，对齐 ChatV2 的 Enter 发送行为
- 新增 agentName ref，从 API 获取后展示在问候语中，替代硬编码的"智能数据助手"
- 深度思考面板改为右箭头(>)表示可展开，展开时旋转 90° 变为向下箭头(∨)
- 深度思考面板收窄：去除 min-height: 42px，改用 padding: 10px 14px，背景改为 #f9fafc，圆角改为 10px
- 为 .query-assistant-body 添加 display:flex + gap:12px，消除思考/工具/文本块间距不一致
- 统一 .query-user-bubble 和 .query-main-text 的 line-height 为 1.65，消除字体行高差异
- 深度思考标签字体由 12px 提升为 13px，与主文本层次对齐

https://claude.ai/code/session_01C66wfVCd3CCX176FSfz5va