### PR TITLE
Extract DataAgent widget loader to shared utility module

### DIFF
--- a/dataagent/README.md
+++ b/dataagent/README.md
@@ -9,7 +9,7 @@
 说明：
 
 - 主应用 `frontend` 不再编译智能问数页面源码；入口 `/intelligent-query` 通过远程 `OpenDataWorksWidget` JS 以内嵌模式加载 DataAgent 问答页。
-- `dataagent-frontend` 是模型、Skills、智能体、Widget 接入配置等 DataAgent 管理 UI 的归属目录，并负责构建 `/widget/opendataworks-widget.bundle.js`。
+- `dataagent-frontend` 是模型、Skills、智能体、Widget 接入配置等 DataAgent 管理 UI 的归属目录，并负责构建 `/widget/opendataworks-widget.bundle.js`。本地联调时，若需要 portal 正确加载 widget，需在 `dataagent-frontend` 目录下先执行一次 `npm run build:widget`，后续 widget 源码有改动时同样需要重新执行。
 - 原 Java `dataagent-backend` 模块已删除。
 - 通用问数 SQL 方法、表字段发现策略、SQL 前检查和结果收口已收敛到 `dataagent-backend/prompts/data_agent_system_prompt.md`，不再由独立通用问数 skill 承载。
 - `dataagent/.claude/skills/opendataworks-business-knowledge` 是随仓库发布的业务知识 skill，负责 OpenDataWorks 平台术语、本体、指标口径、别名、歧义消解和业务规则例外；它不提供 SQL 验证或执行脚本。

--- a/dataagent/dataagent-frontend/vite.config.js
+++ b/dataagent/dataagent-frontend/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
-import { existsSync, readFileSync } from 'fs'
 import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 import ElementPlus from 'unplugin-element-plus/vite'
@@ -51,29 +50,7 @@ export default defineConfig(() => {
           })
         ]
       }),
-      !isTest && ElementPlus(),
-      {
-        name: 'dev-widget-serve',
-        apply: 'serve',
-        configureServer(server) {
-          server.middlewares.use('/widget', (req, res, next) => {
-            const fileName = (req.url || '').replace(/^\//, '')
-            const builtFile = resolve(__dirname, 'dist/widget', fileName)
-            if (existsSync(builtFile)) {
-              res.setHeader('Content-Type', 'application/javascript')
-              res.end(readFileSync(builtFile))
-              return
-            }
-            if (fileName === 'opendataworks-widget.bundle.js') {
-              // Stub so the portal degrades gracefully; run `npm run build:widget` once to get the real bundle
-              res.setHeader('Content-Type', 'application/javascript')
-              res.end("(function(){var api={installWidget:function(){console.warn('[DataAgent] widget bundle not built — run `npm run build:widget` in dataagent-frontend');return{destroy:function(){}}}};if(typeof window!=='undefined'){window.OpenDataWorksWidget=api;}})();")
-              return
-            }
-            next()
-          })
-        }
-      }
+      !isTest && ElementPlus()
     ].filter(Boolean),
     resolve: {
       alias: {

--- a/dataagent/dataagent-frontend/vite.config.js
+++ b/dataagent/dataagent-frontend/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
+import { existsSync, readFileSync } from 'fs'
 import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 import ElementPlus from 'unplugin-element-plus/vite'
@@ -50,7 +51,29 @@ export default defineConfig(() => {
           })
         ]
       }),
