### PR TITLE
结论区只渲染图表本身，不重复搬运整个工具调用框

### DIFF
--- a/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
+++ b/docs/design/2026-05-25-intelligent-query-ui-optimization-design.md
@@ -72,10 +72,10 @@
 修改 `processBlocksForMessage` 与 `finalBlocksForMessage` 两个 computed 属性：
 - **isChartBlock**：判断当前块是否是 `kind === 'tool'`，并且 `ToolOutputRenderer` 可将 `block.tool.output` 解析为 `chart_spec`。检测逻辑与 `ToolOutputRenderer` 共用 `chartSpec.js` 导出的 `extractChartSpec`，作为唯一真源，避免“工具框能渲染图表、但结论区检测不到”的不一致。`extractChartSpec` 不仅识别结构化对象，还会从工具结果的内容块数组（`[{type:'text', text}]`）以及 build 脚本 stdout 文本中深度提取 chart spec，因此通过 Bash/Shell 执行 build 脚本输出的图表也能被外置到结论区。
 - **思考区**：保留 `isChartBlock` 块，深度思考面板中仍展示图表工具的执行（与 shell 运行、文件读写等调试追踪信息并列），便于回溯图表是如何生成的。
-- **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，额外输出 `isChartBlock`，即图表在思考区保留的基础上「附加到结论区」再渲染一次，置于回答文本下方直观呈现。
+- **结论区**：`finalBlocksForMessage` 在输出文本块（`main_text`）的同时，额外输出 `isChartBlock`，即图表在思考区保留的基础上「附加到结论区」再渲染一次，置于回答文本下方直观呈现。结论区只渲染图表本身：通过 `chartOnlyToolProp` 把 `extractChartSpec` 提取到的 chart_spec 包装成合成工具（`name: 'render_chart'`，无 trace），让 `ToolOutputRenderer` 走 `isDirectChart` 分支直接画图，不再带工具调用框的标题、元信息与可展开 trace，避免把整个工具调用重复搬到结论区。
 - 模板中在结论区通过 `<ToolOutputRenderer>` 渲染图表 block，得益于 `ToolOutputRenderer` 对 `chart_spec` 的直观渲染（直接显示折线/柱状/饼图），图表将在文本回答下方优雅呈递。
 - **内联 chart_spec 边界**：当前 `main_text` 中的 `<chart_spec>` 或 ```chart fenced block 已通过 `stripChartSpecsFromText` 从正文中隐藏。本设计不改变该行为，也不把它合成为图表 block；如果后续要展示内联图表，需要同步更新 `NL2SqlChat.spec.js` 中“does not inject inline chart tools into the conclusion area”的既有预期，并补充兼容方案。
-- **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：图表型 `tool_use` 块在内联工具流中保留（仍展示工具执行与图表），并在所有 turn 渲染完成后于回答文本下方的结论区**额外再渲染一次**，即“附加到结论区”而非移出工具流。
+- **Chat V2 与 Widget Chat 对齐**：`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 采用 `_v2state.turns[].blocks` 的逐块渲染模型，不存在 `finalBlocksForMessage` 的分区结构。两者各自实现等价的 `isToolChartBlock` / `conclusionChartBlocks`（同样复用 `extractChartSpec`）：图表型 `tool_use` 块在内联工具流中保留（仍展示工具执行与图表），并在所有 turn 渲染完成后于回答文本下方的结论区**额外再渲染一次**，即“附加到结论区”而非移出工具流。结论区同样只渲染图表本身：用 `chartSpecToToolProp(extractChartSpec(block.output))` 走 `isDirectChart` 直接画图，不重复搬运整个工具调用框。
 
 ---
 

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -173,7 +173,7 @@
                   </div>
 
                   <div v-else-if="block.kind === 'tool' && block.tool" class="query-final-chart">
-                    <ToolOutputRenderer :tool="block.tool" />
+                    <ToolOutputRenderer :tool="chartOnlyToolProp(block.tool)" />
                   </div>
                 </div>
 
