### PR TITLE
Flatten remaining widget/portal chat interaction differences

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -268,16 +268,16 @@
               v-model="inputText"
               class="v2-textarea"
               :placeholder="isStreaming ? '正在回复中…' : '输入数据问题…'"
-              :disabled="isStreaming"
+              :disabled="isStreaming || !availableModels.length"
               rows="1"
-              @keydown.enter.exact.prevent="handleSend"
+              @keydown.enter="onEnterKey"
               @input="autoResize"
             />
             <button
               type="button"
               class="v2-send-btn"
               :class="{ 'v2-cancel-btn': isStreaming }"
-              :disabled="!isStreaming && !inputText.trim()"
+              :disabled="isStreaming ? false : !canSend"
               @click="isStreaming ? handleCancel() : handleSend()"
             >
               <svg v-if="isStreaming" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><rect x="8" y="8" width="8" height="8" rx="1.5" /></svg>
@@ -341,7 +341,7 @@ import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import { blockToToolProp } from './v2StreamParser'
 import { stripChartSpecsFromText } from './chartSpec'
 import { topicStatusKind } from './topicStatus'
-import { hydrateMessageFromApi, renderMarkdown } from './chatMessage'
+import { hydrateMessageFromApi, isPlainEnterSubmit, renderMarkdown } from './chatMessage'
 import { useNl2SqlChat } from './useNl2SqlChat'
 
 const route = useRoute()
@@ -372,7 +372,8 @@ const chat = useNl2SqlChat({
 const {
   topics, topicId: activeTopicId, messages, inputText,
   providers, defaultProviderId, defaultModel, selectedProvider, selectedModel,
-  isBusy: isStreaming,
+  availableModels, canSend, isBusy: isStreaming,
+  thinkingExpanded, toggleThinking,
   send: engineSend, cancel: engineCancel, detach,
 } = chat
 
@@ -393,7 +394,6 @@ const currentAgentName = computed(() => {
   const found = agents.value.find((a) => a.agent_id === currentId)
   return found?.name || '智能数据助手'
 })
-const thinkingExpanded = reactive({})
 const messagesScrollbarRef = ref(null)
 const textareaRef = ref(null)
 const targetMessageId = ref('')
@@ -473,11 +473,6 @@ const isTopicWorking = (topic) =>
 const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
 
 const agentSelectOptions = computed(() => agents.value.map((a) => ({ label: a.name, value: a.agent_id })))
-
-// ── Thinking toggle ────────────────────────────────────────────────────────
-function toggleThinking(key) {
-  thinkingExpanded[key] = !thinkingExpanded[key]
-}
 
 // ── Time formatting ────────────────────────────────────────────────────────
 function formatTime(dateStr) {
@@ -900,6 +895,13 @@ async function handleSend() {
   if (isWidgetMode.value) return
   if (!inputText.value.trim() || isStreaming.value) return
   await engineSend()
+}
+
+// Enter 发送，Shift + Enter 换行;输入法组合输入期间的回车用于确认候选词,不发送。
+function onEnterKey(event) {
+  if (!isPlainEnterSubmit(event)) return
+  event.preventDefault()
+  handleSend()
 }
 
 // Explicit stop: cancel the backend task (engine marks the topic suspended).

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -344,4 +344,39 @@ describe('NL2SqlChatV2 URL location', () => {
     }))
     expect(wrapper.text()).toContain('streamed answer')
   })