-      !isTest && ElementPlus()
+      !isTest && ElementPlus(),
+      {
+        name: 'dev-widget-serve',
+        apply: 'serve',
+        configureServer(server) {
+          server.middlewares.use('/widget', (req, res, next) => {
+            const fileName = (req.url || '').replace(/^\//, '')
+            const builtFile = resolve(__dirname, 'dist/widget', fileName)
+            if (existsSync(builtFile)) {
+              res.setHeader('Content-Type', 'application/javascript')
+              res.end(readFileSync(builtFile))
+              return
+            }
+            if (fileName === 'opendataworks-widget.bundle.js') {
+              // Stub so the portal degrades gracefully; run `npm run build:widget` once to get the real bundle
+              res.setHeader('Content-Type', 'application/javascript')
+              res.end("(function(){var api={installWidget:function(){console.warn('[DataAgent] widget bundle not built — run `npm run build:widget` in dataagent-frontend');return{destroy:function(){}}}};if(typeof window!=='undefined'){window.OpenDataWorksWidget=api;}})();")
+              return
+            }
+            next()
+          })
+        }
+      }
     ].filter(Boolean),
     resolve: {
       alias: {

--- a/frontend/src/utils/dataagentWidgetLoader.js
+++ b/frontend/src/utils/dataagentWidgetLoader.js
@@ -1,0 +1,39 @@
+const SCRIPT_URL = import.meta.env.VITE_DATAAGENT_WIDGET_JS_URL || '/dataagent/widget/opendataworks-widget.bundle.js'
+const SCRIPT_ATTR = 'data-odw-dataagent-widget-script'
+
+export function loadDataAgentWidgetScript() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return Promise.reject(new Error('DataAgent widget script can only be loaded in a browser'))
+  }
+  if (window.OpenDataWorksWidget?.installWidget) {
+    return Promise.resolve(window.OpenDataWorksWidget)
+  }
+  if (window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__) {
+    return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
+  }
+
+  const existingScript = document.querySelector(`script[${SCRIPT_ATTR}]`)
+  window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__ = new Promise((resolve, reject) => {
+    const script = existingScript || document.createElement('script')
+    const handleLoad = () => {
+      if (window.OpenDataWorksWidget?.installWidget) {
+        resolve(window.OpenDataWorksWidget)
+      } else {
+        reject(new Error('DataAgent widget global API is not available after script load'))
+      }
+    }
+    const handleError = () => reject(new Error(`Failed to load DataAgent widget script: ${SCRIPT_URL}`))
+
+    script.addEventListener('load', handleLoad, { once: true })
+    script.addEventListener('error', handleError, { once: true })
+
+    if (!existingScript) {
+      script.setAttribute(SCRIPT_ATTR, '')
+      script.src = SCRIPT_URL
+      script.async = true
+      document.head.appendChild(script)
+    }
+  })
+
+  return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
+}

--- a/frontend/src/views/IntelligentQueryRemoteEmbed.vue
+++ b/frontend/src/views/IntelligentQueryRemoteEmbed.vue
@@ -7,51 +7,13 @@
 
 <script setup>
 import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { loadDataAgentWidgetScript } from '@/utils/dataagentWidgetLoader'
 
-const DATAAGENT_WIDGET_SCRIPT_URL = import.meta.env.VITE_DATAAGENT_WIDGET_JS_URL || '/dataagent/widget/opendataworks-widget.bundle.js'
-const DATAAGENT_WIDGET_SCRIPT_ATTR = 'data-odw-dataagent-widget-script'
 const INLINE_CONTAINER_ID = 'odw-dataagent-inline-widget'
 
 const errorText = ref('')
 let widgetController = null
 let unmounted = false
