### PR TITLE
Add result size guard & SQL export capability for NL2SQL

### DIFF
--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryRequest.java
@@ -1,5 +1,6 @@
 package com.onedata.portal.agentapi.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -18,4 +19,11 @@ public class AgentReadQueryRequest {
     private Integer limit;
 
     private Integer timeoutSeconds;
+
+    /**
+     * 导出模式：由本地导出脚本设置。结果写盘、不进模型上下文，因此跳过结果字节守卫
+     * （仍受行数上限约束）。普通查询保持守卫不变。
+     */
+    @JsonProperty("for_export")
+    private Boolean forExport;
 }

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryResponse.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryResponse.java
@@ -25,5 +25,10 @@ public class AgentReadQueryResponse {
     @JsonProperty("duration_ms")
     private Integer durationMs;
 
+    @JsonProperty("truncated_by_size")
+    private Boolean truncatedBySize;
+
+    private String notice;
+
     private List<Map<String, Object>> rows = new ArrayList<>();
 }

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentMetadataService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentMetadataService.java
@@ -21,6 +21,7 @@ import com.onedata.portal.mapper.DorisClusterMapper;
 import com.onedata.portal.mapper.DorisDbUserMapper;
 import com.onedata.portal.service.LineageService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -39,10 +40,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BackendAgentMetadataService implements AgentMetadataService {
 
+    /** 元数据导出行数安全阀，防止无界导出撑爆 agent 工具结果缓冲。 */
+    private static final int EXPORT_MAX_ROWS = 5000;
     private static final int INSPECT_FETCH_LIMIT = 800;
     private static final int INSPECT_FIELD_FETCH_LIMIT = 2400;
     private static final int INSPECT_LINEAGE_LIMIT = 120;
@@ -299,7 +303,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
                 rows.add(tableExportRow(table, field));
             }
         }
-        return rows;
+        return capExportRows(rows, "tables");
     }
 
     @Override
@@ -333,7 +337,7 @@ public class BackendAgentMetadataService implements AgentMetadataService {
             row.put("downstream_table", downstream == null ? null : downstream.getTableName());
             rows.add(row);
         }
-        return rows;
+        return capExportRows(rows, "lineage");
     }
 
     @Override
@@ -363,7 +367,15 @@ public class BackendAgentMetadataService implements AgentMetadataService {
             row.put("resolved_by", cluster == null ? "platform_runtime" : (dbUser == null ? "data_table" : "readonly_user"));
             rows.add(row);
         }
