### PR TITLE
Add admin widget session audit view with read-only API

### DIFF
--- a/dataagent/dataagent-backend/api/admin_routes.py
+++ b/dataagent/dataagent-backend/api/admin_routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 
 from core.agent_profile_service import (
     agent_capabilities,
@@ -27,9 +27,12 @@ from core.skill_admin_service import (
     update_skill_runtime,
 )
 from core.skill_discovery import resolve_skills_root_dir
+from core.topic_task_store import get_topic_task_store
 from models.schemas import (
     AdminSettingsResponse,
     AdminSettingsUpdateRequest,
+    AdminWidgetTopicPage,
+    AdminWidgetTopicSummary,
     AgentCapabilitiesResponse,
     AgentDataScopeOption,
     AgentProfile,
@@ -47,6 +50,7 @@ from models.schemas import (
     SkillRuntimeConfig,
     SkillRuntimeUpdateRequest,
     SkillUninstallResponse,
+    TopicMessagePageResponse,
 )
 
 router = APIRouter()
@@ -108,6 +112,60 @@ async def create_model_detection(request: ModelDetectionRequest):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return ModelDetectionResponse.model_validate(result)
+
+
+@settings_router.get("/widget-topics", response_model=AdminWidgetTopicPage)
+async def admin_list_widget_topics(
+    website_id: str | None = Query(default=None),
+    external_user_id: str | None = Query(default=None),
+    visitor_id: str | None = Query(default=None),
+    agent_id: str | None = Query(default=None),
+    keyword: str | None = Query(default=None),
+    start: str | None = Query(default=None),
+    end: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=200),
+):
+    """Read-only admin listing of widget-sourced conversations across all
+    sites/users. Bypasses per-user isolation by design; portal session
+    listing is unaffected."""
+    payload = get_topic_task_store().admin_list_topics(
+        source="widget",
+        website_id=website_id,
+        external_user_id=external_user_id,
+        visitor_id=visitor_id,
+        agent_id=agent_id,
+        keyword=keyword,
+        start=start,
+        end=end,
+        page=page,
+        page_size=page_size,
+    )
+    return AdminWidgetTopicPage(
+        items=[AdminWidgetTopicSummary.model_validate(item) for item in payload.get("items") or []],
+        total=int(payload.get("total") or 0),
+        page=int(payload.get("page") or page),
+        page_size=int(payload.get("page_size") or page_size),
+    )
+
+
+@settings_router.get("/widget-topics/{topic_id}/messages", response_model=TopicMessagePageResponse)
+async def admin_list_widget_topic_messages(
+    topic_id: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=200, ge=1, le=500),
+    order: str = Query(default="asc", pattern="^(asc|desc)$"),
+):
+    """Read-only admin view of a conversation's messages. Resolved by
+    topic_id without owner check, since `context=None` reuses the existing
+    `1 = 1` predicate path in the store."""
+    store = get_topic_task_store()
+    if not store.get_topic(topic_id, context=None):
+        raise HTTPException(status_code=404, detail="Topic not found")
+    payload = store.list_topic_messages_page(
+        topic_id=topic_id, page=page, page_size=page_size, order=order, context=None
+    )
+    return TopicMessagePageResponse.model_validate(payload)
 
 
 @skills_router.get("/skills/documents", response_model=list[SkillDocumentSummary])

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -608,6 +608,110 @@ class TopicTaskStore:
                 item["messages"] = self.list_topic_messages(item["topic_id"])
         return result
 
