### PR TITLE
Add tool-type icons and promote chart outputs to conclusion area

### DIFF
--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -75,7 +75,7 @@
 - **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，允许输出 `isChartBlock`。
 - 模板中在结论区通过 `<ToolOutputRenderer>` 渲染图表 block，得益于 `ToolOutputRenderer` 对 `chart_spec` 的直观渲染（直接显示折线/柱状/饼图），图表将在文本回答下方优雅呈递。
 - **内联 chart_spec 边界**：当前 `main_text` 中的 `<chart_spec>` 或 ```chart fenced block 已通过 `stripChartSpecsFromText` 从正文中隐藏。本设计不改变该行为，也不把它合成为图表 block；如果后续要展示内联图表，需要同步更新 `NL2SqlChat.spec.js` 中“does not inject inline chart tools into the conclusion area”的既有预期，并补充兼容方案。
-- **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：内联工具流跳过图表型 `tool_use` 块，在所有 turn 渲染完成后于回答文本下方的结论区统一渲染这些图表，保持与 `NL2SqlChat` 一致的“图表外置”体验。
+- **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：图表型 `tool_use` 块在内联工具流中保留（仍展示工具执行与图表），并在所有 turn 渲染完成后于回答文本下方的结论区**额外再渲染一次**，即“附加到结论区”而非移出工具流。
 
 ---
 

--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -75,6 +75,7 @@
 - **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，允许输出 `isChartBlock`。
 - 模板中在结论区通过 `<ToolOutputRenderer>` 渲染图表 block，得益于 `ToolOutputRenderer` 对 `chart_spec` 的直观渲染（直接显示折线/柱状/饼图），图表将在文本回答下方优雅呈递。
 - **内联 chart_spec 边界**：当前 `main_text` 中的 `<chart_spec>` 或 ```chart fenced block 已通过 `stripChartSpecsFromText` 从正文中隐藏。本设计不改变该行为，也不把它合成为图表 block；如果后续要展示内联图表，需要同步更新 `NL2SqlChat.spec.js` 中“does not inject inline chart tools into the conclusion area”的既有预期，并补充兼容方案。
+- **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：内联工具流跳过图表型 `tool_use` 块，在所有 turn 渲染完成后于回答文本下方的结论区统一渲染这些图表，保持与 `NL2SqlChat` 一致的“图表外置”体验。
 
 ---
 

--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -70,7 +70,7 @@
 
 ### 2.5 结论区图表渲染
 修改 `processBlocksForMessage` 与 `finalBlocksForMessage` 两个 computed 属性：
-- **isChartBlock**：判断当前块是否是 `kind === 'tool'`，并且 `ToolOutputRenderer` 可将 `block.tool.output` 解析为 `chart_spec`。可通过复用 `parseChartSpec` 识别对象、JSON 字符串或数组中的 chart spec。
+- **isChartBlock**：判断当前块是否是 `kind === 'tool'`，并且 `ToolOutputRenderer` 可将 `block.tool.output` 解析为 `chart_spec`。检测逻辑与 `ToolOutputRenderer` 共用 `chartSpec.js` 导出的 `extractChartSpec`，作为唯一真源，避免“工具框能渲染图表、但结论区检测不到”的不一致。`extractChartSpec` 不仅识别结构化对象，还会从工具结果的内容块数组（`[{type:'text', text}]`）以及 build 脚本 stdout 文本中深度提取 chart spec，因此通过 Bash/Shell 执行 build 脚本输出的图表也能被外置到结论区。
 - **思考区**：过滤掉 `isChartBlock` 块，确保深度思考面板中不显示图表，仅保留 shell 运行、文件读写等调试追踪信息。
 - **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，允许输出 `isChartBlock`。
 - 模板中在结论区通过 `<ToolOutputRenderer>` 渲染图表 block，得益于 `ToolOutputRenderer` 对 `chart_spec` 的直观渲染（直接显示折线/柱状/饼图），图表将在文本回答下方优雅呈递。

--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -71,8 +71,8 @@
 ### 2.5 结论区图表渲染
 修改 `processBlocksForMessage` 与 `finalBlocksForMessage` 两个 computed 属性：
 - **isChartBlock**：判断当前块是否是 `kind === 'tool'`，并且 `ToolOutputRenderer` 可将 `block.tool.output` 解析为 `chart_spec`。检测逻辑与 `ToolOutputRenderer` 共用 `chartSpec.js` 导出的 `extractChartSpec`，作为唯一真源，避免“工具框能渲染图表、但结论区检测不到”的不一致。`extractChartSpec` 不仅识别结构化对象，还会从工具结果的内容块数组（`[{type:'text', text}]`）以及 build 脚本 stdout 文本中深度提取 chart spec，因此通过 Bash/Shell 执行 build 脚本输出的图表也能被外置到结论区。