@@ -828,6 +828,19 @@ const shouldRenderToolBlock = (tool) => {
 const isChartBlock = (block) => block?.kind === 'tool'
   && block.tool
   && Boolean(extractChartSpec(block.tool.output))
+
+// In the conclusion area we only want the chart itself, not the full tool-call
+// box (header, meta, expandable trace). Wrap the extracted chart_spec into a
+// synthetic tool so ToolOutputRenderer renders it as a clean direct chart.
+const chartOnlyToolProp = (tool) => ({
+  name: 'render_chart',
+  input: null,
+  output: extractChartSpec(tool?.output),
+  status: 'success',
+  id: tool?.id || null,
+  _callComplete: true,
+  _runtimeStarted: true
+})
 
 const renderBlocksForMessage = (msg) => (Array.isArray(msg?.renderBlocks) ? msg.renderBlocks : []).filter((block) => {
   if (!block || typeof block !== 'object') return false

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -125,13 +125,13 @@
                     </template>
                   </template>
 
-                  <!-- Conclusion area: charts produced by tools, rendered below the answer -->
+                  <!-- Conclusion area: only the chart itself (not the full tool-call box) -->
                   <div
                     v-for="(block, ci) in conclusionChartBlocks(msg)"
                     :key="'v2-chart-' + ci"
                     class="v2-final-chart"
                   >
-                    <ToolOutputRenderer :tool="blockToToolProp(block)" />
+                    <ToolOutputRenderer :tool="chartSpecToToolProp(extractChartSpec(block.output))" />
                   </div>
 
                   <!-- Error from stream -->

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -122,13 +122,13 @@
                     </template>
                   </template>
 
-                  <!-- Conclusion area: charts produced by tools, rendered below the answer -->
+                  <!-- Conclusion area: only the chart itself (not the full tool-call box) -->
                   <div
                     v-for="(block, ci) in conclusionChartBlocks(msg)"
                     :key="'chart-' + ci"
                     class="query-final-chart"
                   >
-                    <ToolOutputRenderer :tool="blockToToolProp(block)" />
+                    <ToolOutputRenderer :tool="chartSpecToToolProp(extractChartSpec(block.output))" />
                   </div>
 
                   <div v-if="msg._v2state.status === 'error'" class="query-error-card">

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -4,6 +4,27 @@ import { nextTick, reactive } from 'vue'
 
 import WidgetChat from '../WidgetChat.vue'
 
+// ECharts touches the canvas API, which jsdom doesn't fully implement. The chart
+// promotion tests only care about which container the chart lands in, so stub the
+// renderer to keep the conclusion-area direct chart from emitting canvas errors.
+const echartsMocks = vi.hoisted(() => {
+  const instance = { setOption: vi.fn(), resize: vi.fn(), clear: vi.fn(), dispose: vi.fn() }
+  return { instance, init: vi.fn(() => instance) }
+})
+
+vi.mock('echarts/core', () => ({
+  use: () => {},
+  init: echartsMocks.init
+}))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {} }))
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  LegendComponent: {},
+  TitleComponent: {},
+  TooltipComponent: {}
+}))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
 const apiMocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   runtimeApi: {


### PR DESCRIPTION
## 背景

承接已合并的 #261（工具类型图标 + 图表外置到结论区）。#261 合并后，发现结论区把图表型工具的**整个工具调用框**（标题、元信息、可展开 trace + 图表）整块又渲染了一遍，重复内容过多。本 PR 收尾这一问题：结论区只保留图表本身。

## 改动

- 将 `extractChartSpec` 提取到的 chart_spec 包装成合成工具（`name: 'render_chart'`，无 trace），让 `ToolOutputRenderer` 走 `isDirectChart` 分支**直接画图**——无标题、无元信息、无可展开框。
- `NL2SqlChat.vue` 新增 `chartOnlyToolProp`；`NL2SqlChatV2.vue` 与 `widget/WidgetChat.vue` 复用 `chartSpecToToolProp(extractChartSpec(block.output))`。
- 工具调用区 / 深度思考区仍保留**完整**工具调用框（含执行回溯，可展开看命令与输出），仅**结论区精简为纯图表**。
- `WidgetChat.spec.js` mock echarts，消除结论区 direct chart 在 jsdom 下的 canvas 渲染噪声。
- 更新设计文档 `docs/design/2026-05-25-intelligent-query-ui-optimization-design.md` 2.5 节。

| 区域 | 内容 |
|---|---|
| 工具调用区 / 深度思考区 | 完整工具调用框（保留执行回溯） |
| 结论区 | 仅图表（干净的折线/柱状/饼图） |

## 验证

- `npm test`：全量 **210 项通过**，无报错。
- `npm run build`：生产构建通过。

https://claude.ai/code/session_01QQXuztWdjTDZg1LUJond47

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQXuztWdjTDZg1LUJond47)_