### PR TITLE
fix(portal-mcp): disable DNS-rebinding protection so Claude CLI can c…

### DIFF
--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -4,6 +4,7 @@ import contextlib
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
@@ -116,6 +117,14 @@ class FrontDoorTokenMiddleware:
 def build_mcp_server(service: PortalToolService) -> FastMCP:
     mcp = FastMCP("portal-mcp", json_response=True)
     mcp.settings.streamable_http_path = "/"
+    # DNS-rebinding protection defaults to localhost-only in FastMCP 1.x, which
+    # rejects requests from the Claude CLI subprocess using the Docker service
+    # hostname (e.g. Host: portal-mcp:8801) with HTTP 421. The service is
+    # already protected by FrontDoorTokenMiddleware, so disable it here.
+    mcp.settings.transport_security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    # Stateless mode: each request is handled independently with no session-ID
+    # handshake required. Correct for a read-only tool server.
+    mcp.settings.stateless_http = True
 
     @mcp.tool(
         name="portal_search_tables",

--- a/dataagent/portal-mcp/tests/test_app.py
+++ b/dataagent/portal-mcp/tests/test_app.py
@@ -93,6 +93,31 @@ def test_mcp_path_accepts_valid_frontdoor_token():
     assert response.status_code != 401
 
 
+def test_mcp_path_accepts_docker_hostname():
+    # Regression: FastMCP 1.x DNS-rebinding protection defaults to
+    # localhost-only and returns 421 for Host: portal-mcp:8801.
+    # The fix disables that check so Claude CLI subprocesses can connect.
+    app = create_app(settings=_settings(), backend_client=FakeBackendClient())
+    with TestClient(app, base_url="http://portal-mcp:8801") as client:
+        response = client.post(
+            "/mcp/",
+            headers={"X-Portal-MCP-Token": "portal-token", "Content-Type": "application/json"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "claude-code", "version": "1.0"},
+                },
+            },
+        )
+
+    assert response.status_code != 421, "MCP server must not reject Docker service hostname"
+    assert response.status_code != 401
+
+
 @pytest.mark.anyio
 async def test_all_tool_service_methods_return_backend_shapes():
     service = PortalToolService(FakeBackendClient())


### PR DESCRIPTION
…onnect

FastMCP 1.x defaults to DNS-rebinding protection with allowed_hosts restricted to localhost/127.0.0.1/[::1]. When the Claude CLI subprocess inside dataagent-backend sends requests to http://portal-mcp:8801/mcp/, the Host header is "portal-mcp:8801" which fails the check and every request returns HTTP 421 Misdirected Request. Tool discovery never succeeds, so Claude falls back to scripts and portal MCP tools are never visible in conversations.

Fix: disable dns_rebinding_protection in build_mcp_server() — the service is already guarded by FrontDoorTokenMiddleware (front-door token required on every /mcp/* request). Also set stateless_http=True since portal-mcp is a read-only tool server with no per-session state, eliminating the Mcp-Session-Id handshake requirement.

Adds regression test: test_mcp_path_accepts_docker_hostname.

https://claude.ai/code/session_01C66wfVCd3CCX176FSfz5va