### PR TITLE
Remove unnecessary watcher reconfiguring autocompletion on tableNames changes

### DIFF
--- a/frontend/src/components/SqlEditor.vue
+++ b/frontend/src/components/SqlEditor.vue
@@ -289,20 +289,11 @@ watch(
   }
 )
 
-watch(
-  () => props.tableNames,
-  () => {
-    reconfigure(
-      completionCompartment,
-      autocompletion({
-        override: [completionSource],
-        activateOnTyping: true
-      })
-    )
-  },
-  { deep: true }
-)
-
+// NOTE: props.tableNames / props.completionContext are read lazily by the
+// completion source (see getTableNames / getCompletionContext closures above),
+// so the autocompletion extension never needs reconfiguring when they change.
+// A previous deep watcher reconfigured the extension on every keystroke (the
+// parent passes a fresh array each render), which caused severe input lag.
 
 watch(
   () => props.highlights,


### PR DESCRIPTION
## Summary
Removed a deep watcher that was reconfiguring the autocompletion extension whenever `props.tableNames` changed. This watcher was causing severe input lag due to the parent component passing a fresh array on every render.

## Key Changes
- Removed the `watch()` callback that reconfigured the `completionCompartment` with the autocompletion extension when `tableNames` changed
- Added explanatory comment documenting why reconfiguration is unnecessary: the completion source lazily reads `tableNames` and `completionContext` via closures, so the extension doesn't need to be reconfigured when these props change

## Implementation Details
The completion source already has access to `getTableNames()` and `getCompletionContext()` closures that read the current prop values on-demand. By removing the deep watcher that was triggering on every keystroke (due to fresh array references from parent renders), we eliminate the performance bottleneck while maintaining the same functionality.

https://claude.ai/code/session_01A3xRbRxwnJRnu75aE9YX66