### PR TITLE
Add workspace boundary validation for file write operations

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -41,6 +41,10 @@ _FILE_BOUNDARY_PATH_KEYS = {
     "LS": ("path",),
     "Glob": ("path", "pattern"),
     "Grep": ("path", "glob"),
+    "Write": ("file_path",),
+    "Edit": ("file_path",),
+    "MultiEdit": ("file_path",),
+    "NotebookEdit": ("notebook_path",),
 }
 _BASH_PARENT_SEGMENT_RE = re.compile(r"(^|[\s;&|()])\.\.(?=$|[/\s;&|()])")
 _URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -270,6 +270,71 @@ def test_workspace_boundary_allows_workspace_and_enabled_skill_roots(tmp_path: P
     assert "outside workspace" in denial
 
 
+def test_workspace_boundary_denies_write_outside_workspace(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Write",
+        {"file_path": str(tmp_path / "outside.txt")},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "outside workspace" in denial
+
+
+def test_workspace_boundary_denies_edit_parent_directory(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Edit",
+        {"file_path": "../escape.txt"},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "parent directory" in denial
+
+
+def test_workspace_boundary_allows_write_inside_workspace(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    assert agent_runtime._validate_workspace_tool_boundary(
+        "Write",
+        {"file_path": str(workspace / "report.md")},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    ) is None
+
+
+def test_workspace_boundary_denies_notebook_edit_outside_workspace(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
+    workspace.mkdir(parents=True)
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "NotebookEdit",
+        {"notebook_path": str(tmp_path / "outside.ipynb")},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "outside workspace" in denial
+
+
 def test_workspace_boundary_denies_bash_parent_directory_lookup(tmp_path: Path):
     workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
     workspace.mkdir(parents=True)


### PR DESCRIPTION
## Summary
Extends workspace boundary validation to cover file write and edit operations, ensuring agents cannot modify files outside their designated workspace.

## Changes
- Added `Write`, `Edit`, `MultiEdit`, and `NotebookEdit` operations to the workspace boundary validation mapping in `agent_runtime.py`
- Added comprehensive test coverage for the new validations:
  - `test_workspace_boundary_denies_write_outside_workspace`: Verifies Write operations outside workspace are blocked
  - `test_workspace_boundary_denies_edit_parent_directory`: Verifies relative path escapes are blocked
  - `test_workspace_boundary_allows_write_inside_workspace`: Verifies Write operations inside workspace are allowed
  - `test_workspace_boundary_denies_notebook_edit_outside_workspace`: Verifies NotebookEdit operations outside workspace are blocked

## Implementation Details
The changes leverage the existing `_validate_workspace_tool_boundary` function by registering the new tool operations with their respective file path parameters. This ensures consistent security enforcement across all file modification operations without requiring additional validation logic.

https://claude.ai/code/session_017mHy5SfGVhfPJWuDDRD5D6