-- **思考区**：过滤掉 `isChartBlock` 块，确保深度思考面板中不显示图表，仅保留 shell 运行、文件读写等调试追踪信息。
-- **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，允许输出 `isChartBlock`。
+- **思考区**：保留 `isChartBlock` 块，深度思考面板中仍展示图表工具的执行（与 shell 运行、文件读写等调试追踪信息并列），便于回溯图表是如何生成的。
+- **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，额外输出 `isChartBlock`，即图表在思考区保留的基础上「附加到结论区」再渲染一次，置于回答文本下方直观呈现。
 - 模板中在结论区通过 `<ToolOutputRenderer>` 渲染图表 block，得益于 `ToolOutputRenderer` 对 `chart_spec` 的直观渲染（直接显示折线/柱状/饼图），图表将在文本回答下方优雅呈递。
 - **内联 chart_spec 边界**：当前 `main_text` 中的 `<chart_spec>` 或 ```chart fenced block 已通过 `stripChartSpecsFromText` 从正文中隐藏。本设计不改变该行为，也不把它合成为图表 block；如果后续要展示内联图表，需要同步更新 `NL2SqlChat.spec.js` 中“does not inject inline chart tools into the conclusion area”的既有预期，并补充兼容方案。
 - **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：图表型 `tool_use` 块在内联工具流中保留（仍展示工具执行与图表），并在所有 turn 渲染完成后于回答文本下方的结论区**额外再渲染一次**，即“附加到结论区”而非移出工具流。

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -872,8 +872,10 @@ const markFollowupToolWithSkillContext = (blocks) => {
   }, [])
 }
 
+// Chart blocks stay in the 深度思考 process panel (showing the tool execution) and
+// are additionally surfaced in the conclusion area below the answer text.
 const processBlocksForMessage = (msg) => markFollowupToolWithSkillContext(renderBlocksForMessage(msg))
-  .filter((block) => ['thinking', 'tool'].includes(block.kind) && !isChartBlock(block))
+  .filter((block) => ['thinking', 'tool'].includes(block.kind))
 
 const finalBlocksForMessage = (msg) => renderBlocksForMessage(msg)
   .filter((block) => ['main_text', 'error'].includes(block.kind) || isChartBlock(block))

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -370,7 +370,7 @@ import { ElMessage } from 'element-plus'
 import { marked } from 'marked'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
-import { parseChartSpec, stripChartSpecsFromText } from './chartSpec'
+import { extractChartSpec, stripChartSpecsFromText } from './chartSpec'
 import { describeToolAction, extractToolSkillName, formatSkillBootstrapLabel, isSkillBootstrapPlaceholder } from './toolPresentation'
 import {
   createAssistantMessageState,
@@ -825,21 +825,9 @@ const shouldRenderToolBlock = (tool) => {
   return Boolean(detail || hasMeaningfulToolPayload(tool.output))
 }
 
-const extractChartSpecFromToolOutput = (value) => {
-  const parsed = parseChartSpec(value)
-  if (parsed) return parsed
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const itemParsed = extractChartSpecFromToolOutput(item)
-      if (itemParsed) return itemParsed
-    }
-  }
-  return null
-}
-
 const isChartBlock = (block) => block?.kind === 'tool'
   && block.tool
-  && Boolean(extractChartSpecFromToolOutput(block.tool.output))
+  && Boolean(extractChartSpec(block.tool.output))
 
 const renderBlocksForMessage = (msg) => (Array.isArray(msg?.renderBlocks) ? msg.renderBlocks : []).filter((block) => {
   if (!block || typeof block !== 'object') return false

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -107,8 +107,8 @@
                         </el-scrollbar>
                       </div>
 
-                      <!-- Tool use block -->
-                      <div v-else-if="block.type === 'tool_use'" class="v2-tool-row">
+                      <!-- Tool use block (chart-producing tools are promoted to the conclusion area below) -->
+                      <div v-else-if="block.type === 'tool_use' && !isToolChartBlock(block)" class="v2-tool-row">
                         <ToolOutputRenderer :tool="blockToToolProp(block)" />
                       </div>
 
@@ -124,6 +124,15 @@
                       </div>
                     </template>
                   </template>
+
+                  <!-- Conclusion area: charts produced by tools, rendered below the answer -->
+                  <div
+                    v-for="(block, ci) in conclusionChartBlocks(msg)"
+                    :key="'v2-chart-' + ci"
+                    class="v2-final-chart"
+                  >
+                    <ToolOutputRenderer :tool="blockToToolProp(block)" />
+                  </div>
 
                   <!-- Error from stream -->
                   <div v-if="msg._v2state.status === 'error'" class="v2-error-card">
@@ -243,7 +252,7 @@ import { ElMessage } from 'element-plus'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import { blockToToolProp, createChatState, processV2Record } from './v2StreamParser'
-import { extractChartSpecsFromText, stripChartSpecsFromText } from './chartSpec'
+import { extractChartSpec, extractChartSpecsFromText, stripChartSpecsFromText } from './chartSpec'
 
 marked.setOptions({ breaks: true, gfm: true })
 
@@ -485,6 +494,23 @@ function extractedChartSpecs(content) {
 
 function chartSpecToToolProp(spec) {
   return { name: 'render_chart', input: null, output: spec, status: 'success', id: null, _callComplete: true, _runtimeStarted: true }
+}
+
+// A tool_use block whose output resolves to a chart_spec is promoted out of the
+// inline tool stream into the conclusion area below the answer text.
+function isToolChartBlock(block) {
+  return block?.type === 'tool_use' && Boolean(extractChartSpec(block.output))
+}
+
+function conclusionChartBlocks(msg) {
+  const turns = Array.isArray(msg?._v2state?.turns) ? msg._v2state.turns : []
+  const blocks = []
+  for (const turn of turns) {
+    for (const block of (turn.blocks || [])) {
+      if (isToolChartBlock(block)) blocks.push(block)
+    }
+  }
+  return blocks
 }
 
 // ── Suggestions ───────────────────────────────────────────────────────────
@@ -1095,6 +1121,7 @@ onBeforeUnmount(() => {
 
 /* ── Tool output row ─────────────────────────────────────────────────────── */
 .v2-tool-row { border-radius: 10px; overflow: hidden; }
+.v2-final-chart { margin-top: 12px; }
 
 /* ── Text block ──────────────────────────────────────────────────────────── */
 .v2-text-block {

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -107,8 +107,8 @@
                         </el-scrollbar>
                       </div>
 
-                      <!-- Tool use block (chart-producing tools are promoted to the conclusion area below) -->
-                      <div v-else-if="block.type === 'tool_use' && !isToolChartBlock(block)" class="v2-tool-row">
+                      <!-- Tool use block (chart-producing tools are also re-rendered in the conclusion area below) -->
+                      <div v-else-if="block.type === 'tool_use'" class="v2-tool-row">
                         <ToolOutputRenderer :tool="blockToToolProp(block)" />
                       </div>
 
@@ -496,8 +496,8 @@ function chartSpecToToolProp(spec) {
   return { name: 'render_chart', input: null, output: spec, status: 'success', id: null, _callComplete: true, _runtimeStarted: true }
 }
 
-// A tool_use block whose output resolves to a chart_spec is promoted out of the
-// inline tool stream into the conclusion area below the answer text.
+// A tool_use block whose output resolves to a chart_spec is also surfaced in the
+// conclusion area below the answer text, in addition to its inline tool row.
 function isToolChartBlock(block) {
   return block?.type === 'tool_use' && Boolean(extractChartSpec(block.output))
 }

--- a/frontend/src/views/intelligence/ToolOutputRenderer.vue
+++ b/frontend/src/views/intelligence/ToolOutputRenderer.vue
@@ -7,6 +7,9 @@
         class="shell-trace-summary"
         @click="togglePanel"
       >
+        <svg class="tool-output-icon shell-trace-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path v-for="(d, index) in iconPaths" :key="index" :d="d" />
+        </svg>
         <span class="shell-trace-summary-text">
           {{ traceSummaryText }}
         </span>
@@ -17,6 +20,9 @@
       </button>
 
       <div v-else class="shell-trace-summary shell-trace-summary-static">
+        <svg class="tool-output-icon shell-trace-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path v-for="(d, index) in iconPaths" :key="index" :d="d" />
+        </svg>
         <span class="shell-trace-summary-text">
           {{ traceSummaryText }}
         </span>
@@ -56,14 +62,19 @@
       :class="{ 'is-interactive': showMainToggle }"
       @click="showMainToggle ? togglePanel() : null"
     >
-      <div class="tool-output-head-content">
-        <div class="tool-output-label">{{ displayLabel }}</div>
+      <div class="tool-output-head-main">
+        <svg class="tool-output-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path v-for="(d, index) in iconPaths" :key="index" :d="d" />
+        </svg>
+        <div class="tool-output-head-content">
+          <div class="tool-output-label">{{ displayLabel }}</div>
 
-        <div class="tool-output-meta" v-if="metaItems.length > 0">
-          <span v-for="(item, index) in metaItems" :key="index">
-            <template v-if="index > 0"> · </template>
-            <span :class="{ 'is-failed': hasError && item === statusLabel }">{{ item }}</span>
-          </span>
+          <div class="tool-output-meta" v-if="metaItems.length > 0">
+            <span v-for="(item, index) in metaItems" :key="index">
+              <template v-if="index > 0"> · </template>
+              <span :class="{ 'is-failed': hasError && item === statusLabel }">{{ item }}</span>
+            </span>
+          </div>
         </div>
       </div>
       <div class="tool-output-head-right">
@@ -228,6 +239,20 @@ const isPlainObject = (value) => value && typeof value === 'object' && !Array.is
 
 const MARKDOWN_PREVIEW_LINES = 5
 
+// Leading icons so each tool-call box is recognizable without expanding it.
+const TOOL_ICON_PATHS = {
+  shell: ['M4 17l6-6-6-6', 'M12 19h8'],
+  read: ['M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z', 'M14 3v5h5', 'M9 13h6', 'M9 17h4'],
+  list: ['M3 7a2 2 0 0 1 2-2h3.5l2 2H19a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z'],
+  search: ['M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14z', 'M21 21l-4.5-4.5'],
+  edit: ['M12 20h9', 'M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z'],
+  skill: ['M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z'],
+  sql: ['M12 3c4.97 0 9 1.34 9 3s-4.03 3-9 3-9-1.34-9-3 4.03-3 9-3z', 'M21 6v6c0 1.66-4.03 3-9 3s-9-1.34-9-3V6', 'M21 12v6c0 1.66-4.03 3-9 3s-9-1.34-9-3v-6'],
+  chart: ['M3 21h18', 'M7 21V11', 'M12 21V5', 'M17 21v-7'],
+  python: ['M8 18l-6-6 6-6', 'M16 6l6 6-6 6'],
+  tool: ['M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-.6-.6-2.4z']
+}
+
 const escapeHtml = (text) => String(text || '')
   .replace(/&/g, '&amp;')
   .replace(/</g, '&lt;')
@@ -385,6 +410,16 @@ const displayLabel = computed(() => {
 
   return toolAction.value.label
 })
+
+const iconKind = computed(() => {
+  if (kind.value === 'sql_execution') return 'sql'
+  if (kind.value === 'chart_spec') return 'chart'
+  if (kind.value === 'python_execution') return 'python'
+  if (toolAction.value.kind === 'tool' && toolNameLower.value.includes('image')) return 'chart'
+  const actionKind = toolAction.value.kind
+  return TOOL_ICON_PATHS[actionKind] ? actionKind : 'tool'
+})
+const iconPaths = computed(() => TOOL_ICON_PATHS[iconKind.value] || TOOL_ICON_PATHS.tool)
 
 const traceKind = computed(() => (toolAction.value.isTrace ? toolAction.value.kind : ''))
 
@@ -1007,9 +1042,40 @@ onBeforeUnmount(() => {
   user-select: none;
 }
 
+.tool-output-head-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
 .tool-output-head-content {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+}
+
+.tool-output-icon {
+  width: 16px;
+  height: 16px;
+  color: #4F81FF;
+  flex-shrink: 0;
+}
+
+.tool-output.failed .tool-output-icon {
+  color: #be185d;
+}
+
+.shell-trace-icon {
+  width: 15px;
+  height: 15px;
+  color: #6b7280;
+}
+
+.shell-trace-summary-static .shell-trace-icon,
+.shell-trace-summary .shell-trace-icon {
+  color: #6b7280;
 }
 
 .tool-output-head-right {

--- a/frontend/src/views/intelligence/ToolOutputRenderer.vue
+++ b/frontend/src/views/intelligence/ToolOutputRenderer.vue
@@ -207,7 +207,7 @@ import {
   TooltipComponent
 } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
-import { buildChartRenderModel, parseChartSpec, parseMaybeJson } from './chartSpec'
+import { buildChartRenderModel, extractChartSpec, extractTextParts, parseMaybeJson } from './chartSpec'
 import { describeToolAction, formatSkillBootstrapLabel } from './toolPresentation'
 
 use([
@@ -295,48 +295,20 @@ const looksLikeMarkdown = (text) => {
     || /\[[^\]]+\]\([^)]+\)/.test(value)
 }
 
-const extractTextParts = (value) => {
-  if (typeof value === 'string') return value
-  if (Array.isArray(value)) {
-    return value.map((item) => {
-      if (typeof item === 'string') return item
-      if (isPlainObject(item)) {
-        if (typeof item.text === 'string') return item.text
-        if (typeof item.content === 'string') return item.content
-      }
-      return ''
-    }).filter(Boolean).join('\n')
-  }
-  if (isPlainObject(value)) {
-    if (typeof value.text === 'string') return value.text
-    if (typeof value.content === 'string') return value.content
-    if (typeof value.stdout === 'string') return value.stdout
-    if (typeof value.result === 'string') return value.result
-  }
-  return ''
-}
-
 const normalizeOutput = (value) => {
-  const normalizedChart = parseChartSpec(value)
+  const normalizedChart = extractChartSpec(value)
   if (normalizedChart) return normalizedChart
+
   if (isPlainObject(value) && value.kind) return value
   if (Array.isArray(value)) {
     for (const item of value) {
-      const normalizedItemChart = parseChartSpec(item)
-      if (normalizedItemChart) return normalizedItemChart
       if (isPlainObject(item) && item.kind) return item
-      const text = extractTextParts(item)
-      const parsed = parseMaybeJson(text)
-      const normalizedParsedChart = parseChartSpec(parsed)
-      if (normalizedParsedChart) return normalizedParsedChart
+      const parsed = parseMaybeJson(extractTextParts(item))
       if (isPlainObject(parsed) && parsed.kind) return parsed
     }
   }
 
-  const text = extractTextParts(value)
-  const parsed = parseMaybeJson(text)
-  const normalizedParsedChart = parseChartSpec(parsed)
-  if (normalizedParsedChart) return normalizedParsedChart
+  const parsed = parseMaybeJson(extractTextParts(value))
   if (isPlainObject(parsed) && parsed.kind) return parsed
   return null
 }

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -1321,7 +1321,7 @@ describe('NL2SqlChat', () => {
     expect(wrapper.find('.query-followup-suggestion').exists()).toBe(false)
   })
 
-  it('renders tool chart_spec blocks in the conclusion area instead of the process panel', async () => {
+  it('keeps tool chart_spec blocks in the process panel and also renders them in the conclusion area', async () => {
     apiMocks.topicApi.getTopicMessages.mockResolvedValue({
       topic_id: 'topic-1',
       page: 1,
@@ -1376,12 +1376,18 @@ describe('NL2SqlChat', () => {
     await flushPromises()
     await flushPromises()
 
-    expect(wrapper.find('.query-process-content').exists()).toBe(false)
+    // Chart is surfaced in the conclusion area below the answer.
     expect(wrapper.find('.query-final-chart .tool-output-renderer-stub').exists()).toBe(true)
     expect(wrapper.find('.query-final-chart .tool-output-renderer-stub').attributes('data-output-kind')).toBe('chart_spec')
+
+    // ...and is also kept inside the 深度思考 process panel (visible once expanded).
+    expect(wrapper.find('.query-process-panel').exists()).toBe(true)
+    expect(wrapper.find('.query-process-content').exists()).toBe(false)
+    await wrapper.find('.query-process-summary').trigger('click')
+    expect(wrapper.find('.query-process-content .tool-output-renderer-stub[data-output-kind="chart_spec"]').exists()).toBe(true)
   })
 
-  it('promotes chart_spec to the conclusion area when the tool emits it as stdout content blocks', async () => {
+  it('surfaces chart_spec in the conclusion area when the tool emits it as stdout content blocks', async () => {
     const chartSpecJson = JSON.stringify({
       kind: 'chart_spec',
       chart_type: 'line',
@@ -1433,9 +1439,10 @@ describe('NL2SqlChat', () => {
     await flushPromises()
     await flushPromises()
 
-    // Chart moves out of the (now absent) process panel into the conclusion area.
-    expect(wrapper.find('.query-process-content').exists()).toBe(false)
+    // Chart from stdout content blocks is detected and rendered in the conclusion area,
+    // while the tool block is still kept in the process panel.
     expect(wrapper.find('.query-final-chart .tool-output-renderer-stub').exists()).toBe(true)
+    expect(wrapper.find('.query-process-panel').exists()).toBe(true)
   })
 
   it('allows another topic to submit while the current topic is still awaiting acceptance', async () => {

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -1381,6 +1381,63 @@ describe('NL2SqlChat', () => {
     expect(wrapper.find('.query-final-chart .tool-output-renderer-stub').attributes('data-output-kind')).toBe('chart_spec')
   })
 
+  it('promotes chart_spec to the conclusion area when the tool emits it as stdout content blocks', async () => {
+    const chartSpecJson = JSON.stringify({
+      kind: 'chart_spec',
+      chart_type: 'line',
+      title: '发布趋势',
+      x_field: 'stat_day',
+      series: [{ name: '发布次数', field: 'publish_cnt', type: 'line' }],
+      dataset: [{ stat_day: '2026-03-10', publish_cnt: 3 }]
+    })
+
+    apiMocks.topicApi.getTopicMessages.mockResolvedValue({
+      topic_id: 'topic-1',
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 1,
+      items: [
+        {
+          message_id: 'a1',
+          topic_id: 'topic-1',
+          task_id: 'task-1',
+          sender_type: 'assistant',
+          type: 'assistant',
+          status: 'finished',
+          content: '最近 30 天共发布 4 次。',
+          blocks: [
+            {
+              block_id: 'tool-chart',
+              type: 'tool',
+              status: 'success',
+              tool_id: 'tool-chart',
+              tool_name: 'Bash',
+              // Build script result delivered as Claude content blocks, not a structured object.
+              output: [{ type: 'text', text: `build ok\n${chartSpecJson}` }]
+            },
+            {
+              block_id: 'main-1',
+              type: 'main_text',
+              status: 'success',
+              text: '最近 30 天共发布 4 次。'
+            }
+          ],
+          created_at: '2026-03-10T02:00:00Z'
+        }
+      ]
+    })
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await flushPromises()
+
+    // Chart moves out of the (now absent) process panel into the conclusion area.
+    expect(wrapper.find('.query-process-content').exists()).toBe(false)
+    expect(wrapper.find('.query-final-chart .tool-output-renderer-stub').exists()).toBe(true)
+  })
+
   it('allows another topic to submit while the current topic is still awaiting acceptance', async () => {
     const firstPending = deferred()
     const secondPending = deferred()

--- a/frontend/src/views/intelligence/__tests__/ToolOutputRenderer.spec.js
+++ b/frontend/src/views/intelligence/__tests__/ToolOutputRenderer.spec.js
@@ -388,4 +388,40 @@ describe('ToolOutputRenderer', () => {
     expect(wrapper.text()).not.toContain('1→alpha')
     expect(wrapper.text()).not.toContain('2→beta')
   })
+
+  it('shows a leading tool-type icon on the collapsed header without expanding', () => {
+    const wrapper = mountRenderer({
+      name: 'SQLQuery',
+      status: 'success',
+      output: {
+        kind: 'sql_execution',
+        sql: 'select 1',
+        columns: ['workflow_id'],
+        rows: [{ workflow_id: 1 }]
+      }
+    })
+
+    const headerIcon = wrapper.find('.tool-output-head .tool-output-icon')
+    expect(headerIcon.exists()).toBe(true)
+    expect(headerIcon.findAll('path').length).toBeGreaterThan(0)
+    // The collapsible panel stays closed, so the icon must be visible up front.
+    expect(wrapper.find('.tool-output-panel').exists()).toBe(false)
+  })
+
+  it('shows a leading tool-type icon on the shell-trace summary line', () => {
+    const wrapper = mountRenderer({
+      name: 'Bash',
+      status: 'success',
+      _callComplete: true,
+      _runtimeStarted: true,
+      input: {
+        command: 'python scripts/run_sql.py --question trend'
+      },
+      output: 'done'
+    })
+
+    const traceIcon = wrapper.find('.shell-trace-summary .shell-trace-icon')
+    expect(traceIcon.exists()).toBe(true)
+    expect(traceIcon.findAll('path').length).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -1,5 +1,6 @@
 import {
   buildChartRenderModel,
+  extractChartSpec,
   extractChartSpecsFromText,
   parseChartSpec,
   stripChartSpecsFromText,
@@ -103,6 +104,36 @@ describe('chartSpec', () => {
     expect(specs).toHaveLength(1)
     expect(specs[0].chart_type).toBe('pie')
     expect(specs[0].series[0].field).toBe('publish_cnt')
+  })
+
+  it('extracts chart specs from tool-result content blocks for conclusion-area promotion', () => {
+    const spec = {
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'line',
+      title: '最近30天工作流发布趋势',
+      x_field: 'stat_day',
+      series: [{ name: '发布次数', field: 'publish_cnt', type: 'line' }],
+      dataset: [{ stat_day: '2026-03-01', publish_cnt: 3 }],
+      error: null
+    }
+
+    // Tool result delivered as Claude content blocks (array of {type,text}).
+    const fromContentBlocks = extractChartSpec([
+      { type: 'text', text: JSON.stringify(spec) }
+    ])
+    expect(fromContentBlocks?.chart_type).toBe('line')
+    expect(fromContentBlocks?.series[0].field).toBe('publish_cnt')
+
+    // Tool result delivered as raw stdout text with surrounding noise.
+    const fromStdout = extractChartSpec(`build ok\n${JSON.stringify(spec)}\n`)
+    expect(fromStdout?.chart_type).toBe('line')
+
+    // Direct object passthrough still works.
+    expect(extractChartSpec(spec)?.title).toBe('最近30天工作流发布趋势')
+
+    // Non-chart output stays null so unrelated tools are not promoted.
+    expect(extractChartSpec([{ type: 'text', text: 'no chart here' }])).toBeNull()
   })
 
   it('extracts and strips xml-style chart spec blocks', () => {

--- a/frontend/src/views/intelligence/chartSpec.js
+++ b/frontend/src/views/intelligence/chartSpec.js
@@ -27,6 +27,47 @@ export const parseMaybeJson = (value) => {
   }
 }
 
+export const extractTextParts = (value) => {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (typeof item === 'string') return item
+      if (isPlainObject(item)) {
+        if (typeof item.text === 'string') return item.text
+        if (typeof item.content === 'string') return item.content
+      }
+      return ''
+    }).filter(Boolean).join('\n')
+  }
+  if (isPlainObject(value)) {
+    if (typeof value.text === 'string') return value.text
+    if (typeof value.content === 'string') return value.content
+    if (typeof value.stdout === 'string') return value.stdout
+    if (typeof value.result === 'string') return value.result
+  }
+  return ''
+}
+
+// Deeply locate a chart_spec inside a tool output, which can arrive as a raw
+// object, an array of tool-result content blocks, or JSON embedded in stdout
+// text. Both the in-box renderer and the conclusion-area promotion logic rely
+// on this single source of truth so detection and rendering never diverge.
+export const extractChartSpec = (value) => {
+  const direct = parseChartSpec(value)
+  if (direct) return direct
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const itemChart = parseChartSpec(item)
+      if (itemChart) return itemChart
+      const itemTextChart = parseChartSpec(extractTextParts(item))
+      if (itemTextChart) return itemTextChart
+    }
+  }
+
+  return parseChartSpec(extractTextParts(value))
+}
+
 const normalizeDataset = (value) => (
   Array.isArray(value)
     ? value.filter(isPlainObject).map((row) => ({ ...row }))

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -104,8 +104,8 @@
                         </div>
                       </div>
 
-                      <!-- Tool use block (chart-producing tools are promoted to the conclusion area below) -->
-                      <div v-else-if="block.type === 'tool_use' && !isToolChartBlock(block)" class="query-tool-row">
+                      <!-- Tool use block (chart-producing tools are also re-rendered in the conclusion area below) -->
+                      <div v-else-if="block.type === 'tool_use'" class="query-tool-row">
                         <ToolOutputRenderer :tool="blockToToolProp(block)" />
                       </div>
 
@@ -414,8 +414,8 @@ const extractedChartSpecs = (content) => extractChartSpecsFromText(String(conten
 
 const chartSpecToToolProp = (spec) => ({ name: 'render_chart', input: null, output: spec, status: 'success', id: null, _callComplete: true, _runtimeStarted: true })
 
-// Chart-producing tool blocks are promoted from the inline tool stream into the
-// conclusion area below the answer text.
+// Chart-producing tool blocks are also surfaced in the conclusion area below the
+// answer text, in addition to their inline tool row.
 const isToolChartBlock = (block) => block?.type === 'tool_use' && Boolean(extractChartSpec(block.output))
 
 const conclusionChartBlocks = (msg) => {

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -104,8 +104,8 @@
                         </div>
                       </div>
 
-                      <!-- Tool use block -->
-                      <div v-else-if="block.type === 'tool_use'" class="query-tool-row">
+                      <!-- Tool use block (chart-producing tools are promoted to the conclusion area below) -->
+                      <div v-else-if="block.type === 'tool_use' && !isToolChartBlock(block)" class="query-tool-row">
                         <ToolOutputRenderer :tool="blockToToolProp(block)" />
                       </div>
 
@@ -121,6 +121,15 @@
                       </div>
                     </template>
                   </template>
+
+                  <!-- Conclusion area: charts produced by tools, rendered below the answer -->
+                  <div
+                    v-for="(block, ci) in conclusionChartBlocks(msg)"
+                    :key="'chart-' + ci"
+                    class="query-final-chart"
+                  >
+                    <ToolOutputRenderer :tool="blockToToolProp(block)" />
+                  </div>
 
                   <div v-if="msg._v2state.status === 'error'" class="query-error-card">
                     <span class="query-error-label">错误</span>
@@ -219,7 +228,7 @@ import { computed, onBeforeUnmount, onMounted, reactive, ref, triggerRef, watch 
 import { marked } from 'marked'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from '@/views/intelligence/ToolOutputRenderer.vue'
-import { extractChartSpecsFromText, stripChartSpecsFromText } from '@/views/intelligence/chartSpec'
+import { extractChartSpec, extractChartSpecsFromText, stripChartSpecsFromText } from '@/views/intelligence/chartSpec'
 import { blockToToolProp, createChatState, processV2Record } from '@/views/intelligence/v2StreamParser'
 
 marked.setOptions({ breaks: true, gfm: true })
@@ -404,6 +413,21 @@ const cleanTextForDisplay = (content) => stripChartSpecsFromText(String(content 
 const extractedChartSpecs = (content) => extractChartSpecsFromText(String(content || ''))
 
 const chartSpecToToolProp = (spec) => ({ name: 'render_chart', input: null, output: spec, status: 'success', id: null, _callComplete: true, _runtimeStarted: true })
+
+// Chart-producing tool blocks are promoted from the inline tool stream into the
+// conclusion area below the answer text.
+const isToolChartBlock = (block) => block?.type === 'tool_use' && Boolean(extractChartSpec(block.output))
+
+const conclusionChartBlocks = (msg) => {
+  const turns = Array.isArray(msg?._v2state?.turns) ? msg._v2state.turns : []
+  const blocks = []
+  for (const turn of turns) {
+    for (const block of (turn.blocks || [])) {
+      if (isToolChartBlock(block)) blocks.push(block)
+    }
+  }
+  return blocks
+}
 
 const buildV2StateFromStoredBlocks = (item) => {
   const v2state = createChatState()

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -254,4 +254,40 @@ describe('WidgetChat history conversations', () => {
       agent_id: 'agent_widget'
     }))
   })
+
+  it('promotes tool-produced chart_spec into the conclusion area below the answer', async () => {
+    const chartSpec = JSON.stringify({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'line',
+      title: '发布趋势',
+      x_field: 'stat_day',
+      series: [{ name: '发布次数', field: 'publish_cnt', type: 'line' }],
+      dataset: [{ stat_day: '2026-03-10', publish_cnt: 3 }],
+      error: null
+    })
+
+    apiMocks.taskApi.streamSdkEvents.mockImplementation(async (_taskId, options) => {
+      options.onRecord({ record_type: 'stream', data: { type: 'message_start', usage: {} } })
+      options.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tool-chart', name: 'Bash' } } })
+      options.onRecord({ record_type: 'stream', data: { type: 'content_block_stop', index: 0 } })
+      // Build script result delivered as tool-result content blocks.
+      options.onRecord({ record_type: 'tool_result', data: { tool_use_id: 'tool-chart', content: [{ type: 'text', text: `build ok\n${chartSpec}` }] } })
+      options.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } })
+      options.onRecord({ record_type: 'stream', data: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: '最近发布趋势如下。' } } })
+      options.onRecord({ record_type: 'stream', data: { type: 'content_block_stop', index: 1 } })
+      options.onRecord({ record_type: 'done', data: {} })
+    })
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('textarea').setValue('最近发布趋势')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    // Chart is promoted to the conclusion area, not left inline in the tool stream.
+    expect(wrapper.find('.query-final-chart').exists()).toBe(true)
+    expect(wrapper.find('.query-tool-row').exists()).toBe(false)
+  })
 })

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -286,8 +286,8 @@ describe('WidgetChat history conversations', () => {
     await wrapper.get('form').trigger('submit')
     await flushPromises()
 
-    // Chart is promoted to the conclusion area, not left inline in the tool stream.
+    // Chart is surfaced in the conclusion area, while the inline tool row is kept.
     expect(wrapper.find('.query-final-chart').exists()).toBe(true)
-    expect(wrapper.find('.query-tool-row').exists()).toBe(false)
+    expect(wrapper.find('.query-tool-row').exists()).toBe(true)
   })
 })

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -801,6 +801,10 @@ export const WIDGET_STYLES = `
   overflow: hidden;
 }
 
