### PR TITLE
fix: build_chart_spec tool invocation and chart rendering UX

### DIFF
--- a/dataagent/.claude/skills/opendataworks-platform-tools/reference/30-tool-recipes.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/reference/30-tool-recipes.md
@@ -93,7 +93,13 @@
 - 用途：把 SQL 结果转换成图表契约。
 - 适用场景：结果结构适合图表，且用户问题需要可视化或对比展示。
 - 参数规则：必须显式传 `--chart-type bar|line|pie|table`。
+- 输入方式（二选一）：
+  - `--data '<JSON rows>'`：直接传 JSON 数组，适用于已有行数据。
+  - `--input '<sql_execution JSON>'`：传 `run_sql.py` 的完整输出 JSON（含 `rows` 字段）。
+- 可选参数：`--title "标题"`, `--x-field <维度字段>`, `--y-field <度量字段>`。
 - 收口规则：成功返回一次 `chart_spec` 后结束本轮，不重复生成。
+- 命令模板：`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|pie|table> --data '<JSON rows>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>]`
+- 注意：`build_chart_spec.py` 不是独立注册的工具名，必须通过 Bash 工具执行上述命令。
 
 ## format_answer.py
 

--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -149,9 +149,13 @@
 当用户问题涉及趋势、分布、排行、占比、对比或其他可视化需求时，必须遵守以下规则：
 
 **强制要求：**
-- 必须通过 `build_chart_spec` 工具生成图表契约，不得用 ASCII 字符、Unicode 符号或纯文字模拟图表；
-- **严禁把 `chart_spec` JSON（或 ```chart、`<chart_spec>` 代码块）直接写进回答正文。图表只能由 `build_chart_spec` 工具产出，前端只渲染来自该工具调用的图表；写进正文的 chart_spec 既不会被渲染，也会被丢弃。**
-- 即便你已经知道图表数据，也必须实际调用 `build_chart_spec` 工具，而不是凭记忆把契约 JSON 输出到文本里；
+- 必须通过 Bash 工具调用 `build_chart_spec.py` 脚本生成图表契约，不得用 ASCII 字符、Unicode 符号或纯文字模拟图表。调用命令模板：
+  ```
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|pie|table> --data '<JSON rows>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>]
+  ```
+  `build_chart_spec.py` 不是一个独立注册的工具名，它是一个通过 Bash 工具执行的脚本。不要尝试直接调用名为 `build_chart_spec` 的工具。
+- **严禁把 `chart_spec` JSON（或 ```chart、`<chart_spec>` 代码块）直接写进回答正文。图表只能由 Bash 调用 `build_chart_spec.py` 脚本产出，前端只渲染来自该工具调用的图表；写进正文的 chart_spec 既不会被渲染，也会被丢弃。**
+- 即便你已经知道图表数据，也必须实际通过 Bash 工具调用 `build_chart_spec.py` 脚本，而不是凭记忆把契约 JSON 输出到文本里；
 - 禁止以任何形式输出 ASCII 图表（包括 `|`, `-`, `*`, `#` 等字符拼成的表格图或条形图）作为图表的替代；
 - 图表契约必须基于真实查询结果构建，不得捏造数据点；
 - 图表类型选择应与数据结构匹配：趋势用折线图、占比用饼图、排行/对比用柱状图、明细用表格。

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -244,6 +244,8 @@ const buildAxisOption = (spec) => {
       : undefined,
     tooltip: {
       trigger: 'axis',
+      transitionDuration: 0,
+      axisPointer: { type: 'line', animation: false },
       valueFormatter: spec.unit ? (value) => `${value}${spec.unit}` : undefined
     },
     legend: { top: 8, right: 0, textStyle: { color: '#607185' } },

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -224,6 +224,7 @@ const buildAxisOption = (spec) => {
   const valueAxis = {
     type: 'value',
     name: spec.unit || '',
+    scale: true,
     axisLabel: { color: '#607185' },
     splitLine: { lineStyle: { color: '#eef3f8' } }
   }


### PR DESCRIPTION
1. Clarify that build_chart_spec is a Bash script instead of an explicit tool in system prompt and recipes to fix tool invocation errors.
2. Enable scale on chart value axis to better show data trends when differences are small.
3. Disable chart tooltip and axis pointer animation to remove hover flashing (marquee effect).