### PR TITLE
Improve Enter key handling for message sending with IME support

### DIFF
--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -192,7 +192,9 @@
           </div>
           <!-- Bottom toolbar -->
           <div class="v2-composer-toolbar">
-            <div class="v2-composer-toolbar-left" />
+            <div class="v2-composer-toolbar-left">
+              <span class="v2-composer-hint">Enter 发送，Shift + Enter 换行</span>
+            </div>
             <div class="v2-composer-toolbar-right">
               <el-dropdown trigger="click" @command="handleModelCommand">
                 <button type="button" class="v2-model-btn" title="切换模型">
@@ -1233,6 +1235,13 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.v2-composer-hint {
+  color: #9aa5b1;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
 }
 
 .v2-composer-toolbar-right {

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -181,6 +181,7 @@
           </div>
           <!-- Toolbar row -->
           <div class="query-composer-toolbar">
+            <div class="query-composer-hint">Enter 发送，Shift + Enter 换行</div>
             <div class="query-model-selector">
               <select v-model="selectedProvider" class="query-model-select" :disabled="!providers.length || isBusy" title="切换提供商">
                 <option v-for="provider in providers" :key="provider.provider_id" :value="provider.provider_id">

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -160,7 +160,7 @@
               rows="1"
               :disabled="!providers.length || !availableModels.length"
               placeholder="输入数据问题…"
-              @keydown.enter.exact.prevent="send"
+              @keydown.enter="onEnterKey"
               @input="autoResizeTextarea"
             />
             <button
@@ -844,6 +844,15 @@ const autoResizeTextarea = (event) => {
   const el = event.target
   el.style.height = 'auto'
   el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+}
+
+// Enter 发送，Shift + Enter 换行。
+// 输入法（如中文）组合输入期间的回车用于确认候选词，不应触发发送。
+const onEnterKey = (event) => {
+  if (event.isComposing || event.keyCode === 229) return
+  if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) return
+  event.preventDefault()
+  send()
 }
 
 watch(

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -198,6 +198,38 @@ describe('WidgetChat history conversations', () => {
     resolveStream()
   })
 
+  it('sends on plain Enter but keeps Shift+Enter / IME Enter as a newline', async () => {
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    const textarea = wrapper.get('textarea')
+    await textarea.setValue('你好')
+
+    // Shift+Enter must not send and must not block the default newline.
+    const shiftEvent = new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, cancelable: true, bubbles: true })
+    textarea.element.dispatchEvent(shiftEvent)
+    await flushPromises()
+    expect(shiftEvent.defaultPrevented).toBe(false)
+    expect(apiMocks.taskApi.deliverMessage).not.toHaveBeenCalled()
+
+    // IME composition Enter (confirming candidates) must not send.
+    const imeEvent = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true })
+    Object.defineProperty(imeEvent, 'isComposing', { value: true })
+    textarea.element.dispatchEvent(imeEvent)
+    await flushPromises()
+    expect(apiMocks.taskApi.deliverMessage).not.toHaveBeenCalled()
+
+    // Plain Enter sends and prevents the newline.
+    const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true })
+    textarea.element.dispatchEvent(enterEvent)
+    await flushPromises()
+    expect(enterEvent.defaultPrevented).toBe(true)
+    expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledWith(expect.objectContaining({
+      content: '你好',
+      agent_id: 'agent_widget'
+    }))
+  })
+
   it('queues outbound messages until runtime config is ready', async () => {
     let resolveConfig
     apiMocks.runtimeApi.getConfig.mockReturnValue(new Promise((resolve) => {

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -954,9 +954,18 @@ export const WIDGET_STYLES = `
 .query-composer-toolbar {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
+  gap: 8px;
   margin-top: 5px;
   padding-inline: 4px;
+}
+
+.query-composer-hint {
+  flex-shrink: 0;
+  color: #9aa5b1;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
 }
 
 .query-model-selector {


### PR DESCRIPTION
## Summary
Improved the Enter key handling in chat interfaces to properly support message sending while maintaining compatibility with Input Method Editors (IME) used for languages like Chinese. The implementation now correctly distinguishes between plain Enter (send), Shift+Enter (newline), and IME composition Enter (candidate selection).

## Key Changes
- **WidgetChat.vue**: Replaced Vue's `@keydown.enter.exact.prevent` directive with a custom `onEnterKey` handler that:
  - Sends message on plain Enter only
  - Allows Shift+Enter to create newlines without sending
  - Prevents sending during IME composition (when `isComposing` is true or `keyCode` is 229)
  - Respects other modifier keys (Ctrl, Alt, Meta)

- **NL2SqlChatV2.vue**: Added user hint text "Enter 发送，Shift + Enter 换行" (Enter to send, Shift+Enter for newline) in the toolbar

- **styles.js**: Updated `.query-composer-toolbar` layout from `flex-end` to `space-between` to accommodate the new hint text, and added `.query-composer-hint` styling for consistent appearance

- **WidgetChat.spec.js**: Added comprehensive test coverage for the new Enter key behavior, validating:
  - Shift+Enter doesn't send and allows default newline behavior
  - IME composition Enter doesn't send
  - Plain Enter sends the message and prevents default newline

## Implementation Details
The `onEnterKey` handler checks `event.isComposing` and `event.keyCode === 229` to detect IME composition state, which is the standard approach for supporting non-Latin input methods. This ensures a better user experience for international users while maintaining the expected behavior for English keyboard input.

https://claude.ai/code/session_01LTTFENUUXEQp1KrH1MydDg