### PR TITLE
Default to fresh conversation instead of auto-selecting latest topic

### DIFF
--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -516,7 +516,9 @@ const loadTopics = async () => {
     const list = await api.topicApi.listTopics({ agent_id: agentId.value || undefined })
     topics.value = (Array.isArray(list) ? list : []).map(normalizeTopic).filter((topic) => topic.topic_id)
     sortTopics()
-    const nextTopicId = topicId.value || topics.value[0]?.topic_id || ''
+    // Default to a fresh conversation on open instead of auto-selecting the latest topic,
+    // so users can ask a new question immediately. Existing topics remain in history.
+    const nextTopicId = topicId.value || ''
     topicId.value = nextTopicId
     await loadTopicMessages(nextTopicId)
   } catch (_error) {


### PR DESCRIPTION
## Summary
Changed the chat widget's topic selection behavior to default to a fresh conversation when opening the chat, rather than automatically selecting the most recent topic.

## Changes
- Modified `loadTopics()` to set `nextTopicId` to an empty string instead of defaulting to the latest topic (`topics.value[0]?.topic_id`)
- Added clarifying comments explaining the rationale: users can now ask a new question immediately without having to manually clear the previous conversation context
- Existing topics remain accessible in the conversation history

## Implementation Details
The change simplifies the topic selection logic by removing the fallback to `topics.value[0]?.topic_id`. Now when `topicId.value` is not set, the chat opens with a blank state, providing a better UX for starting fresh conversations while preserving access to historical topics.

https://claude.ai/code/session_01DNDSMWpzeFPJLpWix1AuB2