### PR TITLE
Add column resizing and width distribution to result grid

### DIFF
--- a/frontend/src/views/datastudio/__tests__/resultGridModel.spec.js
+++ b/frontend/src/views/datastudio/__tests__/resultGridModel.spec.js
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   RESULT_GRID_ROW_KEY,
   buildResultGridColumns,
-  buildResultGridRows
+  buildResultGridRows,
+  distributeColumnWidths
 } from '../components/resultGridModel'
 import { buildCsvContent } from '../csvExport'
 
@@ -27,6 +28,36 @@ describe('resultGridModel', () => {
     })
     expect(columns[1].width).toBeGreaterThan(120)
     expect(columns[2].width).toBe(360)
+  })
+
+  it('marks every column resizable so widths can be dragged', () => {
+    const columns = buildResultGridColumns(['id', 'name'])
+
+    expect(columns.every((column) => column.resizable === true)).toBe(true)
+    expect(columns.every((column) => column.minWidth === 120)).toBe(true)
+  })
+
+  it('widens columns to fit cell content, not just the header', () => {
+    const rows = [{ id: 1, note: 'short' }, { id: 2, note: 'x'.repeat(40) }]
+    const [, noteColumn] = buildResultGridColumns(['id', 'note'], rows)
+
+    expect(noteColumn.width).toBeGreaterThan(120)
+  })
+
+  it('stretches columns to fill the available width when space is left over', () => {
+    const columns = buildResultGridColumns(['a', 'b'])
+    const stretched = distributeColumnWidths(columns, 1000)
+
+    const total = stretched.reduce((sum, column) => sum + column.width, 0)
+    expect(total).toBe(1000)
+    expect(stretched[0].width).toBeGreaterThan(120)
+  })
+
+  it('keeps column widths untouched when they already exceed the available width', () => {
+    const columns = buildResultGridColumns(['a', 'b'])
+    const result = distributeColumnWidths(columns, 100)
+
+    expect(result).toBe(columns)
   })
 
   it('adds stable row keys even when rows contain duplicate values and nulls', () => {

--- a/frontend/src/views/datastudio/components/DataStudioResultGrid.vue
+++ b/frontend/src/views/datastudio/components/DataStudioResultGrid.vue
@@ -7,7 +7,7 @@
       <template #default="{ height, width }">
         <el-table-v2
           v-if="safeHeight(height) > 0 && safeWidth(width) > 0"
-          :columns="gridColumns"
+          :columns="resolveColumns(safeWidth(width))"
           :data="gridRows"
           :width="safeWidth(width)"
           :height="safeHeight(height)"
@@ -23,10 +23,12 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, h, ref, watch } from 'vue'
 import {
+  MIN_COLUMN_WIDTH,
   RESULT_GRID_ROW_KEY,
   buildResultGridColumns,
+  distributeColumnWidths,
   ensureResultGridRows
 } from './resultGridModel'
 
@@ -52,8 +54,63 @@ const props = defineProps({
   }
 })
 
-const gridColumns = computed(() => buildResultGridColumns(props.columns))
 const gridRows = computed(() => ensureResultGridRows(props.rows, props.rowKeyPrefix))
+const gridColumns = computed(() => buildResultGridColumns(props.columns, gridRows.value))
+
+// Widths the user set by dragging a column border. Reset whenever the result
+// set changes so a new query starts from content-based auto sizing again.
+const widthOverrides = ref({})
+watch(gridColumns, () => {
+  widthOverrides.value = {}
+})
+
+// el-table-v2 has no built-in column resizing, so render a drag handle in the
+// header cell and update the column width live while the pointer moves.
+const startColumnResize = (event, column) => {
+  event.preventDefault()
+  event.stopPropagation()
+  const startX = event.clientX
+  const startWidth = Number(column.width) || MIN_COLUMN_WIDTH
+  const onMove = (moveEvent) => {
+    const nextWidth = Math.max(MIN_COLUMN_WIDTH, Math.round(startWidth + (moveEvent.clientX - startX)))
+    widthOverrides.value = { ...widthOverrides.value, [column.key]: nextWidth }
+  }
+  const onUp = () => {
+    document.removeEventListener('mousemove', onMove)
+    document.removeEventListener('mouseup', onUp)
+    document.body.classList.remove('result-grid--resizing')
+  }
+  document.addEventListener('mousemove', onMove)
+  document.addEventListener('mouseup', onUp)
+  document.body.classList.add('result-grid--resizing')
+}
+
+const renderHeaderCell = ({ column }) =>
+  h('div', { class: 'result-grid__header' }, [
+    h('span', { class: 'result-grid__header-title', title: column.title }, column.title),
+    h('span', {
+      class: 'result-grid__resizer',
+      onMousedown: (event) => startColumnResize(event, column)
+    })
+  ])
+
+const renderCell = ({ cellData }) => {
+  const text = cellData == null ? '' : String(cellData)
+  return h('span', { class: 'result-grid__cell-text', title: text }, text)
+}
+
+const resolveColumns = (availableWidth) => {
+  const columns = gridColumns.value.map((column) => ({
+    ...column,
+    width: widthOverrides.value[column.key] ?? column.width,
+    headerCellRenderer: renderHeaderCell,
+    cellRenderer: renderCell
+  }))
+  // Respect manual sizing once the user has dragged a border; otherwise stretch
+  // columns to fill the grid so a couple of short columns are not left narrow.
+  if (Object.keys(widthOverrides.value).length) return columns
+  return distributeColumnWidths(columns, availableWidth)
+}
 
 const safeWidth = (value) => Math.max(0, Math.floor(Number(value) || 0))
 const safeHeight = (value) => Math.max(0, Math.floor(Number(value) || 0))
