### PR TITLE
Refactor history panel layout for floating mode

### DIFF
--- a/frontend/src/widget/WidgetChat.vue
+++ b/frontend/src/widget/WidgetChat.vue
@@ -51,23 +51,6 @@
     </aside>
 
     <main class="query-main">
-      <!-- Top bar: only when messages exist and inline mode (floating has no top-bar content) -->
-      <div v-if="(messages.length || errorText) && isInline" class="query-top-bar">
-        <button
-          class="query-btn-history-toggle"
-          type="button"
-          aria-label="历史会话"
-          title="历史会话"
-          @click="toggleHistory"
-        >
-          <svg class="query-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M3 3v5h5" />
-            <path d="M3.05 13A9 9 0 1 0 6 5.3L3 8" />
-            <path d="M12 7v5l4 2" />
-          </svg>
-        </button>
-      </div>
-
       <div class="query-messages">
         <div class="query-messages-inner" :class="{ 'is-empty': !messages.length }">
           <div v-if="errorText" class="query-error-card query-error-banner">
@@ -579,10 +562,6 @@ const guardIdle = () => {
 
 const closeHistory = () => {
   props.state.historyOpen = false
-}
-
-const toggleHistory = () => {
-  props.state.historyOpen = !props.state.historyOpen
 }
 
 const selectTopic = async (targetTopicId) => {

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -318,33 +318,6 @@ export const WIDGET_STYLES = `
   flex: 1;
 }
 
-.query-btn-history-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--sidebar-bg);
-  color: var(--text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: all 0.2s ease;
-}
-
-.query-btn-history-toggle:hover {
-  background: var(--surface-soft);
-  color: var(--text);
-  border-color: var(--accent);
-}
-
-.query-icon-svg {
-  width: 16px;
-  height: 16px;
-  display: block;
-}
-
 @container (max-width: 600px) {
   .query-workbench.is-history-open {
     grid-template-columns: minmax(0, 1fr);
@@ -586,18 +559,6 @@ export const WIDGET_STYLES = `
 .query-workbench.is-floating .query-messages-inner {
   padding: 14px 16px 120px;
 }
-
-.query-top-bar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 24px 12px;
-  border-bottom: 1px solid var(--line-soft);
-  flex-shrink: 0;
-  background: #fff;
-  min-height: 52px;
-}
-
 
 .query-config-empty {
   margin: 44px auto 0;

--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -119,10 +119,6 @@ export const WIDGET_STYLES = `
   transition: width 0.3s cubic-bezier(0.2, 0, 0, 1);
 }
 
-.odw-widget.is-history-open:not(.is-inline) .odw-panel {
-  width: min(clamp(720px, 52vw, 1080px), calc(100vw - 24px));
-}
-
 .odw-widget.is-dragged {
   right: auto;
   bottom: auto;
@@ -289,6 +285,25 @@ export const WIDGET_STYLES = `
 
 .query-workbench.is-history-open {
   grid-template-columns: 220px minmax(0, 1fr);
+}
+
+/* Floating mode: history panel is an overlay drawer so opening/closing it
+   never changes the panel width or squeezes the chat area. */
+.query-workbench.is-floating.is-history-open {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.query-workbench.is-floating .query-sidebar {
+  position: absolute;
+  inset: 0 auto 0 0;
+  z-index: 8;
+  width: min(240px, 80%);
+  box-shadow: 16px 0 34px rgba(15, 23, 42, 0.16);
+  border-right: 1px solid var(--sidebar-border);
+}
+
+.query-workbench.is-floating .query-sidebar-backdrop {
+  display: block;
 }
 
 .query-workbench .query-sidebar-backdrop {


### PR DESCRIPTION
## Summary
Restructures the widget layout system to properly handle the history panel as an overlay drawer in floating mode, while maintaining the side-by-side layout in inline mode.

## Key Changes
- **Removed inline mode history panel styling**: Deleted the `.odw-widget.is-history-open:not(.is-inline) .odw-panel` rule that was attempting to resize the panel when history opened
- **Added floating mode overlay drawer**: Implemented new styles for `.query-workbench.is-floating` that position the sidebar as an absolute overlay with backdrop, preventing layout shifts when opening/closing history
- **Removed top bar UI**: Deleted the history toggle button and its container from the top bar in `WidgetChat.vue`, along with associated styles (`.query-top-bar`, `.query-btn-history-toggle`, `.query-icon-svg`)
- **Removed toggle function**: Removed the `toggleHistory()` method from the component as the toggle button is no longer needed

## Implementation Details
- In floating mode, the sidebar uses `position: absolute` with `inset: 0 auto 0 0` to overlay on the left side
- The grid layout for floating mode uses `minmax(0, 1fr)` to prevent layout shifts when the overlay appears
- A backdrop element is now displayed in floating mode to handle overlay interactions
- The sidebar width is constrained to `min(240px, 80%)` for responsive behavior on smaller screens
- Box shadow and border styling provide visual separation for the overlay drawer

https://claude.ai/code/session_01NoRhNsdp2qVuZ5MYXLfpxJ