+
+  it('does not send on Enter during IME composition, but sends on plain Enter', async () => {
+    apiMocks.topicApi.createTopic.mockResolvedValue(makeTopic('topic-new', 'hi'))
+    apiMocks.taskApi.deliverMessage.mockResolvedValue({ task_id: 'task-1' })
+    apiMocks.taskApi.getTask = vi.fn().mockResolvedValue({ task_status: 'success' })
+    apiMocks.taskApi.streamSdkEvents.mockResolvedValue()
+
+    const wrapper = mountChat()
+    await flushPromises()
+    await nextTick()
+    await wrapper.find('.v2-btn-new').trigger('click')
+    await wrapper.find('textarea').setValue('hi')
+
+    // IME candidate-selection Enter must not send.
+    await wrapper.find('textarea').trigger('keydown.enter', { isComposing: true })
+    await flushPromises()
+    expect(apiMocks.taskApi.deliverMessage).not.toHaveBeenCalled()
+
+    // Plain Enter sends.
+    await wrapper.find('textarea').trigger('keydown.enter')
+    await flushPromises()
+    expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalled()
+  })
+
+  it('disables the send button when no model is available', async () => {
+    apiMocks.adminApi.getSettings.mockResolvedValue({ default_provider_id: '', default_model: '', providers: [] })
+
+    const wrapper = mountChat()
+    await flushPromises()
+    await nextTick()
+    await wrapper.find('.v2-btn-new').trigger('click')
+    await wrapper.find('textarea').setValue('hi')
+
+    expect(wrapper.find('.v2-send-btn').attributes('disabled')).toBeDefined()
+  })
 })

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chatMessage.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chatMessage.spec.js
@@ -5,6 +5,7 @@ import {
   compareTopicsByRecency,
   extractErrorText,
   hydrateMessageFromApi,
+  isPlainEnterSubmit,
   normalizeTopic,
   renderMarkdown,
 } from '../chatMessage'
