### PR TITLE
docs: Add OAuth login & unified auth design and implementation plan

### DIFF
--- a/docs/design/2026-05-30-configurable-oauth-login-design.md
+++ b/docs/design/2026-05-30-configurable-oauth-login-design.md
@@ -1,0 +1,316 @@
+# 可配置 OAuth 登录与统一身份认证设计
+
+- 日期: 2026-05-30
+- 状态: 草案 (Draft)
+- 范围: `backend/`、`frontend/`,身份契约预留 `dataagent/dataagent-backend/`
+- 变更规模: 中大型(跨前后端 + schema + 部署配置 + 服务间身份契约)
+
+## 1. 背景与现状
+
+OpenDataWorks 当前没有自有的登录与认证体系,身份完全依赖"上游网关注入请求头"的假设,本地实际以匿名方式运行。
+
+现状要点(代码定位):
+
+- 身份载体: `backend/.../context/UserContextHolder.java`,ThreadLocal 持有 `userId` / `username` / `oauthUserId`。
+- 鉴权切面: `backend/.../aspect/AuthenticationAspect.java` + 注解 `backend/.../annotation/RequireAuth.java`。
+  - `@Around` 拦截 `@RequireAuth` 方法,从请求头读取 `X-User-Id` / `X-Username` / `X-OAuth-User-Id`,写入 `UserContextHolder`,`finally` 中清理。
+  - 支持匿名: `auth.anonymous.enabled` / `auth.anonymous.user-id` / `auth.anonymous.username`。
+- 用户表: `platform_users`(`id` / `oauth_user_id` / `username` / `email`),实体 `PlatformUser.java`,无密码字段。
+- 无 JWT 依赖、无登录端点、无 Spring Security。
+- CORS: `backend/.../config/WebConfig.java` 中 `OncePerRequestFilter`,`Access-Control-Allow-Credentials: true` 已开启(Cookie 方案可用)。
+- 前端: 无登录页、无路由守卫、无 user store(Pinia 已初始化但为空);`frontend/src/utils/request.js` 的 axios 无 401 处理、无 `withCredentials`。
+- 动态配置范式: `dolphin_config` 一套(Entity + Service + Controller + Mapper),敏感字段用 `@JsonProperty(access = WRITE_ONLY)` 不回显;Flyway 迁移最新为 `V43`。
+
+## 2. 问题
+
+1. 平台缺少自有登录,无法在没有外部网关时保护任何接口。
+2. 需要同时支持两种登录方式:
+   - 本地用户名 + 密码(管理员一等公民,始终可用)。
+   - OAuth2.0 单点登录(自研 OAuth 服务,授权码模式)。
+3. OAuth 必须像 GitLab 一样**由管理员在前端动态配置**:配置且启用后登录页出现 OAuth 入口;未配置则只能密码登录。配置不能写死在环境变量里。
+4. 认证结果需要能低成本扩展到 Java 后端全部接口,并进一步下发到 `dataagent-backend`,做到**一套身份契约多处复用**。
+
+## 3. 目标与非目标
+
+### 目标
+
+- Java 后端成为认证权威:负责登录(密码 / OAuth)、签发会话、校验会话。
+- OAuth 配置存库、管理员前端可管理,支持启用/停用开关。
+- 默认拦截所有请求 + 小白名单放行(默认安全,新增接口自动受保护)。
+- 复用现有 `UserContextHolder` 与 `@RequireAuth` 语义,避免重写下游业务取身份的方式。
+- 定义统一身份令牌契约,使同一个令牌可被 Java 后端校验,并可向 `dataagent-backend` 透传校验。
+
+### 非目标
+
+- 本期不实现完整 RBAC 细粒度权限矩阵(仅区分 `admin` / `user` 两个角色)。
+- 本期不实现多 OAuth Provider 并存(单 Provider 配置,表结构预留扩展)。
+- 本期不在 `dataagent-backend` 落地强制校验,只交付身份契约与透传,在主后端侧完成对接点(详见第 8 节扩展设计)。
+- 不实现 MFA、社会化登录聚合、SCIM 用户同步。
+
+## 4. 总体方案
+
+### 4.1 认证权威 + 统一身份令牌
+
+Java 后端登录成功后签发一个 **后端自签 JWT(会话令牌)**,这是整个体系的"单一身份契约":
+
+- 浏览器侧: JWT 放入 **HttpOnly + SameSite Cookie**(命名 `odw_session`),前端不接触令牌内容,天然防 XSS 窃取。
+- 服务间: Java 后端调用 `dataagent-backend` 时,透传同一身份(见 8 节),`dataagent-backend` 用**相同密钥/公钥**校验同一令牌契约。
+
+令牌声明(claims)契约:
+
+| claim | 含义 | 示例 |
+|---|---|---|
+| `sub` | 平台用户 ID(对应 `sys_user.id`) | `"1024"` |
+| `username` | 用户名 | `"alice"` |
+| `role` | 角色 | `"admin"` / `"user"` |
+| `auth_source` | 认证来源 | `"local"` / `"oauth"` |
+| `oauth_user_id` | OAuth sub(本地用户为空) | `"sso-abc"` |
+| `iss` | 签发方 | `"opendataworks"` |
+| `iat` / `exp` | 签发/过期时间 | 默认有效期 8h,可配置 |
+
+签名算法: 默认 `HS256` + 共享密钥 `AUTH_JWT_SECRET`(便于内部服务间同密钥校验)。预留 `RS256`(后端持私钥签发,各服务持公钥校验)作为后续更强隔离选项,不在本期实现。
+
+### 4.2 两种登录方式
+
+```
+                         ┌────────────────────────────────────┐
+                         │            Java 后端(认证权威)        │
+  浏览器                  │                                      │
+   │  POST /api/auth/login│  本地密码:bcrypt 校验 sys_user        │
+   ├─────────────────────►│  ─────────────────────────────────► │
+   │                      │  成功 → 签发会话 JWT → Set-Cookie     │
+   │                      │                                      │
+   │ GET /api/auth/oauth/authorize                               │
+   ├─────────────────────►│  读 sys_oauth_config(enabled?)       │
+   │  302 → 授权页          │  拼 authorize_url + state            │
+   │◄─────────────────────┤                                      │
+   │  (在自研 OAuth 服务登录) │                                     │
+   │ GET /api/auth/oauth/callback?code&state                     │
+   ├─────────────────────►│  code 换 token(调一次 OAuth)         │
+   │                      │  验 JWT(jwks)或 调 userinfo          │
+   │                      │  upsert sys_user(auth_source=oauth)  │
+   │  302 → 前端 + Cookie   │  签发会话 JWT → Set-Cookie            │
+   │◄─────────────────────┤                                      │
+```
+
+- 本地密码登录始终可用,与 OAuth 配置无关。
+- OAuth 登录仅在 `sys_oauth_config.enabled = 1` 时可用;前端据 `GET /api/auth/oauth/config` 决定是否渲染 OAuth 按钮。
+
+### 4.3 默认拦截 + 白名单
+
+新增一个 servlet `Filter`(`AuthenticationFilter`,注册在 `WebConfig`,顺序在 CORS 之后):
+
+```
+请求进入
+  → 命中白名单? → 放行
+  → 取 odw_session Cookie(或 Authorization: Bearer 兜底)
+  → 校验 JWT(签名/过期/issuer)
+      → 通过: 解析 claims,写入 UserContextHolder(沿用现有字段)
+      → 失败/缺失: 若 auth.anonymous.enabled 则匿名;否则返回 401 + 登录入口信息
+```
+
+白名单(可配置,默认):
+
+```
+/api/auth/login
+/api/auth/oauth/authorize
+/api/auth/oauth/callback
+/api/auth/oauth/config        # 登录页判断是否显示 OAuth 按钮
+/api/health, /actuator/health
+# widget / agent 已有自有 token 机制的入口按现状保留(见 7.4)
+```
+
+与现有 `AuthenticationAspect` 的关系:Filter 负责"会话校验 + 填充 `UserContextHolder`";`@RequireAuth` 切面保留为"方法级强制要求已登录"的语义(从 `UserContextHolder` 而非外部请求头判断)。两者职责不重叠,详见 7.2。
+
+## 5. 数据模型
+
+### 5.1 `sys_user`(本地账号体系,管理员一等公民)
+
+```sql
+CREATE TABLE `sys_user` (
+  `id`              BIGINT       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `username`        VARCHAR(128) NOT NULL COMMENT '登录用户名',
+  `password_hash`   VARCHAR(255) NULL     COMMENT 'bcrypt 口令哈希;OAuth-only 用户可空',
+  `nickname`        VARCHAR(128) NULL     COMMENT '显示名',
+  `email`           VARCHAR(128) NULL     COMMENT '邮箱',
+  `role`            VARCHAR(32)  NOT NULL DEFAULT 'user' COMMENT '角色 admin/user',
+  `enabled`         TINYINT(1)   NOT NULL DEFAULT 1 COMMENT '是否启用',
+  `auth_source`     VARCHAR(32)  NOT NULL DEFAULT 'local' COMMENT 'local/oauth',
+  `external_id`     VARCHAR(255) NULL     COMMENT 'OAuth sub,本地账号为空',
+  `failed_attempts` INT          NOT NULL DEFAULT 0 COMMENT '连续登录失败次数',
+  `locked_until`    DATETIME     NULL     COMMENT '锁定截止时间',
+  `last_login_at`   DATETIME     NULL     COMMENT '最近登录时间',
+  `created_at`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted`         TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '逻辑删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_username` (`username`),
+  KEY `idx_external_id` (`external_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='平台本地用户表';
+```
+
+- 迁移文件: `V44__create_sys_user.sql`。
+- 与现有 `platform_users` 的关系:`platform_users` 偏 OAuth 画像(`oauth_user_id`),`sys_user` 是登录/密码/角色的权威。OAuth 用户登录时,`sys_user.external_id` 即对应 `platform_users.oauth_user_id`,二者通过 `external_id` 关联,本期不合并表(降风险)。
+- 初始管理员:迁移中插入一条 `admin` 账号(口令哈希由部署初始化注入或首启强制改密,见 7.5),`role=admin`,`auth_source=local`。
+
+### 5.2 `sys_oauth_config`(OAuth Provider 配置,管理员可管理)
+
+```sql
+CREATE TABLE `sys_oauth_config` (
+  `id`             BIGINT       NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `enabled`        TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '是否启用 OAuth 登录',
+  `provider_name`  VARCHAR(64)  NOT NULL DEFAULT 'SSO' COMMENT '登录按钮显示名',
+  `client_id`      VARCHAR(255) NULL     COMMENT 'OAuth client_id',
+  `client_secret`  VARCHAR(512) NULL     COMMENT 'OAuth client_secret(响应不回显)',
+  `authorize_url`  VARCHAR(512) NULL     COMMENT '授权端点',
+  `token_url`      VARCHAR(512) NULL     COMMENT '令牌端点',
+  `userinfo_url`   VARCHAR(512) NULL     COMMENT '用户信息端点(opaque token 用)',
+  `jwks_url`       VARCHAR(512) NULL     COMMENT 'JWKS 公钥端点(JWT 验签用)',
+  `scopes`         VARCHAR(255) NOT NULL DEFAULT 'openid profile' COMMENT '请求 scope',
+  `redirect_uri`   VARCHAR(512) NULL     COMMENT '回调地址',
+  `user_id_field`  VARCHAR(64)  NOT NULL DEFAULT 'sub' COMMENT '用户唯一标识字段',
+  `username_field` VARCHAR(64)  NOT NULL DEFAULT 'preferred_username' COMMENT '用户名字段',
+  `default_role`   VARCHAR(32)  NOT NULL DEFAULT 'user' COMMENT 'OAuth 新用户默认角色',
+  `created_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted`        TINYINT(1)   NOT NULL DEFAULT 0 COMMENT '逻辑删除',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OAuth Provider 配置表';
+```
+
+- 迁移文件: `V45__create_sys_oauth_config.sql`,插入一行 `enabled=0` 的占位配置。
+- 单 Provider:本期固定取 `enabled=1` 的首行;表结构本身支持后续多行扩展(加 `provider_key` 唯一键即可)。
+- `client_secret` 实体上加 `@JsonProperty(access = WRITE_ONLY)`,沿用 `DolphinConfig.token` 的隐藏范式。
+
+## 6. 后端接口设计
+
+### 6.1 认证接口 `AuthController`(前缀 `/api/auth`,全部白名单)
+
+| 方法 | 路径 | 鉴权 | 说明 |
+|---|---|---|---|
+| POST | `/api/auth/login` | 公开 | 本地密码登录;bcrypt 校验 + 失败锁定;成功 `Set-Cookie odw_session` |
+| POST | `/api/auth/logout` | 已登录 | 清 Cookie(可选维护服务端黑名单) |
+| GET | `/api/auth/me` | 已登录 | 返回当前用户(id/username/role/auth_source) |
+| GET | `/api/auth/oauth/config` | 公开 | 仅返回 `enabled` + `provider_name`(不含 secret),供登录页判断 |
+| GET | `/api/auth/oauth/authorize` | 公开 | 读配置拼授权 URL + 下发 `state`,302 跳转 |
+| GET | `/api/auth/oauth/callback` | 公开 | code 换 token → 验身份 → upsert 用户 → 签发会话 → 302 回前端 |
+
+`state` 防 CSRF:`authorize` 生成随机 `state` 写入短时 Cookie(或服务端缓存),`callback` 校验一致。
+
+### 6.2 OAuth 配置管理 `OAuthConfigController`(前缀 `/api/admin/oauth`,需 admin)
+
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| GET | `/api/admin/oauth/config` | 读当前配置(secret 不回显) |
+| PUT | `/api/admin/oauth/config` | 更新配置;secret 留空表示沿用旧值(参考 `DolphinConfigService` 对 token 的保留逻辑) |
+| POST | `/api/admin/oauth/config/test` | 校验 authorize/token/jwks 端点可达性 |
+
+完整复刻 `DolphinConfig` 四件套:`OAuthConfig`(Entity)+ `OAuthConfigMapper` + `OAuthConfigService` + `OAuthConfigController`。
+
+### 6.3 角色校验
+
+- 新增注解 `@RequireRole("admin")` 或在现有 `@RequireAuth` 上加 `role` 属性,由切面读取 `UserContextHolder` 的 role 判定。OAuth 配置管理接口使用之。
+
+## 7. 关键实现点
+
+### 7.1 新增依赖
+
+`backend/pom.xml` 增加:
+
+- `io.jsonwebtoken:jjwt-api/impl/jackson`(签发与校验会话 JWT)。
+- `org.springframework.security:spring-security-crypto`(仅取 `BCryptPasswordEncoder`,不引入完整 Security 过滤链,避免大改)。
+- OAuth 端点调用复用现有 `WebClient`/`RestTemplate`(后端已有 WebFlux)。
+
+### 7.2 Filter 与 Aspect 职责划分
+
+- `AuthenticationFilter`(新增,servlet 层):对所有非白名单请求校验会话 JWT,成功则填充 `UserContextHolder`,失败按匿名开关决定 401 或匿名。`finally` 清理 ThreadLocal。
+- `AuthenticationAspect`(保留,方法层):`@RequireAuth` 改为基于 `UserContextHolder` 现有内容判断"是否已认证",不再直接读外部请求头(请求头注入路径仅保留给受信任的内部服务间调用,见 7.4)。
+- 迁移注意:现有大量 `@RequireAuth` 标注的接口语义不变(仍要求已登录),只是身份来源从"外部网关头"变为"本平台会话"。
+
+### 7.3 会话 Cookie 策略
+
+- `HttpOnly`、`SameSite=Lax`(同站前后端)、生产 `Secure`。
+- 有效期默认 8h(`auth.session.ttl` 可配),可选滑动续期。
+- 前端 axios 加 `withCredentials: true`;CORS 已 `Allow-Credentials: true`,需将 `Allow-Origin` 收敛为具体域(凭证模式不可用 `*`)——`WebConfig` 现已按请求 Origin 回填,符合要求。
+
+### 7.4 既有内部 token 机制的兼容
+
+- widget / agent 入口已有自有令牌(`X-ODW-*` / service token)。这些路径加入白名单或在 Filter 中前置识别,保持现状,不被会话校验影响。
+- 服务间(Java → dataagent)身份透传是"受信任内部头"路径,与外部浏览器请求区分对待。
+
+### 7.5 初始管理员与口令安全
+
+- bcrypt 存储,登录失败计数 + `locked_until` 锁定(如 5 次锁 15 分钟)。
+- 初始 admin 口令不硬编码进迁移:迁移插入占位 + 首次启动校验 `ADMIN_INIT_PASSWORD` 环境变量并强制改密;或部署脚本写入哈希。具体取部署侧约定(见计划文档)。
+
+## 8. 扩展到 backend 与 dataagent-backend(核心扩展性设计)
+
+### 8.1 实际调用拓扑(探查确认)
+
+- 前端 **直连 dataagent-backend**(开发态经 `frontend/vite.config.js` 代理 `/api/v1/dataagent`、`/api/v1/nl2sql`、`/api/v1/nl2sql-admin` → `:8900`),**不经 Java 后端转发**;`/api` 才走 Java 后端 `:8080`。
+- dataagent-backend 当前**完全无鉴权**:`main.py` CORS `allow_origins=["*"]`,`/api/v1/nl2sql-admin/settings` 等 admin 端点无任何校验(可读写 LLM provider、DB 凭证、skill 配置)——这是必须收口的安全缺口,也是本设计扩展到 dataagent 的直接动因。
+- dataagent 现有 `X-ODW-*` 头仅用于 widget 分析画像(`source`/`website_id`/`visitor_id`),不是认证身份。
+
+### 8.2 一套契约,三处复用
+
+统一身份令牌契约(4.1)是扩展性的关键。因为前端直连两套后端,且两套在同站点下(开发经 vite 代理同源,生产经反代同域),**HttpOnly Cookie `odw_session` 会天然随请求带到 dataagent 路径**。由此:
+
+1. **Java 后端自身**:`AuthenticationFilter` 校验会话 JWT → `UserContextHolder`。全部 `@RequireAuth` 接口零改造受益(白名单外默认受保护)。
+2. **dataagent-backend(同密钥校验同一令牌)**:新增 FastAPI 依赖 `verify_identity()`,从 `odw_session` Cookie(或 `Authorization: Bearer` 兜底)取 JWT,用**同一 `AUTH_JWT_SECRET`** 校验同一 claims 契约(`PyJWT`),解析 `user_id` / `username` / `role` 挂到请求上下文。
+   - 业务 NL2SQL 路由:启用身份校验(可经开关灰度)。
+   - admin 路由(`/api/v1/nl2sql-admin/**`):强制 `role=admin`,直接关闭当前裸奔缺口。
+   - widget 路径:保留现有 `X-ODW-*` 机制,与会话校验并行(widget 是匿名外嵌场景,不要求平台登录)。
+3. **可选的服务间直调**:若未来出现 Java 后端 → dataagent 的服务端直调,透传 `Authorization: Bearer <会话JWT>` 即可,无需新机制。
+
+> 约束(遵循 AGENTS.md):不在 `core/nl2sql_agent.py` 等通用运行时硬编码鉴权;`verify_identity()` 作为独立 FastAPI 依赖/中间件存在,保持通用运行时 skill-agnostic。dataagent 侧落地可分阶段:先收口 admin 端点(高危),再对业务路由灰度启用。
+
+### 8.3 生产部署前提
+
+- 生产环境需经反向代理把前端、Java 后端、dataagent-backend 收敛到**同一站点域**,使 `odw_session` Cookie 对三者同域可见;否则需改用 `Authorization: Bearer`(前端从受信渠道获取并注入,牺牲部分 HttpOnly 优势)。本设计默认同域 Cookie 方案,`deploy/` 反代配置需相应调整(见计划文档)。
+- dataagent CORS 由 `*` 收敛为具体前端域(凭证模式要求)。
+
+共享密钥配置(三处一致):
+
+```
+AUTH_JWT_SECRET   # Java 后端签发+校验、dataagent-backend 校验,同一值
+AUTH_JWT_ISSUER=opendataworks
+AUTH_JWT_TTL=8h
+```
+
+`deploy/` 的 env 模板与 compose 需新增以上变量(医疗级别隔离时再切 RS256 公私钥)。
+
+## 9. 前端设计
+
+- 新增 `LoginView.vue` + 路由 `/login`(置于 `Layout` 之外的公开路由)。
+  - 用户名/密码表单;条件渲染"通过 {provider_name} 登录"按钮(读 `/api/auth/oauth/config`)。
+  - OAuth 按钮跳 `/api/auth/oauth/authorize`。
+- `router/index.js` 增 `beforeEach` 守卫:无会话(`/api/auth/me` 401)→ 跳 `/login`;处理 `/auth/callback` 回跳落地。
+- Pinia 新增 `useAuthStore`:`currentUser`、`fetchMe()`、`logout()`。
+- `utils/request.js`:加 `withCredentials: true`;响应拦截器对 401 统一跳 `/login`。
+- `Layout.vue` 头部右侧加用户区(昵称 + 下拉「退出登录」)。
+- 设置页 `ConfigurationManagement.vue` 新增 Tab「OAuth 配置」→ `views/settings/OAuthConfig.vue`(镜像 `DolphinConfig.vue` 表单/校验/API 调用范式,仅 admin 可见)。
+
+## 10. 安全考量
+
+- HttpOnly Cookie 防 XSS 窃取令牌;`SameSite=Lax` + `state` 防 CSRF。
+- `client_secret` 永不回显(WRITE_ONLY);更新时留空沿用旧值。
+- 默认拦截全部 + 小白名单,杜绝漏保护。
+- 失败锁定防暴力破解;bcrypt 防拖库口令还原。
+- 凭证模式下 CORS `Allow-Origin` 必须为具体域,不可 `*`。
+- 共享密钥 `AUTH_JWT_SECRET` 走环境变量/密钥管理,不入库不入仓。
+
+## 11. 待确认 / 风险
+
+- 生产部署是否能把前端 / Java 后端 / dataagent 收敛到同一站点域(同域 Cookie 方案的前提)。若不能,dataagent 侧改用 Bearer 注入。
+- dataagent 业务路由启用身份校验的节奏:admin 端点立即收口为高优先级;业务路由建议灰度开关,避免一次性阻断现有直连前端。
+- 初始 admin 口令注入方式(env 强制改密 vs 部署脚本写哈希)——计划文档定。
+- `platform_users` 与 `sys_user` 是否近期合并(本期不合并,保留风险点)。
+- 会话失效与单点登出在多服务下的传播(本期 JWT 自然过期为主,主动登出黑名单为可选)。
+- widget 匿名场景与平台登录场景在 dataagent 同一路由上的区分逻辑需明确(按 `X-ODW-Client=widget` 走 widget 分支,否则要求会话)。
+
+## 12. 取舍
+
+- 选 HttpOnly Cookie + 后端自签 JWT,而非前端持有 OAuth token:更安全、前端零令牌管理、服务间易透传;代价是后端需维护会话签发/校验,但 jjwt 成本低。
+- 选共享密钥 HS256 而非 RS256:内部服务间最简,密钥同步一处;隔离要求升级时再换 RS256,契约不变。
+- 复用 `UserContextHolder` + `@RequireAuth` 而非引入完整 Spring Security:最小改动、不破坏现有取身份方式;仅借 `BCryptPasswordEncoder` 一个工具类。
+- OAuth 配置存库 + 前端管理而非环境变量:满足 GitLab 式动态配置诉求,运维无需重启改配置。

--- a/docs/design/2026-05-30-configurable-oauth-login-design.md
+++ b/docs/design/2026-05-30-configurable-oauth-login-design.md
@@ -151,7 +151,7 @@ CREATE TABLE `sys_user` (
 
 - 迁移文件: `V44__create_sys_user.sql`。
 - 与现有 `platform_users` 的关系:`platform_users` 偏 OAuth 画像(`oauth_user_id`),`sys_user` 是登录/密码/角色的权威。OAuth 用户登录时,`sys_user.external_id` 即对应 `platform_users.oauth_user_id`,二者通过 `external_id` 关联,本期不合并表(降风险)。
-- 初始管理员:迁移中插入一条 `admin` 账号(口令哈希由部署初始化注入或首启强制改密,见 7.5),`role=admin`,`auth_source=local`。
+- 初始管理员:迁移中**直接插入** `admin` 账号,`role=admin`、`auth_source=local`,`password_hash` 为一个固定默认口令的 bcrypt 哈希(如 `admin` / `admin123`,哈希值写死在 `V44` 迁移里)。部署后管理员可在「个人设置/改密」接口自行修改,无需环境变量或首启流程。
 
 ### 5.2 `sys_oauth_config`(OAuth Provider 配置,管理员可管理)
 
@@ -241,7 +241,8 @@ CREATE TABLE `sys_oauth_config` (
 ### 7.5 初始管理员与口令安全
 
 - bcrypt 存储,登录失败计数 + `locked_until` 锁定(如 5 次锁 15 分钟)。
-- 初始 admin 口令不硬编码进迁移:迁移插入占位 + 首次启动校验 `ADMIN_INIT_PASSWORD` 环境变量并强制改密;或部署脚本写入哈希。具体取部署侧约定(见计划文档)。
+- 初始 admin 口令**直接存库**:`V44` 迁移插入一条 `admin` 账号,`password_hash` 为默认口令(`admin123`)的 bcrypt 哈希。无环境变量、无首启强制改密流程。
+- 提供 `POST /api/auth/password`(已登录)供管理员登录后自行改密;运维默认口令安全责任在部署方,建议首登后立即修改。
 
 ## 8. 扩展到 backend 与 dataagent-backend(核心扩展性设计)
 
@@ -264,10 +265,15 @@ CREATE TABLE `sys_oauth_config` (
 
 > 约束(遵循 AGENTS.md):不在 `core/nl2sql_agent.py` 等通用运行时硬编码鉴权;`verify_identity()` 作为独立 FastAPI 依赖/中间件存在,保持通用运行时 skill-agnostic。dataagent 侧落地可分阶段:先收口 admin 端点(高危),再对业务路由灰度启用。
 
-### 8.3 生产部署前提
+### 8.3 生产部署前提(已确认成立)
 
-- 生产环境需经反向代理把前端、Java 后端、dataagent-backend 收敛到**同一站点域**,使 `odw_session` Cookie 对三者同域可见;否则需改用 `Authorization: Bearer`(前端从受信渠道获取并注入,牺牲部分 HttpOnly 优势)。本设计默认同域 Cookie 方案,`deploy/` 反代配置需相应调整(见计划文档)。
+- 生产经 docker compose 部署,`frontend/nginx.conf` 已把三者收敛到**同一域名**(单一入口):
+  - `/` → 前端静态资源
+  - `/api/` → `backend:8080`
+  - `/api/v1/dataagent/`、`/api/v1/nl2sql/`、`/api/v1/nl2sql-admin/` → `dataagent-backend:8900`
+- 因此 `odw_session` HttpOnly Cookie 设在该单域上,会**自动随请求带到三套服务**,同域 Cookie 方案直接成立,无需 Bearer 兜底。
 - dataagent CORS 由 `*` 收敛为具体前端域(凭证模式要求)。
+- 开发态由 `frontend/vite.config.js` 代理达成同源,行为与 prod 一致。
 
 共享密钥配置(三处一致):
 
@@ -301,9 +307,9 @@ AUTH_JWT_TTL=8h
 
 ## 11. 待确认 / 风险
 
-- 生产部署是否能把前端 / Java 后端 / dataagent 收敛到同一站点域(同域 Cookie 方案的前提)。若不能,dataagent 侧改用 Bearer 注入。
+- ~~同域 Cookie 前提~~:已确认。docker compose + `frontend/nginx.conf` 单域收敛三服务,Cookie 自动覆盖(见 8.3)。
+- ~~初始 admin 口令注入方式~~:已确认。直接存库,`V44` 写死 `admin123` 的 bcrypt 哈希(见 7.5)。
 - dataagent 业务路由启用身份校验的节奏:admin 端点立即收口为高优先级;业务路由建议灰度开关,避免一次性阻断现有直连前端。
-- 初始 admin 口令注入方式(env 强制改密 vs 部署脚本写哈希)——计划文档定。
 - `platform_users` 与 `sys_user` 是否近期合并(本期不合并,保留风险点)。
 - 会话失效与单点登出在多服务下的传播(本期 JWT 自然过期为主,主动登出黑名单为可选)。
 - widget 匿名场景与平台登录场景在 dataagent 同一路由上的区分逻辑需明确(按 `X-ODW-Client=widget` 走 widget 分支,否则要求会话)。

--- a/docs/design/2026-05-30-odw-auth-module-design.md
+++ b/docs/design/2026-05-30-odw-auth-module-design.md
@@ -1,0 +1,277 @@
+# odw-auth 独立认证模块设计
+
+- 日期: 2026-05-30
+- 状态: 草案 (Draft)
+- 配套功能设计: `docs/design/2026-05-30-configurable-oauth-login-design.md`(登录流程/表/接口的业务细节)
+- 配套计划: `docs/plans/2026-05-30-configurable-oauth-login-plan.md`
+- 本文聚焦: **把认证能力抽成可独立演进、可被多服务复用、可整体替换的库模块**
+- 变更规模: 大型(新增 Maven 模块 + Python 包 + 既有代码迁移 + 自动装配契约)
+
+## 1. 目标
+
+把认证从"散落在 `backend` 里的切面 + 头解析"重构为一个**自包含、可插拔、可独立重构**的模块,满足:
+
+- **单一职责**:认证(登录、会话签发/校验、身份上下文、OAuth 对接)全部收敛到一个模块。
+- **可复用**:Java 侧任何 Spring Boot 服务(`backend`、`backend-agent-api`、未来新服务)引入即用;Python 侧 `dataagent-backend` 用同源 Python 包校验同一令牌。
+- **可替换**:宿主服务通过依赖一行开关接入或移除;所有 Bean 可被覆盖,便于后续整体重构甚至拆成独立认证服务。
+- **零侵入业务**:业务代码取身份的方式(`UserContextHolder` / `@RequireAuth`)保持稳定,实现细节在模块内演进。
+
+## 2. 现状与动因
+
+- 根工程已是 Maven Reactor `opendataworks-reactor`(`pom.xml`),聚合 `backend-agent-api` + `backend`,**已具备多模块基础**。
+- 现有认证散落在 `backend`:
+  - `context/UserContextHolder.java`(ThreadLocal:userId/username/oauthUserId)
+  - `aspect/AuthenticationAspect.java`(从 `X-User-Id` 等请求头解析,假设上游网关)
+  - `annotation/RequireAuth.java`
+  - `application.yml` 的 `auth.anonymous.*` 匿名开关
+- 问题:身份来源绑死"外部头注入";无登录/会话;无法被其他服务复用;重构牵动业务代码。
+
+## 3. 模块边界与产物
+
+新增**两个同源产物**,共享同一令牌契约:
+
+| 产物 | 形态 | 服务对象 | 路径 |
+|---|---|---|---|
+| `odw-auth` | Maven JAR 模块(库,非可执行 Boot App) | 所有 Java Spring Boot 服务 | `odw-auth/` |
+| `odw_auth` | Python 包 | `dataagent-backend` 及未来 Python 服务 | `dataagent/odw_auth/` |
+
+> Java Maven 模块无法直接被 Python 复用,因此 Python 侧以**独立包 + 相同令牌契约**实现等价校验,而非跨语言共享代码。两者唯一耦合点是令牌契约(第 7 节),通过契约测试保证一致。
+
+### 3.1 `odw-auth`(Maven 模块)目录
+
+```
+odw-auth/
+├── pom.xml                         # packaging=jar;parent=spring-boot-starter-parent
+└── src/main/
+    ├── java/com/onedata/auth/
+    │   ├── context/
+    │   │   ├── UserContext.java            # userId / username / role
+    │   │   └── UserContextHolder.java      # ThreadLocal,从 backend 迁入并简化
+    │   ├── annotation/
+    │   │   ├── RequireAuth.java            # 重写:基于会话判断
+    │   │   └── RequireRole.java            # 新增:角色校验
+    │   ├── aspect/
+    │   │   └── AuthorizationAspect.java    # 读 UserContextHolder 做强制要求/角色校验
+    │   ├── filter/
+    │   │   └── AuthenticationFilter.java   # 校验会话 JWT → 填充 UserContextHolder
+    │   ├── jwt/
+    │   │   ├── JwtService.java             # 接口:issue / verify(自签会话)
+    │   │   └── Hs256JwtService.java        # 默认实现(jjwt, HS256)
+    │   ├── oauth/
+    │   │   ├── OAuthClient.java            # 接口:authorizeUrl / exchangeCode / fetchIdentity
+    │   │   └── DefaultOAuthClient.java     # WebClient + nimbus(JWKS)/ userinfo
+    │   ├── user/
+    │   │   ├── SysUser.java                # 实体
+    │   │   ├── SysUserMapper.java
+    │   │   └── SysUserService.java         # bcrypt 校验 / 锁定 / upsert OAuth 用户
+    │   ├── config/
+    │   │   ├── SysOAuthConfig.java         # 实体(client_secret WRITE_ONLY)
+    │   │   ├── SysOAuthConfigMapper.java
+    │   │   └── OAuthConfigService.java
+    │   ├── web/
+    │   │   ├── AuthController.java         # /api/auth/**
+    │   │   └── OAuthConfigController.java  # /api/admin/oauth/**
+    │   ├── spi/                            # 扩展点(见第 6 节)
+    │   │   ├── UserResolver.java
+    │   │   ├── SessionCookieCustomizer.java
+    │   │   └── AuthWhitelistProvider.java
+    │   └── autoconfigure/
+    │       ├── OdwAuthProperties.java      # @ConfigurationProperties(prefix="odw.auth")
+    │       └── OdwAuthAutoConfiguration.java
+    └── resources/
+        ├── META-INF/spring/
+        │   └── org.springframework.boot.autoconfigure.AutoConfiguration.imports
+        └── db/migration/
+            ├── V44__create_sys_user.sql
+            └── V45__create_sys_oauth_config.sql
+```
+
+### 3.2 `odw_auth`(Python 包)目录
+
+```
+dataagent/odw_auth/
+├── __init__.py
+├── claims.py        # AuthClaims dataclass + 契约常量(iss/字段名)
+├── verify.py        # decode_session(token, secret) -> AuthClaims;PyJWT
+└── fastapi.py       # verify_identity / require_admin(FastAPI Depends)
+```
+
+## 4. 依赖与装配
+
+### 4.1 Reactor 注册
+
+`pom.xml`(根)`<modules>` 增加 `odw-auth`,置于 `backend` 之前:
+
+```xml
+<modules>
+  <module>odw-auth</module>
+  <module>backend-agent-api</module>
+  <module>backend</module>
+</modules>
+```
+
+### 4.2 宿主服务接入(以 backend 为例)
+
+`backend/pom.xml` 增一条依赖即接入全部能力:
+
+```xml
+<dependency>
+  <groupId>com.onedata</groupId>
+  <artifactId>odw-auth</artifactId>
+  <version>${project.version}</version>
+</dependency>
+```
+
+### 4.3 Spring Boot 2.7 自动装配
+
+`resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`:
+
+```
+com.onedata.auth.autoconfigure.OdwAuthAutoConfiguration
+```
+
+`OdwAuthAutoConfiguration`:
+- `@EnableConfigurationProperties(OdwAuthProperties.class)`
+- `@ComponentScan("com.onedata.auth")`(或显式 `@Bean` 注册,避免误扫)
+- `@MapperScan("com.onedata.auth.user, com.onedata.auth.config")`
+- 每个 Bean 加 `@ConditionalOnMissingBean` → **宿主可覆盖任意实现**
+- `@ConditionalOnProperty("odw.auth.enabled", matchIfMissing=true)` → 总开关
+
+### 4.4 Flyway 多路径
+
+宿主 `application.yml`:
+
+```yaml
+spring:
+  flyway:
+    locations: classpath:db/migration   # backend 自身 + odw-auth 的迁移同一 classpath 路径合并扫描
+```
+
+> `odw-auth` 的迁移版本号 `V44/V45` 接在 `backend` 现有 `V43` 之后,确保全局单调。约定:**认证相关迁移版本段由 odw-auth 占用**,在模块文档登记,避免与 backend 后续迁移撞号(见第 10 节风险)。
+
+## 5. 配置契约(`odw.auth.*`)
+
+```yaml
+odw:
+  auth:
+    enabled: true
+    jwt:
+      secret: ${AUTH_JWT_SECRET}        # 三服务同值
+      issuer: opendataworks
+      ttl: 8h
+      algorithm: HS256                  # 预留 RS256
+    session:
+      cookie-name: odw_session
+      same-site: Lax
+      secure: true                      # 生产
+    anonymous:
+      enabled: false                    # 替代旧 auth.anonymous.*
+    whitelist:                          # 默认拦截 + 白名单
+      - /api/auth/**
+      - /api/health
+      - /actuator/health
+```
+
+环境变量(`deploy/`):`AUTH_JWT_SECRET` / `AUTH_JWT_ISSUER` / `AUTH_JWT_TTL`,Java 与 Python 服务共享。
+
+## 6. 扩展点(SPI)—— 为后续重构预留
+
+模块对外暴露接口,宿主或未来重构按需替换,**不改模块内部**:
+
+| SPI | 用途 | 默认实现 | 重构场景 |
+|---|---|---|---|
+| `JwtService` | 会话签发/校验 | `Hs256JwtService` | 换 RS256 / 外部 KMS 签名 |
+| `OAuthClient` | OAuth 协议交互 | `DefaultOAuthClient` | 换 OIDC discovery / 多 provider |
+| `UserResolver` | OAuth 身份 → 平台用户 | 默认 upsert `sys_user` | 对接外部用户中心 / LDAP |
+| `SessionCookieCustomizer` | Cookie 属性定制 | 默认 HttpOnly+Lax | 跨子域 / 自定义安全策略 |
+| `AuthWhitelistProvider` | 动态白名单 | 读 `odw.auth.whitelist` | 运行时可变白名单 |
+
+所有 SPI 在 `OdwAuthAutoConfiguration` 中以 `@ConditionalOnMissingBean` 注册,宿主声明同类型 Bean 即覆盖。
+
+## 7. 令牌契约(Java ↔ Python 唯一耦合点)
+
+会话 JWT claims(两侧实现必须一致):
+
+| claim | 类型 | 含义 |
+|---|---|---|
+| `sub` | string | 平台用户 ID(`sys_user.id`) |
+| `username` | string | 用户名 |
+| `role` | string | `admin` / `user` |
+| `auth_source` | string | `local` / `oauth` |
+| `iss` | string | `opendataworks` |
+| `iat` / `exp` | number | 签发 / 过期 |
+
+- 算法:`HS256`,密钥 `AUTH_JWT_SECRET`。
+- 载体:HttpOnly Cookie `odw_session`;`Authorization: Bearer` 作兜底。
+- **一致性保证**:`odw-auth` 与 `odw_auth` 各自维护一份契约测试(同一 token 双向 encode/decode),CI 中用固定向量校验,任一侧改契约必须同步另一侧(对应 AGENTS.md "改契约同改测试")。
+
+## 8. 宿主消费方式
+
+### 8.1 backend(Java)
+
+- 删除旧 `context/UserContextHolder`、`aspect/AuthenticationAspect`、`annotation/RequireAuth`、`auth.anonymous.*`。
+- 业务代码 `import com.onedata.auth.context.UserContextHolder` / `com.onedata.auth.annotation.RequireAuth`(包名变更,做一次性 import 替换)。
+- 取身份方式不变:`UserContextHolder.getCurrentUserId()`。
+- `@RequireAuth` 语义升级为"要求已登录会话";`@RequireRole("admin")` 用于管理端点。
+
+### 8.2 dataagent-backend(Python)
+
+```python
+from odw_auth.fastapi import verify_identity, require_admin
+
+@admin_router.put("/settings", dependencies=[Depends(require_admin)])
+async def update_admin_settings(...): ...
+
+@router.post("/nl2sql/...", )
+async def ask(claims = Depends(verify_identity)): ...  # 按开关 DATAAGENT_REQUIRE_AUTH 灰度
+```
+
+- 同域 Cookie(`frontend/nginx.conf` 单域)→ `odw_session` 自动随请求到达,`verify.py` 用同密钥校验。
+- widget 路径(`X-ODW-Client=widget`)保留匿名分支,不强制会话。
+
+### 8.3 backend-agent-api(Java)
+
+暂不改;未来需要保护时,加 `odw-auth` 依赖即可,零额外代码。
+
+## 9. 既有代码迁移
+
+| 旧位置(backend) | 处置 | 新位置(odw-auth) |
+|---|---|---|
+| `context/UserContextHolder` | 迁移 + 简化(去 oauthUserId) | `com.onedata.auth.context.UserContextHolder` |
+| `context/UserContext` | 迁移 + 加 role | 同包 |
+| `aspect/AuthenticationAspect` | 重写(读会话非外部头) | `aspect/AuthorizationAspect` |
+| `annotation/RequireAuth` | 重写 | `annotation/RequireAuth` |
+| `application.yml auth.anonymous.*` | 删除,迁到 `odw.auth.anonymous` | `OdwAuthProperties` |
+| 业务里 `import ...portal.context...` | 全量替换 import | `...auth.context...` |
+
+迁移用一次性脚本批量改 import,编译驱动找残留。
+
+## 10. 测试与验证
+
+- `odw-auth` 单测:`JwtService`(签发/过期/篡改)、`SysUserService`(bcrypt/锁定)、`OAuthClient`(mock token/jwks/userinfo)、`AuthenticationFilter`(白名单/401/匿名)。
+- `odw_auth` 单测:`verify.py` 用与 Java 相同的固定 token 向量。
+- **跨语言契约测试**:Java 签一个 token,Python 解出相同 claims(固定向量入仓)。
+- 接入冒烟:`backend` 引入模块后启动、登录、受保护接口 200/401;`dataagent` admin 端点收口。
+
+## 11. 风险与缓解
+
+- **Flyway 版本撞号**:`odw-auth` 与 `backend` 共享 classpath 迁移路径,版本号需全局协调。缓解:在模块文档登记认证占用的版本段,新增迁移前先查最大版本。
+- **`@ComponentScan` 误扫**:模块包名独立 `com.onedata.auth.*`,与宿主 `com.onedata.portal.*` 隔离,避免重复扫描;优先显式 `@Bean` 注册降低风险。
+- **import 大面积变更**:一次性脚本 + 编译校验;在独立分支 `claude/oauth-login` 上完成,降低对其他分支干扰。
+- **跨语言契约漂移**:固定向量契约测试 + 改契约同改两侧的硬约束。
+- **MyBatis-Plus / Flyway 版本一致性**:模块继承同一 `spring-boot-starter-parent` 与 BOM,版本随 reactor 统一。
+
+## 12. 重构友好性(本设计的核心收益)
+
+- 换算法 / 密钥源 → 仅替换 `JwtService` Bean。
+- 换 OAuth 协议栈(OIDC discovery、多 provider)→ 仅替换 `OAuthClient` / `OAuthConfigService`。
+- 对接外部用户中心 → 实现 `UserResolver`。
+- 抽成独立认证微服务 → `odw-auth` 加 `@SpringBootApplication` 独立启动,契约不变,其他服务改为远程校验。
+- 整体替换认证方案 → 移除 `odw-auth` 依赖换新库,业务仅需重配 Bean。
+
+## 13. 取舍
+
+- **JAR 库 + 自动装配** 而非"复制代码到各服务":单一真源,升级一处生效。
+- **Java 模块 + Python 包双产物** 而非强行跨语言共享:尊重技术栈边界,仅用令牌契约耦合(AGENTS.md:保持模块边界清晰)。
+- **SPI + ConditionalOnMissingBean** 而非硬编码实现:为重构预留替换点,不牺牲开箱即用。
+- **不引入完整 Spring Security**:贴合现有 `UserContextHolder`/`@RequireAuth`,只借 `BCryptPasswordEncoder`,改动面可控。

--- a/docs/plans/2026-05-30-configurable-oauth-login-plan.md
+++ b/docs/plans/2026-05-30-configurable-oauth-login-plan.md
@@ -1,0 +1,119 @@
+# 可配置 OAuth 登录与统一身份认证 实施计划
+
+- 日期: 2026-05-30
+- 配套设计: `docs/design/2026-05-30-configurable-oauth-login-design.md`
+- 涉及栈: `backend/`(主)、`frontend/`、`dataagent/dataagent-backend/`(身份校验落地)、`deploy/`(env + 反代)
+
+## 阶段划分
+
+按风险与依赖分四阶段,可分 PR 交付。阶段 1-2 即可让平台具备登录与保护能力;阶段 3 收口 dataagent;阶段 4 部署收敛。
+
+---
+
+## 阶段 1:后端认证基座(密码登录 + 会话 + 默认拦截)
+
+目标:平台具备本地密码登录、会话签发/校验、默认拦截全部 + 白名单。
+
+### 数据库
+- [ ] `backend/src/main/resources/db/migration/V44__create_sys_user.sql`
+  - 建 `sys_user` 表(见设计 5.1)。
+  - 插入初始 `admin`(占位哈希或留空,配合首启改密)。
+
+### 依赖
+- [ ] `backend/pom.xml` 增加 `io.jsonwebtoken:jjwt-api/impl/jackson`、`org.springframework.security:spring-security-crypto`。
+
+### 代码(`backend/src/main/java/com/onedata/portal/`)
+- [ ] `entity/SysUser.java`(镜像 `DolphinConfig` 注解范式,`password_hash` 加 `@JsonProperty(WRITE_ONLY)`)。
+- [ ] `mapper/SysUserMapper.java`(extends `BaseMapper`,加按 username / external_id 查询)。
+- [ ] `service/AuthService.java`:bcrypt 校验、失败计数 + 锁定、签发/解析会话 JWT。
+- [ ] `service/JwtService.java`:HS256 签发/校验(读 `AUTH_JWT_SECRET` / `AUTH_JWT_ISSUER` / `AUTH_JWT_TTL`)。
+- [ ] `filter/AuthenticationFilter.java`:非白名单校验 `odw_session` Cookie → 填 `UserContextHolder`;失败按 `auth.anonymous.enabled` 决定 401 / 匿名;`finally` 清理。
+- [ ] `config/WebConfig.java`:注册 `AuthenticationFilter`(顺序在 CORS 之后);白名单可配置项 `auth.whitelist`。
+- [ ] `controller/AuthController.java`:`POST /api/auth/login`、`POST /api/auth/logout`、`GET /api/auth/me`。
+- [ ] `aspect/AuthenticationAspect.java`:`@RequireAuth` 改为基于 `UserContextHolder` 判断(不再直接读外部头);新增 `role` 校验支持(`@RequireRole("admin")` 或 `@RequireAuth(role=...)`)。
+- [ ] `application.yml`:`auth.anonymous.enabled` 默认 `false`(生产),开发可 `true`;`auth.session.ttl`、`auth.whitelist`。
+
+### 验证
+- [ ] 后端编译:`mvn -q -pl backend compile`(或仓库现用构建命令)。
+- [ ] 针对 `AuthService` / `JwtService` 的单测(密码校验、锁定、JWT 签发解析、过期/篡改拒绝)。
+- [ ] 手测:登录拿 Cookie → 带 Cookie 访问受保护接口 200 → 不带 401。
+
+---
+
+## 阶段 2:OAuth 可配置登录 + 前端
+
+目标:管理员前端配置 OAuth;配置启用后登录页出现 OAuth 入口;授权码全流程打通。
+
+### 数据库
+- [ ] `V45__create_sys_oauth_config.sql`:建 `sys_oauth_config`,插入 `enabled=0` 占位行。
+
+### 后端
+- [ ] `entity/OAuthConfig.java`(`client_secret` 加 `@JsonProperty(WRITE_ONLY)`)、`mapper/OAuthConfigMapper.java`。
+- [ ] `service/OAuthConfigService.java`:读/更新(secret 留空沿用旧值,参考 `DolphinConfigService` 对 token 的处理)、端点可达性测试。
+- [ ] `service/OAuthLoginService.java`:拼 authorize URL + `state`、code 换 token、JWT 验签(jwks)或调 userinfo、upsert `sys_user`(`auth_source=oauth`、`external_id`)、签发会话。
+- [ ] `controller/AuthController` 增:`GET /api/auth/oauth/config`(公开,仅 enabled+provider_name)、`GET /api/auth/oauth/authorize`、`GET /api/auth/oauth/callback`。
+- [ ] `controller/OAuthConfigController.java`:`GET/PUT /api/admin/oauth/config`、`POST /api/admin/oauth/config/test`(`@RequireRole("admin")`)。
+- [ ] 白名单加入 `/api/auth/oauth/{config,authorize,callback}`。
+
+### 前端(`frontend/src/`)
+- [ ] `views/LoginView.vue` + 路由 `/login`(置于 `Layout` 外公开路由);密码表单 + 条件 OAuth 按钮(读 `/api/auth/oauth/config`)。
+- [ ] `router/index.js`:`beforeEach` 守卫,无会话跳 `/login`;`/auth/callback` 落地处理。
+- [ ] `stores/auth.js`:`useAuthStore`(`currentUser`、`fetchMe`、`logout`)。
+- [ ] `utils/request.js`:`withCredentials: true`;响应拦截 401 → 跳 `/login`。`api/nl2sql.js` / `api/dataagent.js` 同步加 `withCredentials`。
+- [ ] `views/Layout.vue`:头部右侧用户区 + 退出登录。
+- [ ] `views/settings/OAuthConfig.vue` + 在 `views/settings/ConfigurationManagement.vue` 增「OAuth 配置」Tab(镜像 `DolphinConfig.vue`);`api/settings.js` 增 OAuth 配置接口。
+
+### 验证
+- [ ] 前端:`nvm use` 后 `npm --prefix frontend run build`(或 lint)。
+- [ ] 手测:未配置 OAuth → 登录页只有密码;配置并启用 → 出现 OAuth 按钮;走完 authorize→callback→落 Cookie→进首页。
+
+---
+
+## 阶段 3:dataagent-backend 身份校验落地
+
+目标:收口 dataagent admin 裸奔缺口;业务路由灰度启用同一令牌校验。
+
+### 代码(`dataagent/dataagent-backend/`)
+- [ ] `requirements.txt` 增 `PyJWT`。
+- [ ] 新增 `api/auth.py`:`verify_identity()` FastAPI 依赖,从 `odw_session` Cookie 或 `Authorization: Bearer` 取 JWT,用 `AUTH_JWT_SECRET` 校验(算法/issuer 与 Java 端一致),返回 `{user_id, username, role}`;`require_admin()` 依赖。
+- [ ] `api/admin_routes.py`:为 `/settings` 等 admin 端点加 `Depends(require_admin)`(立即收口高危缺口)。
+- [ ] `api/routes.py`:业务 NL2SQL 路由按开关 `DATAAGENT_REQUIRE_AUTH` 接 `Depends(verify_identity)`;`X-ODW-Client=widget` 分支保留匿名 widget 逻辑不变。
+- [ ] `main.py`:CORS `allow_origins` 由 `*` 收敛为前端域(环境变量驱动)。
+- [ ] 不改 `core/nl2sql_agent.py` 等通用运行时(遵循 skill-agnostic 约束)。
+
+### 验证
+- [ ] `pytest` 针对 `verify_identity` / `require_admin`(有效令牌通过、无/过期/篡改拒绝、admin 角色校验)。
+- [ ] 冒烟(按 AGENTS.md 本地 smoke):无令牌调 admin → 401/403;带 admin 会话 Cookie → 通过;widget 头路径不受影响。
+
+---
+
+## 阶段 4:部署与配置收敛
+
+- [ ] `deploy/.env.example` 增:`AUTH_JWT_SECRET`、`AUTH_JWT_ISSUER=opendataworks`、`AUTH_JWT_TTL=8h`、`ADMIN_INIT_PASSWORD`、`DATAAGENT_REQUIRE_AUTH`、前端域(CORS)。
+- [ ] `deploy/` compose:三服务注入同一 `AUTH_JWT_SECRET`。
+- [ ] 反向代理:前端 / Java 后端(`/api`)/ dataagent(`/api/v1/dataagent` 等)收敛到同一站点域,使 `odw_session` Cookie 同域可见。
+- [ ] 生产 Cookie `Secure` 开启;CORS `Allow-Origin` 为具体域。
+- [ ] 文档:更新 `docs/handbook/` 登录与认证说明;若改动公共 API/部署行为,同步相关文档。
+
+---
+
+## 端到端冒烟(完成判据)
+
+- [ ] 密码登录全流程:登录 → Cookie → 访问受保护接口 → 退出 → 401。
+- [ ] OAuth 全流程:配置启用 → authorize → 自研 OAuth 登录 → callback → 落 `sys_user` + Cookie → 进首页。
+- [ ] 未配置 OAuth:登录页无 OAuth 按钮,仅密码可用。
+- [ ] dataagent admin 端点:无令牌拒绝,admin 通过。
+- [ ] dataagent 业务路由(开关开启):带会话通过;widget 头路径仍匿名可用。
+- [ ] 失败锁定:连续错误口令触发锁定。
+
+## 回滚
+
+- 阶段 1-2 回滚:`auth.anonymous.enabled=true` + Filter 直通白名单可临时恢复匿名;DB 迁移为加表,不破坏既有数据。
+- 阶段 3 回滚:`DATAAGENT_REQUIRE_AUTH=false` 关闭业务路由校验;admin 收口建议保留(安全修复)。
+- 阶段 4 回滚:反代/CORS 配置可独立回退。
+
+## 风险与缓解
+
+- 直连拓扑下同域 Cookie 是关键前提 → 阶段 4 反代收敛先行验证;不满足则切 Bearer 注入。
+- 现有大量 `@RequireAuth` 接口语义切换(外部头 → 平台会话)→ 阶段 1 用单测 + 手测覆盖代表性接口。
+- 一次性开启 dataagent 业务校验可能阻断现有前端 → 用 `DATAAGENT_REQUIRE_AUTH` 灰度。

--- a/docs/plans/2026-05-30-configurable-oauth-login-plan.md
+++ b/docs/plans/2026-05-30-configurable-oauth-login-plan.md
@@ -17,7 +17,7 @@
 ### 数据库
 - [ ] `backend/src/main/resources/db/migration/V44__create_sys_user.sql`
   - 建 `sys_user` 表(见设计 5.1)。
-  - 插入初始 `admin`(占位哈希或留空,配合首启改密)。
+  - 直接插入初始 `admin`:`role=admin`、`auth_source=local`、`password_hash` = `admin123` 的 bcrypt 哈希(写死在迁移里)。
 
 ### 依赖
 - [ ] `backend/pom.xml` 增加 `io.jsonwebtoken:jjwt-api/impl/jackson`、`org.springframework.security:spring-security-crypto`。
@@ -29,7 +29,7 @@
 - [ ] `service/JwtService.java`:HS256 签发/校验(读 `AUTH_JWT_SECRET` / `AUTH_JWT_ISSUER` / `AUTH_JWT_TTL`)。
 - [ ] `filter/AuthenticationFilter.java`:非白名单校验 `odw_session` Cookie → 填 `UserContextHolder`;失败按 `auth.anonymous.enabled` 决定 401 / 匿名;`finally` 清理。
 - [ ] `config/WebConfig.java`:注册 `AuthenticationFilter`(顺序在 CORS 之后);白名单可配置项 `auth.whitelist`。
-- [ ] `controller/AuthController.java`:`POST /api/auth/login`、`POST /api/auth/logout`、`GET /api/auth/me`。
+- [ ] `controller/AuthController.java`:`POST /api/auth/login`、`POST /api/auth/logout`、`GET /api/auth/me`、`POST /api/auth/password`(登录后改密)。
 - [ ] `aspect/AuthenticationAspect.java`:`@RequireAuth` 改为基于 `UserContextHolder` 判断(不再直接读外部头);新增 `role` 校验支持(`@RequireRole("admin")` 或 `@RequireAuth(role=...)`)。
 - [ ] `application.yml`:`auth.anonymous.enabled` 默认 `false`(生产),开发可 `true`;`auth.session.ttl`、`auth.whitelist`。
 
@@ -89,11 +89,11 @@
 
 ## 阶段 4:部署与配置收敛
 
-- [ ] `deploy/.env.example` 增:`AUTH_JWT_SECRET`、`AUTH_JWT_ISSUER=opendataworks`、`AUTH_JWT_TTL=8h`、`ADMIN_INIT_PASSWORD`、`DATAAGENT_REQUIRE_AUTH`、前端域(CORS)。
-- [ ] `deploy/` compose:三服务注入同一 `AUTH_JWT_SECRET`。
-- [ ] 反向代理:前端 / Java 后端(`/api`)/ dataagent(`/api/v1/dataagent` 等)收敛到同一站点域,使 `odw_session` Cookie 同域可见。
-- [ ] 生产 Cookie `Secure` 开启;CORS `Allow-Origin` 为具体域。
-- [ ] 文档:更新 `docs/handbook/` 登录与认证说明;若改动公共 API/部署行为,同步相关文档。
+- [ ] `deploy/.env.example` 增:`AUTH_JWT_SECRET`、`AUTH_JWT_ISSUER=opendataworks`、`AUTH_JWT_TTL=8h`、`DATAAGENT_REQUIRE_AUTH`、前端域(CORS)。(无需 `ADMIN_INIT_PASSWORD`,初始口令已存库)
+- [ ] `deploy/docker-compose.prod.yml`:为 `backend` 与 `dataagent-backend` 注入同一 `AUTH_JWT_SECRET`。
+- [ ] 反向代理:**已就绪**。`frontend/nginx.conf` 已把 `/`、`/api/`、`/api/v1/{dataagent,nl2sql,nl2sql-admin}/` 收敛到单域,`odw_session` Cookie 自动同域可见,无需改动路由;仅需确认 cookie 透传不被 nginx 剥离。
+- [ ] 生产 Cookie `Secure` 开启;dataagent CORS `Allow-Origin` 由 `*` 改为具体域。
+- [ ] 文档:更新 `docs/handbook/` 登录与认证说明(含默认 admin 口令 `admin123` 与首登改密提示);若改动公共 API/部署行为,同步相关文档。
 
 ---
 
@@ -114,6 +114,6 @@
 
 ## 风险与缓解
 
-- 直连拓扑下同域 Cookie 是关键前提 → 阶段 4 反代收敛先行验证;不满足则切 Bearer 注入。
+- 同域 Cookie 前提已由 `frontend/nginx.conf` 单域反代满足,风险消除;仅需确认 nginx 不剥离 cookie。
 - 现有大量 `@RequireAuth` 接口语义切换(外部头 → 平台会话)→ 阶段 1 用单测 + 手测覆盖代表性接口。
 - 一次性开启 dataagent 业务校验可能阻断现有前端 → 用 `DATAAGENT_REQUIRE_AUTH` 灰度。

--- a/docs/plans/2026-05-30-configurable-oauth-login-plan.md
+++ b/docs/plans/2026-05-30-configurable-oauth-login-plan.md
@@ -1,18 +1,34 @@
 # 可配置 OAuth 登录与统一身份认证 实施计划
 
 - 日期: 2026-05-30
-- 配套设计: `docs/design/2026-05-30-configurable-oauth-login-design.md`
-- 涉及栈: `backend/`(主)、`frontend/`、`dataagent/dataagent-backend/`(身份校验落地)、`deploy/`(env + 反代)
+- 配套设计:
+  - `docs/design/2026-05-30-configurable-oauth-login-design.md`(登录流程/表/接口业务细节)
+  - `docs/design/2026-05-30-odw-auth-module-design.md`(独立 `odw-auth` 模块架构)
+- 涉及栈: `odw-auth/`(新模块)、`backend/`、`frontend/`、`dataagent/`(`odw_auth` 包 + dataagent-backend 接入)、`deploy/`(env + 反代)
 
 ## 阶段划分
 
-按风险与依赖分四阶段,可分 PR 交付。阶段 1-2 即可让平台具备登录与保护能力;阶段 3 收口 dataagent;阶段 4 部署收敛。
+按风险与依赖分五阶段,可分 PR 交付。阶段 0 立模块骨架;阶段 1-2 让平台具备登录与保护能力;阶段 3 收口 dataagent;阶段 4 部署收敛。
 
 ---
 
-## 阶段 1:后端认证基座(密码登录 + 会话 + 默认拦截)
+## 阶段 0:建立 odw-auth 独立模块骨架
 
-目标:平台具备本地密码登录、会话签发/校验、默认拦截全部 + 白名单。
+目标:Reactor 注册新模块,自动装配可空跑接入。
+
+- [ ] `odw-auth/pom.xml`:`packaging=jar`,parent=`spring-boot-starter-parent`,依赖 jjwt / nimbus-jose-jwt / spring-security-crypto / mybatis-plus / spring-boot-starter-web+aop+webflux。
+- [ ] 根 `pom.xml` `<modules>` 增加 `odw-auth`(置于 `backend` 前)。
+- [ ] `autoconfigure/OdwAuthProperties.java`(`@ConfigurationProperties("odw.auth")`)+ `OdwAuthAutoConfiguration.java`。
+- [ ] `resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`。
+- [ ] 迁移旧代码进模块:`UserContext` / `UserContextHolder`(简化去 oauthUserId,加 role)。
+- [ ] `backend/pom.xml` 增 `odw-auth` 依赖;删除 backend 旧 `context/UserContextHolder`、`aspect/AuthenticationAspect`、`annotation/RequireAuth`、`auth.anonymous.*`;批量改 import。
+- [ ] 验证:`mvn -q -pl odw-auth,backend -am compile` 通过;backend 启动不报装配错误。
+
+---
+
+## 阶段 1:认证核心(密码登录 + 会话 + 默认拦截)
+
+目标:平台具备本地密码登录、会话签发/校验、默认拦截全部 + 白名单。所有代码落在 `odw-auth`。
 
 ### 数据库
 - [ ] `backend/src/main/resources/db/migration/V44__create_sys_user.sql`
@@ -23,20 +39,21 @@
 - [ ] `backend/pom.xml` 增加 `io.jsonwebtoken:jjwt-api/impl/jackson`、`org.springframework.security:spring-security-crypto`。
 
 ### 代码(`backend/src/main/java/com/onedata/portal/`)
-- [ ] `entity/SysUser.java`(镜像 `DolphinConfig` 注解范式,`password_hash` 加 `@JsonProperty(WRITE_ONLY)`)。
-- [ ] `mapper/SysUserMapper.java`(extends `BaseMapper`,加按 username / external_id 查询)。
-- [ ] `service/AuthService.java`:bcrypt 校验、失败计数 + 锁定、签发/解析会话 JWT。
-- [ ] `service/JwtService.java`:HS256 签发/校验(读 `AUTH_JWT_SECRET` / `AUTH_JWT_ISSUER` / `AUTH_JWT_TTL`)。
-- [ ] `filter/AuthenticationFilter.java`:非白名单校验 `odw_session` Cookie → 填 `UserContextHolder`;失败按 `auth.anonymous.enabled` 决定 401 / 匿名;`finally` 清理。
-- [ ] `config/WebConfig.java`:注册 `AuthenticationFilter`(顺序在 CORS 之后);白名单可配置项 `auth.whitelist`。
-- [ ] `controller/AuthController.java`:`POST /api/auth/login`、`POST /api/auth/logout`、`GET /api/auth/me`、`POST /api/auth/password`(登录后改密)。
-- [ ] `aspect/AuthenticationAspect.java`:`@RequireAuth` 改为基于 `UserContextHolder` 判断(不再直接读外部头);新增 `role` 校验支持(`@RequireRole("admin")` 或 `@RequireAuth(role=...)`)。
-- [ ] `application.yml`:`auth.anonymous.enabled` 默认 `false`(生产),开发可 `true`;`auth.session.ttl`、`auth.whitelist`。
+(以下类均在 `odw-auth` 模块 `com.onedata.auth.*` 包内)
+
+- [ ] `user/SysUser.java`(镜像 `DolphinConfig` 注解范式,`password_hash` 加 `@JsonProperty(WRITE_ONLY)`)+ `user/SysUserMapper.java`(按 username / external_id 查询)。
+- [ ] `user/SysUserService.java`:bcrypt 校验、失败计数 + 锁定、upsert OAuth 用户。
+- [ ] `jwt/JwtService.java`(接口)+ `jwt/Hs256JwtService.java`:HS256 签发/校验(读 `odw.auth.jwt.*`)。
+- [ ] `filter/AuthenticationFilter.java`:非白名单校验 `odw_session` Cookie → 填 `UserContextHolder`;失败按 `odw.auth.anonymous.enabled` 决定 401 / 匿名;`finally` 清理。
+- [ ] `web/AuthController.java`:`POST /api/auth/login`、`POST /api/auth/logout`、`GET /api/auth/me`、`POST /api/auth/password`(登录后改密)。
+- [ ] `annotation/RequireAuth`(重写,基于 `UserContextHolder`)+ `annotation/RequireRole` + `aspect/AuthorizationAspect`。
+- [ ] `autoconfigure/OdwAuthAutoConfiguration`:注册 Filter(顺序在 CORS 之后)、各 Bean 加 `@ConditionalOnMissingBean`;白名单来自 `OdwAuthProperties`。
+- [ ] `db/migration/V44__create_sys_user.sql`(建表 + 写死 `admin123` 的 bcrypt 哈希初始 admin)。
 
 ### 验证
-- [ ] 后端编译:`mvn -q -pl backend compile`(或仓库现用构建命令)。
-- [ ] 针对 `AuthService` / `JwtService` 的单测(密码校验、锁定、JWT 签发解析、过期/篡改拒绝)。
-- [ ] 手测:登录拿 Cookie → 带 Cookie 访问受保护接口 200 → 不带 401。
+- [ ] 编译:`mvn -q -pl odw-auth,backend -am compile`。
+- [ ] `odw-auth` 单测:`Hs256JwtService` / `SysUserService` / `AuthenticationFilter`(密码校验、锁定、JWT 签发解析、过期/篡改拒绝、白名单/401)。
+- [ ] 手测:backend 引入模块后,登录拿 Cookie → 带 Cookie 访问受保护接口 200 → 不带 401。
 
 ---
 
@@ -44,15 +61,15 @@
 
 目标:管理员前端配置 OAuth;配置启用后登录页出现 OAuth 入口;授权码全流程打通。
 
-### 数据库
-- [ ] `V45__create_sys_oauth_config.sql`:建 `sys_oauth_config`,插入 `enabled=0` 占位行。
+### 数据库(odw-auth 模块)
+- [ ] `db/migration/V45__create_sys_oauth_config.sql`:建 `sys_oauth_config`,插入 `enabled=0` 占位行。
 
-### 后端
-- [ ] `entity/OAuthConfig.java`(`client_secret` 加 `@JsonProperty(WRITE_ONLY)`)、`mapper/OAuthConfigMapper.java`。
-- [ ] `service/OAuthConfigService.java`:读/更新(secret 留空沿用旧值,参考 `DolphinConfigService` 对 token 的处理)、端点可达性测试。
-- [ ] `service/OAuthLoginService.java`:拼 authorize URL + `state`、code 换 token、JWT 验签(jwks)或调 userinfo、upsert `sys_user`(`auth_source=oauth`、`external_id`)、签发会话。
-- [ ] `controller/AuthController` 增:`GET /api/auth/oauth/config`(公开,仅 enabled+provider_name)、`GET /api/auth/oauth/authorize`、`GET /api/auth/oauth/callback`。
-- [ ] `controller/OAuthConfigController.java`:`GET/PUT /api/admin/oauth/config`、`POST /api/admin/oauth/config/test`(`@RequireRole("admin")`)。
+### 后端(odw-auth 模块 `com.onedata.auth.*`)
+- [ ] `config/SysOAuthConfig.java`(`client_secret` 加 `@JsonProperty(WRITE_ONLY)`)、`config/SysOAuthConfigMapper.java`。
+- [ ] `config/OAuthConfigService.java`:读/更新(secret 留空沿用旧值,参考 `DolphinConfigService` 对 token 的处理)、端点可达性测试。
+- [ ] `oauth/OAuthClient.java`(接口)+ `oauth/DefaultOAuthClient.java`:拼 authorize URL + `state`、code 换 token、JWKS 验签(nimbus)或调 userinfo;`user/UserResolver` upsert `sys_user`(`auth_source=oauth`、`external_id`)。
+- [ ] `web/AuthController` 增:`GET /api/auth/oauth/config`(公开,仅 enabled+provider_name)、`GET /api/auth/oauth/authorize`、`GET /api/auth/oauth/callback`。
+- [ ] `web/OAuthConfigController.java`:`GET/PUT /api/admin/oauth/config`、`POST /api/admin/oauth/config/test`(`@RequireRole("admin")`)。
 - [ ] 白名单加入 `/api/auth/oauth/{config,authorize,callback}`。
 
 ### 前端(`frontend/src/`)
@@ -73,10 +90,10 @@
 
 目标:收口 dataagent admin 裸奔缺口;业务路由灰度启用同一令牌校验。
 
-### 代码(`dataagent/dataagent-backend/`)
-- [ ] `requirements.txt` 增 `PyJWT`。
-- [ ] 新增 `api/auth.py`:`verify_identity()` FastAPI 依赖,从 `odw_session` Cookie 或 `Authorization: Bearer` 取 JWT,用 `AUTH_JWT_SECRET` 校验(算法/issuer 与 Java 端一致),返回 `{user_id, username, role}`;`require_admin()` 依赖。
-- [ ] `api/admin_routes.py`:为 `/settings` 等 admin 端点加 `Depends(require_admin)`(立即收口高危缺口)。
+### 代码(`dataagent/odw_auth/` 包 + `dataagent/dataagent-backend/`)
+- [ ] 新增 Python 包 `dataagent/odw_auth/`:`claims.py`(契约)、`verify.py`(PyJWT 校验,与 Java 同契约/向量)、`fastapi.py`(`verify_identity` / `require_admin` 的 Depends)。
+- [ ] `dataagent-backend/requirements.txt` 增 `PyJWT`,并依赖本地 `odw_auth` 包。
+- [ ] `api/admin_routes.py`:为 `/settings` 等 admin 端点加 `Depends(require_admin)`(立即收口高危缺口),从 `odw_auth.fastapi` 导入。
 - [ ] `api/routes.py`:业务 NL2SQL 路由按开关 `DATAAGENT_REQUIRE_AUTH` 接 `Depends(verify_identity)`;`X-ODW-Client=widget` 分支保留匿名 widget 逻辑不变。
 - [ ] `main.py`:CORS `allow_origins` 由 `*` 收敛为前端域(环境变量驱动)。
 - [ ] 不改 `core/nl2sql_agent.py` 等通用运行时(遵循 skill-agnostic 约束)。


### PR DESCRIPTION
## Summary

Add comprehensive design and implementation plan documentation for configurable OAuth login and unified identity authentication across the OpenDataWorks platform.

## Key Changes

- **`docs/design/2026-05-30-configurable-oauth-login-design.md`**: Complete functional design covering:
  - Two-factor authentication (local password + OAuth2.0 SSO)
  - Session management via HttpOnly JWT cookies
  - Database schema for `sys_user` and `sys_oauth_config` tables
  - Backend API contracts for login, OAuth flow, and admin configuration
  - Frontend login UI and routing guards
  - Extension strategy for `dataagent-backend` using shared token contract
  - Security considerations and risk mitigation

- **`docs/design/2026-05-30-odw-auth-module-design.md`**: Architectural design for extracting authentication into a reusable Maven module:
  - New `odw-auth` JAR module with Spring Boot auto-configuration
  - Parallel Python `odw_auth` package for dataagent-backend
  - SPI extension points for JWT service, OAuth client, user resolution, and whitelist customization
  - Token contract specification for cross-language validation
  - Migration strategy from existing scattered auth code
  - Reusability across multiple Java services and Python backends

- **`docs/plans/2026-05-30-configurable-oauth-login-plan.md`**: Phased implementation roadmap:
  - 5 stages from module skeleton to production deployment
  - Database migrations (V44 `sys_user`, V45 `sys_oauth_config`)
  - Backend implementation checklist (JWT, OAuth flow, controllers)
  - Frontend implementation (login view, routing, stores, API integration)
  - dataagent-backend integration (admin endpoint protection, business route gating)
  - Deployment configuration and end-to-end smoke test criteria

## Notable Implementation Details

- **Default admin account**: Embedded in migration with bcrypt-hashed default password (`admin123`), no environment variable or first-run setup required
- **Single token contract**: Unified JWT claims structure (`sub`, `username`, `role`, `auth_source`, `oauth_user_id`, `iss`, `iat`/`exp`) shared between Java and Python services via HS256 with common secret
- **Default-deny security model**: All non-whitelisted requests require valid session; whitelist includes only auth endpoints, health checks, and existing widget/agent token paths
- **OAuth configuration management**: Stored in database with admin UI, enabling dynamic enable/disable without restart
- **Same-site cookie strategy**: HttpOnly + SameSite=Lax leveraging existing single-domain nginx reverse proxy setup
- **Backward compatibility**: Preserves existing `UserContextHolder` and `@RequireAuth` semantics; Filter handles session validation while Aspect enforces authorization rules

https://claude.ai/code/session_01C66wfVCd3CCX176FSfz5va