### PR TITLE
Add message timestamps to chat interface

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -64,6 +64,7 @@
               <div class="query-user-message-shell">
                 <div class="query-user-bubble">{{ msg.content }}</div>
                 <div class="query-message-footer query-message-footer-user">
+                  <span v-if="msg.created_at" class="query-message-time">{{ formatMessageTime(msg.created_at) }}</span>
                   <button
                     type="button"
                     class="query-message-tool query-message-copy"
@@ -143,6 +144,7 @@
                   </div>
                 </template>
                 <div class="query-message-footer query-message-footer-assistant">
+                  <span v-if="msg.created_at" class="query-message-time">{{ formatMessageTime(msg.created_at) }}</span>
                   <button
                     type="button"
                     class="query-message-tool query-message-copy"
@@ -383,6 +385,12 @@ const formatTime = (value) => {
     return fmtDate(date, { month: '2-digit', day: '2-digit' })
   }
   return fmtDate(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
+}
+
+const formatMessageTime = (value) => {
+  const date = value ? new Date(value) : null
+  if (!date || Number.isNaN(date.getTime())) return ''
+  return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
 }
 
 const uid = () => `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -747,6 +755,11 @@ onBeforeUnmount(() => {
 
 .query-message-footer-assistant {
   justify-content: flex-start;
+}
+
+.query-message-time {
+  font-size: 11px;
+  color: #8a96a8;
 }
 
 .query-message-tool {


### PR DESCRIPTION
## Summary
Display formatted timestamps for both user and assistant messages in the chat widget, showing the time each message was created.

## Changes
- Added `formatMessageTime()` utility function to format timestamps in HH:MM format (24-hour, Chinese locale)
- Display message creation time in user message footer (when `created_at` is available)
- Display message creation time in assistant message footer (when `created_at` is available)
- Added `.query-message-time` CSS styling with 11px font size and muted gray color (#8a96a8)

## Implementation Details
- The timestamp display is conditionally rendered using `v-if="msg.created_at"` to handle cases where the timestamp may not be present
- Invalid or missing dates gracefully return an empty string
- Timestamps use 24-hour format (hour12: false) with Chinese locale for consistency with the application

https://claude.ai/code/session_017hoRXnU9GnyT3Yvv4fdwV5