@@ -86,14 +143,60 @@ defineExpose({
 }
 
 .result-grid :deep(.el-table-v2__header-cell) {
+  padding: 0;
   color: #1f2f3d;
+}
+
+.result-grid :deep(.result-grid__header) {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 0 8px;
+  box-sizing: border-box;
   font-weight: 600;
 }
 
-.result-grid :deep(.el-table-v2__cell) {
-  color: #334155;
-  white-space: nowrap;
+.result-grid :deep(.result-grid__header-title) {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.result-grid :deep(.result-grid__resizer) {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+}
+
+.result-grid :deep(.result-grid__resizer:hover),
+.result-grid :deep(.result-grid__resizer:active) {
+  background: var(--el-color-primary, #409eff);
+  opacity: 0.5;
+}
+
+.result-grid :deep(.result-grid__cell-text) {
+  display: block;
+  width: 100%;
+  color: #334155;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+</style>
+
+<style>
+/* Applied to document.body while a column border is being dragged. */
+body.result-grid--resizing,
+body.result-grid--resizing * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 </style>

--- a/frontend/src/views/datastudio/components/resultGridModel.js
+++ b/frontend/src/views/datastudio/components/resultGridModel.js
@@ -1,18 +1,30 @@
 export const RESULT_GRID_ROW_KEY = '__odwResultGridRowKey'
 
-const MIN_COLUMN_WIDTH = 120
+export const MIN_COLUMN_WIDTH = 120
 const MAX_COLUMN_WIDTH = 360
 const HEADER_PADDING_WIDTH = 48
+const CELL_PADDING_WIDTH = 24
 const AVERAGE_CHARACTER_WIDTH = 9
+const WIDTH_SAMPLE_ROW_LIMIT = 50
 
-const clampColumnWidth = (width) => Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, width))
+const clampColumnWidth = (width) => Math.max(MIN_COLUMN_WIDTH, Math.min(MAX_COLUMN_WIDTH, Math.round(width)))
 
-const estimateColumnWidth = (column) => {
-  const textLength = String(column ?? '').length
-  return clampColumnWidth(textLength * AVERAGE_CHARACTER_WIDTH + HEADER_PADDING_WIDTH)
+const measureTextWidth = (value) => String(value ?? '').length * AVERAGE_CHARACTER_WIDTH
+
+const estimateColumnWidth = (key, rows) => {
+  let widest = measureTextWidth(key) + HEADER_PADDING_WIDTH
+  if (Array.isArray(rows)) {
+    const sample = rows.slice(0, WIDTH_SAMPLE_ROW_LIMIT)
+    for (const row of sample) {
+      if (!row || typeof row !== 'object') continue
+      const cellWidth = measureTextWidth(row[key]) + CELL_PADDING_WIDTH
+      if (cellWidth > widest) widest = cellWidth
+    }
+  }
+  return clampColumnWidth(widest)
 }
 
-export const buildResultGridColumns = (columns = []) => {
+export const buildResultGridColumns = (columns = [], rows = []) => {
   if (!Array.isArray(columns)) return []
   return columns.map((column) => {
     const key = String(column ?? '')
@@ -20,8 +32,29 @@ export const buildResultGridColumns = (columns = []) => {
       key,
       dataKey: key,
       title: key,
-      width: estimateColumnWidth(key)
+      width: estimateColumnWidth(key, rows),
+      minWidth: MIN_COLUMN_WIDTH,
+      resizable: true
     }
+  })
+}
+
+// Stretch columns to fill the available width when the natural content widths
+// leave empty space (e.g. only two short columns in a wide grid). Extra space
+// is distributed proportionally so the table never leaves an awkward gap.
+export const distributeColumnWidths = (columns = [], availableWidth = 0) => {
+  if (!Array.isArray(columns) || !columns.length) return Array.isArray(columns) ? columns : []
+  const total = columns.reduce((sum, column) => sum + (Number(column.width) || 0), 0)
+  if (!(availableWidth > 0) || total <= 0 || total >= availableWidth) return columns
+  const extra = availableWidth - total
+  let allocated = 0
+  return columns.map((column, index) => {
+    const base = Number(column.width) || 0
+    const add = index === columns.length - 1
+      ? extra - allocated
+      : Math.floor((base / total) * extra)
+    allocated += add
+    return { ...column, width: base + add }
   })
 }
 


### PR DESCRIPTION
## Summary
Implement interactive column resizing in the data studio result grid with intelligent width distribution to fill available space.

## Key Changes
- **Column Resizing**: Added drag-to-resize functionality for column borders in the result grid header, with visual feedback and smooth live updates
- **Width Distribution**: Implemented automatic column width stretching to fill available grid width when content widths leave empty space, while respecting manual user adjustments
- **Content-Based Sizing**: Enhanced column width estimation to measure actual cell content (not just headers) up to 50 sample rows, ensuring columns are appropriately sized from the start
- **Custom Renderers**: Added header and cell renderers to support the resize handle UI and proper text truncation with tooltips
- **State Management**: Track user-set column width overrides separately, resetting them when the result set changes to allow fresh auto-sizing for new queries

## Implementation Details
- Resize handle appears as a 6px draggable area on the right edge of each column header with visual hover/active states
- While resizing, a `result-grid--resizing` class is applied to `document.body` to ensure consistent cursor feedback across the entire document
- Column widths are distributed proportionally based on their natural content width to maintain visual balance
- Minimum column width is enforced at 120px; maximum at 360px to prevent extreme sizing
- Width estimation accounts for padding (48px for headers, 24px for cells) and uses 9px as average character width

https://claude.ai/code/session_014VkgYb3Xhc8NSbP9DSjaqf