### PR TITLE
fix(widget): keep new chat sessions first

### DIFF
--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -388,6 +388,17 @@ const sortTopics = () => {
   topics.value = [...topics.value].sort((a, b) => String(b.updated_at || b.created_at).localeCompare(String(a.updated_at || a.created_at)))
 }
 
+const moveTopicToTop = (targetTopicId) => {
+  const target = topics.value.find((topic) => topic.topic_id === targetTopicId)
+  if (!target) return
+  topics.value = [target, ...topics.value.filter((topic) => topic.topic_id !== targetTopicId)]
+}
+
+const upsertTopicAtTop = (topic) => {
+  if (!topic?.topic_id) return
+  topics.value = [topic, ...topics.value.filter((item) => item.topic_id !== topic.topic_id)]
+}
+
 const uid = () => `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
 
 const appendUserMessage = (content) => {
@@ -538,8 +549,16 @@ const loadTopicMessages = async (targetTopicId) => {
 const loadTopics = async () => {
   try {
     const list = await api.topicApi.listTopics({ agent_id: agentId.value || undefined })
-    topics.value = (Array.isArray(list) ? list : []).map(normalizeTopic).filter((topic) => topic.topic_id)
+    const currentTopic = activeTopic.value ? { ...activeTopic.value } : null
+    const nextTopics = (Array.isArray(list) ? list : []).map(normalizeTopic).filter((topic) => topic.topic_id)
+    if (currentTopic?.topic_id && !nextTopics.some((topic) => topic.topic_id === currentTopic.topic_id)) {
+      nextTopics.unshift(currentTopic)
+    }
+    topics.value = nextTopics
     sortTopics()
+    if (currentTopic?.topic_id && currentTopic.topic_id === topicId.value) {
+      moveTopicToTop(currentTopic.topic_id)
+    }
     // Default to a fresh conversation on open instead of auto-selecting the latest topic,
     // so users can ask a new question immediately. Existing topics remain in history.
     const nextTopicId = topicId.value || ''
@@ -602,7 +621,7 @@ const ensureTopic = async (title) => {
   if (topicId.value) return topicId.value
   const topic = normalizeTopic(await api.topicApi.createTopic(title || '新会话', { agent_id: agentId.value || undefined }))
   if (!topic.topic_id) return ''
-  topics.value = [topic, ...topics.value.filter((item) => item.topic_id !== topic.topic_id)]
+  upsertTopicAtTop(topic)
   topicId.value = topic.topic_id
   hydratedTopicIds.add(topic.topic_id)
   return topic.topic_id
@@ -682,7 +701,7 @@ const updateActiveTopicAfterSend = (text, taskId) => {
   target.last_message_preview = text
   target.message_count = Number(target.message_count || 0) + 1
   target.updated_at = new Date().toISOString()
-  sortTopics()
+  moveTopicToTop(target.topic_id)
 }
 
 const send = async () => {
@@ -717,7 +736,7 @@ const send = async () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       }
-      topics.value = [newTopic, ...topics.value]
+      upsertTopicAtTop(newTopic)
       topicId.value = mockTopicId
       hydratedTopicIds.add(mockTopicId)
     } else {

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -182,6 +182,72 @@ describe('WidgetChat history conversations', () => {
     expect(apiMocks.topicApi.deleteTopic).not.toHaveBeenCalled()
   })
 
+  it('creates the first sent conversation at the top of the history list', async () => {
+    apiMocks.topicApi.createTopic.mockResolvedValue(topic('topic-new', '新话题', {
+      message_count: 0,
+      last_message_preview: '',
+      updated_at: '2026-04-30T09:00:00'
+    }))
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('[data-testid="new-conversation"]').trigger('click')
+    await flushPromises()
+
+    expect(apiMocks.topicApi.createTopic).not.toHaveBeenCalled()
+
+    await wrapper.get('textarea').setValue('首次输入创建会话')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('首次输入创建会话', { agent_id: 'agent_widget' })
+    expect(wrapper.findAll('.query-session-title').map((item) => item.text())).toEqual([
+      '首次输入创建会话',
+      '最近 30 天工作流发布趋势',
+      'smoke-ok 测试'
+    ])
+    expect(wrapper.get('[data-testid="history-topic-topic-new"]').classes()).toContain('active')
+    expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledWith(expect.objectContaining({
+      topic_id: 'topic-new',
+      content: '首次输入创建会话',
+      agent_id: 'agent_widget'
+    }))
+  })
+
+  it('keeps the first sent conversation at the top when initial history load resolves late', async () => {
+    let resolveTopics
+    apiMocks.topicApi.listTopics.mockReturnValue(new Promise((resolve) => {
+      resolveTopics = resolve
+    }))
+    apiMocks.topicApi.createTopic.mockResolvedValue(topic('topic-new', '新话题', {
+      message_count: 0,
+      last_message_preview: '',
+      updated_at: '2026-04-30T09:00:00'
+    }))
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('[data-testid="new-conversation"]').trigger('click')
+    await wrapper.get('textarea').setValue('首次输入创建会话')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    resolveTopics([
+      topic('topic-1', '最近 30 天工作流发布趋势'),
+      topic('topic-2', 'smoke-ok 测试')
+    ])
+    await flushPromises()
+
+    expect(wrapper.findAll('.query-session-title').map((item) => item.text())).toEqual([
+      '首次输入创建会话',
+      '最近 30 天工作流发布趋势',
+      'smoke-ok 测试'
+    ])
+    expect(wrapper.get('[data-testid="history-topic-topic-new"]').classes()).toContain('active')
+  })
+
   it('loads topics without agent id filter when agentId is not configured', async () => {
     const { wrapper } = mountChat({ config: { agentId: '', displayMode: 'inline' } })
 


### PR DESCRIPTION
## Summary
- Describe the user-facing objective in one sentence.
- Diff summary: 2 files changed, 89 insertions(+), 4 deletions(-)

## What Changed

### Commit Highlights
- 11e9e35 fix(widget): keep new chat sessions first

### Key Files
- `frontend/src/widget/WidgetChat.vue` (M)
- `frontend/src/widget/__tests__/WidgetChat.spec.js` (M)


## Validation
- [ ] Add commands actually executed and outcomes, for example:
  - [ ] `mvn -q -DskipTests compile`
  - [ ] `npm run build`

## Risks
- Risk: describe the main regression risk.

## Rollback
- Rollback: describe the fastest rollback approach.

## Checklist
- [ ] No secrets or credentials introduced.
- [ ] Backward compatibility reviewed.
- [ ] Documentation/config updated when required.
