### PR TITLE
fix(widget): show history drawer above the landing composer

### DIFF
--- a/frontend/src/widget/styles.js
+++ b/frontend/src/widget/styles.js
@@ -296,7 +296,7 @@ export const WIDGET_STYLES = `
 .query-workbench.is-floating .query-sidebar {
   position: absolute;
   inset: 0 auto 0 0;
-  z-index: 8;
+  z-index: 12;
   width: min(240px, 80%);
   box-shadow: 16px 0 34px rgba(15, 23, 42, 0.16);
   border-right: 1px solid var(--sidebar-border);
@@ -325,7 +325,7 @@ export const WIDGET_STYLES = `
   .query-workbench .query-sidebar {
     position: absolute;
     inset: 0 auto 0 0;
-    z-index: 8;
+    z-index: 12;
     width: min(240px, 80%);
     box-shadow: 16px 0 34px rgba(15, 23, 42, 0.16);
     border-right: 1px solid var(--sidebar-border);
@@ -354,7 +354,7 @@ export const WIDGET_STYLES = `
 .query-sidebar-backdrop {
   position: absolute;
   inset: 0;
-  z-index: 7;
+  z-index: 11;
   background: rgba(15, 23, 42, 0.34);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #281. After the history sidebar became an overlay drawer in floating mode, opening history on the **initial (empty) page** looked unresponsive — clicking 历史 did nothing visible.

## Root cause

On the initial page the landing composer (`.query-composer-bar.is-landing`) is `position: absolute` with `top:0; bottom:0`, an opaque white background, and `z-index: 10`, so it covers the whole workbench. The history drawer overlay was at `z-index: 8` and its backdrop at `z-index: 7` — both **below** the composer. The drawer did open, but behind the opaque landing composer, so it appeared to do nothing.

## Fix

Raise the drawer above the composer in `frontend/src/widget/styles.js`:
- history sidebar overlay: `z-index: 8 → 12` (both the `.is-floating` rule and the `@container (max-width: 600px)` rule)
- backdrop: `z-index: 7 → 11`

Now the drawer and its dimming backdrop stack above the landing composer, so opening history works on the initial page as well as after a conversation has started. Backdrop-click-to-close is unchanged.

## Verification
- `WidgetChat.spec.js` — 13/13 pass
- `npm run build:widget` — builds clean

https://claude.ai/code/session_01NoRhNsdp2qVuZ5MYXLfpxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoRhNsdp2qVuZ5MYXLfpxJ)_