### PR TITLE
Add status badges to session lists for task state visibility

### DIFF
--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -1305,7 +1305,7 @@ const subscribeTask = (taskId, assistantMsg) => {
       const task = await taskApi.getTask(key)
       if (!task) return false
       const taskStatus = String(task.task_status || task.status || '').trim()
-      if (taskStatus === 'suspended' && assistantMsg.status === 'queued') {
+      if (taskStatus === 'suspended' && isActiveTaskStatus(assistantMsg.status)) {
         processEvent(assistantMsg, {
           task_id: key,
           message_id: assistantMsg.message_id,
@@ -1316,7 +1316,7 @@ const subscribeTask = (taskId, assistantMsg) => {
             error: { code: 'task_cancelled', message: '任务已取消' }
           }
         })
-      } else if (taskStatus === 'error' && assistantMsg.status === 'queued') {
+      } else if (taskStatus === 'error' && isActiveTaskStatus(assistantMsg.status)) {
         assistantMsg.status = 'failed'
         if (task.error?.message) {
           assistantMsg.error = { message: String(task.error.message) }

--- a/frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/frontend/src/views/intelligence/NL2SqlChat.vue
@@ -52,7 +52,11 @@
                 <path class="query-session-spinner-head" d="M12 2a10 10 0 0 1 10 10" stroke-width="3" stroke-linecap="round" />
               </svg>
             </span>
-            <span v-else class="query-session-meta">{{ formatTime(topic.updated_at || topic.created_at) }}</span>
+            <span v-else class="query-session-meta">
+              <span v-if="topicBadgeKind(topic) === 'error'" class="query-session-dot is-error" title="执行失败" />
+              <span v-else-if="topicBadgeKind(topic) === 'suspended'" class="query-session-dot is-suspended" title="已取消" />
+              {{ formatTime(topic.updated_at || topic.created_at) }}
+            </span>
           </button>
           <div v-if="!filteredTopics.length" class="query-empty-sessions">暂无话题</div>
         </div>
@@ -367,6 +371,7 @@ import { marked } from 'marked'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import { stripChartSpecsFromText } from './chartSpec'
+import { topicStatusKind } from './topicStatus'
 import { describeToolAction, extractToolSkillName, formatSkillBootstrapLabel, isSkillBootstrapPlaceholder } from './toolPresentation'
 import {
   createAssistantMessageState,
@@ -506,9 +511,13 @@ const isTopicSubmitting = (topicId) => pendingSubmitKeys.value.has(normalizePend
 const isTopicWorking = (topic) => {
   if (!topic) return false
   if (isTopicSubmitting(topic.topic_id)) return true
+  if (topicStatusKind(topic.current_task_status) === 'running') return true
   const msgs = topic.messages || []
   return msgs.some((msg) => msg && msg.role === 'assistant' && isActiveTaskStatus(msg.status))
 }
+
+// Badge kind for a topic that is NOT working (error / suspended); '' otherwise.
+const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
 
 const markTopicSubmitting = (topicId) => {
   const key = normalizePendingTopicKey(topicId)
@@ -1305,6 +1314,10 @@ const subscribeTask = (taskId, assistantMsg) => {
       const task = await taskApi.getTask(key)
       if (!task) return false
       const taskStatus = String(task.task_status || task.status || '').trim()
+      // Keep the session-list badge in sync with the authoritative task status so a
+      // background-running topic shows the spinner and a terminal one shows its dot.
+      const listTopic = topics.value.find((t) => t.topic_id === String(task.topic_id || ''))
+      if (listTopic && taskStatus) listTopic.current_task_status = taskStatus
       if (taskStatus === 'suspended' && isActiveTaskStatus(assistantMsg.status)) {
         processEvent(assistantMsg, {
           task_id: key,
@@ -2005,6 +2018,23 @@ defineExpose({ handleNewTopic })
   color: #A0AABF;
   white-space: nowrap;
   text-align: right;
+}
+
+.query-session-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+
+.query-session-dot.is-error {
+  background: #F56C6C;
+}
+
+.query-session-dot.is-suspended {
+  background: #A0AABF;
 }
 
 .query-session-loading {

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -520,6 +520,15 @@ async function selectTopic(topicId, options = {}) {
   }
 }
 
+// Extract a human-readable message from a persisted task/message error object
+// ({ code, message, detail }) or a raw string.
+function extractErrorText(error) {
+  if (!error) return ''
+  if (typeof error === 'string') return error
+  if (typeof error === 'object') return String(error.message || error.detail || error.code || '')
+  return String(error)
+}
+
 function buildV2StateFromStoredBlocks(item) {
   const v2state = createChatState()
   v2state.status = 'done'
@@ -554,6 +563,13 @@ function buildV2StateFromStoredBlocks(item) {
     const block = { turnIndex: 0, blockIndex: 0, type: 'text', content, status: 'done', id: null, name: null, inputJson: '', input: null, output: null, is_error: false }
     turn.blocks.push(block)
     v2state.blocks.push(block)
+  }
+  // A failed run persists message.status === 'error' (+ error_json). Surface it so
+  // the error card renders on reload / topic restore, not just during live streaming.
+  if (String(item?.status || '') === 'error') {
+    v2state.status = 'error'
+    turn.status = 'error'
+    v2state.errorText = extractErrorText(item?.error) || '会话执行失败'
   }
   return v2state
 }
@@ -784,6 +800,20 @@ async function handleSend() {
         scrollToBottom()
       },
     })
+    // On a hard backend failure the SDK stream can end without a terminal
+    // 'done'/'error' record, leaving v2state stuck on 'streaming'. Reconcile
+    // against the persisted task status so failed runs surface the error card.
+    if (v2state.status !== 'error' && !abortController?.signal.aborted) {
+      try {
+        const taskState = await taskApi.getTask(taskId)
+        if (String(taskState?.task_status || '') === 'error') {
+          v2state.status = 'error'
+          v2state.errorText = extractErrorText(taskState?.error) || v2state.errorText || '会话执行失败'
+        } else if (v2state.status !== 'done') {
+          v2state.status = 'done'
+        }
+      } catch { /* keep current state if status lookup fails */ }
+    }
   } catch (err) {
     if (err?.name !== 'AbortError') {
       v2state.status = 'error'

--- a/frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -37,13 +37,17 @@
             @click="handleSelectTopic(topic.topic_id)"
           >
             <span class="v2-session-title">{{ topic.title || '新话题' }}</span>
-            <span v-if="topic.topic_id === activeTopicId && isStreaming" class="v2-session-loading" title="正在分析中...">
+            <span v-if="isTopicWorking(topic)" class="v2-session-loading" title="正在分析中...">
               <svg class="v2-session-spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                 <circle class="v2-session-spinner-track" cx="12" cy="12" r="10" stroke-width="3" />
                 <path class="v2-session-spinner-head" d="M12 2a10 10 0 0 1 10 10" stroke-width="3" stroke-linecap="round" />
               </svg>
             </span>
-            <span v-else class="v2-session-meta">{{ formatTime(topic.updated_at || topic.created_at) }}</span>
+            <span v-else class="v2-session-meta">
+              <span v-if="topicBadgeKind(topic) === 'error'" class="v2-session-dot is-error" title="执行失败" />
+              <span v-else-if="topicBadgeKind(topic) === 'suspended'" class="v2-session-dot is-suspended" title="已取消" />
+              {{ formatTime(topic.updated_at || topic.created_at) }}
+            </span>
           </button>
           <div v-if="!filteredTopics.length" class="v2-empty-sessions">暂无话题</div>
         </div>
@@ -251,6 +255,7 @@ import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import { blockToToolProp, createChatState, processV2Record } from './v2StreamParser'
 import { stripChartSpecsFromText } from './chartSpec'
+import { topicStatusKind } from './topicStatus'
 
 marked.setOptions({ breaks: true, gfm: true })
 
@@ -295,6 +300,13 @@ const filteredTopics = computed(() => {
 })
 
 const activeTopic = computed(() => topics.value.find((t) => t.topic_id === activeTopicId.value) || null)
+
+// Session-list status badge: the active topic shows the spinner while streaming
+// locally; any topic whose server status is waiting/running also shows it.
+const isTopicWorking = (topic) =>
+  (topic?.topic_id === activeTopicId.value && isStreaming.value) ||
+  topicStatusKind(topic?.current_task_status) === 'running'
+const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
 
 const agentSelectOptions = computed(() => agents.value.map((a) => ({ label: a.name, value: a.agent_id })))
 
@@ -981,6 +993,9 @@ onBeforeUnmount(() => {
 }
 
 .v2-session-meta { flex-shrink: 0; font-size: 11px; color: #8C8C8C; }
+.v2-session-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 5px; vertical-align: middle; }
+.v2-session-dot.is-error { background: #F56C6C; }
+.v2-session-dot.is-suspended { background: #A0AABF; }
 
 .v2-session-loading {
   display: inline-flex;

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChat.spec.js
@@ -337,6 +337,24 @@ describe('NL2SqlChat', () => {
     }
   })
 
+  it('shows status dots in the session list driven by current_task_status', async () => {
+    apiMocks.topicApi.listTopics.mockResolvedValue([
+      { ...makeTopicSummary('topic-err', '失败的话题'), current_task_status: 'error' },
+      { ...makeTopicSummary('topic-sus', '取消的话题'), current_task_status: 'suspended' },
+      { ...makeTopicSummary('topic-ok', '完成的话题'), current_task_status: 'finished' }
+    ])
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await flushPromises()
+
+    const items = wrapper.findAll('.query-session-item')
+    expect(items[0].find('.query-session-dot.is-error').exists()).toBe(true)
+    expect(items[1].find('.query-session-dot.is-suspended').exists()).toBe(true)
+    expect(items[2].find('.query-session-dot').exists()).toBe(false)
+  })
+
   it('shows empty config state when admin settings has no enabled provider', async () => {
     apiMocks.adminApi.getSettings.mockResolvedValue({
       provider_id: '',

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -234,6 +234,26 @@ describe('NL2SqlChatV2 URL location', () => {
     })
   })
 
+  it('shows status dots in the session list driven by current_task_status', async () => {
+    apiMocks.topicApi.listTopics.mockResolvedValue({
+      list: [
+        { ...makeTopic('topic-err', 'Failed topic'), current_task_status: 'error' },
+        { ...makeTopic('topic-sus', 'Cancelled topic'), current_task_status: 'suspended' },
+        { ...makeTopic('topic-ok', 'Done topic'), current_task_status: 'finished' }
+      ]
+    })
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await nextTick()
+
+    const items = wrapper.findAll('.v2-session-item')
+    expect(items[0].find('.v2-session-dot.is-error').exists()).toBe(true)
+    expect(items[1].find('.v2-session-dot.is-suspended').exists()).toBe(true)
+    expect(items[2].find('.v2-session-dot').exists()).toBe(false)
+  })
+
   it('surfaces the error card when reloading a failed (status=error) assistant message', async () => {
     routeState.query = {
       tab: 'chat-v2',

--- a/frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -94,6 +94,24 @@ const topicMessages = {
       content: 'second answer',
       created_at: '2026-05-30T03:01:00Z'
     }
+  ],
+  'topic-3': [
+    {
+      message_id: 'u3',
+      topic_id: 'topic-3',
+      sender_type: 'user',
+      content: 'failing question',
+      created_at: '2026-05-30T04:00:00Z'
+    },
+    {
+      message_id: 'a3',
+      topic_id: 'topic-3',
+      sender_type: 'assistant',
+      status: 'error',
+      content: '',
+      error: { code: 'model_error', message: '模型会话异常结束' },
+      created_at: '2026-05-30T04:01:00Z'
+    }
   ]
 }
 
@@ -171,7 +189,8 @@ describe('NL2SqlChatV2 URL location', () => {
     apiMocks.topicApi.listTopics.mockResolvedValue({
       list: [
         makeTopic('topic-1', 'First topic'),
-        makeTopic('topic-2', 'Second topic')
+        makeTopic('topic-2', 'Second topic'),
+        makeTopic('topic-3', 'Failed topic')
       ]
     })
     apiMocks.topicApi.getTopic.mockImplementation(async (topicId) => makeTopic(topicId, `Topic ${topicId}`))
@@ -213,6 +232,22 @@ describe('NL2SqlChatV2 URL location', () => {
       block: 'center',
       behavior: 'smooth'
     })
+  })
+
+  it('surfaces the error card when reloading a failed (status=error) assistant message', async () => {
+    routeState.query = {
+      tab: 'chat-v2',
+      topic_id: 'topic-3'
+    }
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await nextTick()
+
+    const errorCard = wrapper.find('.v2-error-card')
+    expect(errorCard.exists()).toBe(true)
+    expect(errorCard.text()).toContain('模型会话异常结束')
   })
 
   it('writes the selected topic to the URL and clears the previous message target', async () => {

--- a/frontend/src/views/intelligence/__tests__/topicStatus.spec.js
+++ b/frontend/src/views/intelligence/__tests__/topicStatus.spec.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { topicStatusKind } from '../topicStatus'
+
+describe('topicStatusKind', () => {
+  it('maps in-progress statuses to running', () => {
+    expect(topicStatusKind('waiting')).toBe('running')
+    expect(topicStatusKind('running')).toBe('running')
+  })
+
+  it('maps terminal failure/cancel to their own kinds', () => {
+    expect(topicStatusKind('error')).toBe('error')
+    expect(topicStatusKind('suspended')).toBe('suspended')
+  })
+
+  it('returns empty string for finished, unknown, or missing status', () => {
+    expect(topicStatusKind('finished')).toBe('')
+    expect(topicStatusKind('')).toBe('')
+    expect(topicStatusKind(null)).toBe('')
+    expect(topicStatusKind(undefined)).toBe('')
+    expect(topicStatusKind('something-else')).toBe('')
+  })
+})

--- a/frontend/src/views/intelligence/topicStatus.js
+++ b/frontend/src/views/intelligence/topicStatus.js
@@ -1,0 +1,20 @@
+/**
+ * Map a topic's persisted current_task_status (da_agent_topic.current_task_status,
+ * mirrored from da_agent_task.task_status) to a UI badge kind for the session /
+ * conversation record list.
+ *
+ *   waiting | running  -> 'running'    (in-progress; shown as the loading spinner)
+ *   error              -> 'error'      (failed; red dot)
+ *   suspended          -> 'suspended'  (cancelled; grey dot)
+ *   finished | (none)  -> ''           (no badge; timestamp only)
+ *
+ * Returns '' for any unknown / terminal-success value so callers can treat the
+ * empty string as "render nothing extra".
+ */
+export function topicStatusKind(currentTaskStatus) {
+  const status = String(currentTaskStatus || '').trim()
+  if (status === 'waiting' || status === 'running') return 'running'
+  if (status === 'error') return 'error'
+  if (status === 'suspended') return 'suspended'
+  return ''
+}

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -33,13 +33,17 @@
             @click="selectTopic(topic.topic_id)"
           >
             <div class="query-session-title">{{ truncate(topic.title || '新话题', 26) }}</div>
-            <div v-if="topic.topic_id === topicId && activeTaskId" class="query-session-loading" title="正在分析中...">
+            <div v-if="isTopicWorking(topic)" class="query-session-loading" title="正在分析中...">
               <svg class="query-session-spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                 <circle class="query-session-spinner-track" cx="12" cy="12" r="10" stroke-width="3" />
                 <path class="query-session-spinner-head" d="M12 2a10 10 0 0 1 10 10" stroke-width="3" stroke-linecap="round" />
               </svg>
             </div>
-            <div v-else class="query-session-meta">{{ formatTime(topic.updated_at || topic.created_at) }}</div>
+            <div v-else class="query-session-meta">
+              <span v-if="topicBadgeKind(topic) === 'error'" class="query-session-dot is-error" title="执行失败" />
+              <span v-else-if="topicBadgeKind(topic) === 'suspended'" class="query-session-dot is-suspended" title="已取消" />
+              {{ formatTime(topic.updated_at || topic.created_at) }}
+            </div>
           </button>
           <div v-if="!filteredTopics.length" class="query-empty-sessions">暂无话题</div>
         </div>
@@ -217,6 +221,7 @@ import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from '@/views/intelligence/ToolOutputRenderer.vue'
 import { stripChartSpecsFromText } from '@/views/intelligence/chartSpec'
 import { blockToToolProp, createChatState, processV2Record } from '@/views/intelligence/v2StreamParser'
+import { topicStatusKind } from '@/views/intelligence/topicStatus'
 
 marked.setOptions({ breaks: true, gfm: true })
 
@@ -302,6 +307,20 @@ const filteredTopics = computed(() => {
   if (!keyword) return topics.value
   return topics.value.filter((topic) => String(topic.title || '').toLowerCase().includes(keyword))
 })
+
+// Session-list status badge: spinner for the live active task or any topic whose
+// server status is waiting/running; red/grey dot for error/suspended.
+const isTopicWorking = (topic) =>
+  (topic?.topic_id === topicId.value && Boolean(activeTaskId.value)) ||
+  topicStatusKind(topic?.current_task_status) === 'running'
+const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
+
+// Reflect a task's terminal/active status onto its topic in the list so the
+// badge stays accurate (the widget does not reload the topic list after a run).
+const setTopicTaskStatus = (targetTopicId, status) => {
+  const target = topics.value.find((topic) => topic.topic_id === targetTopicId)
+  if (target) target.current_task_status = String(status || '')
+}
 
 watch(
   isBusy,
@@ -667,6 +686,7 @@ const subscribe = async (taskId, assistant) => {
       } catch { /* keep current state if status lookup fails */ }
     }
     assistant.status = assistant._v2state.status === 'error' ? 'failed' : 'success'
+    setTopicTaskStatus(topicId.value, assistant._v2state.status === 'error' ? 'error' : 'finished')
     emit('event', { name: 'message:done', payload: { taskId } })
   } catch (error) {
     if (abortController.value?.signal?.aborted) return
@@ -674,6 +694,7 @@ const subscribe = async (taskId, assistant) => {
     assistant.error = { message: String(error?.message || '请求失败') }
     assistant._v2state.status = 'error'
     assistant._v2state.errorText = assistant.error.message
+    setTopicTaskStatus(topicId.value, 'error')
     emit('event', { name: 'error', payload: assistant.error.message })
   } finally {
     activeTaskId.value = ''
@@ -842,6 +863,7 @@ const cancel = async () => {
   abortController.value?.abort()
   await api.taskApi.cancelTask(taskId)
   activeTaskId.value = ''
+  setTopicTaskStatus(topicId.value, 'suspended')
   const assistant = messages.value.find((item) => item.id === activeAssistantId.value)
   if (assistant) {
     assistant.status = 'cancelled'

--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -443,6 +443,14 @@ const buildV2StateFromStoredBlocks = (item) => {
     turn.blocks.push(block)
     v2state.blocks.push(block)
   }
+  // A failed run persists message.status === 'error' (+ error). Assistant messages
+  // always carry _v2state, so the error must surface through _v2state.status here —
+  // the separate msg.error card only renders for non-_v2state messages.
+  if (String(item?.status || '') === 'error') {
+    v2state.status = 'error'
+    turn.status = 'error'
+    v2state.errorText = errorMessage(item?.error) || '会话执行失败'
+  }
   return v2state
 }
 
@@ -643,6 +651,21 @@ const subscribe = async (taskId, assistant) => {
         triggerRef(messages)
       }
     })
+    // A hard backend failure can end the stream without a terminal done/error
+    // record, leaving _v2state on 'streaming'. Reconcile against the task status
+    // so failed runs surface the error instead of being marked success.
+    if (assistant._v2state.status !== 'error' && !abortController.value?.signal?.aborted) {
+      try {
+        const taskState = await api.taskApi.getTask(taskId)
+        if (String(taskState?.task_status || '') === 'error') {
+          assistant._v2state.status = 'error'
+          assistant._v2state.errorText = errorMessage(taskState?.error) || '会话执行失败'
+          assistant.error = { message: assistant._v2state.errorText }
+        } else if (assistant._v2state.status !== 'done') {
+          assistant._v2state.status = 'done'
+        }
+      } catch { /* keep current state if status lookup fails */ }
+    }
     assistant.status = assistant._v2state.status === 'error' ? 'failed' : 'success'
     emit('event', { name: 'message:done', payload: { taskId } })
   } catch (error) {

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -182,6 +182,33 @@ describe('WidgetChat history conversations', () => {
     expect(apiMocks.topicApi.deleteTopic).not.toHaveBeenCalled()
   })
 
+  it('surfaces the error card when opening a failed (status=error) history conversation', async () => {
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
+      topic_id: topicId,
+      total: 1,
+      items: [
+        {
+          message_id: `msg-${topicId}`,
+          sender_type: 'assistant',
+          content: '',
+          status: 'error',
+          error: { code: 'model_error', message: '模型会话异常结束' },
+          seq_id: 1
+        }
+      ]
+    }))
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('[data-testid="history-topic-topic-2"]').trigger('click')
+    await flushPromises()
+
+    const errorCard = wrapper.find('.query-error-card')
+    expect(errorCard.exists()).toBe(true)
+    expect(errorCard.text()).toContain('模型会话异常结束')
+  })
+
   it('creates the first sent conversation at the top of the history list', async () => {
     apiMocks.topicApi.createTopic.mockResolvedValue(topic('topic-new', '新话题', {
       message_count: 0,

--- a/frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -182,6 +182,21 @@ describe('WidgetChat history conversations', () => {
     expect(apiMocks.topicApi.deleteTopic).not.toHaveBeenCalled()
   })
 
+  it('shows status dots in the history list driven by current_task_status', async () => {
+    apiMocks.topicApi.listTopics.mockResolvedValue([
+      topic('topic-err', '失败的会话', { current_task_status: 'error' }),
+      topic('topic-sus', '取消的会话', { current_task_status: 'suspended' }),
+      topic('topic-ok', '完成的会话', { current_task_status: 'finished' })
+    ])
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="history-topic-topic-err"] .query-session-dot.is-error').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="history-topic-topic-sus"] .query-session-dot.is-suspended').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="history-topic-topic-ok"] .query-session-dot').exists()).toBe(false)
+  })
+
   it('surfaces the error card when opening a failed (status=error) history conversation', async () => {
     apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
       topic_id: topicId,

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -496,6 +496,23 @@ export const WIDGET_STYLES = `
   font-size: 11px;
 }
 
+.query-session-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+
+.query-session-dot.is-error {
+  background: #F56C6C;
+}
+
+.query-session-dot.is-suspended {
+  background: #A0AABF;
+}
+
 .query-empty-sessions {
   padding: 18px 12px;
   color: var(--text-soft);


### PR DESCRIPTION
## Summary
This change adds visual status indicators (badges/dots) to session/conversation lists across the chat interfaces, allowing users to quickly see which topics have failed or been cancelled without opening them. The implementation also improves error handling by surfacing persisted error states when reloading failed conversations.

## Key Changes

- **New `topicStatus.js` utility**: Introduced a `topicStatusKind()` function that maps task status values (`waiting`, `running`, `error`, `suspended`, `finished`) to UI badge kinds, with comprehensive test coverage.

- **Session list status badges**: Added visual indicators in three components:
  - `NL2SqlChatV2.vue`: Red dot for error, grey dot for suspended topics
  - `NL2SqlChat.vue`: Same badge styling for the v1 chat interface
  - `WidgetChat.vue`: Consistent badges in the widget's history list
  - All badges display only when a topic is not actively working (no spinner)

- **Error state persistence**: Enhanced error handling to surface failed runs on reload:
  - `buildV2StateFromStoredBlocks()` now detects persisted `status: 'error'` messages and reconstructs the error state
  - `handleSend()` in NL2SqlChatV2 reconciles against task status after streaming ends to catch backend failures that don't emit terminal records
  - Similar reconciliation added to `WidgetChat.subscribe()` to handle hard backend failures

- **Topic status synchronization**: 
  - Added `setTopicTaskStatus()` in WidgetChat to keep the session list badge in sync with actual task completion
  - NL2SqlChat now updates `current_task_status` during task polling to maintain accurate spinner/badge display
  - Properly reflects task cancellation and error states back to the topic list

- **Test coverage**: Added comprehensive tests for:
  - Status badge rendering based on `current_task_status`
  - Error card display when reopening failed conversations
  - Status dot visibility in both v2 and v1 chat interfaces and the widget

## Implementation Details

The solution uses a three-tier approach:
1. **Server state** (`current_task_status` on topics) drives the persistent badge display
2. **Live state** (streaming flag) shows the spinner while actively processing
3. **Persisted errors** are reconstructed from stored message objects to surface errors on reload

This ensures the UI accurately reflects task state whether viewing a live stream, reopening a completed conversation, or checking the session list.

https://claude.ai/code/session_01MP3sYYpTyyMPzqQvo1LrSy