### PR TITLE
Add bare column completion from FROM/JOIN tables

### DIFF
--- a/frontend/src/components/__tests__/sqlCompletion.spec.js
+++ b/frontend/src/components/__tests__/sqlCompletion.spec.js
@@ -91,6 +91,30 @@ describe('sql completion source', () => {
     ]))
   })
 
+  it('suggests columns of FROM tables for bare (unqualified) field completion', async () => {
+    const ctx = completionContext()
+    const source = createSqlCompletionSource({
+      getCompletionContext: () => ctx,
+      getTableNames: () => []
+    })
+
+    const doc = 'SELECT order_ FROM dw.fact_orders'
+    const result = await source({
+      pos: 'SELECT order_'.length,
+      explicit: true,
+      state: { doc: { toString: () => doc, sliceString: (from, to) => doc.slice(from, to) } }
+    })
+
+    expect(ctx.loadColumns).toHaveBeenCalledWith({ schema: 'dw', table: 'fact_orders' })
+    expect(result.options).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: 'order_id',
+        type: 'property',
+        detail: 'BIGINT'
+      })
+    ]))
+  })
+
   it('tokenizes long inputs in linear time (no catastrophic backtracking)', async () => {
     const source = createSqlCompletionSource({
       getCompletionContext: () => null,

--- a/frontend/src/components/sqlCompletion.js
+++ b/frontend/src/components/sqlCompletion.js
@@ -307,6 +307,19 @@ export const createSqlCompletionSource = ({ getCompletionContext, getTableNames 
           )
         ))
       }
+
+      // Suggest columns from the tables referenced in the current FROM/JOIN
+      // clauses so bare (unqualified) field names are completed too, not only
+      // the `alias.column` / `schema.table.column` qualified forms.
+      const referencedTables = extractAliases(getDocText(context), currentSchema)
+      const seenTables = new Set()
+      for (const target of referencedTables.values()) {
+        const key = `${target.schema}::${target.table}`
+        if (seenTables.has(key)) continue
+        seenTables.add(key)
+        const columns = await getColumnsFromContext(ctx, target.schema, target.table)
+        options.push(...columns.map(columnOption))
+      }
     }
 
     options.push(...functionOptions(), ...keywordOptions())


### PR DESCRIPTION
## Summary
Enhanced SQL completion to suggest columns from tables referenced in FROM/JOIN clauses, enabling completion of unqualified (bare) field names in addition to the existing qualified forms like `alias.column` or `schema.table.column`.

## Changes
- **sqlCompletion.js**: Added logic to extract tables from FROM/JOIN clauses and load their columns for completion suggestions. The implementation:
  - Extracts referenced tables using the existing `extractAliases()` function
  - Deduplicates tables by schema and table name to avoid redundant column loading
  - Maps loaded columns to completion options and adds them to the suggestions list

- **sqlCompletion.spec.js**: Added test case verifying that bare field completion works correctly:
  - Tests completion for `SELECT order_` from `dw.fact_orders`
  - Verifies that `loadColumns` is called with the correct schema and table
  - Confirms that matching columns (e.g., `order_id`) are included in completion results

## Implementation Details
The feature reuses existing infrastructure (`extractAliases`, `getColumnsFromContext`, `columnOption`) to maintain consistency with qualified completion. A deduplication set prevents loading the same table's columns multiple times when it appears in multiple FROM/JOIN clauses.

https://claude.ai/code/session_01AGbuyta7KtW2PMpsu2CHCy