### PR TITLE
Make DeepEval runner fully offline for intranet deployments

### DIFF
--- a/docs/design/2026-05-13-dataagent-deepeval-evaluation-design.md
+++ b/docs/design/2026-05-13-dataagent-deepeval-evaluation-design.md
@@ -17,6 +17,8 @@ DeepEval should be available as a separate evaluation engine, but its Python dep
 - Run DataAgent cases through the existing HTTP task chain and convert final answers plus evidence into DeepEval `LLMTestCase` instances.
 - Use a custom DeepEval metric to call an independently configured Anthropic-compatible judge endpoint and preserve the existing 10-point rubric, veto rules, and failure attribution.
 - Package DeepEval dependencies only in `opendataworks-dataagent-evals-deepeval:<tag>`.
+- Drive the judge metric with a local loop rather than DeepEval's `evaluate()`. `evaluate()` couples each run to telemetry and Confident AI cloud calls that fail or hang on intranet deployments after every case has already run, which crashed the runner before any report was written. The runner only needs each metric to call the judge, so it iterates the test cases directly as the single primary path. DeepEval telemetry and update checks are opted out at import time so the package never phones home. The only external dependency for judging is the judge endpoint, which can be an internal Anthropic-compatible gateway.
+- Always write the report once cases have run. A single failing judge call is recorded as a failed judge for that case; if the judging step fails late, `summary.json` records `judging_error` and the runner exits non-zero instead of dropping the report.
 
 ## Entrypoints
 

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -229,7 +229,7 @@ def test_deepeval_topic_and_task_requests_include_agent_id(monkeypatch):
     assert calls[1]["payload"]["agent_id"] == "agent_eval"
 
 
-def test_deepeval_evaluate_error_without_all_judges_raises_runner_error(monkeypatch):
+def test_deepeval_run_deepeval_records_failed_judge_when_measure_crashes(monkeypatch, capsys):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
     case = _sample_case()
@@ -239,21 +239,23 @@ def test_deepeval_evaluate_error_without_all_judges_raises_runner_error(monkeypa
     )
     metric = runner.DataAgentEvaluationMetric(runner.JudgeConfig(base_url="http://judge", token="t", model="m"))
 
-    def broken_evaluate(**kwargs):
-        raise RuntimeError("deepeval crashed before measuring")
+    def boom(config, payload):
+        raise RuntimeError("judge call exploded")
 
-    monkeypatch.setattr(runner, "deepeval_evaluate", broken_evaluate)
+    monkeypatch.setattr(runner, "call_judge_model", boom)
 