-        return rows;
+        return capExportRows(rows, "datasource");
+    }
+
+    private List<Map<String, Object>> capExportRows(List<Map<String, Object>> rows, String exportKind) {
+        if (rows == null || rows.size() <= EXPORT_MAX_ROWS) {
+            return rows;
+        }
+        log.warn("agent metadata export '{}' truncated from {} to {} rows", exportKind, rows.size(), EXPORT_MAX_ROWS);
+        return new ArrayList<>(rows.subList(0, EXPORT_MAX_ROWS));
     }
 
     private List<DataTable> findTables(String database, String table, String keyword, int fetchLimit) {

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
@@ -1,26 +1,34 @@
 package com.onedata.portal.agentapi.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.agentapi.dto.AgentDatasourceResolution;
 import com.onedata.portal.agentapi.dto.AgentReadQueryRequest;
 import com.onedata.portal.agentapi.dto.AgentReadQueryResponse;
 import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BackendAgentQueryService implements AgentQueryService {
@@ -29,6 +37,8 @@ public class BackendAgentQueryService implements AgentQueryService {
     private static final int MAX_LIMIT = 10000;
     private static final int DEFAULT_TIMEOUT_SECONDS = 30;
     private static final int MAX_TIMEOUT_SECONDS = 120;
+    /** 单行间分隔与外层数组括号的近似开销，避免低估实际序列化字节。 */
+    private static final int ROW_SERIALIZATION_OVERHEAD_BYTES = 2;
     private static final Pattern LEADING_KEYWORD_PATTERN = Pattern.compile("^\\s*([a-zA-Z]+)");
     private static final Pattern MUTATING_FALLBACK_KEYWORD_PATTERN = Pattern.compile(
             "(^|[^a-zA-Z0-9_])(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|REPLACE|MERGE|CALL|GRANT|REVOKE)([^a-zA-Z0-9_]|$)",
@@ -43,6 +53,15 @@ public class BackendAgentQueryService implements AgentQueryService {
 
     private final AgentMetadataService agentMetadataService;
     private final AgentJdbcExecutor agentJdbcExecutor;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 单次只读查询返回行的字节预算。源头守卫：超预算即截断，防止单条工具结果帧
+     * 撑爆 claude-agent-sdk 的 stdout JSON 缓冲（默认 1MB）。默认 512KB，显著低于
+     * SDK 默认缓冲上限，并为下游脚本路径的美化与信封预留余量。
+     */
+    @Value("${agent.query.max-result-bytes:524288}")
+    private int maxResultBytes = 524288;
 
     @Override
     public AgentReadQueryResponse readQuery(AgentReadQueryRequest request) {
@@ -75,11 +94,55 @@ public class BackendAgentQueryService implements AgentQueryService {
         response.setEngine(datasource.getEngine());
         response.setSql(sql);
         response.setLimit(limit);
-        response.setRows(execution.getRows());
-        response.setRowCount(execution.getRowCount());
-        response.setHasMore(execution.isHasMore());
         response.setDurationMs(execution.getDurationMs());
+
+        List<Map<String, Object>> rows = execution.getRows();
+        int keep = resultByteBudgetKeepCount(rows);
+        if (keep < rows.size()) {
+            int total = rows.size();
+            List<Map<String, Object>> kept = new ArrayList<>(rows.subList(0, keep));
+            response.setRows(kept);
+            response.setRowCount(kept.size());
+            response.setHasMore(true);
+            response.setTruncatedBySize(true);
+            response.setNotice(String.format(
+                    "结果体积超过单次返回上限（约 %d KB），已截断为前 %d 行（原始返回 %d 行）。"
+                            + "如需完整或精确结果，请缩小查询范围：增加过滤条件、做聚合，或降低 LIMIT；"
+                            + "不要对同一口径重复执行。",
+                    maxResultBytes / 1024, keep, total));
+            log.warn("agent readQuery result truncated by size budget. kept={} total={} maxBytes={} sql={}",
+                    keep, total, maxResultBytes, sql);
+        } else {
+            response.setRows(rows);
+            response.setRowCount(execution.getRowCount());
+            response.setHasMore(execution.isHasMore());
+        }
         return response;
+    }
+
+    /**
+     * 逐行估算紧凑 JSON 字节并累加，返回在字节预算内可保留的行数。
+     * 至少保留 1 行（即便首行已超预算），使模型仍有上下文；预算远低于 SDK 缓冲上限，单行安全。
+     */
+    private int resultByteBudgetKeepCount(List<Map<String, Object>> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return 0;
+        }
+        long accumulated = 0;
+        for (int i = 0; i < rows.size(); i++) {
+            long rowBytes;
+            try {
+                rowBytes = objectMapper.writeValueAsBytes(rows.get(i)).length + ROW_SERIALIZATION_OVERHEAD_BYTES;
+            } catch (JsonProcessingException e) {
+                // 无法序列化的单行视为超大，保守在此截断（但至少保留已通过的行）。
+                return Math.max(1, i);
+            }
+            accumulated += rowBytes;
+            if (accumulated > maxResultBytes) {
+                return Math.max(1, i);
+            }
+        }
+        return rows.size();
     }
 
     void validateReadOnlySql(String sql) {

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java
@@ -97,7 +97,8 @@ public class BackendAgentQueryService implements AgentQueryService {
         response.setDurationMs(execution.getDurationMs());
 
         List<Map<String, Object>> rows = execution.getRows();
-        int keep = resultByteBudgetKeepCount(rows);
+        boolean forExport = Boolean.TRUE.equals(request.getForExport());
+        int keep = forExport ? rows.size() : resultByteBudgetKeepCount(rows);
         if (keep < rows.size()) {
             int total = rows.size();
             List<Map<String, Object>> kept = new ArrayList<>(rows.subList(0, keep));

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
@@ -120,6 +120,41 @@ class BackendAgentQueryServiceTest {
     }
 
     @Test
+    void readQueryDoesNotTruncateWhenForExport() {
+        ReflectionTestUtils.setField(backendAgentQueryService, "maxResultBytes", 64);
+
+        AgentReadQueryRequest request = new AgentReadQueryRequest();
+        request.setDatabase("opendataworks");
+        request.setSql("SELECT * FROM big_table");
+        request.setForExport(true);
+
+        AgentDatasourceResolution datasource = new AgentDatasourceResolution();
+        datasource.setDatabase("opendataworks");
+        datasource.setEngine("mysql");
+        when(agentMetadataService.resolveDatasource(eq("opendataworks"), any())).thenReturn(datasource);
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id", i);
+            row.put("payload", "value-with-some-length-" + i);
+            rows.add(row);
+        }
+        AgentJdbcExecutor.QueryExecutionResult execution = new AgentJdbcExecutor.QueryExecutionResult();
+        execution.setRows(rows);
+        execution.setRowCount(rows.size());
+        execution.setHasMore(false);
+        execution.setDurationMs(5);
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), any(), anyInt(), anyInt())).thenReturn(execution);
+
+        AgentReadQueryResponse response = backendAgentQueryService.readQuery(request);
+
+        assertEquals(50, response.getRows().size());
+        assertNull(response.getTruncatedBySize());
+        assertNull(response.getNotice());
+    }
+
+    @Test
     void readQueryKeepsAtLeastOneRowWhenSingleRowExceedsBudget() {
         ReflectionTestUtils.setField(backendAgentQueryService, "maxResultBytes", 1);
 

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.onedata.portal.agentapi;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.agentapi.dto.AgentDatasourceResolution;
 import com.onedata.portal.agentapi.dto.AgentReadQueryRequest;
 import com.onedata.portal.agentapi.dto.AgentReadQueryResponse;
@@ -11,13 +12,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +41,9 @@ class BackendAgentQueryServiceTest {
 
     @Mock
     private AgentJdbcExecutor agentJdbcExecutor;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @InjectMocks
     private BackendAgentQueryService backendAgentQueryService;
@@ -64,6 +78,75 @@ class BackendAgentQueryServiceTest {
         assertEquals(Integer.valueOf(12), response.getDurationMs());
         verify(agentMetadataService).resolveDatasource("opendataworks", "mysql");
         verify(agentJdbcExecutor).executeReadOnlyQuery(datasource, "SELECT 1", 50, 20);
+        assertNull(response.getTruncatedBySize());
+        assertNull(response.getNotice());
+    }
+
+    @Test
+    void readQueryTruncatesResultWhenByteBudgetExceeded() {
+        ReflectionTestUtils.setField(backendAgentQueryService, "maxResultBytes", 64);
+
+        AgentReadQueryRequest request = new AgentReadQueryRequest();
+        request.setDatabase("opendataworks");
+        request.setSql("SELECT * FROM big_table");
+
+        AgentDatasourceResolution datasource = new AgentDatasourceResolution();
+        datasource.setDatabase("opendataworks");
+        datasource.setEngine("mysql");
+        when(agentMetadataService.resolveDatasource(eq("opendataworks"), any())).thenReturn(datasource);
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("id", i);
+            row.put("payload", "value-with-some-length-" + i);
+            rows.add(row);
+        }
+        AgentJdbcExecutor.QueryExecutionResult execution = new AgentJdbcExecutor.QueryExecutionResult();
+        execution.setRows(rows);
+        execution.setRowCount(rows.size());
+        execution.setHasMore(false);
+        execution.setDurationMs(5);
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), any(), anyInt(), anyInt())).thenReturn(execution);
+
+        AgentReadQueryResponse response = backendAgentQueryService.readQuery(request);
+
+        assertEquals(Boolean.TRUE, response.getTruncatedBySize());
+        assertEquals(Boolean.TRUE, response.getHasMore());
+        assertTrue(response.getRows().size() >= 1);
+        assertTrue(response.getRows().size() < rows.size());
+        assertEquals(Integer.valueOf(response.getRows().size()), response.getRowCount());
+        assertNotNull(response.getNotice());
+    }
+
+    @Test
+    void readQueryKeepsAtLeastOneRowWhenSingleRowExceedsBudget() {
+        ReflectionTestUtils.setField(backendAgentQueryService, "maxResultBytes", 1);
+
+        AgentReadQueryRequest request = new AgentReadQueryRequest();
+        request.setDatabase("opendataworks");
+        request.setSql("SELECT * FROM wide_table");
+
+        AgentDatasourceResolution datasource = new AgentDatasourceResolution();
+        datasource.setDatabase("opendataworks");
+        datasource.setEngine("mysql");
+        when(agentMetadataService.resolveDatasource(eq("opendataworks"), any())).thenReturn(datasource);
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            rows.add(Collections.singletonMap("payload", "row-" + i));
+        }
+        AgentJdbcExecutor.QueryExecutionResult execution = new AgentJdbcExecutor.QueryExecutionResult();
+        execution.setRows(rows);
+        execution.setRowCount(rows.size());
+        execution.setHasMore(false);
+        execution.setDurationMs(5);
+        when(agentJdbcExecutor.executeReadOnlyQuery(any(), any(), anyInt(), anyInt())).thenReturn(execution);
+
+        AgentReadQueryResponse response = backendAgentQueryService.readQuery(request);
+
+        assertEquals(1, response.getRows().size());
+        assertEquals(Boolean.TRUE, response.getTruncatedBySize());
     }
 
     @Test

--- a/dataagent/.claude/skills/opendataworks-platform-tools/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/SKILL.md
@@ -49,6 +49,7 @@ OpenDataWorks Platform Tools Skill。平台工具 Skill。
 8. `SELECT` 查询默认带 `LIMIT`，除非已验证的语句类型不支持。
 9. 不暴露数据源账号密码或直连数据库细节。
 10. 首个足够平台结果或不可重试失败归因出现后就停止。
+11. 大结果或要落盘的场景，必须用导出脚本 `export_query.py`，让全量数据写工作区文件、只把路径与预览回给模型；不要用 `portal_query_readonly` 或 `run_sql.py` 把全量结果拉进上下文（会被结果字节守卫截断，且可能撑爆运行时缓冲）。
 
 ## 读取顺序
 
@@ -67,6 +68,7 @@ OpenDataWorks Platform Tools Skill。平台工具 Skill。
 | 解析数据源 | SQL 执行前需要执行引擎/database 路由 | portal MCP 数据源解析，失败再脚本回退 |
 | 验证 SQL | SQL 已就绪，准备脚本回退执行 | 验证脚本 |
 | 执行只读 SQL | SQL 已验证通过，且需要真实结果 | 只读 SQL 执行脚本 |
+| 导出结果到文件 | 结果行数多、或需落盘供后续 Python 处理（如生成 Excel） | 导出脚本 `export_query.py`，全量写工作区 CSV，只回路径+预览 |
 | 图表契约 | SQL 结果形态适合前端图表渲染 | 图表契约脚本 |
 
 ## 最终输出

--- a/dataagent/.claude/skills/opendataworks-platform-tools/bin/odw-cli
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/bin/odw-cli
@@ -17,7 +17,7 @@ Usage:
   odw-cli resolve-datasource --database DB [--preferred-engine mysql|doris]
   odw-cli export --kind tables|lineage|datasource [--database DB]
   odw-cli ddl [--database DB --table TABLE] [--table-id ID]
-  odw-cli query-readonly --database DB --sql SQL [--preferred-engine mysql|doris] [--limit N] [--timeout-seconds N]
+  odw-cli query-readonly --database DB --sql SQL [--preferred-engine mysql|doris] [--limit N] [--timeout-seconds N] [--for-export true]
 EOF
   exit 2
 }