@@ -15,6 +16,17 @@ describe('chatMessage helpers', () => {
     expect(html).not.toContain('<img')
     expect(html).toContain('&lt;img')
     expect(html).toContain('<strong>bold</strong>')
+  })
+
+  it('isPlainEnterSubmit only submits on plain Enter (guards IME and modifiers)', () => {
+    expect(isPlainEnterSubmit({})).toBe(true)
+    expect(isPlainEnterSubmit({ isComposing: true })).toBe(false)
+    expect(isPlainEnterSubmit({ keyCode: 229 })).toBe(false)
+    expect(isPlainEnterSubmit({ shiftKey: true })).toBe(false)
+    expect(isPlainEnterSubmit({ ctrlKey: true })).toBe(false)
+    expect(isPlainEnterSubmit({ altKey: true })).toBe(false)
+    expect(isPlainEnterSubmit({ metaKey: true })).toBe(false)
+    expect(isPlainEnterSubmit(null)).toBe(false)
   })
 
   it('extractErrorText reads strings, objects, and falls back to empty', () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
@@ -26,6 +26,17 @@ export function renderMarkdown(text) {
 // Human-readable text from a persisted task/message error object
 // ({ message, detail, code }) or a raw string. Returns '' when nothing usable is
 // present so callers can apply their own fallback copy.
+// True when an Enter keydown on the composer should submit: plain Enter, no
+// modifier keys, and not confirming an IME (CJK) composition. Shared by the
+// widget and portal composers so both handle IME candidate-selection Enter the
+// same way.
+export function isPlainEnterSubmit(event) {
+  if (!event) return false
+  if (event.isComposing || event.keyCode === 229) return false
+  if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) return false
+  return true
+}
+
 export function extractErrorText(error) {
   if (!error) return ''
   if (typeof error === 'string') return error

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -50,7 +50,7 @@
     </aside>
 
     <main class="query-main">
-      <div class="query-messages">
+      <div ref="messagesEl" class="query-messages" @scroll="onMessagesScroll">
         <div class="query-messages-inner" :class="{ 'is-empty': !messages.length }">
           <div v-if="errorText" class="query-error-card query-error-banner">
             <span class="query-error-label">错误</span>
@@ -199,12 +199,12 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, triggerRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, triggerRef, watch } from 'vue'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from '@/views/intelligence/ToolOutputRenderer.vue'
 import { stripChartSpecsFromText } from '@/views/intelligence/chartSpec'
 import { blockToToolProp, processV2Record } from '@/views/intelligence/v2StreamParser'
-import { extractErrorText, renderMarkdown } from '@/views/intelligence/chatMessage'
+import { extractErrorText, isPlainEnterSubmit, renderMarkdown } from '@/views/intelligence/chatMessage'
 import { useNl2SqlChat } from '@/views/intelligence/useNl2SqlChat'
 
 const props = defineProps({
@@ -248,6 +248,7 @@ const agentId = computed(() => String(props.config.agentId || '').trim())
 const chat = useNl2SqlChat({
   api,
   getAgentId: () => agentId.value,
+  messagePageSize: 500,
   emitEvent: (event) => emit('event', event),
 })
 const {
@@ -499,14 +500,31 @@ const autoResizeTextarea = (event) => {
   el.style.height = `${Math.min(el.scrollHeight, 160)}px`
 }
 
-// Enter 发送，Shift + Enter 换行。
-// 输入法（如中文）组合输入期间的回车用于确认候选词，不应触发发送。
+// Enter 发送，Shift + Enter 换行;输入法组合输入期间的回车用于确认候选词,不发送。
 const onEnterKey = (event) => {
-  if (event.isComposing || event.keyCode === 229) return
-  if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) return
+  if (!isPlainEnterSubmit(event)) return
   event.preventDefault()
   send()
 }
+
+// Pin the message list to the latest content while streaming, but only when the
+// user is already near the bottom (same rule as the portal's autoScroll).
+const messagesEl = ref(null)
+const autoScroll = ref(true)
+const onMessagesScroll = () => {
+  const el = messagesEl.value
+  if (!el) return
+  autoScroll.value = el.scrollHeight - el.scrollTop - el.clientHeight < 60
+}
+const scrollMessagesToBottom = () => {
+  nextTick(() => {
+    const el = messagesEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
+watch(messages, () => {
+  if (autoScroll.value) scrollMessagesToBottom()
+}, { deep: true, flush: 'post' })
 
 watch(
   () => props.state.outboundMessage,

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -172,7 +172,7 @@ describe('WidgetChat history conversations', () => {
 
     await wrapper.get('[data-testid="history-topic-topic-2"]').trigger('click')
     await flushPromises()
-    expect(apiMocks.topicApi.getTopicMessages).toHaveBeenLastCalledWith('topic-2', { page: 1, page_size: 200, order: 'asc' })
+    expect(apiMocks.topicApi.getTopicMessages).toHaveBeenLastCalledWith('topic-2', { page: 1, page_size: 500, order: 'asc' })
     expect(wrapper.text()).toContain('topic-2 历史回复')
 
     await wrapper.get('[data-testid="new-conversation"]').trigger('click')
@@ -333,7 +333,7 @@ describe('WidgetChat history conversations', () => {
     // Switching detaches the run locally without cancelling the backend task,
     // and loads the selected topic's history.
     expect(apiMocks.taskApi.cancelTask).not.toHaveBeenCalled()
-    expect(apiMocks.topicApi.getTopicMessages).toHaveBeenLastCalledWith('topic-2', { page: 1, page_size: 200, order: 'asc' })
+    expect(apiMocks.topicApi.getTopicMessages).toHaveBeenLastCalledWith('topic-2', { page: 1, page_size: 500, order: 'asc' })
     expect(wrapper.text()).toContain('topic-2 历史回复')
 
     resolveStream()


### PR DESCRIPTION
## Summary

Follow-up to #295 (shared `useNl2SqlChat` engine). Now that both `WidgetChat.vue` and `NL2SqlChatV2.vue` run on the same engine, this closes the remaining **accidental** interaction/logic gaps between them so they behave consistently. Intentional widget simplifications are preserved (no agent selector, no session filters). Model selection stays available on both surfaces.

## Changes

- **IME-safe Enter (portal bug fix)**: the portal used `@keydown.enter.exact.prevent` with no IME composition guard, so confirming CJK candidates with Enter could send prematurely. Added a shared `isPlainEnterSubmit(event)` helper in `chatMessage.js` (guards `isComposing` / `keyCode 229` / modifier keys) and routed both composers through it.
- **Widget auto-scroll**: the message list now pins to the latest content while streaming (only when already near the bottom), matching the portal's `autoScroll` behavior.
- **Consistent send gating**: the portal send button + textarea now gate on the engine's `canSend` (text + a resolved provider/model), so neither surface can trigger a send without a usable model.
- **Cleanups**: the portal reuses the engine's `thinkingExpanded` / `toggleThinking` instead of local duplicates; widget loads 500 messages of history (parity with the portal).

This branch also merges current `main`, which independently added message-action alignment (copy / feedback / inline-chart via `useChatMessageActions`); both sets of improvements are kept.

## Verification

- `npx vitest run` — **229 tests pass** (added `isPlainEnterSubmit` unit tests and portal IME / send-disabled tests).
- `npx vite build` and `npx vite build --config vite.widget.config.js` both compile.
- Frontend-only change; no backend or NL2SQL smoke flow required.

https://claude.ai/code/session_01Wpv8Us6p2zvJiy7UvhBvbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wpv8Us6p2zvJiy7UvhBvbW)_