### PR TITLE
feat(widget): support dragging the launcher button

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
+++ b/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
@@ -5,7 +5,7 @@
     :style="[themeStyle, rootStyle]"
     :class="[positionClass, modeClass, state.historyOpen ? 'is-history-open' : '', isDragged ? 'is-dragged' : '', isInteracting ? 'is-interacting' : '']"
   >
-    <button v-if="!isInline && !state.isOpen" class="odw-launcher" type="button" :aria-label="`打开 ${config.projectName}`" @click="open">
+    <button v-if="!isInline && !state.isOpen" class="odw-launcher" type="button" :aria-label="`打开 ${config.projectName}`" @pointerdown="startLauncherDrag" @click="openIfNotDragged">
       <svg class="odw-launcher__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
       </svg>
@@ -94,6 +94,8 @@ const {
   isInteracting,
   startDrag,
   startResize,
+  startLauncherDrag,
+  isLauncherDragMoved,
   bind,
   unbind
 } = useWidgetGeometry({ rootEl, panelEl, config: props.config, state: props.state })
@@ -110,6 +112,11 @@ const open = () => {
   props.state.isOpen = true
   props.state.track?.('widget_open')
   props.emit('open')
+}
+
+const openIfNotDragged = () => {
+  if (isLauncherDragMoved()) return
+  open()
 }
 
 const close = () => {

--- a/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
+++ b/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
@@ -5,7 +5,7 @@
     :style="[themeStyle, rootStyle]"
     :class="[positionClass, modeClass, state.historyOpen ? 'is-history-open' : '', isDragged ? 'is-dragged' : '', isInteracting ? 'is-interacting' : '']"
   >
-    <button v-if="!isInline && !state.isOpen" class="odw-launcher" type="button" :aria-label="`打开 ${config.projectName}`" @pointerdown="startLauncherDrag" @click="openIfNotDragged">
+    <button v-if="!isInline && !state.isOpen" class="odw-launcher" type="button" :aria-label="`打开 ${config.projectName}`" @pointerdown="startLauncherDrag" @click.stop.prevent="openIfNotDragged">
       <svg class="odw-launcher__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
       </svg>

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -80,6 +80,7 @@ export const WIDGET_STYLES = `
     0 2px 8px rgba(0, 0, 0, 0.14),
     0 8px 28px rgba(0, 0, 0, 0.12);
   cursor: pointer;
+  touch-action: none;
   transition: transform 0.18s ease, box-shadow 0.2s ease;
   animation: odw-launcher-entrance 0.35s cubic-bezier(0.34, 1.2, 0.64, 1) both;
 }

--- a/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
+++ b/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
@@ -214,6 +214,7 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     window.addEventListener('pointermove', onLauncherDragMove)
     window.addEventListener('pointerup', endLauncherDrag)
     event.preventDefault()
+    event.stopPropagation()
   }
 
   const isLauncherDragMoved = () => launcherDragMoved

--- a/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
+++ b/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
@@ -1,9 +1,12 @@
 import { computed, reactive } from 'vue'
 
 const STORAGE_PREFIX = 'odw:widget:geom:'
+const LAUNCHER_STORAGE_PREFIX = 'odw:widget:launcher:'
 const MIN_WIDTH = 360
 const MIN_HEIGHT = 420
 const VIEWPORT_MARGIN = 24
+const LAUNCHER_SIZE = 56
+const DRAG_THRESHOLD = 5
 
 const toFiniteOrNull = (value) => {
   if (value == null || value === '') return null
@@ -32,6 +35,7 @@ export const clampSize = (width, height, vw, vh) => {
 }
 
 export const geometryStorageKey = (websiteId) => `${STORAGE_PREFIX}${websiteId || 'default'}`
+export const launcherStorageKey = (websiteId) => `${LAUNCHER_STORAGE_PREFIX}${websiteId || 'default'}`
 
 /** Read persisted geometry; returns null when missing or unusable. */
 export const loadGeometry = (websiteId) => {
@@ -76,6 +80,7 @@ export const clearGeometry = (websiteId) => {
 export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
   const isFloating = () => config.displayMode !== 'inline'
   const geom = reactive({ left: null, top: null, width: null, height: null, dragged: false, interacting: false })
+  const launcherGeom = reactive({ left: null, top: null, dragged: false, interacting: false })
 
   const viewport = () => ({
     vw: Number(window.innerWidth || 0),
@@ -85,8 +90,17 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
   const isVisible = () => isFloating() && Boolean(state.isOpen)
 
   const rootStyle = computed(() => {
-    if (!isVisible() || !geom.dragged || geom.left == null || geom.top == null) return {}
-    return { left: `${geom.left}px`, top: `${geom.top}px` }
+    if (!isFloating()) return {}
+    // When the panel is open, use panel drag position
+    if (state.isOpen) {
+      if (!geom.dragged || geom.left == null || geom.top == null) return {}
+      return { left: `${geom.left}px`, top: `${geom.top}px` }
+    }
+    // When closed (launcher visible), use launcher drag position
+    if (launcherGeom.dragged && launcherGeom.left != null && launcherGeom.top != null) {
+      return { left: `${launcherGeom.left}px`, top: `${launcherGeom.top}px` }
+    }
+    return {}
   })
 
   const panelStyle = computed(() => {
@@ -97,8 +111,12 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     return style
   })
 
-  const isDragged = computed(() => isVisible() && geom.dragged)
-  const isInteracting = computed(() => geom.interacting)
+  const isDragged = computed(() => {
+    if (!isFloating()) return false
+    if (state.isOpen) return geom.dragged
+    return launcherGeom.dragged
+  })
+  const isInteracting = computed(() => geom.interacting || launcherGeom.interacting)
 
   const persist = () => {
     saveGeometry(config.websiteId, {
@@ -107,6 +125,15 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
       width: geom.width,
       height: geom.height
     })
+  }
+
+  const persistLauncher = () => {
+    try {
+      window.localStorage.setItem(launcherStorageKey(config.websiteId), JSON.stringify({
+        left: launcherGeom.left,
+        top: launcherGeom.top
+      }))
+    } catch (_error) { /* non-fatal */ }
   }
 
   // ── Drag ──────────────────────────────────────────────────────────────────
@@ -148,6 +175,49 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     event.preventDefault()
   }
 
+  // ── Launcher Drag ──────────────────────────────────────────────────────────
+  let launcherDragStart = null
+  let launcherDragMoved = false
+
+  const onLauncherDragMove = (event) => {
+    if (!launcherDragStart) return
+    const dx = event.clientX - launcherDragStart.x
+    const dy = event.clientY - launcherDragStart.y
+    if (!launcherDragMoved && Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return
+    launcherDragMoved = true
+    const { vw, vh } = viewport()
+    const nextLeft = Math.min(Math.max(0, launcherDragStart.left + dx), vw - LAUNCHER_SIZE)
+    const nextTop = Math.min(Math.max(0, launcherDragStart.top + dy), vh - LAUNCHER_SIZE)
+    launcherGeom.left = nextLeft
+    launcherGeom.top = nextTop
+  }
+
+  const endLauncherDrag = () => {
+    window.removeEventListener('pointermove', onLauncherDragMove)
+    window.removeEventListener('pointerup', endLauncherDrag)
+    launcherDragStart = null
+    launcherGeom.interacting = false
+    if (launcherDragMoved) {
+      persistLauncher()
+    }
+  }
+
+  const startLauncherDrag = (event) => {
+    if (!isFloating()) return
+    const el = rootEl.value
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    launcherDragStart = { x: event.clientX, y: event.clientY, left: rect.left, top: rect.top }
+    launcherDragMoved = false
+    launcherGeom.dragged = true
+    launcherGeom.interacting = true
+    window.addEventListener('pointermove', onLauncherDragMove)
+    window.addEventListener('pointerup', endLauncherDrag)
+    event.preventDefault()
+  }
+
+  const isLauncherDragMoved = () => launcherDragMoved
+
   // ── Resize ────────────────────────────────────────────────────────────────
   let resizeStart = null
 
@@ -184,8 +254,26 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
   }
 
   // ── Restore / lifecycle ─────────────────────────────────────────────────────
+  const restoreLauncherGeometry = () => {
+    if (!isFloating()) return
+    try {
+      const raw = window.localStorage.getItem(launcherStorageKey(config.websiteId))
+      if (!raw) return
+      const saved = JSON.parse(raw)
+      if (!saved || typeof saved !== 'object') return
+      const left = toFiniteOrNull(saved.left)
+      const top = toFiniteOrNull(saved.top)
+      if (left == null || top == null) return
+      const { vw, vh } = viewport()
+      launcherGeom.left = Math.min(Math.max(0, left), vw - LAUNCHER_SIZE)
+      launcherGeom.top = Math.min(Math.max(0, top), vh - LAUNCHER_SIZE)
+      launcherGeom.dragged = true
+    } catch (_error) { /* non-fatal */ }
+  }
+
   const restoreGeometry = () => {
     if (!isFloating()) return
+    restoreLauncherGeometry()
     const saved = loadGeometry(config.websiteId)
     if (!saved) return
     const { vw, vh } = viewport()
@@ -221,6 +309,10 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
       geom.left = pos.left
       geom.top = pos.top
     }
+    if (launcherGeom.dragged && launcherGeom.left != null && launcherGeom.top != null) {
+      launcherGeom.left = Math.min(Math.max(0, launcherGeom.left), vw - LAUNCHER_SIZE)
+      launcherGeom.top = Math.min(Math.max(0, launcherGeom.top), vh - LAUNCHER_SIZE)
+    }
   }
 
   const resetGeometry = () => {
@@ -231,6 +323,11 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     geom.dragged = false
     geom.interacting = false
     clearGeometry(config.websiteId)
+    launcherGeom.left = null
+    launcherGeom.top = null
+    launcherGeom.dragged = false
+    launcherGeom.interacting = false
+    try { window.localStorage.removeItem(launcherStorageKey(config.websiteId)) } catch (_e) { /* */ }
   }
 
   const bind = () => {
@@ -244,7 +341,9 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     window.removeEventListener('pointerup', endDrag)
     window.removeEventListener('pointermove', onResizeMove)
     window.removeEventListener('pointerup', endResize)
+    window.removeEventListener('pointermove', onLauncherDragMove)
+    window.removeEventListener('pointerup', endLauncherDrag)
   }
 
-  return { rootStyle, panelStyle, isDragged, isInteracting, startDrag, startResize, resetGeometry, bind, unbind }
+  return { rootStyle, panelStyle, isDragged, isInteracting, startDrag, startResize, startLauncherDrag, isLauncherDragMoved, resetGeometry, bind, unbind }
 }

--- a/dataagent/dataagent-frontend/vite.config.js
+++ b/dataagent/dataagent-frontend/vite.config.js
@@ -40,6 +40,17 @@ export default defineConfig(() => {
     base: './',
     plugins: [
       vue(),
+      {
+        name: 'serve-widget-dist',
+        configureServer(server) {
+          server.middlewares.use((req, res, next) => {
+            if (req.url && req.url.startsWith('/widget/')) {
+              req.url = '/dist' + req.url
+            }
+            next()
+          })
+        }
+      },
       Components({
         dirs: [],
         dts: false,


### PR DESCRIPTION
This PR introduces drag-to-move support for the floating launcher button (OpenDataWorks widget), allowing users to move it independently of the main chat panel and persisting its position. It also prevents event propagation and default actions on click and pointerdown to avoid accidental page reloads.