### PR TITLE
fix(datastudio): 修复 SQL 补全卡顿根因并恢复打字时的表/库提示

### DIFF
--- a/frontend/src/components/__tests__/sqlCompletion.spec.js
+++ b/frontend/src/components/__tests__/sqlCompletion.spec.js
@@ -91,6 +91,20 @@ describe('sql completion source', () => {
     ]))
   })
 
+  it('tokenizes long inputs in linear time (no catastrophic backtracking)', async () => {
+    const source = createSqlCompletionSource({
+      getCompletionContext: () => null,
+      getTableNames: () => []
+    })
+
+    // A long word-character run followed by a non-identifier boundary used to
+    // trigger exponential regex backtracking (~18s freeze) in getToken.
+    const doc = `SELECT col_${'a'.repeat(60)} `
+    const started = Date.now()
+    await source(editorContext(doc, true))
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+
   it('keeps legacy tableNames completion for existing callers', async () => {
     const source = createSqlCompletionSource({
       getCompletionContext: () => null,

--- a/frontend/src/components/sqlCompletion.js
+++ b/frontend/src/components/sqlCompletion.js
@@ -1,4 +1,11 @@
-const IDENTIFIER_TOKEN = /(?:`[^`]*`|[\w$]+|\.)+$/
+// NOTE: keep each branch single-character (no nested `+`). A previous form
+// `(?:`[^`]*`|[\w$]+|\.)+$` nested a `+` quantifier inside another `+`, which
+// caused catastrophic regex backtracking: on completion the editor froze for
+// ~18s ("setTimeout handler took 18000ms" in CodeMirror) whenever a long
+// word-character run preceded a non-identifier boundary before the cursor.
+// This form matches the same language (identifiers, dotted paths, backtick
+// quoted names) but runs in linear time.
+const IDENTIFIER_TOKEN = /(?:`[^`]*`|[\w$]|\.)+$/
 const VALID_FOR = /^[`"'\[\]\w$.]*$/
 
 const SQL_KEYWORDS = [


### PR DESCRIPTION
## 背景

DataStudio 增加 schema/表补全后，编辑器输入时出现严重卡顿，控制台反复打印 `Violation 'setTimeout' handler took 18000ms`（来自 `vendor-codemirror-*.js`）。

## 根因：补全分词器正则灾难性回溯

补全源 `getToken` 在**每次按键**用以下正则匹配光标前文本：

```js
/(?:`[^`]*`|[\w$]+|\.)+$/
```

`[\w$]+` 嵌套在外层 `(?:...)+` 之中（嵌套量词）。当光标前存在较长的连续单词字符、且后接非标识符边界时，正则需要回溯失败，回溯量为 `2^n` 级别，直接在主线程同步阻塞十几秒。

实测复现（与线上 18000ms 精确吻合）：

| 单词串长度 | 旧正则耗时 |
|---|---|
| 22 | 5690ms |
| 26 | **18476ms** |
| 28 | 73998ms |

## 修复

将每个分支改为**单字符匹配**，去掉嵌套量词，匹配语言完全不变（标识符、`a.b.c` 点路径、`` `带空格的名字` `` 反引号名照常）：

```js
/(?:`[^`]*`|[\w$]|\.)+$/
```

修复后即使 2000 字符也只需 ~12ms（线性时间）。

## 同时恢复被误删的功能

此前为绕过卡顿，曾在补全源加入「打字时只返回关键字/函数、不提示表/库」的提前 return 守卫。但该守卫位于 `getToken` **之后**，并不能阻止正则爆炸——既没真正解决卡顿，又砍掉了打字即提示表/库的能力。既然本 PR 从根因修复了卡顿，该守卫已移除，恢复完整补全行为。

## 验证

- 复现脚本确认旧式 ~18s、新式亚毫秒/线性
- 新增回归测试：
  - `tokenizes long inputs in linear time`（命中旧正则会挂死约 18s）
  - `suggests current-schema tables while typing bare words`（验证打字时表建议已恢复）
- `vitest` 补全单测 6 项全过
- 合并 main 后 `vite build` 通过

https://claude.ai/code/session_01A3xRbRxwnJRnu75aE9YX66

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3xRbRxwnJRnu75aE9YX66)_