+.query-final-chart {
+  margin-top: 12px;
+}
+
 .query-process-label {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
This change enhances the tool output UI by adding leading icons to identify tool types at a glance, and promotes chart specifications produced by tools into a dedicated conclusion area below the answer text while keeping them in the process panel.

## Key Changes

### Tool Type Icons
- Added `TOOL_ICON_PATHS` constant mapping tool kinds (shell, read, list, search, edit, skill, sql, chart, python, tool) to SVG path definitions
- Computed `iconKind` and `iconPaths` to determine the appropriate icon for each tool based on its kind
- Rendered icons in three locations:
  - Tool output header (`.tool-output-head-main`)
  - Shell trace summary lines (both interactive and static)
  - Styled with blue color (#4F81FF) for normal tools, pink (#be185d) for failed tools, and gray (#6b7280) for shell traces

### Chart Promotion to Conclusion Area
- Extracted `extractTextParts` function to `chartSpec.js` as a shared utility
- Created `extractChartSpec` function that deeply locates chart specs in tool outputs (raw objects, content block arrays, or JSON-embedded stdout text)
- Renamed `parseChartSpec` to `extractChartSpec` in imports where appropriate
- Modified `normalizeOutput` to use the new extraction logic
- Updated `NL2SqlChat.vue` and `WidgetChat.vue` to:
  - Keep chart-producing tool blocks in the process/thinking panel (showing tool execution)
  - Additionally render them in a new conclusion area (`.query-final-chart` / `.v2-final-chart`) below the answer text
  - Added `isToolChartBlock` and `conclusionChartBlocks` helper functions
- Updated `NL2SqlChatV2.vue` with the same pattern for v2 stream parser

### Testing
- Added tests verifying icon rendering on collapsed headers and shell traces
- Added tests for chart extraction from content blocks and stdout text
- Updated existing test expectations to reflect that charts now appear in both process panel and conclusion area

## Implementation Details
- The `extractChartSpec` function serves as the single source of truth for chart detection, ensuring consistency between the tool renderer and conclusion-area promotion logic
- Icons are non-interactive (aria-hidden) and use flex layout to maintain proper alignment with text
- Chart blocks remain in their original tool rows for debugging visibility while being duplicated in the conclusion area for better UX

https://claude.ai/code/session_01QQXuztWdjTDZg1LUJond47