-
-const loadDataAgentWidgetScript = () => {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return Promise.reject(new Error('DataAgent widget script can only be loaded in a browser'))
-  }
-  if (window.OpenDataWorksWidget?.installWidget) {
-    return Promise.resolve(window.OpenDataWorksWidget)
-  }
-  if (window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__) {
-    return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
-  }
-
-  const existingScript = document.querySelector(`script[${DATAAGENT_WIDGET_SCRIPT_ATTR}]`)
-  window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__ = new Promise((resolve, reject) => {
-    const script = existingScript || document.createElement('script')
-    const handleLoad = () => {
-      if (window.OpenDataWorksWidget?.installWidget) {
-        resolve(window.OpenDataWorksWidget)
-      } else {
-        reject(new Error('DataAgent widget global API is not available after script load'))
-      }
-    }
-    const handleError = () => reject(new Error(`Failed to load DataAgent widget script: ${DATAAGENT_WIDGET_SCRIPT_URL}`))
-
-    script.addEventListener('load', handleLoad, { once: true })
-    script.addEventListener('error', handleError, { once: true })
-
-    if (!existingScript) {
-      script.setAttribute(DATAAGENT_WIDGET_SCRIPT_ATTR, '')
-      script.src = DATAAGENT_WIDGET_SCRIPT_URL
-      script.async = true
-      document.head.appendChild(script)
-    }
-  })
-
-  return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
-}
 
 const installInlineWidget = async () => {
   try {

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -43,9 +43,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { DataBoard, DataLine, Connection, Collection, Warning, Setting, Share, Link, ChatDotRound } from '@element-plus/icons-vue'
 import { isDemoMode } from '@/demo/runtime'
 import { preloadRouteComponents, scheduleRouteWarmup } from '@/router/routeWarmup'
-
-const DATAAGENT_WIDGET_SCRIPT_URL = import.meta.env.VITE_DATAAGENT_WIDGET_JS_URL || '/dataagent/widget/opendataworks-widget.bundle.js'
-const DATAAGENT_WIDGET_SCRIPT_ATTR = 'data-odw-dataagent-widget-script'
+import { loadDataAgentWidgetScript } from '@/utils/dataagentWidgetLoader'
 
 const route = useRoute()
 const router = useRouter()
@@ -107,43 +105,6 @@ const preloadMenuRoute = (path) => {
 
 let _widgetCtrl = null
 let _layoutUnmounted = false
-
-const loadDataAgentWidgetScript = () => {
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return Promise.reject(new Error('DataAgent widget script can only be loaded in a browser'))
-  }
-  if (window.OpenDataWorksWidget?.installWidget) {
-    return Promise.resolve(window.OpenDataWorksWidget)
-  }
-  if (window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__) {
-    return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
-  }
-
-  const existingScript = document.querySelector(`script[${DATAAGENT_WIDGET_SCRIPT_ATTR}]`)
-  window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__ = new Promise((resolve, reject) => {
-    const script = existingScript || document.createElement('script')
-    const handleLoad = () => {
-      if (window.OpenDataWorksWidget?.installWidget) {
-        resolve(window.OpenDataWorksWidget)
-      } else {
-        reject(new Error('DataAgent widget global API is not available after script load'))
-      }
-    }
-    const handleError = () => reject(new Error(`Failed to load DataAgent widget script: ${DATAAGENT_WIDGET_SCRIPT_URL}`))
-
-    script.addEventListener('load', handleLoad, { once: true })
-    script.addEventListener('error', handleError, { once: true })
-
-    if (!existingScript) {
-      script.setAttribute(DATAAGENT_WIDGET_SCRIPT_ATTR, '')
-      script.src = DATAAGENT_WIDGET_SCRIPT_URL
-      script.async = true
-      document.head.appendChild(script)
-    }
-  })
-
-  return window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__
-}
 
 const installFloatingWidget = async () => {
   try {


### PR DESCRIPTION
## Summary
Refactored the DataAgent widget script loading logic into a reusable utility module to eliminate code duplication across components.

## Key Changes
- Created new `frontend/src/utils/dataagentWidgetLoader.js` module that exports `loadDataAgentWidgetScript()` function
- Removed duplicate `loadDataAgentWidgetScript()` implementations from:
  - `frontend/src/views/Layout.vue`
  - `frontend/src/views/IntelligentQueryRemoteEmbed.vue`
- Updated both components to import the shared utility function
- Removed local constants (`DATAAGENT_WIDGET_SCRIPT_URL`, `DATAAGENT_WIDGET_SCRIPT_ATTR`) from components; centralized in utility module

## Implementation Details
- The utility module maintains the same functionality: lazy-loads the DataAgent widget script with caching via `window.__ODW_DATAAGENT_WIDGET_SCRIPT_PROMISE__`
- Handles browser environment detection and graceful error handling
- Updated `dataagent/README.md` with clarification on local development setup for widget builds

https://claude.ai/code/session_01C2wH9UfnUqPWtq7S9EiaGT