-    try:
-        runner.run_deepeval([test_case], metric)
-    except runner.EvalRunnerError as exc:
-        assert "deepeval evaluate failed before all judge results were captured" in str(exc)
-    else:
-        raise AssertionError("expected EvalRunnerError")
+    # A crashing case must not abort the batch or lose the report.
+    runner.run_deepeval([test_case], metric)
+
+    judge = runner.DataAgentEvaluationMetric.shared_case_judges["ODW_SAMPLE_001"]
+    assert judge["judge_failed"] is True
+    assert "judge_crash" in judge["failure_attribution"]
+    captured = capsys.readouterr()
+    assert "judge measurement crashed" in captured.err
 
 
-def test_deepeval_evaluate_error_after_all_judges_is_nonfatal(monkeypatch, capsys):
-    _install_fake_deepeval(monkeypatch)
+def test_deepeval_run_deepeval_measures_all_cases_without_cloud_evaluate(monkeypatch):
+    calls = _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
     case = _sample_case()
     test_case = runner.to_deepeval_test_case(
@@ -272,20 +274,26 @@ def test_deepeval_evaluate_error_after_all_judges_is_nonfatal(monkeypatch, capsy
             "comment": "ok",
         }
 
-    def late_error_evaluate(**kwargs):
-        for test_case_item in kwargs["test_cases"]:
-            for metric_item in kwargs["metrics"]:
-                metric_item.measure(test_case_item)
-        raise RuntimeError("deepeval summary writer failed")
-
     monkeypatch.setattr(runner, "call_judge_model", fake_judge)
-    monkeypatch.setattr(runner, "deepeval_evaluate", late_error_evaluate)
 
     runner.run_deepeval([test_case], metric)
 
-    captured = capsys.readouterr()
-    assert "deepeval evaluate warning" in captured.err
     assert metric.case_judges["ODW_SAMPLE_001"]["score"] == 9.0
+    # The offline runner never invokes DeepEval's cloud-coupled evaluate().
+    assert calls["test_cases"] == []
+
+
+def test_deepeval_runner_opts_out_of_cloud_telemetry(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    monkeypatch.delenv("DEEPEVAL_TELEMETRY_OPT_OUT", raising=False)
+    monkeypatch.delenv("DEEPEVAL_UPDATE_WARNING_OPT_OUT", raising=False)
+
+    import os
+
+    _load_runner()
+
+    assert os.environ.get("DEEPEVAL_TELEMETRY_OPT_OUT") == "YES"
+    assert os.environ.get("DEEPEVAL_UPDATE_WARNING_OPT_OUT") == "YES"
 
 
 def test_deepeval_judge_request_embeds_system_prompt_in_user_content(monkeypatch):
@@ -599,4 +607,6 @@ def test_deepeval_runner_drives_dataagent_and_writes_case_outputs(tmp_path, monk
     assert result["task_status"] == "finished"
     assert result["judge"]["score"] == 9.0
     assert result["case_passed"] is True
-    assert len(calls["test_cases"]) == 1
+    # Offline runner drives the judge metric locally; DeepEval's cloud-coupled
+    # evaluate() is never invoked.
+    assert calls["test_cases"] == []

--- a/tools/dataagent-evals/deepeval/README.md
+++ b/tools/dataagent-evals/deepeval/README.md
@@ -33,6 +33,31 @@ python3 tools/dataagent-evals/deepeval/run.py --dry-run --dataset /path/to/priva
 
 Dry run validates the dataset and writes `summary.json` / `report.md` without calling DataAgent or the judge model.
 
+## Offline / Intranet Operation
+
+This runner is built to run on a closed network without any DeepEval cloud
+service (deepeval.com / Confident AI):
+
+- DeepEval telemetry and update checks are opted out at import time
+  (`DEEPEVAL_TELEMETRY_OPT_OUT`, `DEEPEVAL_UPDATE_WARNING_OPT_OUT`,
+  `DEEPEVAL_DISABLE_PROGRESS_BAR`), so importing the package never phones home.
+- The runner drives the judge metric itself with a local loop instead of
+  calling DeepEval's `evaluate()`. `evaluate()` couples each run to telemetry
+  and Confident AI cloud calls that fail or hang on an intranet *after* every
+  case has already run, which previously crashed the tool before any report was
+  written. The local loop has no such dependency.
+- The only external service the runner needs is the judge model endpoint
+  (`--judge-base-url` / `DATAAGENT_EVAL_JUDGE_BASE_URL`). Point it at an internal
+  Anthropic-compatible gateway and no internet access is required.
+
+## Robustness
+
+- A single failing judge call is recorded as a failed judge for that case
+  instead of aborting the whole batch.
+- A complete report is always written once the cases have run, even if the
+  judging step fails late. In that case `summary.json` records `judging_error`
+  and the process exits non-zero.
+
 ## Outputs
 
 The output layout matches the builtin evaluation runner:

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -16,6 +16,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+# Keep DeepEval fully offline for intranet deployments. These flags must be set
+# before importing deepeval so the import never triggers telemetry, update
+# checks, or Confident AI cloud coupling. The runner drives the judge metric
+# itself and does not depend on any deepeval.com / Confident AI service.
+os.environ.setdefault("DEEPEVAL_TELEMETRY_OPT_OUT", "YES")
+os.environ.setdefault("DEEPEVAL_UPDATE_WARNING_OPT_OUT", "YES")
+os.environ.setdefault("DEEPEVAL_DISABLE_PROGRESS_BAR", "YES")
+
 try:
     from deepeval import evaluate as deepeval_evaluate
 except Exception:  # pragma: no cover - exercised in environments without deepeval
@@ -901,26 +909,41 @@ class DataAgentEvaluationMetric(BaseMetric):  # type: ignore[misc, valid-type]
         }
 
 
+def _test_case_case_id(test_case: Any) -> str:
+    try:
+        payload = DataAgentEvaluationMetric._payload_from_test_case(test_case)
+    except Exception:
+        return ""
+    return str((payload.get("case") or {}).get("case_id") or "")
+
+
 def run_deepeval(test_cases: list[Any], metric: DataAgentEvaluationMetric) -> None:
+    """Drive the judge metric locally, fully offline.
+
+    DeepEval's ``evaluate()`` couples each run to telemetry and Confident AI
+    cloud calls. On intranet deployments those calls fail or hang *after* every
+    case has already been measured, which previously crashed the runner before
+    any report was written. The runner only needs each metric to call our own
+    Anthropic-compatible judge, so we iterate the test cases directly. This is
+    the single primary path and requires no deepeval.com / Confident AI service.
+
+    A single failing case is recorded as a failed judge instead of aborting the
+    whole batch, so a complete report is always produced.
+    """
     _ensure_deepeval_available()
     DataAgentEvaluationMetric.shared_case_judges = {}
-    try:
+    for test_case in test_cases:
+        case_id = _test_case_case_id(test_case)
         try:
-            deepeval_evaluate(test_cases=test_cases, metrics=[metric], print_results=False)
-        except TypeError:
-            deepeval_evaluate(test_cases=test_cases, metrics=[metric])
-    except Exception as exc:
-        expected_case_ids = {
-            str(DataAgentEvaluationMetric._payload_from_test_case(test_case).get("case", {}).get("case_id") or "")
-            for test_case in test_cases
-        }
-        expected_case_ids.discard("")
-        captured_case_ids = set(metric.case_judges) | set(DataAgentEvaluationMetric.shared_case_judges)
-        if not expected_case_ids.issubset(captured_case_ids):
-            raise EvalRunnerError(
-                f"deepeval evaluate failed before all judge results were captured: {exc}"
-            ) from exc
-        print(f"deepeval evaluate warning (judge results already captured): {exc}", file=sys.stderr)
+            metric.measure(test_case)
+        except Exception as exc:  # never lose the remaining cases or the report
+            judge = failed_judge(
+                f"judge measurement crashed: {exc}",
+                attribution=["judge_failed", "judge_crash"],
+            )
+            metric.case_judges[case_id] = judge
+            DataAgentEvaluationMetric.shared_case_judges[case_id] = judge
+            print(f"judge measurement crashed for case {case_id or '?'}: {exc}", file=sys.stderr)
 
 
 def _apply_judges(results: list[dict[str, Any]], metric: DataAgentEvaluationMetric) -> list[dict[str, Any]]:
@@ -1129,11 +1152,24 @@ def main(argv: list[str] | None = None) -> int:
         dataset_stats["preflight"] = preflight_payload
         dataset_stats["agent_id"] = str(args.agent_id or "").strip()
         results = _run_cases(base_url, cases, args)
-        metric = DataAgentEvaluationMetric(judge_config)
-        test_cases = [to_deepeval_test_case(case, result) for case, result in zip(cases, results)]
-        run_deepeval(test_cases, metric)
-        _apply_judges(results, metric)
-        summary = build_summary(results, dataset_stats)
+        try:
+            metric = DataAgentEvaluationMetric(judge_config)
+            test_cases = [to_deepeval_test_case(case, result) for case, result in zip(cases, results)]
+            run_deepeval(test_cases, metric)
+            _apply_judges(results, metric)
+            summary = build_summary(results, dataset_stats)
+        except Exception as exc:
+            # The expensive case runs already finished; never drop the report
+            # just because the judging/summary step failed. Persist what we have.
+            for item in results:
+                if not item.get("judge"):
+                    item["judge"] = failed_judge(f"judging aborted: {exc}")
+            summary = build_summary(results, dataset_stats)
+            summary["judging_error"] = str(exc)
+            write_outputs(output_dir, results, summary)
+            print(f"eval outputs written to: {output_dir}")
+            print(f"judging step failed after all cases ran: {exc}", file=sys.stderr)
+            return 1
         write_outputs(output_dir, results, summary)
         print(f"eval outputs written to: {output_dir}")
         return 0 if summary.get("passed") else 1


### PR DESCRIPTION
## Summary

Refactored the DeepEval evaluation runner to operate completely offline without any dependency on DeepEval cloud services (deepeval.com / Confident AI). The runner now drives the judge metric locally instead of using DeepEval's `evaluate()` function, which couples each run to telemetry and cloud calls that fail or hang on intranets after all cases have already run.

## Key Changes

- **Offline telemetry opt-out**: Set `DEEPEVAL_TELEMETRY_OPT_OUT`, `DEEPEVAL_UPDATE_WARNING_OPT_OUT`, and `DEEPEVAL_DISABLE_PROGRESS_BAR` environment variables before importing DeepEval to prevent any cloud coupling at import time.

- **Local judge metric loop**: Replaced `deepeval_evaluate()` call with a direct loop that calls `metric.measure()` on each test case. This eliminates the dependency on DeepEval's cloud-coupled evaluate function while preserving all judge functionality.

- **Graceful error handling**: Individual failing judge calls are now recorded as failed judges for that case instead of aborting the entire batch. This ensures a complete report is always produced.

- **Late failure recovery**: Added exception handling in the main evaluation flow to ensure that if the judging step fails after all cases have run, the report is still written with a `judging_error` field and the process exits non-zero.

- **Helper function**: Added `_test_case_case_id()` to safely extract case IDs for error reporting.

## Implementation Details

- The runner only requires access to the judge model endpoint (`--judge-base-url`), which can point to an internal Anthropic-compatible gateway.
- No internet access is required for the runner itself; all DeepEval dependencies are satisfied locally.
- Updated tests to verify the offline behavior and that DeepEval's `evaluate()` is never invoked.
- Added documentation in README.md explaining offline/intranet operation and robustness guarantees.

https://claude.ai/code/session_013aPcWeyWeKnxJAGpKyQazA