### PR TITLE
feat(widget): resume detached tasks, refresh topic statuses, and polish message UX

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1280,7 +1280,21 @@ onBeforeUnmount(() => {
   max-width: 88%;
 }
 
-.v2-msg-footer { display: flex; gap: 8px; align-items: center; padding: 2px 0; }
+.v2-msg-footer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 2px 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.16s ease;
+}
+
+.v2-msg-row:hover .v2-msg-footer,
+.v2-msg-footer:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+}
 .v2-msg-time { font-size: 11px; color: #A0AABF; }
 
 /* ── Message tools ───────────────────────────────────────────────────────── */

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -69,6 +69,7 @@ vi.mock('element-plus', () => ({
 }))
 
 import NL2SqlChatV2 from '../NL2SqlChatV2.vue'
+import nl2SqlChatV2Source from '../NL2SqlChatV2.vue?raw'
 
 const makeTopic = (topicId, title) => ({
   topic_id: topicId,
@@ -272,6 +273,13 @@ describe('NL2SqlChatV2 URL location', () => {
       block: 'center',
       behavior: 'smooth'
     })
+  })
+
+  it('keeps message action footers hidden until hover or keyboard focus', () => {
+    expect(nl2SqlChatV2Source).toContain('.v2-msg-footer {')
+    expect(nl2SqlChatV2Source).toContain('opacity: 0;')
+    expect(nl2SqlChatV2Source).toContain('.v2-msg-row:hover .v2-msg-footer')
+    expect(nl2SqlChatV2Source).toContain('.v2-msg-footer:focus-within')
   })
 
   it('shows status dots in the session list driven by current_task_status', async () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
@@ -142,6 +142,7 @@ export function hydrateMessageFromApi(item) {
     content: messageContent(item),
     status: item?.status || 'success',
     task_id: String(item?.task_id || ''),
+    resume_after_seq: Number(item?.resume_after_seq || 0),
     error: item?.error || null,
     feedback: String(item?.feedback || ''),
     created_at: item?.created_at || '',

--- a/dataagent/dataagent-frontend/src/views/intelligence/useChatMessageActions.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useChatMessageActions.js
@@ -8,23 +8,34 @@ function resolveValue(value) {
 }
 
 async function copyTextToClipboard(text) {
+  let clipboardError = null
   if (typeof navigator !== 'undefined' && navigator.clipboard && typeof window !== 'undefined' && window.isSecureContext) {
-    await navigator.clipboard.writeText(text)
-    return
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      clipboardError = error
+    }
   }
   if (typeof document === 'undefined') {
-    throw new Error('clipboard unavailable')
+    throw clipboardError || new Error('clipboard unavailable')
   }
   const textarea = document.createElement('textarea')
   textarea.value = text
+  textarea.setAttribute('readonly', '')
   textarea.style.position = 'fixed'
   textarea.style.left = '-9999px'
   textarea.style.top = '-9999px'
   document.body.appendChild(textarea)
   textarea.focus()
   textarea.select()
-  document.execCommand('copy')
-  document.body.removeChild(textarea)
+  textarea.setSelectionRange(0, textarea.value.length)
+  try {
+    const copied = document.execCommand?.('copy')
+    if (!copied) throw clipboardError || new Error('clipboard unavailable')
+  } finally {
+    document.body.removeChild(textarea)
+  }
 }
 
 export function useChatMessageActions(options = {}) {

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -110,6 +110,7 @@ export function useNl2SqlChat(options) {
     (topic?.topic_id === topicId.value && Boolean(activeTaskId.value)) ||
     topicStatusKind(topic?.current_task_status) === 'running'
   const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
+  const isTopicTaskActive = (topic) => topicStatusKind(topic?.current_task_status) === 'running'
 
   // Reflect a task's terminal/active status onto its topic so the badge stays
   // accurate without reloading the list.
@@ -142,6 +143,7 @@ export function useNl2SqlChat(options) {
       content: '',
       status: 'queued',
       task_id: taskId || '',
+      resume_after_seq: 0,
       error: null,
       created_at: new Date().toISOString(),
       _v2state: reactive(createChatState()),
@@ -157,9 +159,9 @@ export function useNl2SqlChat(options) {
   const loadTopicMessages = async (targetTopicId) => {
     if (!targetTopicId) {
       messages.value = []
-      return
+      return messages.value
     }
-    if (String(targetTopicId).startsWith('topic_mock_')) return
+    if (String(targetTopicId).startsWith('topic_mock_')) return messages.value
     try {
       const page = await api.topicApi.getTopicMessages(targetTopicId, { page: 1, page_size: messagePageSize, order: 'asc' })
       messages.value = (page?.items || [])
@@ -170,6 +172,7 @@ export function useNl2SqlChat(options) {
       console.warn('[useNl2SqlChat] failed to load messages:', error)
       messages.value = []
     }
+    return messages.value
   }
 
   // ── Config / topics ────────────────────────────────────────────────────────
@@ -189,23 +192,29 @@ export function useNl2SqlChat(options) {
     return config
   }
 
+  const refreshTopics = async () => {
+    const data = await api.topicApi.listTopics(listTopicsParams())
+    const currentTopic = activeTopic.value ? { ...activeTopic.value } : null
+    const list = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
+    const nextTopics = list.map(normalizeTopic).filter((t) => t.topic_id)
+    if (currentTopic?.topic_id && !nextTopics.some((t) => t.topic_id === currentTopic.topic_id)) {
+      nextTopics.unshift(currentTopic)
+    }
+    topics.value = nextTopics
+    sortTopics()
+    if (currentTopic?.topic_id && currentTopic.topic_id === topicId.value) {
+      moveTopicToTop(currentTopic.topic_id)
+    }
+    return topics.value
+  }
+
   const loadTopics = async () => {
     try {
-      const data = await api.topicApi.listTopics(listTopicsParams())
-      const currentTopic = activeTopic.value ? { ...activeTopic.value } : null
-      const list = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
-      const nextTopics = list.map(normalizeTopic).filter((t) => t.topic_id)
-      if (currentTopic?.topic_id && !nextTopics.some((t) => t.topic_id === currentTopic.topic_id)) {
-        nextTopics.unshift(currentTopic)
-      }
-      topics.value = nextTopics
-      sortTopics()
-      if (currentTopic?.topic_id && currentTopic.topic_id === topicId.value) {
-        moveTopicToTop(currentTopic.topic_id)
-      }
+      await refreshTopics()
       // Default to a fresh conversation on open instead of auto-selecting the
       // latest topic, so a new question can be asked immediately.
       await loadTopicMessages(topicId.value || '')
+      resumeActiveTopicTask(topicId.value)
     } catch {
       topics.value = []
       messages.value = []
@@ -235,15 +244,22 @@ export function useNl2SqlChat(options) {
   }
 
   // ── Run lifecycle ────────────────────────────────────────────────────────
-  const subscribe = async (taskId, assistant, controller, runId) => {
+  const subscribe = async (taskId, assistant, controller, runId, options = {}) => {
+    const { refreshAfterTerminal = false } = options
     // The owning topic is captured up front because a new conversation can change
     // topicId mid-stream; the engine writes task status onto its topic directly.
     const runTopicId = topicId.value
+    let afterId = Math.max(0, Number(assistant?.resume_after_seq || 0))
     try {
       await api.taskApi.streamSdkEvents(taskId, {
         signal: controller?.signal,
-        afterId: 0,
+        afterId,
         onRecord: (record) => {
+          const seqId = Number(record?.seq_id || record?.id || 0)
+          if (seqId > afterId) {
+            afterId = seqId
+            assistant.resume_after_seq = afterId
+          }
           processV2Record(assistant._v2state, record)
           triggerRef(messages)
         },
@@ -265,6 +281,7 @@ export function useNl2SqlChat(options) {
       assistant.status = assistant._v2state.status === 'error' ? 'failed' : 'success'
       setTopicTaskStatus(runTopicId, assistant._v2state.status === 'error' ? 'error' : 'finished')
       emitEvent({ name: 'message:done', payload: { taskId } })
+      if (refreshAfterTerminal) await afterRun()
     } catch (error) {
       // Detached / cancelled locally: the aborted fetch rejects with AbortError.
       if (error?.name === 'AbortError') return
@@ -274,6 +291,7 @@ export function useNl2SqlChat(options) {
       assistant._v2state.errorText = assistant.error.message
       setTopicTaskStatus(runTopicId, 'error')
       emitEvent({ name: 'error', payload: assistant.error.message })
+      if (refreshAfterTerminal) await afterRun()
     } finally {
       if (runId === runToken && activeTaskId.value === taskId) {
         activeTaskId.value = ''
@@ -281,6 +299,32 @@ export function useNl2SqlChat(options) {
         abortController.value = null
       }
     }
+  }
+
+  const findAssistantForTask = (taskId) => messages.value.find((message) => (
+    message?.role === 'assistant' && String(message?.task_id || '') === String(taskId || '')
+  ))
+
+  const resumeActiveTopicTask = (targetTopicId = topicId.value) => {
+    if (!targetTopicId || targetTopicId !== topicId.value) return
+    const topic = topics.value.find((item) => item.topic_id === targetTopicId)
+    const taskId = String(topic?.current_task_id || '').trim()
+    if (!taskId || !isTopicTaskActive(topic) || activeTaskId.value === taskId) return
+
+    const assistant = findAssistantForTask(taskId) || appendAssistantMessage(taskId)
+    assistant.task_id = taskId
+    assistant.status = 'running'
+    if (assistant._v2state && assistant._v2state.status !== 'error') {
+      assistant._v2state.status = 'streaming'
+    }
+
+    const runId = ++runToken
+    const controller = new AbortController()
+    abortController.value = controller
+    activeTaskId.value = taskId
+    activeAssistantId.value = assistant.id
+    isSubmitting.value = false
+    void subscribe(taskId, assistant, controller, runId, { refreshAfterTerminal: true })
   }
 
   // Detach from the in-flight run by aborting the local stream (chat v2's
@@ -375,6 +419,7 @@ export function useNl2SqlChat(options) {
     topicId.value = targetTopicId
     errorText.value = ''
     await loadTopicMessages(targetTopicId)
+    resumeActiveTopicTask(targetTopicId)
   }
 
   const newConversation = async () => {
@@ -395,6 +440,7 @@ export function useNl2SqlChat(options) {
     const nextTopicId = topics.value[0]?.topic_id || ''
     topicId.value = nextTopicId
     await loadTopicMessages(nextTopicId)
+    resumeActiveTopicTask(nextTopicId)
   }
 
   return {
@@ -412,7 +458,8 @@ export function useNl2SqlChat(options) {
     appendUserMessage, appendAssistantMessage,
     toggleThinking, isThinkingExpanded, isActiveTask,
     // actions
-    loadConfig, loadTopics, loadTopicMessages, ensureTopic, updateActiveTopicAfterSend,
+    loadConfig, loadTopics, refreshTopics, loadTopicMessages, ensureTopic, updateActiveTopicAfterSend,
+    resumeActiveTopicTask,
     subscribe, send, detach, cancel,
     selectTopic, newConversation, deleteConversation,
   }

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -50,6 +50,8 @@
     </aside>
 
     <main class="query-main">
+      <div v-if="copyNotice" class="query-copy-toast" role="status">{{ copyNotice }}</div>
+
       <div ref="messagesEl" class="query-messages" @scroll="onMessagesScroll">
         <div class="query-messages-inner" :class="{ 'is-empty': !messages.length }">
           <div v-if="errorText" class="query-error-card query-error-banner">
@@ -289,6 +291,7 @@ const DEFAULT_SUGGESTIONS = [
   '最近 30 天工作流发布次数趋势',
   '各工作流发布操作类型占比'
 ]
+const TOPIC_STATUS_REFRESH_INTERVAL_MS = 3000
 
 const agentPresetQuestions = ref([])
 const agentName = ref('智能数据助手')
@@ -297,6 +300,7 @@ const suggestions = computed(() => agentPresetQuestions.value.length ? agentPres
 // widget-only UI state
 const inputSource = ref('typed')
 const pendingOutboundMessage = ref('')
+const copyNotice = ref('')
 
 const isInline = computed(() => props.config.displayMode === 'inline')
 const agentId = computed(() => String(props.config.agentId || '').trim())
@@ -313,7 +317,7 @@ const chat = useNl2SqlChat({
   emitEvent: (event) => emit('event', event),
 })
 const {
-  topicId, messages, errorText,
+  topics, topicId, messages, errorText,
   providers, defaultProviderId, defaultModel, selectedProvider, selectedModel,
   inputText, searchKeyword,
   isSubmitting, activeTaskId, activeAssistantId, abortController, hydratedTopicIds,
@@ -321,12 +325,13 @@ const {
   isTopicWorking, topicBadgeKind, upsertTopicAtTop, updateActiveTopicAfterSend,
   appendUserMessage, appendAssistantMessage,
   toggleThinking, isThinkingExpanded, isActiveTask,
-  loadConfig: loadRuntimeConfig, loadTopics,
+  loadConfig: loadRuntimeConfig, loadTopics, refreshTopics,
   send: sendReal, cancel,
   selectTopic: selectTopicEngine, newConversation: newConversationEngine, deleteConversation,
 } = chat
 
 const historyVisible = computed(() => isInline.value || Boolean(props.state.historyOpen))
+const hasWorkingTopicRecord = computed(() => topics.value.some((topic) => isTopicWorking(topic)))
 const canDeliverPendingOutbound = computed(() => (
   Boolean(pendingOutboundMessage.value)
   && !isBusy.value
@@ -390,10 +395,21 @@ const cleanTextForDisplay = (content) => stripChartSpecsFromText(String(content 
 // (fenced, tagged, or raw JSON) renders as a real chart instead of leaking JSON.
 const answerSegments = (content) => splitChartSpecText(String(content || ''))
 
+let copyNoticeTimer = null
+const showCopyNotice = (message) => {
+  copyNotice.value = String(message || '已复制')
+  if (copyNoticeTimer) window.clearTimeout(copyNoticeTimer)
+  copyNoticeTimer = window.setTimeout(() => {
+    copyNotice.value = ''
+    copyNoticeTimer = null
+  }, 1400)
+}
+
 const { handleCopyMessage, toggleMessageFeedback } = useChatMessageActions({
   api,
   topicId,
   cleanText: cleanTextForDisplay,
+  notifyCopied: showCopyNotice,
   notifyError: (message) => emit('event', { name: 'error', payload: message }),
   emitEvent: (event) => emit('event', event),
 })
@@ -614,6 +630,38 @@ watch(canDeliverPendingOutbound, (value) => {
   if (value) sendPendingOutbound()
 })
 
+let topicStatusRefreshTimer = null
+const stopTopicStatusRefresh = () => {
+  if (!topicStatusRefreshTimer) return
+  window.clearInterval(topicStatusRefreshTimer)
+  topicStatusRefreshTimer = null
+}
+const refreshTopicStatuses = async () => {
+  if (!hasWorkingTopicRecord.value) {
+    stopTopicStatusRefresh()
+    return
+  }
+  try {
+    await refreshTopics()
+  } catch {
+    // Keep the current list; the next interval will retry while a topic is marked running.
+  }
+}
+const startTopicStatusRefresh = () => {
+  if (topicStatusRefreshTimer) return
+  topicStatusRefreshTimer = window.setInterval(() => {
+    void refreshTopicStatuses()
+  }, TOPIC_STATUS_REFRESH_INTERVAL_MS)
+}
+watch(
+  hasWorkingTopicRecord,
+  (value) => {
+    if (value) startTopicStatusRefresh()
+    else stopTopicStatusRefresh()
+  },
+  { immediate: true }
+)
+
 watch(
   () => props.state.cancelSignal,
   (value) => {
@@ -662,6 +710,8 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  stopTopicStatusRefresh()
+  if (copyNoticeTimer) window.clearTimeout(copyNoticeTimer)
   abortController.value?.abort()
 })
 </script>
@@ -680,6 +730,15 @@ onBeforeUnmount(() => {
   gap: 6px;
   margin-top: 4px;
   min-height: 24px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.16s ease;
+}
+
+.query-message-row:hover .query-message-footer,
+.query-message-footer:focus-within {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .query-message-footer-user {
@@ -719,5 +778,21 @@ onBeforeUnmount(() => {
 .query-message-feedback-dislike.active {
   background: #fff1f0;
   color: #d93025;
+}
+
+.query-copy-toast {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  z-index: 20;
+  transform: translateX(-50%);
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.88);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1.4;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  pointer-events: none;
 }
 </style>

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive } from 'vue'
 
 import WidgetChat from '../WidgetChat.vue'
+import widgetChatSource from '../WidgetChat.vue?raw'
 
 // ECharts touches the canvas API, which jsdom doesn't fully implement. The chart
 // promotion tests only care about which container the chart lands in, so stub the
@@ -199,6 +200,38 @@ describe('WidgetChat history conversations', () => {
     expect(wrapper.find('[data-testid="history-topic-topic-ok"] .query-session-dot').exists()).toBe(false)
   })
 
+  it('refreshes session record statuses while background widget topics are running', async () => {
+    vi.useFakeTimers()
+    apiMocks.topicApi.listTopics
+      .mockResolvedValueOnce([
+        topic('topic-bg', '后台运行会话', {
+          current_task_id: 'task-bg',
+          current_task_status: 'running'
+        })
+      ])
+      .mockResolvedValueOnce([
+        topic('topic-bg', '后台运行会话', {
+          current_task_id: 'task-bg',
+          current_task_status: 'finished'
+        })
+      ])
+
+    try {
+      const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+      await flushPromises()
+
+      expect(wrapper.find('[data-testid="history-topic-topic-bg"] .query-session-loading').exists()).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(3000)
+      await flushPromises()
+
+      expect(apiMocks.topicApi.listTopics).toHaveBeenCalledTimes(2)
+      expect(wrapper.find('[data-testid="history-topic-topic-bg"] .query-session-loading').exists()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('surfaces the error card when opening a failed (status=error) history conversation', async () => {
     apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
       topic_id: topicId,
@@ -252,6 +285,42 @@ describe('WidgetChat history conversations', () => {
     await wrapper.get('[data-testid="feedback-dislike-msg-topic-2"]').trigger('click')
     expect(apiMocks.topicApi.updateMessageFeedback).toHaveBeenCalledWith('topic-2', 'msg-topic-2', 'dislike')
     expect(wrapper.get('[data-testid="feedback-dislike-msg-topic-2"]').classes()).toContain('active')
+  })
+
+  it('falls back when the widget clipboard API rejects and shows copy feedback', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'))
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true
+    })
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('[data-testid="history-topic-topic-2"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.get('[data-testid="copy-message-msg-topic-2"]').trigger('click')
+    await flushPromises()
+
+    expect(writeText).toHaveBeenCalledWith('topic-2 历史回复')
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(wrapper.find('.query-copy-toast').text()).toBe('已复制')
+  })
+
+  it('keeps widget message action footers hidden until hover or keyboard focus', () => {
+    expect(widgetChatSource).toContain('.query-message-footer {\n  display: flex;')
+    expect(widgetChatSource).toContain('opacity: 0;')
+    expect(widgetChatSource).toContain('.query-message-row:hover .query-message-footer')
+    expect(widgetChatSource).toContain('.query-message-footer:focus-within')
   })
 
   it('renders inline chart specs from assistant text without showing raw spec markup', async () => {
@@ -441,6 +510,114 @@ describe('WidgetChat history conversations', () => {
     }))
 
     resolveStream()
+  })
+
+  it('reattaches the running task when returning to a detached widget conversation', async () => {
+    const streams = []
+    let topicAFinished = false
+    apiMocks.topicApi.listTopics.mockResolvedValue([
+      topic('topic-b', '另一个运行会话', {
+        current_task_id: 'task-b',
+        current_task_status: 'running'
+      })
+    ])
+    apiMocks.topicApi.createTopic.mockResolvedValue(topic('topic-a', '当前新会话', {
+      message_count: 0,
+      last_message_preview: '',
+      updated_at: '2026-04-30T09:00:00'
+    }))
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => {
+      if (topicId === 'topic-a') {
+        return {
+          topic_id: topicId,
+          total: 2,
+          items: [
+            { message_id: 'user-a', sender_type: 'user', content: '新会话问题', seq_id: 1 },
+            {
+              message_id: 'assistant-a',
+              sender_type: 'assistant',
+              status: topicAFinished ? 'success' : 'running',
+              task_id: 'task-a',
+              content: '',
+              blocks: topicAFinished ? [{ kind: 'main_text', text: '恢复完成' }] : [],
+              resume_after_seq: 7,
+              seq_id: 2
+            }
+          ]
+        }
+      }
+      if (topicId === 'topic-b') {
+        return {
+          topic_id: topicId,
+          total: 2,
+          items: [
+            { message_id: 'user-b', sender_type: 'user', content: '另一个问题', seq_id: 1 },
+            {
+              message_id: 'assistant-b',
+              sender_type: 'assistant',
+              status: 'running',
+              task_id: 'task-b',
+              content: '',
+              blocks: [],
+              resume_after_seq: 3,
+              seq_id: 2
+            }
+          ]
+        }
+      }
+      return messagePage(topicId, `${topicId} 历史回复`)
+    })
+    apiMocks.taskApi.deliverMessage.mockResolvedValue({ task_id: 'task-a' })
+    apiMocks.taskApi.streamSdkEvents.mockImplementation((taskId, options = {}) => new Promise((resolve, reject) => {
+      const stream = { taskId, options, resolve, reject }
+      streams.push(stream)
+      options.signal?.addEventListener('abort', () => {
+        const error = new Error('aborted')
+        error.name = 'AbortError'
+        reject(error)
+      })
+    }))
+    apiMocks.taskApi.getTask.mockImplementation(async (taskId) => ({
+      task_id: taskId,
+      topic_id: taskId === 'task-a' ? 'topic-a' : 'topic-b',
+      task_status: 'finished'
+    }))
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('textarea').setValue('新会话问题')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(streams.map((stream) => stream.taskId)).toEqual(['task-a'])
+
+    await wrapper.get('[data-testid="history-topic-topic-b"]').trigger('click')
+    await flushPromises()
+
+    expect(streams.map((stream) => stream.taskId)).toEqual(['task-a', 'task-b'])
+    expect(apiMocks.taskApi.cancelTask).not.toHaveBeenCalled()
+    expect(wrapper.find('.query-cancel-btn').exists()).toBe(true)
+
+    await wrapper.get('[data-testid="history-topic-topic-a"]').trigger('click')
+    await flushPromises()
+
+    expect(streams.map((stream) => stream.taskId)).toEqual(['task-a', 'task-b', 'task-a'])
+    expect(streams.at(-1).options.afterId).toBe(7)
+    expect(wrapper.find('.query-cancel-btn').exists()).toBe(true)
+
+    const resumedStream = streams.at(-1)
+    resumedStream.options.onRecord({ seq_id: 8, record_type: 'stream', data: { type: 'message_start', usage: {} } })
+    resumedStream.options.onRecord({ seq_id: 9, record_type: 'stream', data: { type: 'content_block_start', index: 0, content_block: { type: 'text' } } })
+    resumedStream.options.onRecord({ seq_id: 10, record_type: 'stream', data: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: '恢复完成' } } })
+    resumedStream.options.onRecord({ seq_id: 11, record_type: 'stream', data: { type: 'content_block_stop', index: 0 } })
+    resumedStream.options.onRecord({ seq_id: 12, record_type: 'done', data: {} })
+    topicAFinished = true
+    resumedStream.resolve()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('恢复完成')
+    expect(wrapper.find('.query-cancel-btn').exists()).toBe(false)
+    expect(apiMocks.topicApi.listTopics).toHaveBeenCalledTimes(2)
   })
 
   it('sends on plain Enter but keeps Shift+Enter / IME Enter as a newline', async () => {


### PR DESCRIPTION
## 变更说明

### 功能增强

1. **恢复后台运行任务** — 切换回一个有进行中任务的 widget 会话时，自动重新订阅事件流（使用 `resume_after_seq` 作为 `afterId`），恢复部分输出而不丢失已有内容
2. **话题状态自动刷新** — 当话题列表中有运行中的任务时，每 3 秒自动刷新话题列表以保持侧边栏状态指示（spinner）的准确性
3. **复制成功提示** — Widget 聊天中复制消息后显示 toast 通知
4. **剪贴板降级** — 当 `navigator.clipboard.writeText` 被拒绝时，降级到 `document.execCommand('copy')`

### UX 优化

5. **消息操作按钮隐藏** — Chat V2 和 WidgetChat 中的消息操作按钮（复制/反馈）默认隐藏，hover 或键盘聚焦时显示

### 重构

6. **提取 `refreshTopics()`** — 从 `loadTopics()` 中拆分出 `refreshTopics()`，用于轻量的话题列表状态刷新（不重新加载消息）

## 修改文件

| 文件 | 说明 |
|------|------|
| `useNl2SqlChat.js` | 新增 `refreshTopics()`、`resumeActiveTopicTask()`，支持 `afterId` 恢复订阅 |
| `useChatMessageActions.js` | 增加 `notifyCopied` 回调支持 |
| `chatMessage.js` | 添加 `resume_after_seq` 字段 |
| `NL2SqlChatV2.vue` | 消息操作按钮 hover 显示样式 |
| `WidgetChat.vue` | 话题状态刷新、复制 toast、hover footer、任务恢复 |
| `NL2SqlChatV2.spec.js` | 新增 hover footer 测试 |
| `WidgetChat.spec.js` | 新增任务恢复、状态刷新、剪贴板降级、hover footer 测试 |