### PR TITLE
Apply assistant filter to widget topics query

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -661,6 +661,9 @@ async function loadTopics() {
 async function loadWidgetTopics() {
   try {
     const params = { page: 1, page_size: 50 }
+    // Assistant filter mirrors portal mode so the same agent selector narrows
+    // both sources; the admin widget endpoint accepts agent_id server-side.
+    if (route.query.agent_id) params.agent_id = route.query.agent_id
     // User filter is applied server-side so it stays accurate across pages.
     if (filterUser.value.startsWith('ext:')) params.external_user_id = filterUser.value.slice(4)
     else if (filterUser.value.startsWith('vis:')) params.visitor_id = filterUser.value.slice(4)
@@ -1073,7 +1076,7 @@ onMounted(async () => {
 })
 
 watch(() => route.query.agent_id, async () => {
-  if (isWidgetMode.value) return
+  // Re-query both sources: widget mode also honors the assistant filter.
   activeTopicId.value = ''
   messages.value = []
   await loadTopics()

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -30,8 +30,18 @@ const routeState = vi.hoisted(() => ({
 
 const routerReplace = vi.hoisted(() => vi.fn())
 
+const dataagentApiMock = vi.hoisted(() => ({
+  listWidgetTopics: vi.fn(),
+  listWidgetUsers: vi.fn(),
+  getWidgetTopicMessages: vi.fn()
+}))
+
 vi.mock('@/api/nl2sql', () => ({
   createNl2SqlApiClient: () => apiMocks
+}))
+
+vi.mock('@/api/dataagent', () => ({
+  dataagentApi: dataagentApiMock
 }))
 
 vi.mock('vue-router', () => ({
@@ -176,8 +186,15 @@ describe('NL2SqlChatV2 URL location', () => {
     Object.values(apiMocks.taskApi).forEach((fn) => fn.mockReset())
     Object.values(apiMocks.adminApi).forEach((fn) => fn.mockReset())
     Object.values(apiMocks.agentApi).forEach((fn) => fn.mockReset())
+    Object.values(dataagentApiMock).forEach((fn) => fn.mockReset())
     routerReplace.mockReset()
     scrollbarSetScrollTop.mockReset()
+
+    dataagentApiMock.listWidgetTopics.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 50 })
+    dataagentApiMock.listWidgetUsers.mockResolvedValue({ items: [] })
+    dataagentApiMock.getWidgetTopicMessages.mockResolvedValue({
+      topic_id: '', page: 1, page_size: 500, order: 'asc', total: 0, items: []
+    })
 
     routeState.path = '/intelligent-query'
     routeState.name = 'IntelligentQuery'
@@ -310,5 +327,23 @@ describe('NL2SqlChatV2 URL location', () => {
         topic_id: 'topic-2'
       }
     })
+  })
+
+  it('forwards the selected assistant to the widget topic query', async () => {
+    routeState.query = { tab: 'chat-v2', agent_id: 'agent_sales' }
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await nextTick()
+
+    const widgetTab = wrapper.findAll('.v2-source-tab').find((b) => b.text() === 'Widget')
+    expect(widgetTab).toBeTruthy()
+    await widgetTab.trigger('click')
+    await flushPromises()
+
+    expect(dataagentApiMock.listWidgetTopics).toHaveBeenCalled()
+    expect(dataagentApiMock.listWidgetTopics).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agent_id: 'agent_sales' })
+    )
   })
 })


### PR DESCRIPTION
## Summary
Updated the NL2SqlChatV2 component to pass the selected assistant (agent_id) filter to the widget topics API endpoint, ensuring consistent filtering behavior across both portal and widget data sources.

## Changes
- **NL2SqlChatV2.vue**: Modified `loadWidgetTopics()` to include `agent_id` parameter when present in route query, mirroring the assistant filtering applied to portal mode
- **NL2SqlChatV2.vue**: Updated the `route.query.agent_id` watcher to re-query both data sources instead of skipping widget mode, ensuring the widget topics are refreshed when the assistant selection changes
- **NL2SqlChatV2.spec.js**: Added comprehensive test coverage for the dataagent API mocking and verified that the widget topics query correctly forwards the selected assistant ID

## Implementation Details
The assistant filter is now consistently applied across both data sources. When a user selects an assistant via the agent selector, the widget topics endpoint receives the `agent_id` parameter server-side, keeping the filtered results accurate across pagination. The watcher logic was simplified to treat both sources equally, removing the previous exception for widget mode.

https://claude.ai/code/session_01RDHHcVpgtYawuuYBjXqSUC