@@ -310,6 +310,7 @@ parse_query_readonly() {
   preferred_engine=""
   limit=""
   timeout_seconds=""
+  for_export=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --database)
@@ -332,6 +333,10 @@ parse_query_readonly() {
         timeout_seconds="${2:-}"
         shift 2
         ;;
+      --for-export)
+        for_export="${2:-}"
+        shift 2
+        ;;
       *)
         echo "unknown query-readonly arg: $1" >&2
         usage
@@ -348,6 +353,7 @@ parse_query_readonly() {
   [ -n "$preferred_engine" ] && payload="${payload},\"preferredEngine\":\"$(json_escape "$preferred_engine")\""
   [ -n "$limit" ] && payload="${payload},\"limit\":${limit}"
   [ -n "$timeout_seconds" ] && payload="${payload},\"timeoutSeconds\":${timeout_seconds}"
+  [ "$for_export" = "true" ] && payload="${payload},\"for_export\":true"
   payload="${payload}}"
 
   run_post_json "$AI_BASE_URL" "query/read" "$payload"

--- a/dataagent/.claude/skills/opendataworks-platform-tools/reference/30-tool-recipes.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/reference/30-tool-recipes.md
@@ -6,9 +6,10 @@
 
 - fallback 脚本统一通过：`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/<name>.py" ...`
 - 若运行时暴露了 `mcp__portal__portal_*`，优先直接调用 MCP tools，不要先绕回脚本。
-- 固定脚本只有：`inspect_metadata.py`、`resolve_datasource.py`、`get_lineage.py`、`get_table_ddl.py`、`validate_sql.py`、`run_sql.py`、`build_chart_spec.py`、`format_answer.py`、`query_opendataworks_metadata.py`
-- validate_sql.py 是唯一推荐的 SQL 验证入口；脚本 fallback 下必须先 `validate_sql.py`，再 `run_sql.py`。
+- 固定脚本只有：`inspect_metadata.py`、`resolve_datasource.py`、`get_lineage.py`、`get_table_ddl.py`、`validate_sql.py`、`run_sql.py`、`export_query.py`、`build_chart_spec.py`、`format_answer.py`、`query_opendataworks_metadata.py`
+- validate_sql.py 是唯一推荐的 SQL 验证入口；脚本 fallback 下必须先 `validate_sql.py`，再 `run_sql.py` 或 `export_query.py`。
 - run_sql.py 是唯一推荐的 SQL 执行入口；不要新增或猜测其他 SQL 执行脚本。
+- 大结果或需落盘的场景改用 `export_query.py`（结果写文件、不进上下文）；它服务于导出，不替代 run_sql.py 把结果回上下文的入口地位。
 - 标准链路：语义确认 → SQL 生成 → SQL 验证 → run_sql.py 执行 → 结果收口。
 - 语义技能只提供语义；不要在语义技能中寻找或维护 SQL 验证/执行脚本。
 - 不要自己拼脚本路径或脚本名；禁止使用 primary `DATAAGENT_SKILL_ROOT`、部署绝对路径、裸相对路径或猜测脚本名。
@@ -76,6 +77,16 @@
   - `result_state=empty_result`：查询成功但无数据，说明口径和空结果，不换表试探。
   - `result_state=failed`：按 `error_code`、`failure_attribution`、`stop_reason` 说明原因。
 - 命令模板：`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/run_sql.py" --database <db> --engine <mysql|doris> --sql "<SQL>"`
+- 注意：`run_sql.py` 与 `portal_query_readonly` 的结果会进模型上下文，受结果字节守卫（默认 512KB）约束；超限会返回 `truncated_by_size=true` 与 `error_code=result_truncated`。大结果或要落盘时改用 `export_query.py`。
+
+## export_query.py
+
+- 用途：把只读 SQL 的**全量结果**写入工作区 CSV 文件，只把路径、列、行数与少量预览回给模型；全量数据不进模型上下文，因此不触发结果字节守卫，也不会撑爆运行时缓冲。
+- 适用场景：结果行数多、或需要落盘供后续 Python 处理（如读 CSV 生成多 sheet Excel）。
+- 固定链路：`export_query.py -> backend 只读查询 API（导出模式，绕过字节守卫，仍受行数上限保护）`。
+- 行数上限：默认且最大 10000 行；命中上限时 `has_more=true`，应改用更精确的过滤或聚合。
+- 后续处理：模型用 Bash/Python 读取返回的 `file_path`（CSV）再生成最终文件，不要把 CSV 内容整体读进上下文。
+- 命令模板：`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/export_query.py" --database <db> --engine <mysql|doris> --sql "<SQL>" --output <relative/or/abs/path.csv>`
 
 ## build_chart_spec.py
 

--- a/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
@@ -48,6 +48,8 @@
   "rows": [{"category": "A", "row_count": 3}],
   "row_count": 1,
   "has_more": false,
+  "truncated_by_size": false,
+  "notice": null,
   "duration_ms": 120,
   "summary": "返回分组统计结果",
   "result_state": "success",
@@ -62,10 +64,16 @@
 `sql_execution` 必须提供这些收口字段：
 
 - `result_state`: `success`、`empty_result` 或 `failed`
-- `error_code`: 成功时为 `null`；空结果为 `empty_result`；失败时为 `permission_denied`、`datasource_mismatch`、`unknown_table`、`unknown_column`、`tool_timeout`、`non_readonly_sql` 或 `query_failed`
+- `error_code`: 成功时为 `null`；空结果为 `empty_result`；按体积截断为 `result_truncated`；失败时为 `permission_denied`、`datasource_mismatch`、`unknown_table`、`unknown_column`、`tool_timeout`、`non_readonly_sql` 或 `query_failed`
 - `failure_attribution`: 用于报告归因，例如 `empty_result`、`permission_denied`、`schema_mismatch`、`datasource_mismatch`、`tool_timeout`、`invalid_sql`
 - `retryable`: 当前 agent 是否应该继续重试
-- `stop_reason`: 失败或空结果时给模型的中文收口理由
+- `stop_reason`: 失败、空结果或按体积截断时给模型的中文收口理由
+
+结果体积守卫：
+
+- 后端 `/v1/ai/query/read` 在源头按字节预算（默认 512KB）截断返回行，避免单条工具结果撑爆运行时 JSON 缓冲。
+- 截断时返回 `truncated_by_size=true`、`has_more=true` 与中文 `notice`/`stop_reason`。
+- 收到截断信号应缩小查询范围（增加过滤、聚合或降低 LIMIT）后再查，不要对同一口径重复执行；若样本已足够回答也可直接基于已返回行作答并说明结果不完整。
 
 ## 图表契约
 

--- a/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
@@ -75,6 +75,36 @@
 - 截断时返回 `truncated_by_size=true`、`has_more=true` 与中文 `notice`/`stop_reason`。
 - 收到截断信号应缩小查询范围（增加过滤、聚合或降低 LIMIT）后再查，不要对同一口径重复执行；若样本已足够回答也可直接基于已返回行作答并说明结果不完整。
 
+## SQL 导出
+
+`export_query.py` 把全量结果写工作区 CSV，只回路径与预览（`kind=sql_export`）：
+
+```json
+{
+  "kind": "sql_export",
+  "tool_label": "SQL 导出",
+  "engine": "mysql",
+  "database": "example_schema",
+  "sql": "SELECT ...",
+  "file_path": "/path/to/workspace/exports/result.csv",
+  "file_format": "csv",
+  "columns": ["col_a", "col_b"],
+  "row_count": 621,
+  "has_more": false,
+  "preview_rows": [{ "col_a": "x", "col_b": 1 }],
+  "summary": "已导出 621 行到 /path/to/workspace/exports/result.csv",
+  "result_state": "success",
+  "error_code": null,
+  "failure_attribution": [],
+  "retryable": false,
+  "stop_reason": "",
+  "error": null
+}
+```
+
+- 全量数据在文件里，不在 `preview_rows`；后续处理（如生成 Excel）应让 Python 读 `file_path`，不要把整份 CSV 读进上下文。
+- `has_more=true` 表示命中行数上限（默认/最大 10000），应改用更精确的过滤或聚合。
+
 ## 图表契约
 
 图表输出统一通过 `chart_spec`，由 `chart_type` 区分：

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
@@ -281,6 +281,8 @@ def query_readonly(
         "row_count": payload.get("row_count"),
         "has_more": payload.get("has_more"),
         "duration_ms": payload.get("duration_ms"),
+        "truncated_by_size": payload.get("truncated_by_size"),
+        "notice": payload.get("notice"),
     }
 
 

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py
@@ -255,6 +255,7 @@ def query_readonly(
     preferred_engine: str | None = None,
     limit: int | None = None,
     timeout_seconds: int | None = None,
+    for_export: bool = False,
 ) -> dict[str, Any]:
     target_database = str(database or "").strip()
     if not target_database:
@@ -270,6 +271,8 @@ def query_readonly(
         preferred_engine=preferred_engine,
         limit=limit,
         timeout_seconds=timeout_seconds,
+        # 导出模式：结果写盘、不进模型上下文，跳过后端字节守卫（仍受行数上限保护）。
+        for_export="true" if for_export else None,
     )
     return {
         "kind": payload.get("kind"),

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/export_query.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/export_query.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from pathlib import Path
+
+from _opendataworks_runtime import (
+    ensure_read_only,
+    env_int,
+    error_payload,
+    print_json,
+    query_readonly,
+    serializable_rows,
+)
+
+# 行数硬上限与后端 MAX_LIMIT 对齐：导出仍是有界的，超出范围应改用更精确的过滤或聚合。
+EXPORT_MAX_LIMIT = 10000
+
+
+def _resolve_output_path(raw: str) -> Path:
+    path = Path(str(raw or "").strip()).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path
+
+
+def _ordered_columns(rows: list[dict[str, object]]) -> list[str]:
+    columns: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row.keys():
+            if key not in seen:
+                seen.add(key)
+                columns.append(str(key))
+    return columns
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export read-only SQL results to a workspace CSV file (full data stays out of the model context)"
+    )
+    parser.add_argument("--database", required=True)
+    parser.add_argument("--sql", required=True)
+    parser.add_argument("--output", required=True, help="CSV output path (relative paths resolve under the workspace cwd)")
+    parser.add_argument("--engine", default="")
+    parser.add_argument("--limit", type=int, default=EXPORT_MAX_LIMIT)
+    parser.add_argument(
+        "--preview-rows",
+        type=int,
+        default=env_int("DATAAGENT_RESULT_PREVIEW_ROWS", 20),
+    )
+    args = parser.parse_args()
+
+    database = str(args.database or "").strip()
+    preferred_engine = str(args.engine or "").strip().lower() or None
+    sql = str(args.sql or "").strip()
+    limit = max(1, min(int(args.limit or EXPORT_MAX_LIMIT), EXPORT_MAX_LIMIT))
+    preview_rows = max(0, int(args.preview_rows if args.preview_rows is not None else 20))
+
+    try:
+        ensure_read_only(sql)
+        result = query_readonly(
+            database=database,
+            sql=sql,
+            preferred_engine=preferred_engine,
+            limit=limit,
+            timeout_seconds=max(1, env_int("DATAAGENT_SQL_READ_TIMEOUT_SECONDS", 60)),
+            for_export=True,
+        )
+
+        rows = serializable_rows(list(result.get("rows") or []))
+        columns = _ordered_columns(rows)
+
+        output_path = _resolve_output_path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8-sig", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=columns, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({col: row.get(col, "") for col in columns})
+
+        has_more = bool(result.get("has_more"))
+        preview = rows[:preview_rows]
+        stop_reason = (
+            f"已导出 {len(rows)} 行（命中行数上限 {limit}，可能仍有更多数据，请用更精确的过滤或聚合）。"
+            if has_more
+            else ""
+        )
+
+        print_json(
+            {
+                "kind": "sql_export",
+                "tool_label": "SQL 导出",
+                "engine": result.get("engine"),
+                "database": result.get("database"),
+                "sql": sql,
+                "file_path": str(output_path),
+                "file_format": "csv",
+                "columns": columns,
+                "row_count": len(rows),
+                "has_more": has_more,
+                "preview_rows": preview,
+                "summary": f"已导出 {len(rows)} 行到 {output_path}",
+                "result_state": "success",
+                "error_code": None,
+                "failure_attribution": [],
+                "retryable": False,
+                "stop_reason": stop_reason,
+                "error": None,
+            }
+        )
+    except Exception as exc:
+        print_json(
+            error_payload(
+                "sql_export",
+                str(exc),
+                tool_label="SQL 导出",
+                database=database,
+                engine=preferred_engine,
+                sql=sql,
+                file_path=None,
+                columns=[],
+                row_count=0,
+                has_more=False,
+                result_state="failed",
+                error_code="export_failed",
+                failure_attribution=["tool_error"],
+                retryable=False,
+                stop_reason="SQL 结果导出失败，请根据错误信息修正查询或输出路径后重试。",
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/run_sql.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/run_sql.py
@@ -162,17 +162,27 @@ def main():
         preview_rows = list(result.get("rows") or [])[:limit]
         serialized_rows = serializable_rows(preview_rows)
         columns = list(serialized_rows[0].keys()) if serialized_rows else []
-        execution_detail = (
-            empty_result_detail()
-            if not serialized_rows
-            else {
+        truncated_by_size = bool(result.get("truncated_by_size"))
+        notice = str(result.get("notice") or "").strip()
+        if not serialized_rows:
+            execution_detail = empty_result_detail()
+        elif truncated_by_size:
+            execution_detail = {
+                "result_state": "success",
+                "error_code": "result_truncated",
+                "failure_attribution": [],
+                "retryable": False,
+                "stop_reason": notice
+                or "结果过大已按体积截断，已返回前若干行；如需完整或精确结果请缩小查询范围（增加过滤、聚合或降低 LIMIT），不要对同一口径重复执行。",
+            }
+        else:
+            execution_detail = {
                 "result_state": "success",
                 "error_code": None,
                 "failure_attribution": [],
                 "retryable": False,
                 "stop_reason": "",
             }
-        )
 
         print_json(
             {
@@ -186,7 +196,13 @@ def main():
                 "row_count": len(serialized_rows),
                 "has_more": bool(result.get("has_more")),
                 "duration_ms": int(result.get("duration_ms") or 0),
-                "summary": f"返回 {len(serialized_rows)} 行结果",
+                "truncated_by_size": truncated_by_size,
+                "notice": notice or None,
+                "summary": (
+                    f"返回 {len(serialized_rows)} 行结果（已按体积截断）"
+                    if truncated_by_size
+                    else f"返回 {len(serialized_rows)} 行结果"
+                ),
                 "error": None,
                 **execution_detail,
             }

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -32,6 +32,10 @@ class Settings(BaseSettings):
     agent_interactive_sql_read_timeout_seconds: int = 300
     agent_background_sql_read_timeout_seconds: int = 900
     agent_sql_write_timeout_seconds: int = 60
+    # Max bytes when buffering a single CLI stdout JSON message before decoding.
+    # The SDK default is 1MB; large NL2SQL tool results / partial messages can
+    # exceed it and trigger "JSON message exceeded maximum buffer size".
+    agent_max_buffer_size_bytes: int = 10 * 1024 * 1024
     followup_suggestions_timeout_seconds: int = 20
     run_events_stream_poll_interval_seconds: int = 1
     run_events_stream_ping_seconds: int = 10

--- a/dataagent/dataagent-backend/core/followup_suggestions.py
+++ b/dataagent/dataagent-backend/core/followup_suggestions.py
@@ -268,6 +268,7 @@ async def _default_model_runner(
         "allowed_tools": [],
         "mcp_servers": {},
         "include_partial_messages": bool(runtime_target.get("supports_partial_messages", True)),
+        "max_buffer_size": max(1024 * 1024, int(cfg.agent_max_buffer_size_bytes)),
         "env": runtime_env,
         "stderr": lambda line: logger.error(
             "followup_suggestions.stderr provider=%s model=%s %s",

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -676,6 +676,7 @@ async def _run_model_detection(
         allowed_tools=[],
         mcp_servers={},
         include_partial_messages=supports_partial_messages,
+        max_buffer_size=max(1024 * 1024, int(get_settings().agent_max_buffer_size_bytes)),
         env=runtime_env,
         stderr=lambda line: logger.error(
             "model_detection.stderr provider=%s model=%s %s",

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -863,6 +863,7 @@ async def execute_task_stream(
         allowed_tools=allowed_tools,
         mcp_servers=mcp_servers,
         include_partial_messages=supports_partial_messages,
+        max_buffer_size=max(1024 * 1024, int(cfg.agent_max_buffer_size_bytes)),
         env=runtime_env,
         hooks=_build_workspace_boundary_hooks(project_cwd, skill_runtime, runtime_env),
         stderr=lambda line: logger.error(

--- a/dataagent/dataagent-backend/tests/test_export_query_script.py
+++ b/dataagent/dataagent-backend/tests/test_export_query_script.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+PLATFORM_TOOLS_ROOT = BACKEND_ROOT.parent / ".claude" / "skills" / "opendataworks-platform-tools"
+SKILL_SCRIPTS_ROOT = PLATFORM_TOOLS_ROOT / "scripts"
+if str(SKILL_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SKILL_SCRIPTS_ROOT))
+
+
+def _load_export_module():
+    module_path = SKILL_SCRIPTS_ROOT / "export_query.py"
+    spec = importlib.util.spec_from_file_location("dataagent_export_query", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_export_query_writes_full_csv_and_returns_preview(tmp_path, monkeypatch, capsys):
+    module = _load_export_module()
+
+    rows = [{"id": i, "name": f"row-{i}"} for i in range(120)]
+    captured = {}
+
+    def fake_query_readonly(database, sql, preferred_engine=None, limit=None, timeout_seconds=None, for_export=False):
+        captured["for_export"] = for_export
+        captured["limit"] = limit
+        return {
+            "engine": "mysql",
+            "database": database,
+            "rows": rows,
+            "row_count": len(rows),
+            "has_more": False,
+        }
+
+    monkeypatch.setattr(module, "query_readonly", fake_query_readonly)
+
+    output = tmp_path / "exports" / "result.csv"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_query.py",
+            "--database",
+            "opendataworks",
+            "--sql",
+            "SELECT id, name FROM demo",
+            "--output",
+            str(output),
+            "--preview-rows",
+            "5",
+        ],
+    )
+
+    module.main()
+
+    # 导出模式必须开启，且行数上限传入。
+    assert captured["for_export"] is True
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "sql_export"
+    assert payload["result_state"] == "success"
+    assert payload["row_count"] == 120
+    assert payload["file_path"] == str(output)
+    assert len(payload["preview_rows"]) == 5
+
+    # 全量数据落盘，CSV 行数与全量一致（不受预览行数限制）。
+    assert output.exists()
+    with open(output, "r", encoding="utf-8-sig", newline="") as handle:
+        csv_rows = list(csv.DictReader(handle))
+    assert len(csv_rows) == 120
+    assert csv_rows[0]["name"] == "row-0"
+    assert csv_rows[-1]["name"] == "row-119"
+
+
+def test_export_query_rejects_non_readonly_sql(tmp_path, monkeypatch, capsys):
+    module = _load_export_module()
+
+    output = tmp_path / "out.csv"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_query.py",
+            "--database",
+            "opendataworks",
+            "--sql",
+            "DELETE FROM demo",
+            "--output",
+            str(output),
+        ],
+    )
+
+    module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "sql_export"
+    assert payload["result_state"] == "failed"
+    assert payload["error_code"] == "export_failed"
+    assert not output.exists()

--- a/dataagent/dataagent-backend/tests/test_odw_cli.py
+++ b/dataagent/dataagent-backend/tests/test_odw_cli.py
@@ -148,6 +148,57 @@ def test_odw_cli_query_readonly_uses_query_endpoint_for_legacy_metadata_base_url
     }
 
 
+def test_odw_cli_query_readonly_includes_for_export_flag(tmp_path: Path):
+    env = _base_env(tmp_path, "http://backend:8080/api/v1/ai")
+
+    completed = subprocess.run(
+        [
+            "sh",
+            str(ODW_CLI),
+            "query-readonly",
+            "--database",
+            "opendataworks",
+            "--sql",
+            "SELECT 1",
+            "--for-export",
+            "true",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads((tmp_path / "curl-payload.txt").read_text(encoding="utf-8"))
+    assert payload["for_export"] is True
+    assert payload["database"] == "opendataworks"
+
+
+def test_odw_cli_query_readonly_omits_for_export_when_not_requested(tmp_path: Path):
+    env = _base_env(tmp_path, "http://backend:8080/api/v1/ai")
+
+    completed = subprocess.run(
+        [
+            "sh",
+            str(ODW_CLI),
+            "query-readonly",
+            "--database",
+            "opendataworks",
+            "--sql",
+            "SELECT 1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads((tmp_path / "curl-payload.txt").read_text(encoding="utf-8"))
+    assert "for_export" not in payload
+
+
 def test_odw_cli_query_readonly_forwards_agent_data_scope_header(tmp_path: Path):
     env = _base_env(tmp_path, "http://backend:8080/api/v1/ai")
     env["ODW_AGENT_DATA_SCOPE_HEADER"] = "encoded-scope"

--- a/docs/design/2026-06-03-nl2sql-result-export-design.md
+++ b/docs/design/2026-06-03-nl2sql-result-export-design.md
@@ -1,0 +1,62 @@
+# 智能问数 SQL 结果导出文件能力 — 设计
+
+- 日期：2026-06-03
+- 范围：`backend`（agentapi 只读查询新增导出模式）、`dataagent`（odw-cli、运行时桥接、新增 skill 导出脚本与文档）
+- 类型：中型（跨后端 / odw-cli / skill 脚本，新增工具能力与请求字段）
+- 关联：承接 `2026-06-03-nl2sql-result-size-guard-design.md`（源头字节守卫）；本设计解决「字节守卫挡住了批量导出场景」的缺口
+
+## 现状与问题
+
+源头字节守卫（默认 512KB）已能防止大结果撑爆运行时 JSON 缓冲，但它对**批量导出到文件**场景是反作用的：真实案例中用户要把「全部未解决架构风险（约 600+ 条、14 个宽文本列）」导出为 Excel，守卫会把结果截断、并提示模型缩小范围——与用户目标相悖。
+
+根因是反模式：数据走了 `DB → 工具结果 → 模型上下文 → 模型再转写进 Python`。大批量数据**不应穿过模型上下文**。
+
+关键事实：skill 这条路**不依赖 MCP 查询**。`run_sql.py` 经 `odw-cli query-readonly` → 后端 `/v1/ai/query/read`，与 `mcp__portal__portal_query_readonly` 是通往同一后端端点的两条平行路径。因此一个 **skill 本地脚本可以「查询 + 落盘」一步到位**：脚本在 agent 工作区内运行，把全量结果取回脚本进程并直接写工作区文件，只向 stdout 打印「路径 + 列结构 + 行数 + 少量预览」。全量数据只在「脚本进程 ↔ 磁盘文件」之间流动，odw-cli 输出被脚本子进程直接读取，**不经过 SDK 的 stdout 缓冲**，因此不会触发溢出；模型随后用 Python 读该文件生成 Excel。
+
+不采用「MCP 新增存储文件接口」：portal-mcp 是独立 HTTP 服务，其写入的文件落在自身文件系统，未必与 agent 工作区共享卷，返回的路径模型未必可读；且会把导出逻辑复制进通用 MCP 服务。仅当存在「纯 MCP、无本地执行能力」的 agent 且保证共享卷时才考虑。
+
+## 范围
+
+- 目标：新增 skill 本地导出脚本，基于只读 SQL 把**全量结果**（受 `MAX_LIMIT=10000` 行上限保护）物化为**工作区 CSV 文件**，只回路径+列+行数+预览给模型。
+- 后端补一个**导出模式**：本地导出调用可显式跳过字节守卫（因为结果写盘、不进上下文）。
+- 更新 skill 路由规则：大结果/要落盘 → 用导出脚本，不要用 `portal_query_readonly` / `run_sql.py` 把全量拉进上下文。
+- 不在本期范围：xlsx 直出（由模型 Python 读 CSV 生成）、超过 10000 行的分页导出、parquet、MCP store-file 接口。
+- 决策（已确认）：架构＝skill 本地导出脚本；格式＝CSV 数据文件。
+
+## 方案
+
+### 1. 后端导出模式
+
+- `AgentReadQueryRequest` 增 `for_export`（Boolean，默认 null/false）。
+- `BackendAgentQueryService.readQuery`：当 `for_export=true` 时跳过字节守卫，直接返回（受 `normalizeLimit` 的 `MAX_LIMIT=10000` 行上限保护）；否则维持现有字节守卫。
+
+### 2. odw-cli
+
+- `parse_query_readonly` 增 `--for-export` 开关，为真时在请求体加 `"forExport":true`。
+
+### 3. 运行时桥接
+
+- `_opendataworks_runtime.query_readonly(..., for_export=False)`：为真时向 odw-cli 传 `for_export="true"`。默认行为不变。
+
+### 4. skill 导出脚本 `export_query.py`
+
+- 参数：`--database`、`--sql`、`--output`、`--engine`、`--limit`（默认 10000）、`--preview-rows`（默认取 `DATAAGENT_RESULT_PREVIEW_ROWS`，回退 20）。
+- 流程：`ensure_read_only` → `query_readonly(for_export=True)` → 写 CSV 到工作区（自动建父目录）→ `print_json` 输出 `sql_export` 契约（绝对路径、列、行数、`has_more`、前 N 行预览、`result_state`、`stop_reason`）。
+- 失败时复用 `error_payload` + `classify_sql_execution_failure` 风格收口。
+
+### 5. skill 文档
+
+- SKILL.md 工具清单与路由规则补导出脚本；`reference/50-tool-output-contract.md` 增 `sql_export` 契约；`reference/30-tool-recipes.md` 增「大结果导出」配方。
+- 执行引用使用完整形式：`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_SKILL_ROOT}/scripts/export_query.py" ...`（遵循仓库 invocation 契约）。
+
+## 接口与契约影响
+
+- `POST /v1/ai/query/read` 请求新增可选字段 `for_export`，向后兼容（默认不变）。
+- 新增 skill 工具输出 `kind=sql_export`。
+- 字节守卫默认行为不变；仅导出这条显式开关绕过。
+
+## 取舍
+
+- skill 本地脚本 vs MCP store-file：选前者，避免共享卷耦合与逻辑重复，且查询+导出可在一个本地脚本内完成。
+- CSV vs xlsx 直出：选 CSV，脚本职责单一、通用；Excel 表现层交给模型 Python。
+- 导出绕过字节守卫的安全性：仅本地脚本可触发，结果写盘、只回预览，不进模型上下文，故安全；行数仍受 `MAX_LIMIT=10000` 硬上限约束。

--- a/docs/design/2026-06-03-nl2sql-result-size-guard-design.md
+++ b/docs/design/2026-06-03-nl2sql-result-size-guard-design.md
@@ -1,0 +1,80 @@
+# 智能问数结果体积守卫（避免 SDK JSON 缓冲溢出）— 设计
+
+- 日期：2026-06-03
+- 范围：`backend`（agentapi 只读查询与元数据导出）、`dataagent`（portal-mcp 透传、skill 脚本 `run_sql.py` 与运行时桥接）
+- 类型：中型（跨后端 / portal-mcp / skill 脚本，工具结果契约新增字段）
+- 关联：`config.py` 已先行将 `agent_max_buffer_size_bytes` 从 1MB 提升到 10MB（缓解阈值，非根因修复）
+
+## 现状
+
+智能问数运行时通过 `claude-agent-sdk` 拉起 Claude CLI 子进程，按行缓冲其 stdout 上的 JSON 消息帧。SDK 在 `_internal/transport/subprocess_cli.py` 中对单条 JSON 帧设有上限（默认 1MB，可经 `ClaudeAgentOptions.max_buffer_size` 配置），单帧超限即 `raise SDKJSONDecodeError`。
+
+工具结果（tool_result）会被 CLI 包成**单条** stdout JSON 帧。NL2SQL 的结果有两条产出路径：
+
+- **MCP 路径（主路径）**：模型调 `mcp__portal__portal_query_readonly`，portal-mcp（`dataagent/portal-mcp`）透传后端结果，无任何截断。
+- **脚本回退路径**：skill 脚本 `run_sql.py` → `_opendataworks_runtime.query_readonly()` → `odw-cli query-readonly`。
+
+经核实，两条路径最终都 curl 同一个后端端点 `POST /v1/ai/query/read`（`AgentQueryController` → `BackendAgentQueryService.readQuery`）。该服务当前只有**行数上限**（`DEFAULT_LIMIT=1000`、`MAX_LIMIT=10000`），**没有字节上限**：1000 行宽表或含大文本字段的结果可轻松超过 1MB 乃至 10MB。
+
+此外 `BackendAgentMetadataService` 的 `exportTables/exportLineage/exportDatasource` 完全无行数上限，属于次要但真实的溢出来源。
+
+## 问题
+
+1. 一旦单条工具结果帧超过缓冲上限，SDK 从读取 stdout 的异步生成器内部抛错，`claude_query` 整个流不可恢复地终止；`task_executor` 把它当作普通异常归到 `error`，且不走超时类的 partial 恢复路径。结果是：**一次本应成功的问数因一条超大结果帧整体失败**。
+2. 仅提升 `max_buffer_size` 只是把阈值抬高，治标不治本——更大的结果仍会再次触发，且把超大 payload 灌进对话也会拖慢与污染上下文。
+
+## 范围
+
+- 目标：在**产出结果的源头**（`readQuery`）对返回行做**字节预算守卫**；超限时**截断为前 N 行**并通过工具结果显式告知模型“结果过大、已截断、请缩小范围”，使本次 run 继续、由模型自行调整查询参数（加过滤 / 聚合 / 降低 LIMIT）。
+- 同步给无界的 `export*` 元数据接口补**行数安全上限**。
+- 让两条消费路径都能向模型透出截断信号：MCP 路径天然透传新字段；脚本路径在 `_opendataworks_runtime.query_readonly()` 与 `run_sql.py` 中补透传与提示。
+- 不在本期范围：分页 / 游标式拉取、按列裁剪、export 接口的逐字段截断提示、前端展示改造。
+- 决策（已与需求方确认）：
+  - 超限行为＝**截断 + 提示**（非硬报错）。
+  - 落点＝**统一在 Java 后端源头** `readQuery`，一处覆盖 MCP 与脚本两条路径。
+
+## 方案
+
+### 1. 后端字节预算守卫（核心）
+
+`BackendAgentQueryService.readQuery` 在拿到 `execution.getRows()` 后、写入响应前：
+
+- 逐行用 Jackson 估算紧凑 JSON 字节数并累加；累计超过预算 `maxResultBytes` 时在该行截断。
+- 至少保留 1 行（即便首行已超预算，仍返回该行，使模型有上下文；预算远低于缓冲上限，单行安全）。
+- 截断发生时：`rows` 置为截断后子集，`rowCount` 反映返回行数，`hasMore=true`，新增 `truncatedBySize=true`、`notice=<面向模型的中文引导语>`。
+
+预算来源：新增可配置项 `agent.query.max-result-bytes`，默认 `524288`（512KB）。该默认值选取原则：
+
+- 显著低于 SDK 默认 1MB，确保即便未启用 `max_buffer_size=10MB` 也安全；
+- 为脚本路径 `run_sql.py` 的 `indent=2` 美化与外层信封预留余量；
+- 与 `agent_max_buffer_size_bytes`（dataagent 侧，默认 10MB）构成两级关系：源头预算 < 传输缓冲上限。
+
+### 2. 响应契约新增字段
+
+`AgentReadQueryResponse` 增加：
+
+- `@JsonProperty("truncated_by_size") Boolean truncatedBySize`
+- `String notice`
+
+仅在截断时置值；未截断时为 `null`，对既有消费者向后兼容。
+
+### 3. export 元数据行数安全上限
+
+`BackendAgentMetadataService` 新增 `EXPORT_MAX_ROWS`（默认 5000）常量，`exportTables/exportLineage/exportDatasource` 返回前截断至上限并 `log.warn`。这是防溢出安全阀，不改变返回结构。
+
+### 4. 脚本路径透出
+
+- `_opendataworks_runtime.query_readonly()`：返回字典补 `truncated_by_size`、`notice` 两个键的透传。
+- `run_sql.py`：成功分支读取上述字段；截断时在输出中带上 `truncated_by_size`/`notice`，并将 `stop_reason` 设为“结果过大已截断，请缩小范围……”，与现有 `classify_sql_execution_failure` 的引导风格一致，使脚本路径下模型也能继续并调整。
+
+## 接口与契约影响
+
+- `POST /v1/ai/query/read` 响应新增两个可选字段，向后兼容。
+- `mcp__portal__portal_query_readonly` 结果新增两个可选字段，模型据此识别截断。
+- skill 结果 schema（`sql_execution`）新增 `truncated_by_size`/`notice`，并复用 `stop_reason` 语义。
+
+## 取舍
+
+- 选“截断+提示”而非“硬报错”：保证 run 必然继续且模型拿到样本数据，同时明确告知不完整，避免模型在无法缩小时反复试探；代价是模型需自行判断是否需要更精确口径。
+- 选“统一在 Java 源头”而非“agent 面向层各加一份”：一处覆盖两条路径、避免重复字节守卫逻辑；代价是脚本路径需少量透传管线（不复制守卫逻辑本身）。
+- 字节预算固定为单一保守默认值并可配置，符合“一条稳定主路径 + 最小回退”的仓库准则。

--- a/docs/plans/2026-06-03-nl2sql-result-export-plan.md
+++ b/docs/plans/2026-06-03-nl2sql-result-export-plan.md
@@ -1,0 +1,40 @@
+# 智能问数 SQL 结果导出文件能力 — 执行计划
+
+- 日期：2026-06-03
+- 关联设计：`docs/design/2026-06-03-nl2sql-result-export-design.md`
+- 受影响栈：`backend`（agentapi 查询）、`dataagent`（odw-cli、运行时桥接、skill 脚本与文档）
+
+## 任务与触达文件
+
+1. 请求字段 — `backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryRequest.java`
+   - 增 `for_export`（Boolean）。
+
+2. 后端导出模式 — `backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java`
+   - `readQuery`：`for_export=true` 时跳过字节守卫，直接返回（仍受 `MAX_LIMIT` 行上限）。
+
+3. odw-cli — `dataagent/.claude/skills/opendataworks-platform-tools/bin/odw-cli`
+   - `parse_query_readonly` 增 `--for-export` → 请求体加 `"forExport":true`；更新 usage。
+
+4. 运行时桥接 — `dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py`
+   - `query_readonly(..., for_export=False)`：为真传 `for_export="true"`。
+
+5. 导出脚本（新增）— `dataagent/.claude/skills/opendataworks-platform-tools/scripts/export_query.py`
+   - 查询全量 → 写工作区 CSV → 输出 `sql_export` 契约（路径+列+行数+预览）。
+
+6. skill 文档 —
+   - `dataagent/.claude/skills/opendataworks-platform-tools/SKILL.md`（工具清单 + 路由规则）
+   - `reference/50-tool-output-contract.md`（`sql_export` 契约）
+   - `reference/30-tool-recipes.md`（大结果导出配方）
+
+## 验证
+
+- 后端：`mvn -pl backend -am -Dtest=BackendAgentQueryServiceTest test`
+  - 新增用例：`for_export=true` 且结果超字节预算时，不截断、`truncated_by_size` 为 null。
+- odw-cli：`pytest dataagent/dataagent-backend/tests/test_odw_cli.py`
+  - 新增用例：`--for-export` 时请求体含 `"forExport":true`。
+- 脚本：`python -m py_compile export_query.py`；用 monkeypatch `query_readonly` 的轻量测试验证写 CSV + 预览输出。
+- 端到端冒烟（环境可用时）：对真实大结果查询用导出脚本，验证 CSV 落盘、行数完整、stdout 只回预览且不触发缓冲溢出；若无法本地起全链路，明确标注未跑端到端。
+
+## 回滚
+
+- 改动均为新增字段/开关/脚本，向后兼容；回滚即还原上述文件。

--- a/docs/plans/2026-06-03-nl2sql-result-size-guard-plan.md
+++ b/docs/plans/2026-06-03-nl2sql-result-size-guard-plan.md
@@ -1,0 +1,40 @@
+# 智能问数结果体积守卫 — 执行计划
+
+- 日期：2026-06-03
+- 关联设计：`docs/design/2026-06-03-nl2sql-result-size-guard-design.md`
+- 受影响栈：`backend`（agentapi 查询/导出）、`dataagent`（portal-mcp 透传无需改动、skill 脚本与运行时桥接）
+
+## 任务与触达文件
+
+1. 响应契约新增字段 — `backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentReadQueryResponse.java`
+   - 增 `truncated_by_size`（Boolean）、`notice`（String），默认 `null`。
+
+2. 后端字节预算守卫 — `backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentQueryService.java`
+   - 注入 `ObjectMapper`（Spring 容器已有）。
+   - 新增 `@Value("${agent.query.max-result-bytes:524288}") int maxResultBytes`。
+   - 新增私有方法 `applyResultByteBudget(rows)`：逐行估算紧凑 JSON 字节并累加，超预算处截断；返回截断后的行 + 是否截断标记。
+   - `readQuery` 在 `setRows` 前应用守卫；截断时设置 `rowCount`/`hasMore=true`/`truncatedBySize`/`notice`。
+
+3. export 行数安全上限 — `backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentMetadataService.java`
+   - 新增 `EXPORT_MAX_ROWS=5000`；`exportTables/exportLineage/exportDatasource` 返回前截断并 `log.warn`。
+
+4. 运行时桥接透传 — `dataagent/.claude/skills/opendataworks-platform-tools/scripts/_opendataworks_runtime.py`
+   - `query_readonly()` 返回字典补 `truncated_by_size`、`notice`。
+
+5. skill 脚本提示 — `dataagent/.claude/skills/opendataworks-platform-tools/scripts/run_sql.py`
+   - 成功分支读取 `truncated_by_size`/`notice`；截断时在 `print_json` 输出带上两字段，并把 `execution_detail.stop_reason` 改为截断引导语。
+
+6. skill 文档 — `dataagent/.claude/skills/opendataworks-platform-tools/SKILL.md` 及相关 `reference/*`
+   - 在 `sql_execution` 结果 schema 说明中补 `truncated_by_size`/`notice` 与“截断后应缩小范围”的恢复规则。
+
+## 验证
+
+- 后端：`mvn -pl backend -am -Dtest=BackendAgentQueryServiceTest test`
+  - 新增用例：构造超预算大结果，断言 `truncatedBySize=true`、`hasMore=true`、`rows` 被截断、`notice` 非空；小结果不截断、字段为 `null`。
+- portal-mcp：`pytest dataagent/portal-mcp/tests/test_app.py`（契约透传，应保持绿色；如断言响应字段需补充）。
+- skill 脚本：`pytest dataagent/dataagent-backend/tests/test_metadata_cli_bridge.py`（query_readonly 桥接透传）。
+- 端到端冒烟（环境可用时，按 AGENTS.md 本地冒烟法）：对返回大结果的真实 NL2SQL 请求验证不再触发缓冲溢出、工具结果出现 `notice` 且 run 正常收尾；若无法本地起全链路，明确标注脚本路径/后端单测已验证、端到端未验证。
+
+## 回滚
+
+- 改动均为新增字段 + 截断守卫，向后兼容。回滚即还原上述文件；`agent.query.max-result-bytes` 调大可临时放宽守卫。


### PR DESCRIPTION
## Summary

Implements two complementary features to handle large SQL query results safely:

1. **Result Size Guard**: Prevents large query results from exceeding the SDK's JSON buffer limit (1MB default) by truncating results at the source when they exceed a configurable byte budget (512KB default).

2. **SQL Export to File**: Adds a new skill script (`export_query.py`) that exports full query results directly to CSV files in the workspace, bypassing the model context entirely for batch export scenarios.

## Key Changes

### Backend (Java)

- **`BackendAgentQueryService`**: 
  - Adds byte budget enforcement via `maxResultBytes` configuration (default 512KB)
  - Implements `resultByteBudgetKeepCount()` to estimate JSON serialization size per row and truncate when budget exceeded
  - When truncation occurs, sets `truncatedBySize=true`, `hasMore=true`, and provides user-facing `notice` explaining the limit
  - Respects `forExport=true` flag to skip truncation for export scenarios (results still bounded by `MAX_LIMIT=10000` rows)

- **`AgentReadQueryResponse`**: Adds optional fields `truncatedBySize` (Boolean) and `notice` (String) to signal truncation to the model

- **`AgentReadQueryRequest`**: Adds optional `forExport` flag for export mode

- **`BackendAgentMetadataService`**: Adds `EXPORT_MAX_ROWS=5000` safety limit for metadata exports (`exportTables`, `exportLineage`, `exportDatasource`)

### DataAgent (Python)

- **New `export_query.py` script**: 
  - Accepts `--database`, `--sql`, `--output`, `--engine`, `--limit`, `--preview-rows` parameters
  - Calls backend with `for_export=true` to bypass size guard
  - Writes full result set to workspace CSV file
  - Returns `sql_export` contract with file path, columns, row count, and preview rows only
  - Ensures full data stays on disk, not in model context

- **`_opendataworks_runtime.py`**: Adds `for_export` parameter to `query_readonly()` for runtime bridge

- **`odw-cli`**: Adds `--for-export` flag to `query-readonly` command

- **`run_sql.py`**: 
  - Detects `truncated_by_size` from backend response
  - Sets `error_code=result_truncated` and provides guidance in `stop_reason` when truncation occurs
  - Allows model to adjust query parameters and retry

### Documentation

- **Design docs**: `2026-06-03-nl2sql-result-size-guard-design.md` and `2026-06-03-nl2sql-result-export-design.md` explain rationale, architecture, and tradeoffs
- **Execution plans**: Detailed task breakdowns for both features
- **Tool contract**: Updated `50-tool-output-contract.md` with `sql_export` schema and truncation behavior
- **Recipes**: Updated `30-tool-recipes.md` with export guidance and routing rules
- **SKILL.md**: Added export script to tool inventory and routing rules

### Tests

- **Backend**: New test cases for truncation behavior, export mode bypass, and minimum row guarantee
- **odw-cli**: Tests for `--for-export` flag presence/absence in request payload
- **Export script**: Tests for CSV writing, preview generation, and error handling

## Implementation Details

- **Byte estimation**: Uses Jackson `ObjectMapper` to serialize each row and estimate JSON size, accounting for row separators and array overhead
- **Minimum row guarantee**: Always returns at least 1 row even if it exceeds budget, ensuring model has context
- **Backward compatibility**: New response fields are optional (null when not truncated); `for_export` defaults to false
- **Two-level protection**: Source-level byte guard (512KB) + SDK buffer limit (1MB default, configurable to 10MB)
- **Export safety**: Export mode skips byte guard but respects `MAX_LIMIT=10000` row hard limit; results written to disk, not model

https://claude.ai/code/session_01315SJCPsmrELauhMfkTR5Q