### PR TITLE
fix: update schema comments migration revision and add widget event table

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260601_000014_add_dataagent_schema_comments.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260601_000014_add_dataagent_schema_comments.py
@@ -1,7 +1,7 @@
 """add dataagent schema comments
 
 Revision ID: 20260601_000014
-Revises: 20260529_000013
+Revises: 20260529_000014
 Create Date: 2026-06-01 10:00:00
 """
 from __future__ import annotations
@@ -15,7 +15,7 @@ from alembic import op
 
 
 revision = "20260601_000014"
-down_revision = "20260529_000013"
+down_revision = "20260529_000014"
 branch_labels = None
 depends_on = None
 
@@ -33,6 +33,7 @@ TABLE_COMMENTS: dict[str, str] = {
     "da_agent_message_schedule_log": "DataAgent定时消息执行日志表",
     "da_agent_profile": "DataAgent智能体配置表",
     "da_agent_sdk_record": "DataAgent SDK原始流记录表",
+    "da_agent_widget_event": "DataAgent嵌入组件事件埋点表",
 }
 
 
@@ -241,6 +242,21 @@ COLUMN_COMMENTS: dict[str, dict[str, str]] = {
         "event_type": "事件类型",
         "data": "SDK原始事件数据JSON",
         "created_at": "创建时间",
+    },
+    "da_agent_widget_event": {
+        "id": "自增主键",
+        "event_type": "事件类型",
+        "source": "事件来源，portal或widget",
+        "website_id": "嵌入站点ID",
+        "external_user_id": "外部用户ID",
+        "visitor_id": "访客ID",
+        "agent_id": "智能体ID",
+        "topic_id": "关联会话主题ID",
+        "task_id": "关联任务ID",
+        "message_id": "关联消息ID",
+        "payload_json": "事件负载JSON",
+        "client_ts": "客户端事件时间",
+        "created_at": "服务端创建时间",
     },
 }
 

--- a/dataagent/dataagent-backend/tests/test_schema_comment_migration.py
+++ b/dataagent/dataagent-backend/tests/test_schema_comment_migration.py
@@ -91,3 +91,17 @@ def test_build_column_definition_preserves_auto_increment() -> None:
     assert migration._build_column_definition(row, "自增主键") == (
         "bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键'"
     )
+
+
+def test_comment_migration_extends_current_dataagent_head() -> None:
+    migration = _load_migration()
+
+    assert migration.down_revision == "20260529_000014"
+
+
+def test_comment_migration_covers_widget_event_table() -> None:
+    migration = _load_migration()
+
+    assert migration.TABLE_COMMENTS["da_agent_widget_event"] == "DataAgent嵌入组件事件埋点表"
+    assert migration.COLUMN_COMMENTS["da_agent_widget_event"]["event_type"] == "事件类型"
+    assert migration.COLUMN_COMMENTS["da_agent_widget_event"]["payload_json"] == "事件负载JSON"

--- a/docs/design/2026-06-01-dataagent-schema-comments-design.md
+++ b/docs/design/2026-06-01-dataagent-schema-comments-design.md
@@ -28,6 +28,7 @@ This change covers the current DataAgent-owned `da_*` tables at Alembic head:
 - `da_agent_message_schedule_log`
 - `da_agent_profile`
 - `da_agent_sdk_record`
+- `da_agent_widget_event`
 
 The legacy `da_chat_*` tables are out of scope because they are dropped by `20260323_000004_magic_task_model.py`.
 
@@ -35,7 +36,7 @@ No public API, runtime behavior, persistence contract, or deployment contract ch
 
 ## Solution
 
-Add a new Alembic migration after `20260529_000013_add_agent_preset_questions.py` that applies MySQL table and column comments to the current DataAgent schema.
+Add a new Alembic migration after the current DataAgent Alembic head `20260529_000014_add_widget_event_log.py` that applies MySQL table and column comments to the current DataAgent schema.
 
 The migration will be defensive:
 

--- a/docs/plans/2026-06-01-dataagent-schema-comments-plan.md
+++ b/docs/plans/2026-06-01-dataagent-schema-comments-plan.md
@@ -114,6 +114,20 @@ def test_build_column_definition_preserves_auto_increment() -> None:
     assert migration._build_column_definition(row, "自增主键") == (
         "bigint NOT NULL AUTO_INCREMENT COMMENT '自增主键'"
     )
+
+
+def test_comment_migration_extends_current_dataagent_head() -> None:
+    migration = _load_migration()
+
+    assert migration.down_revision == "20260529_000014"
+
+
+def test_comment_migration_covers_widget_event_table() -> None:
+    migration = _load_migration()
+
+    assert migration.TABLE_COMMENTS["da_agent_widget_event"] == "DataAgent嵌入组件事件埋点表"
+    assert migration.COLUMN_COMMENTS["da_agent_widget_event"]["event_type"] == "事件类型"
+    assert migration.COLUMN_COMMENTS["da_agent_widget_event"]["payload_json"] == "事件负载JSON"
 ```
 
 - [ ] **Step 2: Run the test and confirm RED**
@@ -136,7 +150,7 @@ Expected: fail with `ModuleNotFoundError` because the migration has not been cre
 
 - [ ] **Step 1: Implement the migration**
 
-Create a migration with revision `20260601_000014`, down revision `20260529_000013`, helper functions for quoting/default rendering, and comment dictionaries for all in-scope tables and columns.
+Create a migration with revision `20260601_000014`, down revision `20260529_000014`, helper functions for quoting/default rendering, and comment dictionaries for all in-scope tables and columns.
 
 - [ ] **Step 2: Re-run the focused test and confirm GREEN**
 


### PR DESCRIPTION
Updates the down_revision of the schema comments migration to accommodate the newly added widget event table, and adds comments for the new table.