### PR TITLE
Increase bottom padding in floating query messages panel

### DIFF
--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -524,7 +524,7 @@ export const WIDGET_STYLES = `
 }
 
 .query-workbench.is-floating .query-messages-inner {
-  padding: 14px 16px 20px;
+  padding: 14px 16px 120px;
 }
 
 .query-top-bar {


### PR DESCRIPTION
## Summary
Adjusted the bottom padding of the query messages inner container when in floating mode to prevent content from being obscured.

## Changes
- Increased bottom padding in `.query-workbench.is-floating .query-messages-inner` from `20px` to `120px`

## Details
This change ensures that content within the floating query messages panel has sufficient bottom padding, likely to accommodate a fixed or absolutely positioned element (such as a button or control) that appears at the bottom of the panel.

https://claude.ai/code/session_01CVcBqsktG1PXhUzUCYwsws