### PR TITLE
Fix nginx location matching priority for widget bundles

### DIFF
--- a/dataagent/dataagent-frontend/nginx.conf
+++ b/dataagent/dataagent-frontend/nginx.conf
@@ -12,7 +12,10 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    location /widget/ {
+    # 使用 ^~ 确保 /widget/ 前缀优先于下方的静态资源正则匹配，
+    # 否则未带哈希的 widget bundle（*.bundle.js）会落入 \.js$ 正则，
+    # 被错误地按 1 年 immutable 缓存，升级后客户端拿到旧脚本。
+    location ^~ /widget/ {
         try_files $uri =404;
         add_header Cache-Control "public, max-age=300";
     }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,7 +17,10 @@ server {
         return 301 /dataagent/;
     }
 
-    location /dataagent/ {
+    # 使用 ^~ 确保 /dataagent/ 前缀优先于下方的静态资源正则匹配，
+    # 否则 widget bundle（/dataagent/widget/*.js）会被 \.js$ 正则拦截，
+    # nginx 转去本地 dist 查找该文件并返回 404，导致智能问数加载失败。
+    location ^~ /dataagent/ {
         proxy_pass http://dataagent-frontend:80/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
Updated nginx configuration in both `dataagent-frontend` and `frontend` services to use prefix matching (`^~`) for `/widget/` and `/dataagent/` locations, ensuring they take precedence over regex-based static resource caching rules.

## Problem
Without the `^~` prefix modifier, nginx was matching widget bundle files (`.js` files) against the generic `\.js$` regex pattern, causing them to be cached with a 1-year immutable cache header. This prevented clients from receiving updated widget scripts after deployments.

## Changes
- **dataagent-frontend/nginx.conf**: Changed `location /widget/` to `location ^~ /widget/` with explanatory comment
- **frontend/nginx.conf**: Changed `location /dataagent/` to `location ^~ /dataagent/` with explanatory comment

The `^~` modifier ensures these prefix locations are evaluated with higher priority than any subsequent regex location blocks, preventing widget bundle files from being incorrectly cached with long expiration times.

## Impact
- Widget bundle updates will now be properly served to clients without stale cache issues
- Smart Q&A feature loading will work correctly by ensuring proper routing of `/dataagent/widget/*.js` requests

https://claude.ai/code/session_01TVVzYfphU7hqiFVkT4dPY6