### PR TITLE
fix: build_chart_spec tool invocation and chart rendering UX

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChat.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChat.vue
@@ -2571,7 +2571,8 @@ defineExpose({ handleNewTopic })
 .query-process-thought-content :deep(code) {
   padding: 2px 4px;
   border-radius: 4px;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--el-color-primary-light-9, rgba(0, 0, 0, 0.04));
+  color: var(--el-color-primary, inherit);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 12px;
 }
@@ -2759,8 +2760,8 @@ defineExpose({ handleNewTopic })
 .query-main-text :deep(code) {
   padding: 2px 6px;
   border-radius: 6px;
-  background: #edf2ff;
-  color: #425cc8;
+  background: var(--el-color-primary-light-9, #edf2ff);
+  color: var(--el-color-primary, #425cc8);
   font-size: 13px;
 }
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1426,7 +1426,14 @@ onBeforeUnmount(() => {
   overflow-x: auto;
   font-size: 13px;
 }
-.v2-text-block :deep(code) { font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 13px; }
+.v2-text-block :deep(code) {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 13px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--odw-primary) 8%, transparent);
+  color: var(--odw-primary);
+}
 .v2-text-block :deep(table) { border-collapse: collapse; width: 100%; margin: 10px 0; }
 .v2-text-block :deep(th), .v2-text-block :deep(td) { border: 1px solid #dbe3ef; padding: 6px 12px; font-size: 13px; }
 .v2-text-block :deep(th) { background: #f4f7fb; font-weight: 600; }

--- a/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
@@ -970,8 +970,8 @@ onBeforeUnmount(() => {
 .tool-markdown-body :deep(code) {
   padding: 1px 5px;
   border-radius: 6px;
-  background: #f4f7fb;
-  color: #1f3b57;
+  background: color-mix(in srgb, var(--odw-primary, var(--el-color-primary, #1f3b57)) 8%, transparent);
+  color: var(--odw-primary, var(--el-color-primary, #1f3b57));
   font-size: 12px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
 }


### PR DESCRIPTION
1. Clarify that build_chart_spec is a Bash script instead of an explicit tool in system prompt and recipes to fix tool invocation errors.
2. Enable scale on chart value axis to better show data trends when differences are small.
3. Disable chart tooltip and axis pointer animation to remove hover flashing (marquee effect).
4. Update Markdown code tags to dynamically adapt to the application theme's primary color instead of static grey/blue.