+    def admin_list_topics(
+        self,
+        *,
+        source: str = "widget",
+        website_id: str | None = None,
+        external_user_id: str | None = None,
+        visitor_id: str | None = None,
+        agent_id: str | None = None,
+        keyword: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> dict[str, Any]:
+        """Admin-only paginated read across topics, bypassing the per-user
+        context isolation used by `list_topics`. Defaults to widget-sourced
+        topics. All filters are explicit and additive so the isolation
+        semantics in `_topic_context_predicate` are never reused or weakened.
+        """
+        self._ensure_ready()
+        filters: list[str] = []
+        params: list[Any] = []
+
+        safe_source = str(source or "").strip().lower()
+        if safe_source:
+            filters.append("t.source = %s")
+            params.append(safe_source)
+
+        for column, value in (
+            ("website_id", website_id),
+            ("external_user_id", external_user_id),
+            ("visitor_id", visitor_id),
+            ("agent_id", agent_id),
+        ):
+            safe_value = str(value or "").strip()
+            if safe_value:
+                filters.append(f"t.{column} = %s")
+                params.append(safe_value)
+
+        safe_keyword = str(keyword or "").strip()
+        if safe_keyword:
+            filters.append("t.title LIKE %s")
+            params.append(f"%{safe_keyword}%")
+
+        safe_start = str(start or "").strip()
+        if safe_start:
+            filters.append("t.created_at >= %s")
+            params.append(safe_start)
+        safe_end = str(end or "").strip()
+        if safe_end:
+            filters.append("t.created_at <= %s")
+            params.append(safe_end)
+
+        where_sql = " AND ".join(filters) if filters else "1 = 1"
+        safe_page = max(1, int(page or 1))
+        safe_page_size = max(1, min(200, int(page_size or 20)))
+        offset = (safe_page - 1) * safe_page_size
+
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT COUNT(*) AS total FROM da_agent_topic t WHERE {where_sql}",
+                    params,
+                )
+                total_row = cur.fetchone() or {}
+                cur.execute(
+                    f"""
+                    SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
+                           t.current_task_id, t.current_task_status, t.source, t.website_id,
+                           t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.created_at, t.updated_at,
+                           COALESCE(stats.message_count, 0) AS message_count,
+                           COALESCE(stats.last_message_preview, '') AS last_message_preview
+                    FROM da_agent_topic t
+                    LEFT JOIN (
+                        SELECT topic_id,
+                               COUNT(*) AS message_count,
+                               SUBSTRING_INDEX(
+                                   GROUP_CONCAT(COALESCE(NULLIF(content, ''), '') ORDER BY seq_id DESC SEPARATOR '\n'),
+                                   '\n',
+                                   1
+                               ) AS last_message_preview
+                        FROM da_agent_message
+                        WHERE show_in_ui = 1
+                        GROUP BY topic_id
+                    ) stats ON stats.topic_id = t.topic_id
+                    WHERE {where_sql}
+                    ORDER BY t.updated_at DESC, t.created_at DESC
+                    LIMIT %s OFFSET %s
+                    """,
+                    [*params, safe_page_size, offset],
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+
+        return {
+            "items": [self._normalize_topic_row(row, include_messages=False) for row in rows],
+            "total": int(total_row.get("total") or 0),
+            "page": safe_page,
+            "page_size": safe_page_size,
+        }
+
     def get_topic(self, topic_id: str, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
         self._ensure_ready()
         context_sql, context_params = self._topic_context_predicate(context, alias="t")

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -510,6 +510,24 @@ class TopicMessagePageResponse(BaseModel):
     items: List[TopicMessage] = Field(default_factory=list)
 
 
+class AdminWidgetTopicSummary(TopicSummary):
+    """Topic summary for the admin (read-only) widget-session view. Extends
+    TopicSummary with the isolation dimensions so operators can tell which
+    site / external user / visitor a conversation belongs to."""
+
+    source: str = "portal"
+    website_id: str = ""
+    external_user_id: str = ""
+    visitor_id: str = ""
+
+
+class AdminWidgetTopicPage(BaseModel):
+    items: List[AdminWidgetTopicSummary] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 20
+
+
 class UpdateMessageFeedbackRequest(BaseModel):
     feedback: str = ""
 

--- a/dataagent/dataagent-backend/tests/test_admin_routes.py
+++ b/dataagent/dataagent-backend/tests/test_admin_routes.py
@@ -415,3 +415,83 @@ def test_agent_profile_routes_contract(monkeypatch):
     deleted = client.delete("/api/v1/dataagent/agents/agent_1")
     assert deleted.status_code == 200
     assert deleted.json()["status"] == "ok"
+
+
+class _FakeWidgetStore:
+    """Records admin store calls so the route contract can be asserted without MySQL."""
+
+    def __init__(self):
+        self.list_calls = []
+        self.message_calls = []
+
+    def admin_list_topics(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return {
+            "items": [
+                {
+                    "topic_id": "topic_widget_1",
+                    "title": "嵌入站会话",
+                    "chat_topic_id": "chat_1",
+                    "chat_conversation_id": "conv_1",
+                    "agent_id": "agent_default",
+                    "current_task_id": None,
+                    "current_task_status": None,
+                    "message_count": 4,
+                    "last_message_preview": "最近一条",
+                    "source": "widget",
+                    "website_id": "site_a",
+                    "external_user_id": "",
+                    "visitor_id": "visitor_x",
+                    "created_at": "2026-06-01T10:00:00",
+                    "updated_at": "2026-06-01T12:00:00",
+                }
+            ],
+            "total": 1,
+            "page": kwargs.get("page", 1),
+            "page_size": kwargs.get("page_size", 20),
+        }
+
+    def get_topic(self, topic_id, context=None):
+        return {"topic_id": topic_id} if topic_id == "topic_widget_1" else None
+
+    def list_topic_messages_page(self, *, topic_id, page, page_size, order, context=None):
+        self.message_calls.append({"topic_id": topic_id, "context": context, "order": order})
+        return {
+            "topic_id": topic_id,
+            "page": page,
+            "page_size": page_size,
+            "order": order,
+            "total": 1,
+            "items": [],
+        }
+
+
+def test_admin_widget_topics_routes_contract(monkeypatch):
+    store = _FakeWidgetStore()
+    monkeypatch.setattr(admin_routes, "get_topic_task_store", lambda: store)
+
+    client = TestClient(app)
+
+    listing = client.get(
+        "/api/v1/nl2sql-admin/widget-topics",
+        params={"website_id": "site_a", "keyword": "嵌入", "page": 1, "page_size": 20},
+    )
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["total"] == 1
+    assert body["items"][0]["source"] == "widget"
+    assert body["items"][0]["website_id"] == "site_a"
+    assert body["items"][0]["visitor_id"] == "visitor_x"
+    # Admin listing must always scope to widget source and forward filters.
+    assert store.list_calls[0]["source"] == "widget"
+    assert store.list_calls[0]["website_id"] == "site_a"
+    assert store.list_calls[0]["keyword"] == "嵌入"
+
+    messages = client.get("/api/v1/nl2sql-admin/widget-topics/topic_widget_1/messages")
+    assert messages.status_code == 200
+    assert messages.json()["topic_id"] == "topic_widget_1"
+    # Admin message read bypasses owner isolation via context=None.
+    assert store.message_calls[0]["context"] is None
+
+    missing = client.get("/api/v1/nl2sql-admin/widget-topics/unknown/messages")
+    assert missing.status_code == 404

--- a/dataagent/dataagent-backend/tests/test_topic_task_store.py
+++ b/dataagent/dataagent-backend/tests/test_topic_task_store.py
@@ -416,3 +416,77 @@ def test_widget_event_types_allowlist_contains_expected_values():
     assert "history_close" in WIDGET_EVENT_TYPES
     assert "conversation_new" in WIDGET_EVENT_TYPES
     assert "message_send" in WIDGET_EVENT_TYPES
+
+
+def test_admin_list_topics_scopes_to_widget_and_forwards_filters(monkeypatch):
+    class FakeCursor:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            self.conn.executed.append((sql, list(params)))
+
+        def fetchone(self):
+            return {"total": 1}
+
+        def fetchall(self):
+            return [
+                {
+                    "topic_id": "topic_widget_1",
+                    "title": "嵌入站会话",
+                    "chat_topic_id": "chat_1",
+                    "chat_conversation_id": "conv_1",
+                    "current_task_id": None,
+                    "current_task_status": None,
+                    "source": "widget",
+                    "website_id": "site_a",
+                    "external_user_id": "",
+                    "visitor_id": "visitor_x",
+                    "agent_id": "agent_default",
+                    "agent_snapshot_json": None,
+                    "created_at": None,
+                    "updated_at": None,
+                    "message_count": 3,
+                    "last_message_preview": "最近一条",
+                }
+            ]
+
+    class FakeConnection:
+        def __init__(self):
+            self.executed = []
+
+        def cursor(self):
+            return FakeCursor(self)
+
+        def close(self):
+            return None
+
+    store = TopicTaskStore()
+    conn = FakeConnection()
+    monkeypatch.setattr(store, "_ensure_ready", lambda: None)
+    monkeypatch.setattr(store, "_connect", lambda database: conn)
+
+    result = store.admin_list_topics(website_id="site_a", visitor_id="visitor_x", page=2, page_size=10)
+
+    assert result["total"] == 1
+    assert result["page"] == 2
+    assert result["items"][0]["source"] == "widget"
+    assert result["items"][0]["website_id"] == "site_a"
+
+    count_sql, count_params = conn.executed[0]
+    assert "COUNT(*)" in count_sql
+    assert "t.source = %s" in count_sql
+    assert count_params == ["widget", "site_a", "visitor_x"]
+
+    list_sql, list_params = conn.executed[1]
+    assert "LIMIT %s OFFSET %s" in list_sql
+    # widget source + filters first, then pagination (page 2, size 10 -> offset 10)
+    assert list_params == ["widget", "site_a", "visitor_x", 10, 10]
+    # Per-user isolation predicate must never be reused by the admin path.
+    assert "COALESCE(t.source" not in list_sql

--- a/docs/design/2026-06-02-widget-session-admin-view-design.md
+++ b/docs/design/2026-06-02-widget-session-admin-view-design.md
@@ -1,0 +1,41 @@
+# 后台查看 Widget 会话 — 设计
+
+- 日期：2026-06-02
+- 范围：`dataagent/dataagent-backend`、`frontend`
+- 类型：中型（新增公开 API 契约 + 新前端页面，跨 dataagent/frontend 层）
+
+## 现状
+
+智能问数的会话存储在 `da_agent_topic`，通过 `source`(`portal`/`widget`) + `website_id` + `external_user_id`/`visitor_id` 做多租户隔离：
+
+- 所有会话接口（`GET/POST/PUT/DELETE /api/v1/nl2sql/topics*`）都经过 `api/routes.py:_request_context()` → `core/topic_task_store.py:_topic_context_predicate()`。
+- 门户/后台请求不带 widget 请求头时，context 被判定为 `source='portal'`，SQL 过滤固定为 `COALESCE(source,'portal')='portal'`。
+- `api/admin_routes.py` 没有任何会话相关端点。
+
+## 问题
+
+管理后台**完全看不到任何 widget 来源的会话**。这不是数据丢失，而是缺少跨隔离的只读管理能力：portal 视图被 `source='portal'` 过滤掉了所有 `source='widget'` 行，且没有任何 admin 端点能跨站点/用户聚合查看。
+
+## 范围
+
+- 目标：后台新增**独立、只读**的「Widget 会话」审计页面与对应管理端 API，可按站点/外部用户/访客/agent/关键词/时间筛选并查看会话与消息。
+- 不在本期范围：删除/清理会话、跨 portal 会话的统一管理、导出。
+- 约束：不得改动或复用 per-user 隔离逻辑（`_topic_context_predicate`），不得让普通用户的 portal 会话列表看到 widget 会话。
+
+## 方案
+
+1. store 层新增只读 `admin_list_topics(...)`：默认 `source='widget'`，支持显式、可叠加的过滤与分页，**独立拼装 WHERE**，复用既有 SELECT 与消息统计子查询；不复用隔离谓词。消息查看复用既有 `get_topic(context=None)` 与 `list_topic_messages_page(context=None)`（`_topic_context_predicate(None)` 已返回 `"1 = 1"`）。
+2. schema 新增 `AdminWidgetTopicSummary`（在 `TopicSummary` 上暴露 `source`/`website_id`/`external_user_id`/`visitor_id`）与分页包装 `AdminWidgetTopicPage`；消息复用 `TopicMessagePageResponse`。
+3. 路由在 `settings_router`（prefix `/api/v1/nl2sql-admin`）新增两个只读端点：`GET /widget-topics`、`GET /widget-topics/{topic_id}/messages`。
+4. 前端新增独立页 `views/settings/WidgetConversations.vue`，并在 `IntelligentQueryView.vue` 注册 `widget-sessions` Tab；API 客户端在 `api/dataagent.js` 新增 `listWidgetTopics` / `getWidgetTopicMessages`。
+
+## 接口
+
+- `GET /api/v1/nl2sql-admin/widget-topics?website_id&external_user_id&visitor_id&agent_id&keyword&start&end&page&page_size` → `AdminWidgetTopicPage`
+- `GET /api/v1/nl2sql-admin/widget-topics/{topic_id}/messages?page&page_size&order` → `TopicMessagePageResponse`
+
+## 取舍与风险
+
+- admin 端点跨用户只读、不做 owner 校验，与现有 admin 端点一致，依赖网关/主后端的鉴权；本设计显式记录该假设。
+- `admin_list_topics` 的 SELECT 与 `list_topics`/`get_topic` 存在与现状一致的 SQL 复制（既有代码已在两处重复），为降低风险沿用该模式，不做共享重构。
+- 纯新增，不改动 portal 隔离逻辑，回退成本低。

--- a/docs/plans/2026-06-02-widget-session-admin-view-plan.md
+++ b/docs/plans/2026-06-02-widget-session-admin-view-plan.md
@@ -1,0 +1,32 @@
+# 后台查看 Widget 会话 — 执行计划
+
+- 日期：2026-06-02
+- 关联设计：`docs/design/2026-06-02-widget-session-admin-view-design.md`
+- 受影响栈：`dataagent/dataagent-backend`、`frontend`
+
+## 任务与触达文件
+
+1. store 层 — `dataagent/dataagent-backend/core/topic_task_store.py`
+   - 新增 `admin_list_topics(...)`：`source='widget'` 默认 + `website_id`/`external_user_id`/`visitor_id`/`agent_id`/`keyword`/`start`/`end` 过滤 + `page`/`page_size` 分页，返回 `{items,total,page,page_size}`。
+   - 消息查看复用既有 `get_topic(context=None)` 与 `list_topic_messages_page(context=None)`，不新增方法。
+2. schema — `dataagent/dataagent-backend/models/schemas.py`
+   - 新增 `AdminWidgetTopicSummary`（继承 `TopicSummary` 增加隔离维度字段）与 `AdminWidgetTopicPage`。
+3. 路由 — `dataagent/dataagent-backend/api/admin_routes.py`
+   - 在 `settings_router` 新增 `GET /widget-topics` 与 `GET /widget-topics/{topic_id}/messages`，经 `get_topic_task_store()` 调 store。
+4. 前端 API — `frontend/src/api/dataagent.js`
+   - 新增 `listWidgetTopics(params)`、`getWidgetTopicMessages(topicId, params)`。
+5. 前端页面 — `frontend/src/views/settings/WidgetConversations.vue`（新增，只读筛选表格 + 消息抽屉）。
+6. 前端 Tab — `frontend/src/views/intelligence/IntelligentQueryView.vue`
+   - `validTabs` 加 `widget-sessions`，新增菜单项与 `<WidgetConversations>` 分支及 import。
+
+## 验证
+
+- 后端：`pytest tests/test_topic_task_store.py tests/test_admin_routes.py`
+  - 新增 store 单测断言 admin 查询固定 `source='widget'`、过滤/分页参数顺序正确、不复用隔离谓词。
+  - 新增 route 契约测试断言端点、参数透传、404、消息读取 `context=None`。
+- 前端：`nvm use` 后 `npx vitest run .../IntelligentQueryView.spec.js` + `npx vite build`。
+- 本地端到端 smoke（环境可用时）：用 widget 请求头创建会话 → admin 端点可见 → portal `GET /topics` 仍不可见（隔离未破坏）。
+
+## 回退
+
+- 纯新增（store 方法 / schema / 端点 / 前端页面与 Tab）。回退即移除新增项与 Tab 注册，无数据迁移。

--- a/frontend/src/api/dataagent.js
+++ b/frontend/src/api/dataagent.js
@@ -100,5 +100,13 @@ export const dataagentApi = {
 
   listDataScopeOptions() {
     return dataagentRequest.get('/v1/dataagent/data-scope/options')
+  },
+
+  listWidgetTopics(params = {}) {
+    return dataagentRequest.get('/v1/nl2sql-admin/widget-topics', { params })
+  },
+
+  getWidgetTopicMessages(topicId, params = {}) {
+    return dataagentRequest.get(`/v1/nl2sql-admin/widget-topics/${encodeURIComponent(topicId)}/messages`, { params })
   }
 }

--- a/frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -30,6 +30,10 @@
           <el-icon><Monitor /></el-icon>
           <span>Widget 接入</span>
         </el-menu-item>
+        <el-menu-item index="widget-sessions">
+          <el-icon><ChatLineSquare /></el-icon>
+          <span>Widget 会话</span>
+        </el-menu-item>
       </el-menu>
     </aside>
 
@@ -40,6 +44,7 @@
       <SkillStudio v-else-if="activeTab === 'skills'" />
       <DataAgentConfig v-else-if="activeTab === 'models'" />
       <WidgetAccessConfig v-else-if="activeTab === 'widget'" />
+      <WidgetConversations v-else-if="activeTab === 'widget-sessions'" />
       <NL2SqlChatV2 v-else-if="activeTab === 'chat-v2'" />
       <NL2SqlChat v-else />
     </main>
@@ -49,7 +54,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChatDotRound, Collection, Cpu, MagicStick, Monitor, User } from '@element-plus/icons-vue'
+import { ChatDotRound, ChatLineSquare, Collection, Cpu, MagicStick, Monitor, User } from '@element-plus/icons-vue'
 import NL2SqlChat from './NL2SqlChat.vue'
 import NL2SqlChatV2 from './NL2SqlChatV2.vue'
 import AgentStudio from './AgentStudio.vue'
@@ -57,11 +62,12 @@ import AgentDetailView from './AgentDetailView.vue'
 import SkillStudio from '../settings/SkillStudio.vue'
 import DataAgentConfig from '../settings/DataAgentConfig.vue'
 import WidgetAccessConfig from '../settings/WidgetAccessConfig.vue'
+import WidgetConversations from '../settings/WidgetConversations.vue'
 import SkillDetailView from '../settings/SkillDetailView.vue'
 
 const route = useRoute()
 const router = useRouter()
-const validTabs = new Set(['chat', 'chat-v2', 'skills', 'agents', 'models', 'widget'])
+const validTabs = new Set(['chat', 'chat-v2', 'skills', 'agents', 'models', 'widget', 'widget-sessions'])
 
 const isSkillDetailRoute = computed(() => (
   route.name === 'IntelligentQuerySkillDetail' || route.path.startsWith('/intelligent-query/skills/')

--- a/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
+++ b/frontend/src/views/intelligence/__tests__/IntelligentQueryView.spec.js
@@ -26,6 +26,7 @@ const stubs = {
   SkillStudio: { template: '<div data-test="skill-studio">Skills 内容</div>' },
   DataAgentConfig: { template: '<div data-test="dataagent-config">模型管理内容</div>' },
   WidgetAccessConfig: { template: '<div data-test="widget-access">Widget 接入内容</div>' },
+  WidgetConversations: { template: '<div data-test="widget-sessions">Widget 会话内容</div>' },
   SkillDetailView: { template: '<div data-test="skill-detail">Skill 详情</div>' },
   'el-menu': {
     props: ['defaultActive'],
@@ -94,6 +95,14 @@ describe('IntelligentQueryView', () => {
     expect(wrapper.find('[data-test="widget-access"]').exists()).toBe(true)
     expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(false)
     expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('widget')
+  })
+
+  it('renders widget conversations from the tab query', () => {
+    const wrapper = mountView({ query: { tab: 'widget-sessions' } })
+
+    expect(wrapper.find('[data-test="widget-sessions"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="nl2sql-chat"]').exists()).toBe(false)
+    expect(wrapper.find('.el-menu-stub').attributes('data-active')).toBe('widget-sessions')
   })
 
   it('renders agent studio from the tab query', () => {

--- a/frontend/src/views/settings/WidgetConversations.vue
+++ b/frontend/src/views/settings/WidgetConversations.vue
@@ -1,0 +1,343 @@
+<template>
+  <div v-loading="loading" class="widget-conversations">
+    <header class="page-header">
+      <div class="page-header-main">
+        <div class="page-kicker">智能问数 · Widget 会话</div>
+        <h2 class="page-title">Widget 会话审计</h2>
+        <p class="page-desc">
+          查看通过嵌入式 Widget 产生的会话（只读）。门户与 Widget、以及各站点/访客之间的会话隔离不受影响，此页面仅供后台审计使用。
+        </p>
+      </div>
+      <div class="page-header-actions">
+        <el-button :icon="Refresh" :loading="loading" @click="reload">刷新</el-button>
+      </div>
+    </header>
+
+    <section class="filter-bar">
+      <el-form :inline="true" @submit.prevent>
+        <el-form-item label="站点">
+          <el-select
+            v-model="filters.website_id"
+            clearable
+            filterable
+            allow-create
+            default-first-option
+            placeholder="全部站点"
+            class="filter-site"
+          >
+            <el-option
+              v-for="site in siteOptions"
+              :key="site.website_id"
+              :label="site.label"
+              :value="site.website_id"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="外部用户">
+          <el-input v-model="filters.external_user_id" clearable placeholder="external_user_id" />
+        </el-form-item>
+        <el-form-item label="访客">
+          <el-input v-model="filters.visitor_id" clearable placeholder="visitor_id" />
+        </el-form-item>
+        <el-form-item label="关键词">
+          <el-input v-model="filters.keyword" clearable placeholder="按标题搜索" @keyup.enter="applyFilters" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" :icon="Search" @click="applyFilters">查询</el-button>
+          <el-button :icon="RefreshLeft" @click="resetFilters">重置</el-button>
+        </el-form-item>
+      </el-form>
+    </section>
+
+    <el-table :data="topics" border stripe class="topic-table" empty-text="暂无 Widget 会话">
+      <el-table-column prop="title" label="标题" min-width="180" show-overflow-tooltip />
+      <el-table-column label="来源" width="90">
+        <template #default="{ row }">
+          <el-tag size="small" type="warning">{{ row.source || 'widget' }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="website_id" label="站点" min-width="120" show-overflow-tooltip />
+      <el-table-column label="用户 / 访客" min-width="160" show-overflow-tooltip>
+        <template #default="{ row }">
+          <span v-if="row.external_user_id">用户：{{ row.external_user_id }}</span>
+          <span v-else-if="row.visitor_id">访客：{{ row.visitor_id }}</span>
+          <span v-else class="muted">—</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="message_count" label="消息数" width="90" align="center" />
+      <el-table-column prop="last_message_preview" label="最近消息" min-width="200" show-overflow-tooltip />
+      <el-table-column prop="updated_at" label="更新时间" width="180" />
+      <el-table-column label="操作" width="110" fixed="right">
+        <template #default="{ row }">
+          <el-button type="primary" link :icon="ChatLineSquare" @click="openMessages(row)">查看消息</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div class="pager">
+      <el-pagination
+        v-model:current-page="page"
+        v-model:page-size="pageSize"
+        :total="total"
+        :page-sizes="[10, 20, 50, 100]"
+        layout="total, sizes, prev, pager, next"
+        @current-change="loadTopics"
+        @size-change="onPageSizeChange"
+      />
+    </div>
+
+    <el-drawer
+      v-model="drawerVisible"
+      :title="drawerTitle"
+      size="46%"
+      direction="rtl"
+    >
+      <div v-loading="messagesLoading" class="message-pane">
+        <div v-if="!messages.length && !messagesLoading" class="empty-block">
+          <div class="empty-title">暂无消息</div>
+        </div>
+        <div v-for="msg in messages" :key="msg.message_id" class="message-item" :class="msg.sender_type">
+          <div class="message-meta">
+            <el-tag size="small" :type="msg.sender_type === 'user' ? 'info' : 'success'">
+              {{ msg.sender_type === 'user' ? '用户' : '助手' }}
+            </el-tag>
+            <span class="message-time">{{ msg.created_at }}</span>
+          </div>
+          <div class="message-content">{{ msg.content || '（无文本内容）' }}</div>
+        </div>
+      </div>
+    </el-drawer>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { ChatLineSquare, Refresh, RefreshLeft, Search } from '@element-plus/icons-vue'
+import { dataagentApi } from '@/api/dataagent'
+
+const loading = ref(false)
+const topics = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = ref(20)
+
+const siteOptions = ref([])
+
+const filters = reactive({
+  website_id: '',
+  external_user_id: '',
+  visitor_id: '',
+  keyword: ''
+})
+
+const drawerVisible = ref(false)
+const drawerTitle = ref('')
+const messages = ref([])
+const messagesLoading = ref(false)
+
+const buildParams = () => {
+  const params = { page: page.value, page_size: pageSize.value }
+  for (const key of ['website_id', 'external_user_id', 'visitor_id', 'keyword']) {
+    const value = String(filters[key] || '').trim()
+    if (value) params[key] = value
+  }
+  return params
+}
+
+const loadTopics = async () => {
+  loading.value = true
+  try {
+    const payload = await dataagentApi.listWidgetTopics(buildParams())
+    topics.value = Array.isArray(payload?.items) ? payload.items : []
+    total.value = Number(payload?.total || 0)
+  } catch (error) {
+    if (!error?.__odwNotified) {
+      ElMessage.error(error?.message || '加载 Widget 会话失败')
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+const loadSiteOptions = async () => {
+  try {
+    const payload = await dataagentApi.getSettings()
+    const list = Array.isArray(payload?.widget_allowed_sites) ? payload.widget_allowed_sites : []
+    siteOptions.value = list
+      .map((site) => ({
+        website_id: String(site?.website_id || '').trim(),
+        label: String(site?.project_name || '').trim()
+          ? `${String(site.project_name).trim()}（${String(site.website_id).trim()}）`
+          : String(site?.website_id || '').trim()
+      }))
+      .filter((item) => item.website_id)
+  } catch {
+    siteOptions.value = []
+  }
+}
+
+const applyFilters = () => {
+  page.value = 1
+  loadTopics()
+}
+
+const resetFilters = () => {
+  filters.website_id = ''
+  filters.external_user_id = ''
+  filters.visitor_id = ''
+  filters.keyword = ''
+  applyFilters()
+}
+
+const onPageSizeChange = () => {
+  page.value = 1
+  loadTopics()
+}
+
+const reload = () => {
+  loadSiteOptions()
+  loadTopics()
+}
+
+const openMessages = async (row) => {
+  drawerVisible.value = true
+  drawerTitle.value = row.title || 'Widget 会话'
+  messages.value = []
+  messagesLoading.value = true
+  try {
+    const payload = await dataagentApi.getWidgetTopicMessages(row.topic_id, { page: 1, page_size: 200, order: 'asc' })
+    messages.value = Array.isArray(payload?.items) ? payload.items : []
+  } catch (error) {
+    if (!error?.__odwNotified) {
+      ElMessage.error(error?.message || '加载会话消息失败')
+    }
+  } finally {
+    messagesLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadSiteOptions()
+  loadTopics()
+})
+</script>
+
+<style scoped>
+.widget-conversations {
+  color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 18px 20px;
+  border: 1px solid #cddceb;
+  border-left: 4px solid #1f5f99;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f4f8fc 0%, #ffffff 72%);
+}
+
+.page-header-main {
+  min-width: 0;
+}
+
+.page-kicker {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #2c659b;
+}
+
+.page-title {
+  margin: 7px 0 6px;
+  font-size: 22px;
+  font-weight: 700;
+  color: #16324f;
+}
+
+.page-desc {
+  margin: 0;
+  max-width: 720px;
+  color: #5b6b7c;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.filter-bar {
+  padding: 14px 16px 2px;
+  border: 1px solid #e5eaf0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.filter-site {
+  width: 220px;
+}
+
+.topic-table {
+  width: 100%;
+}
+
+.muted {
+  color: #9aa7b4;
+}
+
+.pager {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.message-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 120px;
+}
+
+.message-item {
+  border: 1px solid #e5eaf0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #fafcff;
+}
+
+.message-item.user {
+  background: #f5f7fa;
+}
+
+.message-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.message-time {
+  font-size: 12px;
+  color: #9aa7b4;
+}
+
+.message-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #1f2937;
+}
+
+.empty-block {
+  padding: 24px;
+  text-align: center;
+  color: #9aa7b4;
+}
+
+.empty-title {
+  font-size: 14px;
+}
+</style>


### PR DESCRIPTION
## Summary

Adds a new read-only admin interface for auditing widget-sourced conversations across all sites and users, bypassing per-user isolation by design. Includes backend store method, admin API endpoints, schema definitions, and a new frontend audit page.

## Key Changes

**Backend (dataagent-backend)**
- `core/topic_task_store.py`: New `admin_list_topics()` method that defaults to `source='widget'` and supports filtering by website_id, external_user_id, visitor_id, agent_id, keyword, and date range with pagination. Explicitly constructs WHERE clauses without reusing per-user isolation predicates.
- `models/schemas.py`: New `AdminWidgetTopicSummary` (extends `TopicSummary` with isolation dimensions) and `AdminWidgetTopicPage` response models.
- `api/admin_routes.py`: Two new read-only endpoints in `settings_router`:
  - `GET /api/v1/nl2sql-admin/widget-topics` — paginated widget topic listing with filters
  - `GET /api/v1/nl2sql-admin/widget-topics/{topic_id}/messages` — message view for a topic (bypasses owner check via `context=None`)
- `tests/test_topic_task_store.py` & `tests/test_admin_routes.py`: New unit and contract tests verifying admin queries scope to widget source, forward filters correctly, and don't reuse isolation logic.

**Frontend**
- `views/settings/WidgetConversations.vue`: New read-only audit page with filterable table (site, external user, visitor, keyword), message drawer, and pagination.
- `views/intelligence/IntelligentQueryView.vue`: Added "Widget 会话" menu item and conditional rendering of new component.
- `api/dataagent.js`: New `listWidgetTopics()` and `getWidgetTopicMessages()` API methods.
- `views/intelligence/__tests__/IntelligentQueryView.spec.js`: Updated test stubs for new component.

**Documentation**
- `docs/design/2026-06-02-widget-session-admin-view-design.md`: Design rationale, scope, and architectural decisions.
- `docs/plans/2026-06-02-widget-session-admin-view-plan.md`: Implementation plan and verification steps.

## Implementation Details

- Admin endpoints are read-only and cross-user; they rely on gateway/upstream authentication (consistent with existing admin routes).
- `admin_list_topics()` constructs its own WHERE clause to avoid accidentally reusing or weakening the per-user isolation in `_topic_context_predicate()`.
- Message retrieval reuses existing `get_topic(context=None)` and `list_topic_messages_page(context=None)` which already return `"1 = 1"` when context is None.
- Portal session isolation is unaffected; widget conversations remain invisible to regular user portal queries.
- Pure addition with no breaking changes; rollback is straightforward (remove new methods, schemas, endpoints, and frontend tab registration).

https://claude.ai/code/session_017VsXCSWzuT8KhU1wYNk8VL