### PR TITLE
docs: backfill Chat V2 design and plan documentation

### DIFF
--- a/docs/design/2026-05-31-chat-v2-design.md
+++ b/docs/design/2026-05-31-chat-v2-design.md
@@ -1,0 +1,226 @@
+# Chat V2 Design
+
+**Date:** 2026-05-31
+**Goal:** Document the shipped "Chat V2" intelligent-query chat surface — an async-task + native-SDK-event-stream chat that renders the live Anthropic streaming protocol and reloaded history through one shared block model, reused by the floating widget.
+**Tech Stack:** Frontend (Vue 3 / Pinia / Element Plus / Sass), DataAgent backend (FastAPI, MySQL, Alembic). No new backend work is owned by this design; it consumes the existing async task / `da_agent_sdk_record` persistence.
+
+> Status: Implemented. This design is backfilled from the shipped code so the
+> already-merged Chat V2 work has a single source of truth, per the repo
+> Design & Plan Workflow.
+
+## Scope
+
+In scope:
+
+- The Chat V2 full-page view `frontend/src/views/intelligence/NL2SqlChatV2.vue`,
+  mounted by `IntelligentQueryView.vue` under the `chat-v2` tab alongside the
+  retained V1 (`NL2SqlChat.vue`).
+- The shared SDK-stream parser
+  `frontend/src/views/intelligence/v2StreamParser.js`
+  (`createChatState`, `processV2Record`, `blockToToolProp`).
+- The Chat V2 API surface in `frontend/src/api/nl2sql.js` (`taskApi`/`topicApi`).
+- The backend SDK-record persistence and server-side block projection consumed
+  by Chat V2 (`da_agent_sdk_record`, `sdk_block_writer.py`,
+  `topic_task_store.py`, `api/routes.py`).
+- Widget alignment: `frontend/src/widget/WidgetChat.vue` imports the same parser
+  and uses the same deliver-message → SDK-event-stream flow.
+- Claude.ai-style layout (centered column, `clamp()` width, composer aligned to
+  message width, typing indicator, new-chat landing with preset questions).
+
+Out of scope:
+
+- Backend task/coordinator internals (covered by
+  `2026-03-12-nl2sql-async-background-design.md` and
+  `2026-03-23-dataagent-magic-task-model-design.md`).
+- Widget floating/drag/resize/allowlist behavior (separate widget designs).
+- Removal of V1 — retained as a fallback tab (see Risks).
+
+## Current State
+
+V1 (`NL2SqlChat.vue`) consumes the "magic event" stream
+(`da_agent_message`/`da_agent_chunk`) via the ~800-line `messageStream.js`
+adapter, and reconstructs both the live turn and reloaded history from that
+transient path.
+
+The backend now persists each agent turn natively. Alongside the magic-event
+tables, `core/sdk_block_writer.py` ingests the raw Anthropic SDK messages and
+writes them to the `da_agent_sdk_record` table (Alembic
+`20260529_000012_sdk_block_records.py`). `core/topic_task_store.py` stores
+(`append_sdk_record`), lists (`list_sdk_records`), and projects
+(`_project_sdk_records`) those rows back into rendered blocks.
+
+Chat V2 was added as a second tab (`chat-v2`) in `IntelligentQueryView.vue`. It
+streams the native SDK protocol live and reconstructs history from the persisted
+SDK records, both through one block model. It shipped across ~20 commits with no
+design doc.
+
+## Problem
+
+- V1 history hydration depended on the transient magic-event path and could
+  diverge from what was streamed (e.g. pre-tool text mis-promoted to "thinking",
+  missing/duplicated tool blocks after reload).
+- Live rendering and history rendering used different code paths.
+- The full-page chat and the floating widget had separate render logic, so fixes
+  were applied twice and drifted.
+- There was no documented block model or API contract for the chat surface.
+
+## Design
+
+### Components
+
+| Layer | File | Responsibility |
+| --- | --- | --- |
+| Host | `frontend/src/views/intelligence/IntelligentQueryView.vue` | Tab nav; renders `<NL2SqlChatV2>` when `activeTab === 'chat-v2'`, else `<NL2SqlChat>` (V1) |
+| Full-page view | `frontend/src/views/intelligence/NL2SqlChatV2.vue` | Block rendering, composer, new-chat landing, Claude.ai layout, stream + history wiring |
+| Parser | `frontend/src/views/intelligence/v2StreamParser.js` | Canonical block model; `createChatState`, `processV2Record` (live), `blockToToolProp` |
+| API client | `frontend/src/api/nl2sql.js` | `topicApi` / `taskApi` over `runtimeRequest` (prefix `/api/v1/nl2sql`) |
+| SDK persistence | `core/sdk_block_writer.py`, `core/topic_task_store.py`, `api/routes.py`, Alembic `20260529_000012_sdk_block_records.py` | Write/list/project `da_agent_sdk_record`; serve SDK-event stream and projected message blocks |
+| Widget | `frontend/src/widget/WidgetChat.vue` | Imports `v2StreamParser`; same deliver-message → SDK-event-stream flow |
+| V1 (retained) | `frontend/src/views/intelligence/NL2SqlChat.vue` | Legacy magic-event chat, fallback tab |
+
+### Block model (canonical contract)
+
+`createChatState()` returns one state object per assistant message:
+
+```
+{
+  turns: [ { turnIndex, blocks: [...], status } ],  // one turn per message_start…message_stop
+  blocks: [...],                                     // flat lookup across turns
+  status: 'idle' | 'streaming' | 'done' | 'error',
+  usage: { input_tokens?, output_tokens? } | null,
+  errorText: string | null
+}
+```
+
+Each block:
+
+```
+{
+  turnIndex, blockIndex,
+  type: 'thinking' | 'text' | 'tool_use',
+  content: string,            // thinking / text
+  status: 'streaming' | 'done',
+  id, name,                   // tool_use: tool_use_id and tool name
+  inputJson: string,          // accumulates input_json_delta
+  input: object | null,       // parsed at content_block_stop
+  output: any | null,         // filled by a later tool_result record
+  is_error: boolean
+}
+```
+
+Charts/tables are not parser block types: text blocks may embed chart specs that
+the view extracts (`chartSpec.js`) and renders through `ToolOutputRenderer`;
+`tool_use` blocks render through `ToolOutputRenderer` via `blockToToolProp`.
+
+### Send + live-stream lifecycle (`NL2SqlChatV2.vue`)
+
+1. If no active topic: `topicApi.createTopic(title, { agent_id })`.
+2. Append the local user message and an assistant placeholder whose `_v2state`
+   is a fresh `createChatState()`.
+3. `taskApi.deliverMessage({ topic_id, content, provider_id?, model?, agent_id? })`
+   → `POST /api/v1/nl2sql/tasks/deliver-message`, returns `taskResp.task_id`.
+4. `taskApi.streamSdkEvents(taskId, { onRecord, signal, afterId: 0 })` — a
+   `fetch`-based SSE reader over
+   `GET /api/v1/nl2sql/tasks/{taskId}/sdk-events/stream?after_id=`.
+5. Each record → `processV2Record(_v2state, record)`, which mutates the state in
+   place for Vue reactivity.
+6. Cancellation aborts the `signal`; `taskApi.cancelTask(taskId)` →
+   `POST /api/v1/nl2sql/tasks/{taskId}/cancel`.
+
+### History hydration
+
+1. `topicApi.getTopicMessages(topicId, { page: 1, page_size: 500, order: 'asc' })`
+   → `GET /api/v1/nl2sql/topics/{topicId}/messages`, reading the response
+   `items` field.
+2. Each assistant message carries a `blocks` array that the backend already
+   projected from `da_agent_sdk_record` via `topic_task_store._project_sdk_records`
+   (replaying the same SDK protocol the live parser uses).
+3. `buildV2StateFromStoredBlocks(item)` in the view rebuilds the same
+   `createChatState`-shaped state from those stored blocks (handling the flat
+   `thinking` / `main_text` / `tool_use` schema, with a legacy nested fallback).
+
+This is the central correctness decision: **history is reconstructed from the
+durable `da_agent_sdk_record` (server-projected into message `blocks`) using the
+same block vocabulary as the live SDK stream**, so a reloaded conversation
+matches what was streamed. This replaced the earlier magic-event reconstruction.
+
+### Layout
+
+Centered single content column (`max-width: 1280px`, fluid
+`padding-inline: clamp(40px, 5%, 64px)`); sidebar grid `260px/300px 1fr`;
+composer aligned to the messages width (`860px` on the landing page); typing
+indicator and streaming cursor during a run; new-chat landing with greeting and
+preset/agent suggested questions in a pill-style input bar.
+
+## Interfaces / Data Model
+
+API client (`frontend/src/api/nl2sql.js`, `runtimeRequest`, prefix `/api/v1/nl2sql`):
+
+| Function | Method & path |
+| --- | --- |
+| `taskApi.deliverMessage(data)` | `POST /tasks/deliver-message` → `task_id` |
+| `taskApi.cancelTask(taskId)` | `POST /tasks/{taskId}/cancel` |
+| `taskApi.streamSdkEvents(taskId, {onRecord, signal, afterId})` | SSE `GET /tasks/{taskId}/sdk-events/stream?after_id=` (**used by V2**) |
+| `taskApi.streamTaskEvents(taskId, {onEvent, afterSeq})` | SSE `GET /tasks/{taskId}/events/stream?after_seq=` (magic events, V1) |
+| `taskApi.getTaskEvents(taskId, params)` | `GET /tasks/{taskId}/events` |
+| `topicApi.getTopicMessages(topicId, params)` | `GET /topics/{topicId}/messages` (returns `items`, each assistant item has `blocks`) |
+| `topicApi.listTopics(params)` | `GET /topics` |
+| `topicApi.createTopic(title, data)` | `POST /topics` |
+
+Parser entry points (`v2StreamParser.js`):
+
+- `createChatState() -> state`.
+- `processV2Record(state, record)` — mutates `state`. `record.record_type`:
+  `stream` (native Anthropic event in `record.data`: `message_start`,
+  `content_block_start|delta|stop`, `message_delta`, `message_stop`),
+  `tool_result` (populates the matching `tool_use` block's `output`/`is_error`),
+  `done` (terminal status), `error` (sets `errorText`).
+- `blockToToolProp(block) -> { name, input, output, status, id, ... }` for
+  `ToolOutputRenderer`.
+
+Backend SDK-record interfaces:
+
+| Endpoint / function | Purpose |
+| --- | --- |
+| `GET /tasks/{task_id}/sdk-events/stream?after_id=` | SSE of SDK records (live) |
+| `GET /tasks/{task_id}/sdk-events?after_id=&limit=` | JSON page of SDK records |
+| `sdk_block_writer.ingest(...)` | Convert SDK messages → `append_sdk_record` |
+| `topic_task_store.list_sdk_records(task_id, after_id, limit)` | Read records, `id` ASC |
+| `topic_task_store._project_sdk_records(...)` | Replay records → rendered `blocks` for message history |
+
+Data model — `da_agent_sdk_record` (Alembic `20260529_000012`):
+`id` (PK, AUTO_INCREMENT), `topic_id`, `task_id`, `turn_index`, `record_type`
+(`stream`/`tool_result`/`done`/`error`), `event_type` (`message_start`, …, nullable),
+`data` (JSON, raw SDK event/metadata), `created_at`; index `(task_id, id)`.
+
+## Risks / Alternatives
+
+- **Native SDK-event stream vs magic-event stream.** V2 streams the native SDK
+  protocol (`/sdk-events/stream`) so live render and persisted records share one
+  block model; the magic-event path (`/events/stream`) remains for V1. Cost:
+  reliance on the SDK-record write/projection being faithful.
+- **`page_size=500` history.** A single large page avoids client pagination for
+  typical topics; very long topics could exceed it and would need real
+  pagination.
+- **Server-side block projection (`_project_sdk_records`).** Keeps the FE parser
+  thin and shared, but duplicates the SDK-protocol replay logic on the backend;
+  the two must stay in sync.
+- **Keeping V1 alongside V2.** V1 remains a fallback tab to de-risk migration;
+  the duplicate surface is the cost. Consolidation onto V2 is a follow-up.
+- **Backout:** hide/disable the `chat-v2` tab so the surface falls back to V1;
+  the parser, `nl2sql.js`, and SDK-record additions are additive and can remain.
+
+## Verification
+
+- Frontend unit (run after `nvm use`): `IntelligentQueryView.spec.js`,
+  `NL2SqlChat.spec.js`, and the widget `WidgetChat.spec.js` (which mocks
+  `deliverMessage`/`streamSdkEvents` and exercises the shared render path). A
+  dedicated `NL2SqlChatV2.spec.js` / `v2StreamParser.spec.js` does not yet exist
+  and is a recommended follow-up.
+- DataAgent: focused coverage for `sdk_block_writer` ingest and
+  `topic_task_store._project_sdk_records` projection.
+- End-to-end smoke (per AGENTS.md intelligent-query smoke method): on the
+  `chat-v2` tab, submit a real NL2SQL question; verify `deliver-message` returns
+  a `task_id`, SDK records stream and render incrementally, the run reaches a
+  terminal state, the turn persists to `da_agent_sdk_record`, and history rebuilds
+  correctly via `getTopicMessages` (projected `blocks`) after reload.

--- a/docs/plans/2026-05-31-chat-v2-plan.md
+++ b/docs/plans/2026-05-31-chat-v2-plan.md
@@ -1,0 +1,85 @@
+# Chat V2 Plan
+
+**Date:** 2026-05-31
+**Topic slug:** `chat-v2`
+**Related design:** `docs/design/2026-05-31-chat-v2-design.md`
+
+> Status: Implemented. This plan is backfilled from the shipped code.
+
+## Objective
+
+Document the executable shape of the already-shipped Chat V2 work: the async-task
++ native-SDK-event-stream chat view, the shared block-model parser, the Chat V2
+API surface, history reconstructed from `da_agent_sdk_record`, and the widget
+alignment to the same model.
+
+## Affected Stacks
+
+- Frontend (Vue 3 / Pinia / Element Plus / Sass): intelligent-query views,
+  parser, widget.
+- DataAgent backend (FastAPI / MySQL / Alembic): SDK-record persistence and
+  server-side block projection consumed by Chat V2.
+
+## Tasks & Touched Files
+
+1. **SDK persistence + projection (backend)** — `core/sdk_block_writer.py`,
+   `core/topic_task_store.py`, `api/routes.py`,
+   `alembic/versions/20260529_000012_sdk_block_records.py`
+   - `da_agent_sdk_record` table; `append_sdk_record` / `list_sdk_records`.
+   - `_project_sdk_records` replays records into rendered `blocks` for history.
+   - SSE `GET /tasks/{id}/sdk-events/stream?after_id=` and JSON
+     `GET /tasks/{id}/sdk-events`.
+2. **Shared SDK-stream parser** — `frontend/src/views/intelligence/v2StreamParser.js`
+   - `createChatState()` → `{ turns, blocks, status, usage, errorText }`.
+   - `processV2Record(state, record)` — handle `record_type`
+     `stream` (native Anthropic events) / `tool_result` / `done` / `error`.
+   - `blockToToolProp(block)` for `ToolOutputRenderer`.
+   - Block model: `{ turnIndex, blockIndex, type:'thinking'|'text'|'tool_use',
+     content, status, id, name, inputJson, input, output, is_error }`.
+3. **Chat V2 API surface** — `frontend/src/api/nl2sql.js` (`runtimeRequest`,
+   prefix `/api/v1/nl2sql`)
+   - `taskApi.deliverMessage` (`POST /tasks/deliver-message`), `cancelTask`,
+     `streamSdkEvents` (fetch SSE `/tasks/{id}/sdk-events/stream?after_id=`).
+   - `topicApi.getTopicMessages` (`GET /topics/{id}/messages`, `page_size=500`,
+     `order=asc`, reads `items`; assistant items carry projected `blocks`).
+4. **Full-page view** — `frontend/src/views/intelligence/NL2SqlChatV2.vue`
+   - Send: `createTopic` (lazy) → `deliverMessage` → `streamSdkEvents` →
+     `processV2Record` into the message `_v2state`.
+   - History: `getTopicMessages` → `buildV2StateFromStoredBlocks(item)` from the
+     stored `blocks` (flat thinking/main_text/tool_use schema, legacy fallback).
+   - Rendering (thinking/text/tool_use, embedded chart specs via `chartSpec.js`),
+     typing indicator/cursor, new-chat landing with preset questions, Claude.ai
+     layout (centered `max-width:1280px`, `clamp()` padding-inline, composer
+     aligned to messages, pill-style input bar).
+5. **Host wiring** — `frontend/src/views/intelligence/IntelligentQueryView.vue`
+   - `chat-v2` in `validTabs`; render `<NL2SqlChatV2>` when
+     `activeTab === 'chat-v2'`, else `<NL2SqlChat>`.
+6. **Widget alignment** — `frontend/src/widget/WidgetChat.vue`
+   - Import `v2StreamParser` + `chartSpec`; same `deliverMessage` /
+     `streamSdkEvents` / `processV2Record` flow for identical rendering.
+7. **V1 retained** — `frontend/src/views/intelligence/NL2SqlChat.vue` left as the
+   fallback tab.
+
+## Verification
+
+- `nvm use`, then run focused frontend unit tests: `IntelligentQueryView.spec.js`,
+  `NL2SqlChat.spec.js`, `WidgetChat.spec.js`.
+- DataAgent: focused coverage for `sdk_block_writer` ingest and
+  `topic_task_store._project_sdk_records` projection.
+- End-to-end smoke (per AGENTS.md): on `chat-v2`, submit a real NL2SQL question;
+  verify `deliver-message` → `task_id`, SDK-event stream rendering, terminal
+  state, persistence to `da_agent_sdk_record`, and history rebuild via
+  `getTopicMessages` (projected `blocks`) after reload.
+
+## Rollout & Backout
+
+- **Rollout:** `chat-v2` tab in `IntelligentQueryView.vue`; V1 stays reachable.
+- **Backout:** hide/disable the `chat-v2` tab to fall back to V1; the parser,
+  `nl2sql.js`, and SDK-record additions are additive and can remain.
+
+## Follow-ups
+
+- Add `NL2SqlChatV2.spec.js` / `v2StreamParser.spec.js`.
+- Real history pagination beyond `page_size=500` for very long topics.
+- Keep the FE parser and backend `_project_sdk_records` projection in sync.
+- Remove V1 once V2 has soaked.

--- a/frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
+++ b/frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest'
+import { createChatState, processV2Record, blockToToolProp } from '../v2StreamParser'
+
+// Helpers to build the SSE records the backend emits from /sdk-events/stream.
+const stream = (data) => ({ record_type: 'stream', data })
+const toolResult = (data) => ({ record_type: 'tool_result', data })
+
+function feed(state, records) {
+  for (const record of records) processV2Record(state, record)
+  return state
+}
+
+describe('createChatState', () => {
+  it('returns an empty idle state', () => {
+    expect(createChatState()).toEqual({
+      turns: [],
+      blocks: [],
+      status: 'idle',
+      usage: null,
+      errorText: null,
+    })
+  })
+})
+
+describe('processV2Record — stream lifecycle', () => {
+  it('message_start opens a streaming turn', () => {
+    const state = feed(createChatState(), [stream({ type: 'message_start' })])
+    expect(state.status).toBe('streaming')
+    expect(state.turns).toHaveLength(1)
+    expect(state.turns[0]).toMatchObject({ turnIndex: 0, status: 'streaming', blocks: [] })
+  })
+
+  it('ignores block events that arrive before any turn', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'text' } }),
+    ])
+    expect(state.turns).toHaveLength(0)
+    expect(state.blocks).toHaveLength(0)
+  })
+
+  it('streams a text block via content_block_start/delta/stop', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'text' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello ' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'world' } }),
+      stream({ type: 'content_block_stop', index: 0 }),
+    ])
+    const [block] = state.blocks
+    expect(block).toMatchObject({
+      type: 'text',
+      turnIndex: 0,
+      blockIndex: 0,
+      content: 'Hello world',
+      status: 'done',
+    })
+    // The block is shared between the flat list and the turn.
+    expect(state.turns[0].blocks[0]).toBe(block)
+  })
+
+  it('accumulates thinking_delta into a thinking block', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'thinking' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'step 1 ' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'step 2' } }),
+    ])
+    expect(state.blocks[0]).toMatchObject({ type: 'thinking', content: 'step 1 step 2', status: 'streaming' })
+  })
+
+  it('parses tool_use input JSON on content_block_stop', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_1', name: 'run_sql' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"sql":' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '"select 1"}' } }),
+      stream({ type: 'content_block_stop', index: 0 }),
+    ])
+    expect(state.blocks[0]).toMatchObject({
+      type: 'tool_use',
+      id: 'tu_1',
+      name: 'run_sql',
+      input: { sql: 'select 1' },
+      status: 'done',
+    })
+  })
+
+  it('falls back to raw inputJson string when the JSON is malformed', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_1', name: 'run_sql' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{bad json' } }),
+      stream({ type: 'content_block_stop', index: 0 }),
+    ])
+    expect(state.blocks[0].input).toBe('{bad json')
+  })
+
+  it('captures usage on message_delta and closes the turn on message_stop', () => {
+    const usage = { input_tokens: 10, output_tokens: 20 }
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'message_delta', usage }),
+      stream({ type: 'message_stop' }),
+    ])
+    expect(state.usage).toEqual(usage)
+    expect(state.turns[0].status).toBe('done')
+  })
+
+  it('keeps blocks separate across multiple turns', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'text' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'a' } }),
+      stream({ type: 'message_stop' }),
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'text' } }),
+      stream({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'b' } }),
+    ])
+    expect(state.turns).toHaveLength(2)
+    expect(state.turns[0].blocks[0]).toMatchObject({ turnIndex: 0, content: 'a' })
+    expect(state.turns[1].blocks[0]).toMatchObject({ turnIndex: 1, content: 'b' })
+    expect(state.blocks).toHaveLength(2)
+  })
+})
+
+describe('processV2Record — tool_result', () => {
+  it('attaches output and error flag to the matching tool_use block', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_1', name: 'run_sql' } }),
+      stream({ type: 'content_block_stop', index: 0 }),
+      toolResult({ tool_use_id: 'tu_1', content: [{ type: 'text', text: 'rows: 3' }], is_error: false }),
+    ])
+    expect(state.blocks[0].output).toEqual([{ type: 'text', text: 'rows: 3' }])
+    expect(state.blocks[0].is_error).toBe(false)
+  })
+
+  it('marks the block as errored when is_error is set', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      stream({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu_1', name: 'run_sql' } }),
+      toolResult({ tool_use_id: 'tu_1', content: 'boom', is_error: true }),
+    ])
+    expect(state.blocks[0]).toMatchObject({ output: 'boom', is_error: true })
+  })
+
+  it('ignores a tool_result with no matching block', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      toolResult({ tool_use_id: 'missing', content: 'x' }),
+    ])
+    expect(state.blocks).toHaveLength(0)
+  })
+})
+
+describe('processV2Record — terminal records', () => {
+  it('done marks the state done', () => {
+    const state = feed(createChatState(), [stream({ type: 'message_start' }), { record_type: 'done', data: {} }])
+    expect(state.status).toBe('done')
+  })
+
+  it('done with is_error marks the state errored', () => {
+    const state = feed(createChatState(), [{ record_type: 'done', data: { is_error: true } }])
+    expect(state.status).toBe('error')
+  })
+
+  it('error record records status and message', () => {
+    const state = feed(createChatState(), [{ record_type: 'error', data: { message: 'timeout' } }])
+    expect(state.status).toBe('error')
+    expect(state.errorText).toBe('timeout')
+  })
+
+  it('error record falls back to a default message', () => {
+    const state = feed(createChatState(), [{ record_type: 'error', data: {} }])
+    expect(state.errorText).toBe('未知错误')
+  })
+})
+
+describe('blockToToolProp', () => {
+  const baseBlock = (over) => ({
+    type: 'tool_use',
+    id: 'tu_1',
+    name: 'run_sql',
+    input: { sql: 'select 1' },
+    output: null,
+    is_error: false,
+    status: 'streaming',
+    ...over,
+  })
+
+  it('maps a still-streaming tool call', () => {
+    expect(blockToToolProp(baseBlock())).toMatchObject({
+      name: 'run_sql',
+      input: { sql: 'select 1' },
+      status: 'streaming',
+      _callComplete: false,
+      _runtimeStarted: false,
+    })
+  })
+
+  it('maps a finished call awaiting its result as pending', () => {
+    expect(blockToToolProp(baseBlock({ status: 'done' }))).toMatchObject({
+      status: 'pending',
+      _callComplete: true,
+      _runtimeStarted: false,
+    })
+  })
+
+  it('maps a successful result', () => {
+    expect(blockToToolProp(baseBlock({ status: 'done', output: 'rows: 3' }))).toMatchObject({
+      status: 'success',
+      _callComplete: true,
+      _runtimeStarted: true,
+    })
+  })
+
+  it('maps a failed result', () => {
+    expect(blockToToolProp(baseBlock({ status: 'done', output: 'boom', is_error: true }))).toMatchObject({
+      status: 'failed',
+      _runtimeStarted: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add comprehensive design and plan documentation for the already-shipped Chat V2 intelligent-query chat surface. These documents serve as the single source of truth for the async-task + native-SDK-event-stream architecture that replaced the transient magic-event path.

## Key Changes

- **`docs/design/2026-05-31-chat-v2-design.md`** — Complete design specification covering:
  - Architecture overview: full-page view, shared SDK-stream parser, API surface, backend SDK persistence
  - Canonical block model contract (`createChatState`, `processV2Record`, block schema)
  - Send + live-stream lifecycle and history hydration from `da_agent_sdk_record`
  - Claude.ai-style layout (centered column, `clamp()` width, composer alignment)
  - Component responsibilities and data flow across frontend (Vue 3/Pinia/Element Plus) and DataAgent backend (FastAPI/MySQL/Alembic)
  - Risk analysis and verification strategy

- **`docs/plans/2026-05-31-chat-v2-plan.md`** — Executable plan documenting:
  - Objective and affected stacks
  - Seven task areas with touched files: SDK persistence, parser, API surface, full-page view, host wiring, widget alignment, V1 retention
  - Verification approach (unit tests, DataAgent coverage, E2E smoke)
  - Rollout and backout strategy
  - Follow-up work (test coverage, pagination, projection sync, V1 removal)

## Implementation Details

Both documents are backfilled from shipped code per the Design & Plan Workflow in AGENTS.md. They document:

- The shift from magic-event reconstruction (V1) to native SDK-event streaming with durable `da_agent_sdk_record` persistence
- Shared block model used by both full-page chat and floating widget
- Server-side block projection (`_project_sdk_records`) ensuring history matches streamed content
- V1 retained as fallback tab to de-risk migration

These serve as the canonical reference for the Chat V2 architecture and enable future maintenance and consolidation work.

https://claude.ai/code/session_01BVvKkWiHZQC1XsTWewoemp