### PR TITLE
Switch eval runners to Chat V2 projected message blocks

### DIFF
--- a/dataagent/contracts/sdk-block-projection/cases.json
+++ b/dataagent/contracts/sdk-block-projection/cases.json
@@ -1,0 +1,110 @@
+{
+  "description": "Golden contract fixtures for SDK-record -> rendered-block projection. Both the backend (topic_task_store._project_sdk_records) and the frontend (v2StreamParser.processV2Record) must normalize each case's `records` to the same canonical `expected` block list. Canonical block shape: {kind: 'thinking'|'text'|'tool_use', text?, tool_name?, input?, output?, is_error?}. Empty thinking/text blocks are dropped.",
+  "cases": [
+    {
+      "name": "text answer only",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello "}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "world"}}},
+        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 6, "record_type": "stream", "data": {"type": "message_stop"}}
+      ],
+      "expected": [
+        {"kind": "text", "text": "Hello world"}
+      ]
+    },
+    {
+      "name": "thinking then text",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "let me think"}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
+        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "answer"}}},
+        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+      ],
+      "expected": [
+        {"kind": "thinking", "text": "let me think"},
+        {"kind": "text", "text": "answer"}
+      ]
+    },
+    {
+      "name": "tool_use with success result then text",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"sql\":"}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "\"select 1\"}"}}},
+        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 6, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": [{"type": "text", "text": "rows: 3"}], "is_error": false}},
+        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
+        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "done"}}},
+        {"seq_id": 9, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+      ],
+      "expected": [
+        {"kind": "tool_use", "tool_name": "run_sql", "input": {"sql": "select 1"}, "output": [{"type": "text", "text": "rows: 3"}], "is_error": false},
+        {"kind": "text", "text": "done"}
+      ]
+    },
+    {
+      "name": "tool_use with error result",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"sql\":\"bad\"}"}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 5, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": "boom", "is_error": true}}
+      ],
+      "expected": [
+        {"kind": "tool_use", "tool_name": "run_sql", "input": {"sql": "bad"}, "output": "boom", "is_error": true}
+      ]
+    },
+    {
+      "name": "empty text block is dropped",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
+        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "real"}}},
+        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+      ],
+      "expected": [
+        {"kind": "text", "text": "real"}
+      ]
+    },
+    {
+      "name": "two turns are flattened in order",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "a"}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 5, "record_type": "stream", "data": {"type": "message_stop"}},
+        {"seq_id": 6, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
+        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "b"}}},
+        {"seq_id": 9, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}}
+      ],
+      "expected": [
+        {"kind": "text", "text": "a"},
+        {"kind": "text", "text": "b"}
+      ]
+    },
+    {
+      "name": "malformed tool input json falls back to raw string",
+      "records": [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{bad"}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}}
+      ],
+      "expected": [
+        {"kind": "tool_use", "tool_name": "run_sql", "input": "{bad", "output": null, "is_error": false}
+      ]
+    }
+  ]
+}

--- a/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
@@ -1,0 +1,60 @@
+"""Contract test: backend SDK-record projection matches the shared golden fixtures.
+
+The SDK-record -> rendered-block projection now lives in exactly two places:
+
+* backend ``topic_task_store._project_sdk_records`` (history / eval evidence)
+* frontend ``v2StreamParser.processV2Record`` (live streaming)
+
+Both must turn the same ``records`` into the same canonical block list. This test
+locks the backend side against ``dataagent/contracts/sdk-block-projection/cases.json``;
+``sdkBlockProjection.contract.spec.js`` locks the frontend side against the same file.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from core.topic_task_store import _project_sdk_records
+
+_CASES_PATH = Path(__file__).resolve().parents[2] / "contracts" / "sdk-block-projection" / "cases.json"
+
+
+def _load_cases() -> list[dict[str, Any]]:
+    data = json.loads(_CASES_PATH.read_text(encoding="utf-8"))
+    return list(data.get("cases") or [])
+
+
+def _to_canonical(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize backend projection blocks to the shared canonical shape."""
+    canonical: list[dict[str, Any]] = []
+    for block in blocks:
+        btype = block.get("type")
+        if btype == "tool_use":
+            canonical.append(
+                {
+                    "kind": "tool_use",
+                    "tool_name": block.get("tool_name"),
+                    "input": block.get("input"),
+                    "output": block.get("output"),
+                    "is_error": bool(block.get("is_error")),
+                }
+            )
+        else:
+            kind = "text" if btype == "main_text" else str(btype or "")
+            text = str(block.get("text") or "")
+            if not text.strip():
+                continue
+            canonical.append({"kind": kind, "text": text})
+    return canonical
+
+
+def test_contract_fixtures_exist() -> None:
+    cases = _load_cases()
+    assert cases, f"no projection contract cases found at {_CASES_PATH}"
+
+
+def test_backend_projection_matches_golden_fixtures() -> None:
+    for case in _load_cases():
+        projected = _project_sdk_records(case["records"])["blocks"]
+        assert _to_canonical(projected) == case["expected"], f"case mismatch: {case.get('name')}"

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { createChatState, processV2Record } from '../v2StreamParser'
+
+// Contract test: the live streaming parser must project the same `records` into
+// the same canonical block list as the backend `topic_task_store._project_sdk_records`.
+// The Python side locks the same fixtures in test_sdk_block_projection_contract.py.
+// vitest runs from the dataagent-frontend root, so `..` reaches the dataagent dir.
+const casesPath = resolve(process.cwd(), '..', 'contracts', 'sdk-block-projection', 'cases.json')
+const fixtures = JSON.parse(readFileSync(casesPath, 'utf-8'))
+
+// Normalize v2StreamParser blocks to the shared canonical shape.
+function toCanonical(blocks) {
+  const canonical = []
+  for (const block of blocks) {
+    if (block.type === 'tool_use') {
+      canonical.push({
+        kind: 'tool_use',
+        tool_name: block.name ?? null,
+        input: block.input ?? null,
+        output: block.output ?? null,
+        is_error: Boolean(block.is_error),
+      })
+    } else {
+      const text = String(block.content ?? '')
+      if (!text.trim()) continue
+      canonical.push({ kind: block.type, text })
+    }
+  }
+  return canonical
+}
+
+describe('v2StreamParser projection contract', () => {
+  it('loads shared golden fixtures', () => {
+    expect(Array.isArray(fixtures.cases) && fixtures.cases.length).toBeTruthy()
+  })
+
+  for (const testCase of fixtures.cases) {
+    it(`matches golden fixture: ${testCase.name}`, () => {
+      const state = createChatState()
+      for (const record of testCase.records) processV2Record(state, record)
+      expect(toCanonical(state.blocks)).toEqual(testCase.expected)
+    })
+  }
+})

--- a/docs/design/2026-06-04-eval-chatv2-interface-design.md
+++ b/docs/design/2026-06-04-eval-chatv2-interface-design.md
@@ -1,9 +1,12 @@
 # DataAgent Eval — Chat V2 Interface Design
 
 **Date:** 2026-06-04
-**Goal:** Switch the DataAgent online-evaluation runners from the V1 "magic event"
-task stream to the Chat V2 SDK-event interface, so the eval tool observes each run
-through the same protocol the shipped Chat V2 chat surface uses.
+**Goal:** Switch the DataAgent online-evaluation runners off the V1 "magic event"
+task stream so the eval tool observes each run through Chat V2. Rather than
+re-deriving blocks from the raw SDK-event stream, the runners consume the
+**server-projected history blocks** that Chat V2 already persists, so the eval sees
+exactly what the product renders/persists — and the projection logic stays in one
+backend implementation instead of being copied into the eval tool.
 **Tech Stack:** Evaluation tooling (`tools/dataagent-evals/*`, stdlib-only Python).
 DataAgent backend is the system under test through `/api/v1/nl2sql/*`; no backend
 change is owned by this design.
@@ -15,7 +18,12 @@ In scope:
 - `tools/dataagent-evals/builtin/run.py` — stdlib evaluation runner.
 - `tools/dataagent-evals/deepeval/run.py` — DeepEval-driven runner.
 - The per-case run evidence (tool names, SQL outputs, chart outputs, tool-event
-  summary, token usage) now derived from Chat V2 SDK records instead of magic events.
+  summary, token usage) now derived from the Chat V2 server-projected assistant
+  message blocks instead of magic events.
+- Shared projection contract fixtures + tests locking the two remaining projection
+  implementations (`dataagent/contracts/sdk-block-projection/cases.json`,
+  `dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py`,
+  `dataagent/dataagent-frontend/.../sdkBlockProjection.contract.spec.js`).
 - The associated regression tests (`tests/test_run_dataagent_evals.py`,
   `tests/test_dataagent_deepeval_evals.py`).
 
@@ -23,10 +31,9 @@ Out of scope:
 
 - Topic creation (`POST /topics`) and task submission
   (`POST /tasks/deliver-message`) — already shared with Chat V2, unchanged.
-- Final assistant answer sourcing from `GET /topics/{id}/messages` `content` —
-  the persisted assistant message, unchanged.
-- Backend SDK-record persistence/projection (covered by
-  `2026-05-31-chat-v2-design.md`).
+- Backend SDK-record persistence/projection itself (covered by
+  `2026-05-31-chat-v2-design.md`); this design consumes its output, it does not
+  change the projection.
 - Judge model call, scoring gates, report shape — unchanged.
 
 ## Current State
@@ -60,36 +67,33 @@ coupled to the legacy adapter the repo is consolidating away from.
 
 ## Design
 
-### Interface switch
+### Interface switch — consume projected history, don't re-project
 
-Replace the magic-event polling in `_poll_task` with SDK-event paging:
+The eval runs a case, polls to a terminal state, then reads the run's evidence from
+the **already-projected** assistant message in `GET /topics/{id}/messages`. Each
+assistant message Chat V2 persists carries:
 
-`GET /api/v1/nl2sql/tasks/{task_id}/sdk-events?after_id=<cursor>&limit=500`
+- `content` — the final assistant answer (already used).
+- `blocks` — the server-projected `thinking` / `main_text` / `tool_use` blocks,
+  produced by `topic_task_store._project_sdk_records` (the same projection the Chat
+  V2 history surface renders).
+- `usage` — per-message token usage.
 
-`_poll_task` keeps the same outer contract — poll task status, accumulate the
-run's records, follow recovered/replacement tasks (`task_recovered`), honour the
-deadline, and return `(task, records, errors)` — but `records` are now SDK records
-keyed by `seq_id` with a `next_after_id` cursor and `has_more` paging drained per
-poll. The recovered-task detection is status/error based and is unchanged.
+So the eval no longer needs the raw SDK-event stream, and no longer carries its own
+copy of the projection. `_poll_task` is reduced to a status-only poll: poll
+`GET /tasks/{id}`, follow recovered/replacement tasks (`task_recovered`), honour the
+deadline, and return `(task, errors)`. The recovered-task detection is unchanged.
+After the terminal status the runner reads `/messages` once and selects the last
+assistant message for the final task id (`_final_assistant_message`).
 
-### Block projection (shared vocabulary)
+This removes the per-poll event paging entirely (fewer round-trips) and is strictly
+more Chat-V2-aligned: the eval evidence is now byte-for-byte the projection the
+product persists, not a re-derivation of it.
 
-A new local `_project_sdk_blocks(records)` mirrors backend `_project_sdk_records`
-and frontend `v2StreamParser.js`, returning the ordered blocks plus accumulated
-usage:
+### Evidence derivation (from the projected message blocks)
 
-```
-block = {
-  type: 'thinking' | 'main_text' | 'tool_use',
-  text,                       # thinking / main_text
-  tool_id, tool_name,         # tool_use
-  input,  output, is_error,   # tool_use (input parsed from input_json_delta)
-  seq_id,                     # originating record seq for ordering
-}
-usage = { input_tokens?, output_tokens?, ... }   # from message_start / message_delta
-```
-
-### Evidence derivation (from blocks, not magic events)
+`blocks = message["blocks"]` (projected block shape:
+`{type, text?, tool_id?, tool_name?, input?, output?, is_error?}`).
 
 - `_collect_tool_names(blocks)` — `tool_name` of each `tool_use` block, de-duped.
 - `_extract_sql_outputs(blocks, final_answer)` — SQL from `tool_use` block `input`
@@ -97,47 +101,75 @@ usage = { input_tokens?, output_tokens?, ... }   # from message_start / message_
   final answer. Reuses the existing `_looks_like_sql` / `_normalise_sql` helpers.
 - `_extract_chart_outputs(blocks)` — chart specs embedded in `tool_use`
   input/output.
-- `_summarize_tool_events(blocks)` — `[{ seq_id, tool_name, input, output }]`,
-  bounded/truncated for the judge payload (builtin runner).
-- `_collect_usage(task, messages, stream_usage)` — merges projected stream usage
-  with `task.usage` and message usage (single primary source: the SDK stream).
+- `_summarize_tool_events(blocks)` — `[{ seq_id, tool_name, input, output }]` where
+  `seq_id` is the tool's ordinal among `tool_use` blocks (the projected blocks are
+  already in render order; no raw record seq is needed). Bounded/truncated for the
+  judge payload (builtin runner).
+- `_collect_usage(task, message)` — merges `task.usage` with the assistant
+  `message.usage`.
 
-The final assistant answer still comes from `GET /topics/{id}/messages` `content`
-(unchanged); only the run-evidence source moves to the Chat V2 interface. There is
-no fallback to the magic-event endpoint — one primary path per repo working rules.
+There is no fallback to the magic-event endpoint or the raw `/sdk-events` stream —
+one primary path per repo working rules.
+
+### Projection contract (collapsing three copies to two)
+
+Removing the eval's `_project_sdk_blocks` leaves exactly two projection
+implementations that must agree, and they are inherently coupled (live stream vs.
+persisted history rendering the same answer):
+
+- backend `topic_task_store._project_sdk_records` (Python)
+- frontend `v2StreamParser.processV2Record` (JS)
+
+A shared golden-fixture file, `dataagent/contracts/sdk-block-projection/cases.json`,
+encodes `records → expected canonical blocks` for representative cases (text,
+thinking, tool_use success/error, dropped-empty, multi-turn flatten, malformed input
+JSON). Canonical block shape:
+`{kind: 'thinking'|'text'|'tool_use', text?, tool_name?, input?, output?, is_error?}`.
+Two thin contract tests normalize each implementation's output to that canonical
+shape and assert equality against the same fixtures:
+
+- `dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py`
+- `dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js`
 
 ## Interfaces / Data Model
 
-Eval tool → DataAgent (changed call only):
+Eval tool → DataAgent (run-evidence sourcing only):
 
-| Before (V1 magic events) | After (Chat V2 SDK events) |
+| Before (V1 magic events) | After (Chat V2 projected history) |
 | --- | --- |
-| `GET /tasks/{id}/events?after_seq=&limit=` | `GET /tasks/{id}/sdk-events?after_id=&limit=` |
-| response `events[]`, `next_after_seq` | response `records[]`, `next_after_id`, `has_more` |
-| event `{ seq_id, event_type, data:{tool_name,input,output} }` | record `{ seq_id, record_type, event_type, data }` |
+| `GET /tasks/{id}/events?after_seq=&limit=` (per-poll) | `GET /tasks/{id}` status poll only |
+| evidence from `events[].data.{tool_name,input,output}` | evidence from assistant `message.blocks` in `GET /topics/{id}/messages` |
+| `_poll_task → (task, records, errors)` | `_poll_task → (task, errors)` |
 
 No schema, deployment, or report-format change. Exit codes and gate semantics are
 unchanged.
 
 ## Risks / Alternatives
 
-- **Projection duplicated in three places.** FE `v2StreamParser.js`, backend
-  `_project_sdk_records`, and now the eval `_project_sdk_blocks` must stay in
-  sync. Mitigated by keeping the eval projection minimal (only the fields the eval
-  needs) and covering it with regression tests.
-- **SQL now from tool input, not magic `output.sql`.** SDK `tool_use` input carries
-  the executed SQL; the magic event surfaced it under `output.sql`. The extractor
-  reads both block `input` and `output`, so structured SQL is still captured.
-- **No magic-event fallback.** Intentional, per "one verified primary path". Backout
-  is to revert the runners (the magic-event endpoint still exists for V1).
+- **Projection now in two places, not three.** The eval no longer projects; it
+  consumes the backend projection. The remaining FE/backend pair is locked by the
+  shared contract fixtures so live streaming and persisted history cannot silently
+  diverge.
+- **Charts embedded in answer text are not extracted.** `_extract_chart_outputs`
+  reads `tool_use` input/output only; charts emitted as fenced specs inside
+  `main_text` are not surfaced as `chart_outputs`. This matches the prior
+  magic-event behavior (it also keyed off event fields), so it is not a regression.
+- **Evidence requires the assistant message to be projected.** Blocks are read after
+  the task is terminal, when `da_agent_sdk_record` rows are complete, so the
+  projection is whole. Alternative considered and rejected: keep polling
+  `/sdk-events` and re-project in the eval — that is the third copy this change
+  removes.
+- **Backout** is to revert the runners (the magic-event and `/sdk-events` endpoints
+  both still exist).
 
 ## Verification
 
 - `pytest tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py`
-  with fakes updated to serve `/sdk-events` records.
+  with fakes updated to serve assistant `message.blocks` from `/messages`.
+- Projection contract: `pytest dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py`
+  and `vitest run .../sdkBlockProjection.contract.spec.js` against the shared
+  fixtures.
 - Dry-run path unchanged (no service calls).
 - End-to-end smoke (per AGENTS.md intelligent-query smoke method) remains the
   recommended full validation: run one real case and confirm tool/SQL evidence is
-  populated from SDK records.
-</content>
-</invoke>
+  populated from the projected message blocks.

--- a/docs/design/2026-06-04-eval-chatv2-interface-design.md
+++ b/docs/design/2026-06-04-eval-chatv2-interface-design.md
@@ -1,0 +1,143 @@
+# DataAgent Eval — Chat V2 Interface Design
+
+**Date:** 2026-06-04
+**Goal:** Switch the DataAgent online-evaluation runners from the V1 "magic event"
+task stream to the Chat V2 SDK-event interface, so the eval tool observes each run
+through the same protocol the shipped Chat V2 chat surface uses.
+**Tech Stack:** Evaluation tooling (`tools/dataagent-evals/*`, stdlib-only Python).
+DataAgent backend is the system under test through `/api/v1/nl2sql/*`; no backend
+change is owned by this design.
+
+## Scope
+
+In scope:
+
+- `tools/dataagent-evals/builtin/run.py` — stdlib evaluation runner.
+- `tools/dataagent-evals/deepeval/run.py` — DeepEval-driven runner.
+- The per-case run evidence (tool names, SQL outputs, chart outputs, tool-event
+  summary, token usage) now derived from Chat V2 SDK records instead of magic events.
+- The associated regression tests (`tests/test_run_dataagent_evals.py`,
+  `tests/test_dataagent_deepeval_evals.py`).
+
+Out of scope:
+
+- Topic creation (`POST /topics`) and task submission
+  (`POST /tasks/deliver-message`) — already shared with Chat V2, unchanged.
+- Final assistant answer sourcing from `GET /topics/{id}/messages` `content` —
+  the persisted assistant message, unchanged.
+- Backend SDK-record persistence/projection (covered by
+  `2026-05-31-chat-v2-design.md`).
+- Judge model call, scoring gates, report shape — unchanged.
+
+## Current State
+
+Both runners drive a run, then read evidence from the V1 magic-event stream:
+
+- `GET /api/v1/nl2sql/tasks/{task_id}/events?after_seq=&limit=` returns
+  `{ events: [{ seq_id, event_type, data: { tool_name, input, output, ... } }], next_after_seq }`.
+- `_poll_task` accumulates those magic events; `_collect_tool_names`,
+  `_extract_sql_outputs`, `_extract_chart_outputs`, `_summarize_tool_events`,
+  `_collect_usage` read structured `tool_name` / `input` / `output` fields off them.
+
+Chat V2 (`docs/design/2026-05-31-chat-v2-design.md`) instead consumes the native
+SDK record stream and reconstructs blocks through one model:
+
+- `GET /api/v1/nl2sql/tasks/{task_id}/sdk-events?after_id=&limit=` returns
+  `{ records: [{ seq_id, turn_index, record_type, event_type, data }], next_after_id, has_more, task_status }`.
+- `record_type`: `stream` (raw Anthropic event in `data`), `tool_result`
+  (`data.tool_use_id` / `data.content` / `data.is_error`), `done`, `error`.
+- Backend `core/topic_task_store._project_sdk_records` and frontend
+  `v2StreamParser.js` replay those records into blocks
+  (`thinking` / `main_text` / `tool_use`).
+
+## Problem
+
+The eval tool observes runs through a different interface than the product chat
+surface. The magic-event path is V1's transient adapter; Chat V2 is the path the
+product renders and persists. Evaluating through magic events can diverge from what
+users actually see (tool blocks, inputs/outputs, ordering), and keeps the eval tool
+coupled to the legacy adapter the repo is consolidating away from.
+
+## Design
+
+### Interface switch
+
+Replace the magic-event polling in `_poll_task` with SDK-event paging:
+
+`GET /api/v1/nl2sql/tasks/{task_id}/sdk-events?after_id=<cursor>&limit=500`
+
+`_poll_task` keeps the same outer contract — poll task status, accumulate the
+run's records, follow recovered/replacement tasks (`task_recovered`), honour the
+deadline, and return `(task, records, errors)` — but `records` are now SDK records
+keyed by `seq_id` with a `next_after_id` cursor and `has_more` paging drained per
+poll. The recovered-task detection is status/error based and is unchanged.
+
+### Block projection (shared vocabulary)
+
+A new local `_project_sdk_blocks(records)` mirrors backend `_project_sdk_records`
+and frontend `v2StreamParser.js`, returning the ordered blocks plus accumulated
+usage:
+
+```
+block = {
+  type: 'thinking' | 'main_text' | 'tool_use',
+  text,                       # thinking / main_text
+  tool_id, tool_name,         # tool_use
+  input,  output, is_error,   # tool_use (input parsed from input_json_delta)
+  seq_id,                     # originating record seq for ordering
+}
+usage = { input_tokens?, output_tokens?, ... }   # from message_start / message_delta
+```
+
+### Evidence derivation (from blocks, not magic events)
+
+- `_collect_tool_names(blocks)` — `tool_name` of each `tool_use` block, de-duped.
+- `_extract_sql_outputs(blocks, final_answer)` — SQL from `tool_use` block `input`
+  (`sql` / `query` keys) and structured `output`, plus fenced ```sql blocks in the
+  final answer. Reuses the existing `_looks_like_sql` / `_normalise_sql` helpers.
+- `_extract_chart_outputs(blocks)` — chart specs embedded in `tool_use`
+  input/output.
+- `_summarize_tool_events(blocks)` — `[{ seq_id, tool_name, input, output }]`,
+  bounded/truncated for the judge payload (builtin runner).
+- `_collect_usage(task, messages, stream_usage)` — merges projected stream usage
+  with `task.usage` and message usage (single primary source: the SDK stream).
+
+The final assistant answer still comes from `GET /topics/{id}/messages` `content`
+(unchanged); only the run-evidence source moves to the Chat V2 interface. There is
+no fallback to the magic-event endpoint — one primary path per repo working rules.
+
+## Interfaces / Data Model
+
+Eval tool → DataAgent (changed call only):
+
+| Before (V1 magic events) | After (Chat V2 SDK events) |
+| --- | --- |
+| `GET /tasks/{id}/events?after_seq=&limit=` | `GET /tasks/{id}/sdk-events?after_id=&limit=` |
+| response `events[]`, `next_after_seq` | response `records[]`, `next_after_id`, `has_more` |
+| event `{ seq_id, event_type, data:{tool_name,input,output} }` | record `{ seq_id, record_type, event_type, data }` |
+
+No schema, deployment, or report-format change. Exit codes and gate semantics are
+unchanged.
+
+## Risks / Alternatives
+
+- **Projection duplicated in three places.** FE `v2StreamParser.js`, backend
+  `_project_sdk_records`, and now the eval `_project_sdk_blocks` must stay in
+  sync. Mitigated by keeping the eval projection minimal (only the fields the eval
+  needs) and covering it with regression tests.
+- **SQL now from tool input, not magic `output.sql`.** SDK `tool_use` input carries
+  the executed SQL; the magic event surfaced it under `output.sql`. The extractor
+  reads both block `input` and `output`, so structured SQL is still captured.
+- **No magic-event fallback.** Intentional, per "one verified primary path". Backout
+  is to revert the runners (the magic-event endpoint still exists for V1).
+
+## Verification
+
+- `pytest tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py`
+  with fakes updated to serve `/sdk-events` records.
+- Dry-run path unchanged (no service calls).
+- End-to-end smoke (per AGENTS.md intelligent-query smoke method) remains the
+  recommended full validation: run one real case and confirm tool/SQL evidence is
+  populated from SDK records.
+</content>
+</invoke>

--- a/docs/plans/2026-06-04-eval-chatv2-interface-plan.md
+++ b/docs/plans/2026-06-04-eval-chatv2-interface-plan.md
@@ -1,0 +1,67 @@
+# DataAgent Eval — Chat V2 Interface Plan
+
+**Date:** 2026-06-04
+**Topic slug:** `eval-chatv2-interface`
+**Related design:** `docs/design/2026-06-04-eval-chatv2-interface-design.md`
+
+## Objective
+
+Switch both DataAgent eval runners from the V1 magic-event task stream
+(`/tasks/{id}/events`) to the Chat V2 SDK-event interface
+(`/tasks/{id}/sdk-events`), deriving run evidence from SDK records projected into
+the Chat V2 block model. Final-answer sourcing, judge call, scoring, and report
+shape are unchanged.
+
+## Affected Stacks
+
+- Evaluation tooling (stdlib Python): `tools/dataagent-evals/builtin/run.py`,
+  `tools/dataagent-evals/deepeval/run.py`.
+- Tests: `tests/test_run_dataagent_evals.py`,
+  `tests/test_dataagent_deepeval_evals.py`.
+
+## Tasks & Touched Files
+
+1. **builtin runner** — `tools/dataagent-evals/builtin/run.py`
+   - Add `_fetch_sdk_records(base_url, task_id, after_id)` paging helper over
+     `GET /tasks/{id}/sdk-events?after_id=&limit=500` (drain `has_more`).
+   - Rework `_poll_task` to accumulate SDK records (cursor `next_after_id`),
+     keeping recovered-task handling and the deadline; return `(task, records, errors)`.
+   - Add `_project_sdk_blocks(records) -> (blocks, usage)` mirroring
+     `_project_sdk_records` / `v2StreamParser.js`.
+   - Rewrite `_collect_tool_names`, `_extract_sql_outputs`,
+     `_extract_chart_outputs`, `_summarize_tool_events`, `_collect_usage`,
+     `auto_rule_check` to consume blocks.
+   - `run_case`: project records once; feed blocks into the evidence helpers and
+     judge payload.
+2. **deepeval runner** — `tools/dataagent-evals/deepeval/run.py`
+   - Same `_fetch_sdk_records` / `_poll_task` / `_project_sdk_blocks` changes.
+   - Rewrite the evidence helpers to consume blocks; populate `tool_events` in the
+     case result so the metric payload carries SDK-derived tool evidence.
+3. **Tests** — `tests/test_run_dataagent_evals.py`,
+   `tests/test_dataagent_deepeval_evals.py`
+   - Update fakes to serve `/sdk-events` records (`record_type` `stream` /
+     `tool_result` / `done`) instead of `/events`.
+   - Update `_poll_task`, `_extract_sql_outputs`, `_summarize_tool_events`,
+     `auto_rule_check`, recovered-task, and full HTTP scenario tests to the SDK
+     record shape.
+
+## Verification
+
+- `python -m pytest tests/test_run_dataagent_evals.py
+  tests/test_dataagent_deepeval_evals.py`.
+- `tests/test_runtime_excludes_eval_api.py` and
+  `tests/test_deepeval_packaging_hooks.py` still pass (no API surface change).
+- Dry-run still writes `summary.json` / `report.md` with no service calls.
+
+## Rollout & Backout
+
+- **Rollout:** runners consume `/sdk-events`; topic/task/messages calls unchanged.
+- **Backout:** revert the two runners; the magic-event endpoint remains for V1.
+
+## Follow-ups
+
+- Keep `_project_sdk_blocks` in sync with backend `_project_sdk_records` and FE
+  `v2StreamParser.js` when the SDK block schema changes.
+- Optionally consolidate the duplicated projection into a shared eval helper if a
+  third consumer appears.
+</content>

--- a/docs/plans/2026-06-04-eval-chatv2-interface-plan.md
+++ b/docs/plans/2026-06-04-eval-chatv2-interface-plan.md
@@ -6,62 +6,76 @@
 
 ## Objective
 
-Switch both DataAgent eval runners from the V1 magic-event task stream
-(`/tasks/{id}/events`) to the Chat V2 SDK-event interface
-(`/tasks/{id}/sdk-events`), deriving run evidence from SDK records projected into
-the Chat V2 block model. Final-answer sourcing, judge call, scoring, and report
-shape are unchanged.
+Switch both DataAgent eval runners off the V1 magic-event task stream
+(`/tasks/{id}/events`) by sourcing run evidence from the Chat V2 **server-projected
+assistant message blocks** in `GET /topics/{id}/messages`, rather than re-deriving
+blocks from the raw SDK-event stream. This removes the eval's own copy of the block
+projection (three copies → two) and locks the remaining backend/frontend projection
+pair with shared contract fixtures. Final-answer sourcing, judge call, scoring, and
+report shape are unchanged.
 
 ## Affected Stacks
 
 - Evaluation tooling (stdlib Python): `tools/dataagent-evals/builtin/run.py`,
   `tools/dataagent-evals/deepeval/run.py`.
-- Tests: `tests/test_run_dataagent_evals.py`,
+- Backend tests (DataAgent): `dataagent/dataagent-backend/tests/`.
+- Frontend tests (DataAgent): `dataagent/dataagent-frontend/src/views/intelligence/__tests__/`.
+- Shared fixtures: `dataagent/contracts/sdk-block-projection/`.
+- Eval tests: `tests/test_run_dataagent_evals.py`,
   `tests/test_dataagent_deepeval_evals.py`.
 
 ## Tasks & Touched Files
 
 1. **builtin runner** — `tools/dataagent-evals/builtin/run.py`
-   - Add `_fetch_sdk_records(base_url, task_id, after_id)` paging helper over
-     `GET /tasks/{id}/sdk-events?after_id=&limit=500` (drain `has_more`).
-   - Rework `_poll_task` to accumulate SDK records (cursor `next_after_id`),
-     keeping recovered-task handling and the deadline; return `(task, records, errors)`.
-   - Add `_project_sdk_blocks(records) -> (blocks, usage)` mirroring
-     `_project_sdk_records` / `v2StreamParser.js`.
-   - Rewrite `_collect_tool_names`, `_extract_sql_outputs`,
-     `_extract_chart_outputs`, `_summarize_tool_events`, `_collect_usage`,
-     `auto_rule_check` to consume blocks.
-   - `run_case`: project records once; feed blocks into the evidence helpers and
-     judge payload.
+   - Remove `_project_sdk_blocks` and `_fetch_sdk_records`.
+   - Reduce `_poll_task` to a status-only poll over `GET /tasks/{id}`, keeping
+     recovered-task handling and the deadline; return `(task, errors)`.
+   - Replace `_final_assistant_answer` with `_final_assistant_message` returning the
+     selected assistant message dict.
+   - `run_case`: read `/messages`, take `message.blocks` / `message.content` /
+     `message.usage`; feed blocks into the existing evidence helpers.
+   - `_summarize_tool_events` orders by tool ordinal; `_collect_usage(task, message)`.
 2. **deepeval runner** — `tools/dataagent-evals/deepeval/run.py`
-   - Same `_fetch_sdk_records` / `_poll_task` / `_project_sdk_blocks` changes.
-   - Rewrite the evidence helpers to consume blocks; populate `tool_events` in the
-     case result so the metric payload carries SDK-derived tool evidence.
-3. **Tests** — `tests/test_run_dataagent_evals.py`,
+   - Same removals and `_poll_task` / `_final_assistant_message` / `run_case` changes.
+3. **Projection contract** (new)
+   - `dataagent/contracts/sdk-block-projection/cases.json` — shared golden cases
+     (`records → expected canonical blocks`).
+   - `dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py` —
+     normalize `_project_sdk_records` output, assert against fixtures.
+   - `dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js`
+     — normalize `processV2Record` output, assert against the same fixtures.
+4. **Eval tests** — `tests/test_run_dataagent_evals.py`,
    `tests/test_dataagent_deepeval_evals.py`
-   - Update fakes to serve `/sdk-events` records (`record_type` `stream` /
-     `tool_result` / `done`) instead of `/events`.
-   - Update `_poll_task`, `_extract_sql_outputs`, `_summarize_tool_events`,
-     `auto_rule_check`, recovered-task, and full HTTP scenario tests to the SDK
-     record shape.
+   - Fakes serve assistant `message.blocks` from `/messages`; drop `/sdk-events`
+     handlers. Update `_poll_task`, `_summarize_tool_events`, recovered-task, and
+     full HTTP scenario tests.
 
 ## Verification
 
 - `python -m pytest tests/test_run_dataagent_evals.py
-  tests/test_dataagent_deepeval_evals.py`.
-- `tests/test_runtime_excludes_eval_api.py` and
-  `tests/test_deepeval_packaging_hooks.py` still pass (no API surface change).
+  tests/test_dataagent_deepeval_evals.py` — passing (42 tests).
+- `python -m pytest dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py`
+  (runs in DataAgent CI; locally blocked only by an unrelated `cryptography` rust
+  panic in the sandbox — the projection logic was verified by exec-ing the real
+  function against the fixtures).
+- `vitest run src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js`
+  and `v2StreamParser.spec.js` — passing.
+- `tests/test_runtime_excludes_eval_api.py`, `tests/test_deepeval_packaging_hooks.py`
+  still pass (no API surface change).
 - Dry-run still writes `summary.json` / `report.md` with no service calls.
 
 ## Rollout & Backout
 
-- **Rollout:** runners consume `/sdk-events`; topic/task/messages calls unchanged.
-- **Backout:** revert the two runners; the magic-event endpoint remains for V1.
+- **Rollout:** runners poll task status, then read projected `message.blocks`;
+  topic/task/messages calls otherwise unchanged.
+- **Backout:** revert the two runners; the magic-event and `/sdk-events` endpoints
+  both remain.
 
 ## Follow-ups
 
-- Keep `_project_sdk_blocks` in sync with backend `_project_sdk_records` and FE
-  `v2StreamParser.js` when the SDK block schema changes.
-- Optionally consolidate the duplicated projection into a shared eval helper if a
-  third consumer appears.
+- Keep the backend `_project_sdk_records` and FE `v2StreamParser.js` projections in
+  sync; the shared contract fixtures fail loudly if they drift.
+- If a chart-spec-in-text case becomes important to score, extend
+  `_extract_chart_outputs` to parse `main_text` fenced specs (currently keyed off
+  `tool_use` input/output only, matching prior behavior).
 </content>

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -326,33 +326,25 @@ def test_deepeval_judge_request_embeds_system_prompt_in_user_content(monkeypatch
     assert "你是 DataAgent 在线问数评测裁判" in body["messages"][0]["content"]
 
 
-def test_deepeval_poll_task_retries_transient_event_error(monkeypatch):
+def test_deepeval_poll_task_tolerates_transient_status_error(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
-    calls = {"task": 0, "events": 0}
+    calls = {"task": 0}
 
     def fake_http_json(method, url, **kwargs):
-        if "/sdk-events" in url:
-            calls["events"] += 1
-            if calls["events"] == 1:
-                raise runner.EvalRunnerError("request failed sdk-events timeout")
-            return {
-                "task_id": "task_1",
-                "task_status": "finished",
-                "next_after_id": 1,
-                "has_more": False,
-                "records": [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}],
-            }
         calls["task"] += 1
-        return {"task_id": "task_1", "task_status": "running" if calls["task"] == 1 else "finished"}
+        if calls["task"] == 1:
+            raise runner.EvalRunnerError("request failed transient status")
+        return {"task_id": "task_1", "task_status": "finished"}
 
     monkeypatch.setattr(runner, "http_json", fake_http_json)
+    monkeypatch.setattr(runner.time, "sleep", lambda *_: None)
 
-    task, records, errors = runner._poll_task("http://dataagent", "task_1", 5)
+    task, errors = runner._poll_task("http://dataagent", "task_1", 5)
 
     assert task["task_status"] == "finished"
-    assert records == [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}]
     assert errors == []
+    assert calls["task"] == 2
 
 
 def test_deepeval_run_case_uses_recovered_task_answer(monkeypatch):
@@ -371,28 +363,20 @@ def test_deepeval_run_case_uses_recovered_task_answer(monkeypatch):
                 "task_status": "suspended",
                 "error": {"code": "task_recovered", "message": "任务租约已过期，已转移到 task_2"},
             }
-        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_1/sdk-events"):
-            return {"task_id": "task_1", "task_status": "suspended", "next_after_id": 0, "has_more": False, "records": []}
         if url == "http://dataagent/api/v1/nl2sql/topics/topic_1":
             return {"topic_id": "topic_1", "current_task_id": "task_2", "current_task_status": "finished"}
         if url == "http://dataagent/api/v1/nl2sql/tasks/task_2":
             return {"task_id": "task_2", "topic_id": "topic_1", "task_status": "finished"}
-        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_2/sdk-events"):
-            return {
-                "task_id": "task_2",
-                "task_status": "finished",
-                "next_after_id": 2,
-                "has_more": False,
-                "records": [
-                    {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
-                    {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-                ],
-            }
         if url.startswith("http://dataagent/api/v1/nl2sql/topics/topic_1/messages"):
             return {
                 "items": [
                     {"sender_type": "assistant", "task_id": "task_1", "content": ""},
-                    {"sender_type": "assistant", "task_id": "task_2", "content": "recovered answer"},
+                    {
+                        "sender_type": "assistant",
+                        "task_id": "task_2",
+                        "content": "recovered answer",
+                        "blocks": [{"type": "tool_use", "tool_id": "toolu_1", "tool_name": "run_sql", "input": {"sql": "select 1"}, "output": "ok", "is_error": False}],
+                    },
                 ]
             }
         raise AssertionError(f"unexpected request: {method} {url}")
@@ -558,25 +542,25 @@ def test_deepeval_runner_drives_dataagent_and_writes_case_outputs(tmp_path, monk
                 self._json({"status": "ok"})
             elif self.path == "/api/v1/nl2sql-admin/settings":
                 self._json({"provider_id": "fake", "model": "fake-model"})
-            elif self.path.startswith("/api/v1/nl2sql/tasks/task_1/sdk-events"):
-                self._json(
-                    {
-                        "task_id": "task_1",
-                        "task_status": "finished",
-                        "after_id": 0,
-                        "next_after_id": 3,
-                        "has_more": False,
-                        "records": [
-                            {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
-                            {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-                            {"seq_id": 3, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": "ok", "is_error": False}},
-                        ],
-                    }
-                )
             elif self.path == "/api/v1/nl2sql/tasks/task_1":
                 self._json({"task_id": "task_1", "task_status": "finished"})
             elif self.path.startswith("/api/v1/nl2sql/topics/topic_1/messages"):
-                self._json({"items": [{"sender_type": "assistant", "task_id": "task_1", "content": "最近 30 天工作流发布次数按日期聚合如下。"}]})
+                self._json(
+                    {
+                        "items": [
+                            {
+                                "sender_type": "assistant",
+                                "task_id": "task_1",
+                                "content": "最近 30 天工作流发布次数按日期聚合如下。",
+                                "usage": {"input_tokens": 1, "output_tokens": 2},
+                                "blocks": [
+                                    {"type": "tool_use", "tool_id": "toolu_1", "tool_name": "run_sql", "input": {"sql": "select 1"}, "output": "ok", "is_error": False},
+                                    {"type": "main_text", "text": "最近 30 天工作流发布次数按日期聚合如下。"},
+                                ],
+                            }
+                        ]
+                    }
+                )
             else:
                 self._json({"error": self.path}, code=404)
 

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -332,25 +332,26 @@ def test_deepeval_poll_task_retries_transient_event_error(monkeypatch):
     calls = {"task": 0, "events": 0}
 
     def fake_http_json(method, url, **kwargs):
-        if "/events" in url:
+        if "/sdk-events" in url:
             calls["events"] += 1
             if calls["events"] == 1:
-                raise runner.EvalRunnerError("request failed events timeout")
+                raise runner.EvalRunnerError("request failed sdk-events timeout")
             return {
                 "task_id": "task_1",
                 "task_status": "finished",
-                "next_after_seq": 1,
-                "events": [{"seq_id": 1, "data": {"tool_name": "run_sql"}}],
+                "next_after_id": 1,
+                "has_more": False,
+                "records": [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}],
             }
         calls["task"] += 1
         return {"task_id": "task_1", "task_status": "running" if calls["task"] == 1 else "finished"}
 
     monkeypatch.setattr(runner, "http_json", fake_http_json)
 
-    task, events, errors = runner._poll_task("http://dataagent", "task_1", 5)
+    task, records, errors = runner._poll_task("http://dataagent", "task_1", 5)
 
     assert task["task_status"] == "finished"
-    assert events == [{"seq_id": 1, "data": {"tool_name": "run_sql"}}]
+    assert records == [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}]
     assert errors == []
 
 
@@ -370,18 +371,22 @@ def test_deepeval_run_case_uses_recovered_task_answer(monkeypatch):
                 "task_status": "suspended",
                 "error": {"code": "task_recovered", "message": "任务租约已过期，已转移到 task_2"},
             }
-        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_1/events"):
-            return {"task_id": "task_1", "task_status": "suspended", "next_after_seq": 0, "events": []}
+        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_1/sdk-events"):
+            return {"task_id": "task_1", "task_status": "suspended", "next_after_id": 0, "has_more": False, "records": []}
         if url == "http://dataagent/api/v1/nl2sql/topics/topic_1":
             return {"topic_id": "topic_1", "current_task_id": "task_2", "current_task_status": "finished"}
         if url == "http://dataagent/api/v1/nl2sql/tasks/task_2":
             return {"task_id": "task_2", "topic_id": "topic_1", "task_status": "finished"}
-        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_2/events"):
+        if url.startswith("http://dataagent/api/v1/nl2sql/tasks/task_2/sdk-events"):
             return {
                 "task_id": "task_2",
                 "task_status": "finished",
-                "next_after_seq": 1,
-                "events": [{"seq_id": 1, "data": {"tool_name": "run_sql"}}],
+                "next_after_id": 2,
+                "has_more": False,
+                "records": [
+                    {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
+                    {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+                ],
             }
         if url.startswith("http://dataagent/api/v1/nl2sql/topics/topic_1/messages"):
             return {
@@ -413,7 +418,7 @@ def test_deepeval_auto_rule_check_adds_generic_failure_attribution(monkeypatch):
     result = runner.auto_rule_check(
         _sample_case(),
         final_answer="当前 OpenDataWorks 平台元数据未找到目标。请在目标数据库中执行 SQL：SELECT ... WHERE ds = '{target_date}'",
-        events=[{"data": {"output": {"row_count": 0}}}],
+        blocks=[{"type": "tool_use", "tool_name": "run_sql", "output": {"row_count": 0}}],
         sql_outputs=["SELECT count(1) FROM opendataworks.workflow_publish_record WHERE ds = '{target_date}'"],
         tool_names=[],
     )
@@ -553,8 +558,21 @@ def test_deepeval_runner_drives_dataagent_and_writes_case_outputs(tmp_path, monk
                 self._json({"status": "ok"})
             elif self.path == "/api/v1/nl2sql-admin/settings":
                 self._json({"provider_id": "fake", "model": "fake-model"})
-            elif self.path.startswith("/api/v1/nl2sql/tasks/task_1/events"):
-                self._json({"task_id": "task_1", "task_status": "finished", "next_after_seq": 1, "events": [{"data": {"tool_name": "run_sql"}}]})
+            elif self.path.startswith("/api/v1/nl2sql/tasks/task_1/sdk-events"):
+                self._json(
+                    {
+                        "task_id": "task_1",
+                        "task_status": "finished",
+                        "after_id": 0,
+                        "next_after_id": 3,
+                        "has_more": False,
+                        "records": [
+                            {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
+                            {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+                            {"seq_id": 3, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": "ok", "is_error": False}},
+                        ],
+                    }
+                )
             elif self.path == "/api/v1/nl2sql/tasks/task_1":
                 self._json({"task_id": "task_1", "task_status": "finished"})
             elif self.path.startswith("/api/v1/nl2sql/topics/topic_1/messages"):

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -347,6 +347,52 @@ def test_deepeval_poll_task_tolerates_transient_status_error(monkeypatch):
     assert calls["task"] == 2
 
 
+def test_deepeval_extracts_evidence_from_bash_script_text_outputs(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    actual_sql = "select count(1) from public.dim_tech_public_env_cmp_df"
+    chart_spec = {
+        "kind": "chart_spec",
+        "chart_type": "bar",
+        "dataset": [{"env_name": "PROD", "cmp_cnt": 301}],
+        "series": [{"name": "组件数", "field": "cmp_cnt"}],
+    }
+    blocks = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "input": {
+                "command": (
+                    '"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/run_sql.py" '
+                    f'--database public --engine mysql --sql "{actual_sql}"'
+                )
+            },
+            "output": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "kind": "sql_execution",
+                            "sql": actual_sql,
+                            "rows": [{"cmp_cnt": 301}],
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ],
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "input": {"command": "build_chart_spec.py --chart-type bar"},
+            "output": json.dumps(chart_spec, ensure_ascii=False),
+        },
+    ]
+
+    assert runner._extract_sql_outputs(blocks, "") == [actual_sql]
+    assert runner._extract_chart_outputs(blocks) == [chart_spec]
+
+
 def test_deepeval_run_case_uses_recovered_task_answer(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -5,12 +5,31 @@ import json
 import threading
 import time
 import types
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUNNER_PATH = REPO_ROOT / "tools" / "dataagent-evals" / "builtin" / "run.py"
+
+_RUN_SQL = "select count(1) from opendataworks.workflow_publish_record"
+
+
+def _sdk_run_sql_records():
+    """Chat V2 SDK records for one run_sql tool call followed by a text answer."""
+    return [
+        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
+        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
+        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": json.dumps({"sql": _RUN_SQL})}}},
+        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
+        {"seq_id": 5, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": [{"type": "text", "text": json.dumps({"rows": [{"cnt": 1}], "sql": _RUN_SQL})}], "is_error": False}},
+        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
+        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "answer"}}},
+        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}},
+        {"seq_id": 9, "record_type": "stream", "data": {"type": "message_delta", "usage": {"output_tokens": 2}}},
+        {"seq_id": 10, "record_type": "done", "data": {"is_error": False}},
+    ]
 
 
 def _sample_case(case_id: str = "ODW_SAMPLE_001"):
@@ -257,25 +276,26 @@ def test_poll_task_retries_transient_event_error(monkeypatch):
     calls = {"task": 0, "events": 0}
 
     def fake_http_json(method, url, **kwargs):
-        if "/events" in url:
+        if "/sdk-events" in url:
             calls["events"] += 1
             if calls["events"] == 1:
-                raise runner.EvalRunnerError("request failed events timeout")
+                raise runner.EvalRunnerError("request failed sdk-events timeout")
             return {
                 "task_id": "task-1",
                 "task_status": "success",
-                "next_after_seq": 1,
-                "events": [{"seq_id": 1, "data": {"tool_name": "run_sql"}}],
+                "next_after_id": 1,
+                "has_more": False,
+                "records": [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}],
             }
         calls["task"] += 1
         return {"task_id": "task-1", "task_status": "running" if calls["task"] == 1 else "success"}
 
     monkeypatch.setattr(runner, "http_json", fake_http_json)
 
-    task, events, errors = runner._poll_task("http://dataagent", "task-1", 5)
+    task, records, errors = runner._poll_task("http://dataagent", "task-1", 5)
 
     assert task["task_status"] == "success"
-    assert events == [{"seq_id": 1, "data": {"tool_name": "run_sql"}}]
+    assert records == [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}]
     assert errors == []
 
 
@@ -285,7 +305,7 @@ def test_auto_rule_check_adds_generic_failure_attribution():
     result = runner.auto_rule_check(
         _sample_case(),
         final_answer="当前 OpenDataWorks 平台元数据未找到目标。请在目标数据库中执行 SQL：SELECT ... WHERE ds = '{target_date}'",
-        events=[{"data": {"output": {"row_count": 0}}}],
+        blocks=[{"type": "tool_use", "tool_name": "run_sql", "output": {"row_count": 0}}],
         sql_outputs=["SELECT count(1) FROM opendataworks.workflow_publish_record WHERE ds = '{target_date}'"],
         tool_names=[],
     )
@@ -302,27 +322,24 @@ def test_extract_sql_outputs_ignores_reference_text_and_uses_tool_sql():
         "FROM public.dim_tech_public_env_cmp_df "
         "WHERE env_name = 'PROD'"
     )
-    events = [
+    blocks = [
         {
-            "event_type": "BEFORE_AGENT_REPLY",
-            "data": {
-                "content": "技能说明：不要使用 SELECT *，模板中的 <SQL> 不是实际执行 SQL。",
-            },
+            "type": "main_text",
+            "seq_id": 1,
+            "text": "技能说明：不要使用 SELECT *，模板中的 <SQL> 不是实际执行 SQL。",
         },
         {
-            "event_type": "AFTER_TOOL_CALL",
-            "data": {
-                "tool_name": "run_sql",
-                "output": {
-                    "kind": "sql_execution",
-                    "sql": actual_sql,
-                    "rows": [{"cmp_cnt": 301}],
-                },
-            },
+            "type": "tool_use",
+            "seq_id": 2,
+            "tool_id": "toolu_1",
+            "tool_name": "run_sql",
+            "input": {"sql": actual_sql},
+            "output": [{"type": "text", "text": json.dumps({"rows": [{"cmp_cnt": 301}]})}],
+            "is_error": False,
         },
     ]
 
-    sql_outputs = runner._extract_sql_outputs(events, "当前 PROD 环境共有 301 个分级保障组件。")
+    sql_outputs = runner._extract_sql_outputs(blocks, "当前 PROD 环境共有 301 个分级保障组件。")
 
     assert sql_outputs == [actual_sql]
 
@@ -339,18 +356,18 @@ def test_auto_rule_check_ignores_sql_style_forbidden_patterns():
         "FROM public.dim_tech_public_env_cmp_df "
         "WHERE env_name = 'PROD'"
     )
-    events = [
+    blocks = [
         {
-            "data": {
-                "content": "参考文档提示：避免 SELECT *；OpenDataWorks 平台元数据不是本题答案。",
-            },
+            "type": "main_text",
+            "seq_id": 1,
+            "text": "参考文档提示：避免 SELECT *；OpenDataWorks 平台元数据不是本题答案。",
         }
     ]
 
     result = runner.auto_rule_check(
         case,
         final_answer="当前 PROD 环境共有 301 个分级保障组件。",
-        events=events,
+        blocks=blocks,
         sql_outputs=[actual_sql],
         tool_names=["run_sql"],
     )
@@ -380,41 +397,32 @@ def test_judge_payload_removes_sql_style_veto_rules():
 
 def test_summarize_tool_events_drops_reasoning_noise_and_keeps_evidence():
     runner = _load_runner()
-    events = [
+    blocks = [
+        {"type": "thinking", "seq_id": 1, "text": "reasoning " + ("x" * 20000)},
+        {"type": "main_text", "seq_id": 2, "text": "答案文本"},
         {
-            "event_type": "BEFORE_AGENT_REPLY",
-            "data": {"content": "reasoning " + ("x" * 20000)},
-        },
-        {
+            "type": "tool_use",
             "seq_id": 10,
-            "event_type": "BEFORE_TOOL_CALL",
-            "data": {
-                "tool_name": "run_sql",
-                "input": {
-                    "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
-                    "description": "count components",
-                },
+            "tool_id": "toolu_1",
+            "tool_name": "run_sql",
+            "is_error": False,
+            "input": {
+                "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
+                "description": "count components",
             },
-        },
-        {
-            "seq_id": 11,
-            "event_type": "AFTER_TOOL_CALL",
-            "data": {
-                "tool_name": "run_sql",
-                "output": {
-                    "kind": "sql_execution",
-                    "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
-                    "columns": ["cnt"],
-                    "rows": [{"cnt": 301}],
-                    "row_count": 1,
-                    "result_state": "success",
-                    "summary": "返回 1 行结果",
-                },
+            "output": {
+                "kind": "sql_execution",
+                "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
+                "columns": ["cnt"],
+                "rows": [{"cnt": 301}],
+                "row_count": 1,
+                "result_state": "success",
+                "summary": "返回 1 行结果",
             },
         },
     ]
 
-    summary = runner._summarize_tool_events(events)
+    summary = runner._summarize_tool_events(blocks)
     serialized = json.dumps(summary, ensure_ascii=False)
 
     assert len(serialized) < 4000
@@ -422,17 +430,11 @@ def test_summarize_tool_events_drops_reasoning_noise_and_keeps_evidence():
     assert summary == [
         {
             "seq_id": 10,
-            "event_type": "BEFORE_TOOL_CALL",
             "tool_name": "run_sql",
             "input": {
                 "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
                 "description": "count components",
             },
-        },
-        {
-            "seq_id": 11,
-            "event_type": "AFTER_TOOL_CALL",
-            "tool_name": "run_sql",
             "output": {
                 "kind": "sql_execution",
                 "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
@@ -510,6 +512,23 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_sdk_page(self, task_id: str, records: list):
+        query = urllib.parse.urlsplit(self.path).query
+        after_id = int((urllib.parse.parse_qs(query).get("after_id") or ["0"])[0])
+        page_records = [r for r in records if int(r.get("seq_id") or 0) > after_id]
+        next_after_id = int(page_records[-1]["seq_id"]) if page_records else after_id
+        self._send(
+            200,
+            {
+                "task_id": task_id,
+                "task_status": "success",
+                "after_id": after_id,
+                "next_after_id": next_after_id,
+                "has_more": False,
+                "records": page_records,
+            },
+        )
+
     def do_GET(self):  # noqa: N802
         if self.path == "/api/v1/nl2sql/health":
             if self.scenario == "preflight_error":
@@ -533,59 +552,12 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
                 },
             )
             return
-        if self.path.startswith("/api/v1/nl2sql/tasks/task-2/events"):
-            self._send(
-                200,
-                {
-                    "task_id": "task-2",
-                    "task_status": "success",
-                    "after_seq": 0,
-                    "next_after_seq": 1,
-                    "has_more": False,
-                    "events": [
-                        {
-                            "record_type": "event",
-                            "seq_id": 1,
-                            "event_type": "AFTER_TOOL_CALL",
-                            "data": {
-                                "tool_name": "run_sql",
-                                "output": {
-                                    "rows": [{"cnt": 1}],
-                                    "sql": "select count(1) from opendataworks.workflow_publish_record",
-                                },
-                            },
-                        },
-                    ],
-                },
-            )
+        if self.path.startswith("/api/v1/nl2sql/tasks/task-2/sdk-events"):
+            self._send_sdk_page("task-2", _sdk_run_sql_records())
             return
-        if self.path.startswith("/api/v1/nl2sql/tasks/task-1/events"):
-            self._send(
-                200,
-                {
-                    "task_id": "task-1",
-                    "task_status": "suspended" if self.scenario == "recovered" else "success",
-                    "after_seq": 0,
-                    "next_after_seq": 0 if self.scenario == "recovered" else 2,
-                    "has_more": False,
-                    "events": []
-                    if self.scenario == "recovered"
-                    else [
-                        {
-                            "record_type": "event",
-                            "seq_id": 1,
-                            "event_type": "BEFORE_TOOL_CALL",
-                            "data": {"tool_name": "run_sql", "input": {"sql": "select count(1) from opendataworks.workflow_publish_record"}},
-                        },
-                        {
-                            "record_type": "event",
-                            "seq_id": 2,
-                            "event_type": "AFTER_TOOL_CALL",
-                            "data": {"output": {"rows": [{"cnt": 1}], "sql": "select count(1) from opendataworks.workflow_publish_record"}},
-                        },
-                    ],
-                },
-            )
+        if self.path.startswith("/api/v1/nl2sql/tasks/task-1/sdk-events"):
+            records = [] if self.scenario == "recovered" else _sdk_run_sql_records()
+            self._send_sdk_page("task-1", records)
             return
         if self.path == "/api/v1/nl2sql/tasks/task-1":
             self.__class__.task_poll_count += 1

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -334,6 +334,51 @@ def test_extract_sql_outputs_ignores_reference_text_and_uses_tool_sql():
     assert sql_outputs == [actual_sql]
 
 
+def test_extract_evidence_from_bash_script_text_outputs():
+    runner = _load_runner()
+    actual_sql = "select count(1) from public.dim_tech_public_env_cmp_df"
+    chart_spec = {
+        "kind": "chart_spec",
+        "chart_type": "bar",
+        "dataset": [{"env_name": "PROD", "cmp_cnt": 301}],
+        "series": [{"name": "组件数", "field": "cmp_cnt"}],
+    }
+    blocks = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "input": {
+                "command": (
+                    '"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/run_sql.py" '
+                    f'--database public --engine mysql --sql "{actual_sql}"'
+                )
+            },
+            "output": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "kind": "sql_execution",
+                            "sql": actual_sql,
+                            "rows": [{"cmp_cnt": 301}],
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ],
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "input": {"command": "build_chart_spec.py --chart-type bar"},
+            "output": json.dumps(chart_spec, ensure_ascii=False),
+        },
+    ]
+
+    assert runner._extract_sql_outputs(blocks, "") == [actual_sql]
+    assert runner._extract_chart_outputs(blocks) == [chart_spec]
+
+
 def test_auto_rule_check_ignores_sql_style_forbidden_patterns():
     runner = _load_runner()
     case = {

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -5,7 +5,6 @@ import json
 import threading
 import time
 import types
-import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -16,19 +15,18 @@ RUNNER_PATH = REPO_ROOT / "tools" / "dataagent-evals" / "builtin" / "run.py"
 _RUN_SQL = "select count(1) from opendataworks.workflow_publish_record"
 
 
-def _sdk_run_sql_records():
-    """Chat V2 SDK records for one run_sql tool call followed by a text answer."""
+def _assistant_blocks(answer: str):
+    """Chat V2 server-projected blocks attached to an assistant message."""
     return [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start", "message": {"usage": {"input_tokens": 1}}}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": json.dumps({"sql": _RUN_SQL})}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 5, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": [{"type": "text", "text": json.dumps({"rows": [{"cnt": 1}], "sql": _RUN_SQL})}], "is_error": False}},
-        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
-        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "answer"}}},
-        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}},
-        {"seq_id": 9, "record_type": "stream", "data": {"type": "message_delta", "usage": {"output_tokens": 2}}},
-        {"seq_id": 10, "record_type": "done", "data": {"is_error": False}},
+        {
+            "type": "tool_use",
+            "tool_id": "toolu_1",
+            "tool_name": "run_sql",
+            "input": {"sql": _RUN_SQL},
+            "output": [{"type": "text", "text": json.dumps({"rows": [{"cnt": 1}], "sql": _RUN_SQL})}],
+            "is_error": False,
+        },
+        {"type": "main_text", "text": answer},
     ]
 
 
@@ -271,32 +269,24 @@ def test_compact_judge_payload_bounds_large_evidence_payload():
     assert "truncated" in serialized
 
 
-def test_poll_task_retries_transient_event_error(monkeypatch):
+def test_poll_task_tolerates_transient_status_error(monkeypatch):
     runner = _load_runner()
-    calls = {"task": 0, "events": 0}
+    calls = {"task": 0}
 
     def fake_http_json(method, url, **kwargs):
-        if "/sdk-events" in url:
-            calls["events"] += 1
-            if calls["events"] == 1:
-                raise runner.EvalRunnerError("request failed sdk-events timeout")
-            return {
-                "task_id": "task-1",
-                "task_status": "success",
-                "next_after_id": 1,
-                "has_more": False,
-                "records": [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}],
-            }
         calls["task"] += 1
-        return {"task_id": "task-1", "task_status": "running" if calls["task"] == 1 else "success"}
+        if calls["task"] == 1:
+            raise runner.EvalRunnerError("request failed transient status")
+        return {"task_id": "task-1", "task_status": "success"}
 
     monkeypatch.setattr(runner, "http_json", fake_http_json)
+    monkeypatch.setattr(runner.time, "sleep", lambda *_: None)
 
-    task, records, errors = runner._poll_task("http://dataagent", "task-1", 5)
+    task, errors = runner._poll_task("http://dataagent", "task-1", 5)
 
     assert task["task_status"] == "success"
-    assert records == [{"seq_id": 1, "record_type": "done", "data": {"is_error": False}}]
     assert errors == []
+    assert calls["task"] == 2
 
 
 def test_auto_rule_check_adds_generic_failure_attribution():
@@ -429,7 +419,7 @@ def test_summarize_tool_events_drops_reasoning_noise_and_keeps_evidence():
     assert "xxxxxxxxxx" not in serialized
     assert summary == [
         {
-            "seq_id": 10,
+            "seq_id": 1,
             "tool_name": "run_sql",
             "input": {
                 "sql": "select count(1) from public.dim_tech_public_env_cmp_df",
@@ -512,23 +502,6 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _send_sdk_page(self, task_id: str, records: list):
-        query = urllib.parse.urlsplit(self.path).query
-        after_id = int((urllib.parse.parse_qs(query).get("after_id") or ["0"])[0])
-        page_records = [r for r in records if int(r.get("seq_id") or 0) > after_id]
-        next_after_id = int(page_records[-1]["seq_id"]) if page_records else after_id
-        self._send(
-            200,
-            {
-                "task_id": task_id,
-                "task_status": "success",
-                "after_id": after_id,
-                "next_after_id": next_after_id,
-                "has_more": False,
-                "records": page_records,
-            },
-        )
-
     def do_GET(self):  # noqa: N802
         if self.path == "/api/v1/nl2sql/health":
             if self.scenario == "preflight_error":
@@ -551,13 +524,6 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
                     "current_task_status": "success" if self.scenario == "recovered" else "running",
                 },
             )
-            return
-        if self.path.startswith("/api/v1/nl2sql/tasks/task-2/sdk-events"):
-            self._send_sdk_page("task-2", _sdk_run_sql_records())
-            return
-        if self.path.startswith("/api/v1/nl2sql/tasks/task-1/sdk-events"):
-            records = [] if self.scenario == "recovered" else _sdk_run_sql_records()
-            self._send_sdk_page("task-1", records)
             return
         if self.path == "/api/v1/nl2sql/tasks/task-1":
             self.__class__.task_poll_count += 1
@@ -621,6 +587,7 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
                                 "status": "success",
                                 "content": "answer with opendataworks.workflow_publish_record",
                                 "usage": {"input_tokens": 1, "output_tokens": 2},
+                                "blocks": _assistant_blocks("answer with opendataworks.workflow_publish_record"),
                             },
                         ],
                     },
@@ -645,6 +612,7 @@ class _FakeDataAgentHandler(BaseHTTPRequestHandler):
                             "status": "success",
                             "content": "answer with opendataworks.workflow_publish_record",
                             "usage": {"input_tokens": 1, "output_tokens": 2},
+                            "blocks": _assistant_blocks("answer with opendataworks.workflow_publish_record"),
                         },
                     ],
                 },

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -297,22 +297,42 @@ def _normalise_sql(text: str) -> str:
     return re.sub(r"\s+", " ", str(text or "").strip()).rstrip(";")
 
 
-def _collect_structured_sql(value: Any) -> list[str]:
-    if isinstance(value, list):
-        sqls: list[str] = []
-        for item in value:
-            sqls.extend(_collect_structured_sql(item))
-        return sqls
-    if not isinstance(value, dict):
-        return []
+def _parse_json_text(value: str) -> Any | None:
+    text = str(value or "").strip()
+    if not text or text[0] not in "[{":
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
 
+
+def _iter_structured_evidence(value: Any) -> list[Any]:
+    values = [value]
+    if isinstance(value, str):
+        parsed = _parse_json_text(value)
+        if parsed is not None:
+            values.extend(_iter_structured_evidence(parsed))
+        return values
+    if isinstance(value, list):
+        for item in value:
+            values.extend(_iter_structured_evidence(item))
+        return values
+    if isinstance(value, dict):
+        for item in value.values():
+            values.extend(_iter_structured_evidence(item))
+    return values
+
+
+def _collect_structured_sql(value: Any) -> list[str]:
     sqls: list[str] = []
-    for key, item in value.items():
-        key_text = str(key or "").lower()
-        if key_text in {"sql", "query"} and isinstance(item, str) and _looks_like_sql(item):
-            sqls.append(_normalise_sql(item))
+    for item in _iter_structured_evidence(value):
+        if not isinstance(item, dict):
             continue
-        sqls.extend(_collect_structured_sql(item))
+        for key, field in item.items():
+            key_text = str(key or "").lower()
+            if key_text in {"sql", "query"} and isinstance(field, str) and _looks_like_sql(field):
+                sqls.append(_normalise_sql(field))
     return sqls
 
 
@@ -334,15 +354,30 @@ def _extract_sql_outputs(blocks: list[dict[str, Any]], final_answer: str) -> lis
 
 def _extract_chart_outputs(blocks: list[dict[str, Any]]) -> list[Any]:
     charts: list[Any] = []
+    seen: set[str] = set()
+
+    def add_chart(value: Any) -> None:
+        try:
+            key = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+        except TypeError:
+            key = repr(value)
+        if key not in seen:
+            seen.add(key)
+            charts.append(value)
+
     for block in blocks:
         if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
         for source in (block.get("input"), block.get("output")):
-            if isinstance(source, dict):
+            for item in _iter_structured_evidence(source):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("kind") == "chart_spec":
+                    add_chart(item)
                 for key in ("chart", "chart_spec", "echarts", "spec"):
-                    value = source.get(key)
+                    value = item.get(key)
                     if value is not None:
-                        charts.append(value)
+                        add_chart(value)
     return charts
 
 

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -278,21 +278,106 @@ def _flatten_strings(value: Any) -> list[str]:
     return []
 
 
-def _collect_tool_names(events: list[dict[str, Any]]) -> list[str]:
+def _project_sdk_blocks(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Replay Chat V2 SDK records into rendered blocks.
+
+    Mirrors the backend ``topic_task_store._project_sdk_records`` and the frontend
+    ``v2StreamParser.js`` so eval evidence matches what Chat V2 renders/persists.
+    Returns ``(blocks, usage)`` where each block is
+    ``{type: 'thinking'|'main_text'|'tool_use', text, tool_id, tool_name, input,
+    output, is_error, seq_id}`` and usage is the accumulated token usage.
+    """
+    ordered: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] | None = None
+    by_index: dict[int, dict[str, Any]] = {}
+    by_tool_id: dict[str, dict[str, Any]] = {}
+    usage: dict[str, Any] = {}
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        seq_id = int(record.get("seq_id") or 0)
+        record_type = str(record.get("record_type") or "")
+        data = record.get("data") if isinstance(record.get("data"), dict) else {}
+
+        if record_type == "stream":
+            etype = str(data.get("type") or "")
+            if etype == "message_start":
+                current = []
+                by_index = {}
+                message = data.get("message") if isinstance(data.get("message"), dict) else {}
+                if isinstance(message.get("usage"), dict):
+                    usage.update(message["usage"])
+            elif etype == "content_block_start" and current is not None:
+                cb = data.get("content_block") if isinstance(data.get("content_block"), dict) else {}
+                block_type = str(cb.get("type") or "text")
+                raw_index = data.get("index")
+                index = raw_index if isinstance(raw_index, int) else len(current)
+                if block_type == "thinking":
+                    block: dict[str, Any] = {"type": "thinking", "text": "", "seq_id": seq_id}
+                elif block_type == "tool_use":
+                    tool_id = str(cb.get("id") or "")
+                    block = {
+                        "type": "tool_use",
+                        "tool_id": tool_id,
+                        "tool_name": str(cb.get("name") or "Tool"),
+                        "_input_json": "",
+                        "input": None,
+                        "output": None,
+                        "is_error": False,
+                        "seq_id": seq_id,
+                    }
+                    if tool_id:
+                        by_tool_id[tool_id] = block
+                else:
+                    block = {"type": "main_text", "text": "", "seq_id": seq_id}
+                current.append(block)
+                by_index[index] = block
+                ordered.append(block)
+            elif etype == "content_block_delta" and current is not None:
+                raw_index = data.get("index")
+                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
+                if block:
+                    delta = data.get("delta") if isinstance(data.get("delta"), dict) else {}
+                    dtype = str(delta.get("type") or "")
+                    if dtype == "thinking_delta":
+                        block["text"] = str(block.get("text") or "") + str(delta.get("thinking") or "")
+                    elif dtype == "text_delta":
+                        block["text"] = str(block.get("text") or "") + str(delta.get("text") or "")
+                    elif dtype == "input_json_delta":
+                        block["_input_json"] = str(block.get("_input_json") or "") + str(delta.get("partial_json") or "")
+            elif etype == "content_block_stop" and current is not None:
+                raw_index = data.get("index")
+                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
+                if block and block.get("type") == "tool_use":
+                    input_json = str(block.get("_input_json") or "")
+                    if input_json:
+                        try:
+                            block["input"] = json.loads(input_json)
+                        except Exception:
+                            block["input"] = input_json
+            elif etype == "message_delta":
+                if isinstance(data.get("usage"), dict):
+                    usage.update(data["usage"])
+        elif record_type == "tool_result":
+            tool_use_id = str(data.get("tool_use_id") or "")
+            block = by_tool_id.get(tool_use_id)
+            if block is not None:
+                block["output"] = data.get("content")
+                block["is_error"] = bool(data.get("is_error"))
+
+    blocks = [{k: v for k, v in block.items() if not k.startswith("_")} for block in ordered]
+    return blocks, usage
+
+
+def _collect_tool_names(blocks: list[dict[str, Any]]) -> list[str]:
     names: list[str] = []
-    for event in events:
-        data = event.get("data") if isinstance(event, dict) else {}
-        candidates = []
-        if isinstance(event, dict):
-            candidates.extend([event.get("tool_name"), event.get("name"), event.get("tool")])
-        if isinstance(data, dict):
-            candidates.extend([data.get("tool_name"), data.get("name"), data.get("tool")])
-        for candidate in candidates:
-            if isinstance(candidate, dict):
-                candidate = candidate.get("name")
-            text = str(candidate or "").strip()
-            if text and text not in names:
-                names.append(text)
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        text = str(block.get("tool_name") or "").strip()
+        if text and text not in names:
+            names.append(text)
     return names
 
 
@@ -323,10 +408,13 @@ def _collect_structured_sql(value: Any) -> list[str]:
     return sqls
 
 
-def _extract_sql_outputs(events: list[dict[str, Any]], final_answer: str) -> list[str]:
+def _extract_sql_outputs(blocks: list[dict[str, Any]], final_answer: str) -> list[str]:
     sqls: list[str] = []
-    for event in events:
-        sqls.extend(_collect_structured_sql(event))
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        sqls.extend(_collect_structured_sql(block.get("input")))
+        sqls.extend(_collect_structured_sql(block.get("output")))
     fenced = re.findall(r"```sql\s*(.*?)```", str(final_answer or ""), flags=re.IGNORECASE | re.DOTALL)
     sqls.extend(_normalise_sql(item) for item in fenced if _looks_like_sql(item))
     result: list[str] = []
@@ -336,15 +424,17 @@ def _extract_sql_outputs(events: list[dict[str, Any]], final_answer: str) -> lis
     return result
 
 
-def _extract_chart_outputs(events: list[dict[str, Any]]) -> list[Any]:
+def _extract_chart_outputs(blocks: list[dict[str, Any]]) -> list[Any]:
     charts: list[Any] = []
-    for event in events:
-        for key in ("chart", "chart_spec", "echarts", "spec"):
-            value = event.get(key) if isinstance(event, dict) else None
-            if value is None and isinstance(event.get("data") if isinstance(event, dict) else None, dict):
-                value = event["data"].get(key)
-            if value is not None:
-                charts.append(value)
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        for source in (block.get("input"), block.get("output")):
+            if isinstance(source, dict):
+                for key in ("chart", "chart_spec", "echarts", "spec"):
+                    value = source.get(key)
+                    if value is not None:
+                        charts.append(value)
     return charts
 
 
@@ -397,52 +487,34 @@ def _compact_judge_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
-def _event_tool_name(event: dict[str, Any], data: dict[str, Any]) -> str:
-    for candidate in (event.get("tool_name"), event.get("name"), event.get("tool"), data.get("tool_name"), data.get("name"), data.get("tool")):
-        if isinstance(candidate, dict):
-            candidate = candidate.get("name")
-        text = str(candidate or "").strip()
-        if text:
-            return text
-    return ""
-
-
-def _summarize_tool_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     summarized: list[dict[str, Any]] = []
-    for event in events:
-        if not isinstance(event, dict):
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
-        data = event.get("data") if isinstance(event.get("data"), dict) else {}
-        event_type = str(event.get("event_type") or data.get("event_type") or "")
-        tool_name = _event_tool_name(event, data)
-        if not tool_name and "TOOL" not in event_type and not any(key in data for key in ("input", "output", "error")):
-            continue
-
         item: dict[str, Any] = {
-            "seq_id": event.get("seq_id"),
-            "event_type": event_type,
-            "tool_name": tool_name,
+            "seq_id": block.get("seq_id"),
+            "tool_name": str(block.get("tool_name") or ""),
         }
-        for key in ("input", "output", "error"):
-            if key in data:
-                item[key] = _truncate_for_judge(data.get(key))
-            elif key in event:
-                item[key] = _truncate_for_judge(event.get(key))
+        if block.get("input") not in (None, ""):
+            item["input"] = _truncate_for_judge(block.get("input"))
+        if block.get("output") not in (None, ""):
+            item["output"] = _truncate_for_judge(block.get("output"))
+        if block.get("is_error"):
+            item["is_error"] = True
         summarized.append({key: value for key, value in item.items() if value not in (None, "")})
     return summarized
 
 
-def _collect_usage(task: dict[str, Any], messages: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+def _collect_usage(task: dict[str, Any], messages: dict[str, Any], stream_usage: dict[str, Any]) -> dict[str, Any]:
     usage: dict[str, Any] = {}
+    if isinstance(stream_usage, dict):
+        usage.update(stream_usage)
     if isinstance(task.get("usage"), dict):
         usage.update(task["usage"])
     for message in messages.get("items") or []:
         if isinstance(message, dict) and isinstance(message.get("usage"), dict):
             usage.update(message["usage"])
-    for event in events:
-        data = event.get("data") if isinstance(event, dict) else None
-        if isinstance(data, dict) and isinstance(data.get("usage"), dict):
-            usage.update(data["usage"])
     return usage
 
 
@@ -481,7 +553,7 @@ def _auto_failure_attribution(
     return _dedupe(failures)
 
 
-def auto_rule_check(case: dict[str, Any], *, final_answer: str, events: list[dict[str, Any]], sql_outputs: list[str], tool_names: list[str]) -> dict[str, Any]:
+def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dict[str, Any]], sql_outputs: list[str], tool_names: list[str]) -> dict[str, Any]:
     assessment_text = "\n".join(sql_outputs + [final_answer])
     missing_sql_fragments = [
         fragment
@@ -583,6 +655,26 @@ def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any
     return ""
 
 
+def _fetch_sdk_records(base_url: str, task_id: str, after_id: int) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
+    """Page through the Chat V2 SDK-event interface, draining ``has_more``."""
+    collected: list[dict[str, Any]] = []
+    cursor = max(0, after_id)
+    last_page: dict[str, Any] = {}
+    while True:
+        page = http_json(
+            "GET",
+            f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/sdk-events?after_id={cursor}&limit=500",
+            timeout=60,
+        )
+        last_page = page
+        records = [item for item in page.get("records") or [] if isinstance(item, dict)]
+        collected.extend(records)
+        cursor = max(cursor, int(page.get("next_after_id") or cursor))
+        if not page.get("has_more"):
+            break
+    return collected, cursor, last_page
+
+
 def _poll_task(
     base_url: str,
     task_id: str,
@@ -593,8 +685,8 @@ def _poll_task(
     deadline = time.time() + max(1, timeout_seconds)
     current_task_id = task_id
     seen_task_ids = {task_id}
-    after_seq = 0
-    all_events: list[dict[str, Any]] = []
+    after_id = 0
+    all_records: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     last_task: dict[str, Any] = {}
     last_poll_error = ""
@@ -608,14 +700,8 @@ def _poll_task(
 
         status = str(last_task.get("task_status") or "").lower()
         try:
-            page = http_json(
-                "GET",
-                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}/events?after_seq={after_seq}&limit=1000",
-                timeout=60,
-            )
-            events = [item for item in page.get("events") or [] if isinstance(item, dict)]
-            all_events.extend(events)
-            after_seq = max(after_seq, int(page.get("next_after_seq") or after_seq))
+            records, after_id, page = _fetch_sdk_records(base_url, current_task_id, after_id)
+            all_records.extend(records)
             status = str(last_task.get("task_status") or page.get("task_status") or "").lower()
         except EvalRunnerError as exc:
             last_poll_error = str(exc)
@@ -626,9 +712,9 @@ def _poll_task(
                 if recovered_task_id and recovered_task_id not in seen_task_ids:
                     current_task_id = recovered_task_id
                     seen_task_ids.add(recovered_task_id)
-                    after_seq = 0
+                    after_id = 0
                     continue
-            return last_task, all_events, errors
+            return last_task, all_records, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
@@ -638,7 +724,7 @@ def _poll_task(
     else:
         last_task = dict(last_task)
         last_task["task_status"] = str(last_task.get("task_status") or "timeout")
-    return last_task, all_events, errors
+    return last_task, all_records, errors
 
 
 def _json_object_text(raw: str) -> str:
@@ -863,14 +949,14 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     topic_id = ""
     task_id = ""
     task: dict[str, Any] = {}
-    events: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
     messages: dict[str, Any] = {}
     final_answer = ""
     try:
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
+        task, records, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
         final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
@@ -885,18 +971,19 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     except EvalRunnerError as exc:
         errors.append({"code": "runner_error", "message": str(exc)})
 
-    tool_names = _collect_tool_names(events)
-    sql_outputs = _extract_sql_outputs(events, final_answer)
-    chart_outputs = _extract_chart_outputs(events)
-    usage = _collect_usage(task, messages, events)
-    rule_check = auto_rule_check(case, final_answer=final_answer, events=events, sql_outputs=sql_outputs, tool_names=tool_names)
+    blocks, stream_usage = _project_sdk_blocks(records)
+    tool_names = _collect_tool_names(blocks)
+    sql_outputs = _extract_sql_outputs(blocks, final_answer)
+    chart_outputs = _extract_chart_outputs(blocks)
+    usage = _collect_usage(task, messages, stream_usage)
+    rule_check = auto_rule_check(case, final_answer=final_answer, blocks=blocks, sql_outputs=sql_outputs, tool_names=tool_names)
     judge_payload = {
         "case": _case_for_judge(case),
         "user_question": str(case.get("question") or ""),
         "final_answer": final_answer,
         "task_status": str(task.get("task_status") or ""),
         "task_error": task.get("error") if isinstance(task.get("error"), dict) else None,
-        "tool_events": _summarize_tool_events(events),
+        "tool_events": _summarize_tool_events(blocks),
         "sql_outputs": sql_outputs,
         "chart_outputs": chart_outputs,
         "auto_rule_check": rule_check,

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -278,98 +278,6 @@ def _flatten_strings(value: Any) -> list[str]:
     return []
 
 
-def _project_sdk_blocks(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Replay Chat V2 SDK records into rendered blocks.
-
-    Mirrors the backend ``topic_task_store._project_sdk_records`` and the frontend
-    ``v2StreamParser.js`` so eval evidence matches what Chat V2 renders/persists.
-    Returns ``(blocks, usage)`` where each block is
-    ``{type: 'thinking'|'main_text'|'tool_use', text, tool_id, tool_name, input,
-    output, is_error, seq_id}`` and usage is the accumulated token usage.
-    """
-    ordered: list[dict[str, Any]] = []
-    current: list[dict[str, Any]] | None = None
-    by_index: dict[int, dict[str, Any]] = {}
-    by_tool_id: dict[str, dict[str, Any]] = {}
-    usage: dict[str, Any] = {}
-
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        seq_id = int(record.get("seq_id") or 0)
-        record_type = str(record.get("record_type") or "")
-        data = record.get("data") if isinstance(record.get("data"), dict) else {}
-
-        if record_type == "stream":
-            etype = str(data.get("type") or "")
-            if etype == "message_start":
-                current = []
-                by_index = {}
-                message = data.get("message") if isinstance(data.get("message"), dict) else {}
-                if isinstance(message.get("usage"), dict):
-                    usage.update(message["usage"])
-            elif etype == "content_block_start" and current is not None:
-                cb = data.get("content_block") if isinstance(data.get("content_block"), dict) else {}
-                block_type = str(cb.get("type") or "text")
-                raw_index = data.get("index")
-                index = raw_index if isinstance(raw_index, int) else len(current)
-                if block_type == "thinking":
-                    block: dict[str, Any] = {"type": "thinking", "text": "", "seq_id": seq_id}
-                elif block_type == "tool_use":
-                    tool_id = str(cb.get("id") or "")
-                    block = {
-                        "type": "tool_use",
-                        "tool_id": tool_id,
-                        "tool_name": str(cb.get("name") or "Tool"),
-                        "_input_json": "",
-                        "input": None,
-                        "output": None,
-                        "is_error": False,
-                        "seq_id": seq_id,
-                    }
-                    if tool_id:
-                        by_tool_id[tool_id] = block
-                else:
-                    block = {"type": "main_text", "text": "", "seq_id": seq_id}
-                current.append(block)
-                by_index[index] = block
-                ordered.append(block)
-            elif etype == "content_block_delta" and current is not None:
-                raw_index = data.get("index")
-                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
-                if block:
-                    delta = data.get("delta") if isinstance(data.get("delta"), dict) else {}
-                    dtype = str(delta.get("type") or "")
-                    if dtype == "thinking_delta":
-                        block["text"] = str(block.get("text") or "") + str(delta.get("thinking") or "")
-                    elif dtype == "text_delta":
-                        block["text"] = str(block.get("text") or "") + str(delta.get("text") or "")
-                    elif dtype == "input_json_delta":
-                        block["_input_json"] = str(block.get("_input_json") or "") + str(delta.get("partial_json") or "")
-            elif etype == "content_block_stop" and current is not None:
-                raw_index = data.get("index")
-                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
-                if block and block.get("type") == "tool_use":
-                    input_json = str(block.get("_input_json") or "")
-                    if input_json:
-                        try:
-                            block["input"] = json.loads(input_json)
-                        except Exception:
-                            block["input"] = input_json
-            elif etype == "message_delta":
-                if isinstance(data.get("usage"), dict):
-                    usage.update(data["usage"])
-        elif record_type == "tool_result":
-            tool_use_id = str(data.get("tool_use_id") or "")
-            block = by_tool_id.get(tool_use_id)
-            if block is not None:
-                block["output"] = data.get("content")
-                block["is_error"] = bool(data.get("is_error"))
-
-    blocks = [{k: v for k, v in block.items() if not k.startswith("_")} for block in ordered]
-    return blocks, usage
-
-
 def _collect_tool_names(blocks: list[dict[str, Any]]) -> list[str]:
     names: list[str] = []
     for block in blocks:
@@ -489,11 +397,13 @@ def _compact_judge_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     summarized: list[dict[str, Any]] = []
+    seq = 0
     for block in blocks:
         if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
+        seq += 1
         item: dict[str, Any] = {
-            "seq_id": block.get("seq_id"),
+            "seq_id": seq,
             "tool_name": str(block.get("tool_name") or ""),
         }
         if block.get("input") not in (None, ""):
@@ -506,15 +416,12 @@ def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]
     return summarized
 
 
-def _collect_usage(task: dict[str, Any], messages: dict[str, Any], stream_usage: dict[str, Any]) -> dict[str, Any]:
+def _collect_usage(task: dict[str, Any], message: dict[str, Any]) -> dict[str, Any]:
     usage: dict[str, Any] = {}
-    if isinstance(stream_usage, dict):
-        usage.update(stream_usage)
     if isinstance(task.get("usage"), dict):
         usage.update(task["usage"])
-    for message in messages.get("items") or []:
-        if isinstance(message, dict) and isinstance(message.get("usage"), dict):
-            usage.update(message["usage"])
+    if isinstance(message.get("usage"), dict):
+        usage.update(message["usage"])
     return usage
 
 
@@ -580,7 +487,8 @@ def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dic
     }
 
 
-def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
+def _final_assistant_message(messages: dict[str, Any], task_id: str) -> dict[str, Any]:
+    """Pick the last assistant message for ``task_id`` (Chat V2 projected blocks)."""
     candidates = []
     for message in messages.get("items") or []:
         if not isinstance(message, dict):
@@ -594,7 +502,7 @@ def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
         for message in messages.get("items") or []:
             if isinstance(message, dict) and str(message.get("sender_type") or "") == "assistant":
                 candidates.append(message)
-    return str((candidates[-1] if candidates else {}).get("content") or "").strip()
+    return candidates[-1] if candidates else {}
 
 
 def _create_topic(base_url: str, case: dict[str, Any], agent_id: str) -> str:
@@ -655,38 +563,22 @@ def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any
     return ""
 
 
-def _fetch_sdk_records(base_url: str, task_id: str, after_id: int) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
-    """Page through the Chat V2 SDK-event interface, draining ``has_more``."""
-    collected: list[dict[str, Any]] = []
-    cursor = max(0, after_id)
-    last_page: dict[str, Any] = {}
-    while True:
-        page = http_json(
-            "GET",
-            f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/sdk-events?after_id={cursor}&limit=500",
-            timeout=60,
-        )
-        last_page = page
-        records = [item for item in page.get("records") or [] if isinstance(item, dict)]
-        collected.extend(records)
-        cursor = max(cursor, int(page.get("next_after_id") or cursor))
-        if not page.get("has_more"):
-            break
-    return collected, cursor, last_page
-
-
 def _poll_task(
     base_url: str,
     task_id: str,
     timeout_seconds: int,
     *,
     topic_id: str = "",
-) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Poll task status until terminal, following recovered/replacement tasks.
+
+    Run evidence is no longer pulled from a per-poll event stream: after the task
+    is terminal the runner reads the Chat V2 server-projected ``blocks`` from
+    ``GET /topics/{id}/messages`` (the same projection the Chat V2 history uses).
+    """
     deadline = time.time() + max(1, timeout_seconds)
     current_task_id = task_id
     seen_task_ids = {task_id}
-    after_id = 0
-    all_records: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     last_task: dict[str, Any] = {}
     last_poll_error = ""
@@ -699,22 +591,14 @@ def _poll_task(
             continue
 
         status = str(last_task.get("task_status") or "").lower()
-        try:
-            records, after_id, page = _fetch_sdk_records(base_url, current_task_id, after_id)
-            all_records.extend(records)
-            status = str(last_task.get("task_status") or page.get("task_status") or "").lower()
-        except EvalRunnerError as exc:
-            last_poll_error = str(exc)
-
         if status in TERMINAL_STATUSES:
             if _is_recovered_task(last_task):
                 recovered_task_id = _resolve_recovered_task_id(base_url, topic_id, last_task)
                 if recovered_task_id and recovered_task_id not in seen_task_ids:
                     current_task_id = recovered_task_id
                     seen_task_ids.add(recovered_task_id)
-                    after_id = 0
                     continue
-            return last_task, all_records, errors
+            return last_task, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
@@ -724,7 +608,7 @@ def _poll_task(
     else:
         last_task = dict(last_task)
         last_task["task_status"] = str(last_task.get("task_status") or "timeout")
-    return last_task, all_records, errors
+    return last_task, errors
 
 
 def _json_object_text(raw: str) -> str:
@@ -949,14 +833,13 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     topic_id = ""
     task_id = ""
     task: dict[str, Any] = {}
-    records: list[dict[str, Any]] = []
-    messages: dict[str, Any] = {}
+    message: dict[str, Any] = {}
     final_answer = ""
     try:
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, records, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
+        task, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
         final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
@@ -964,18 +847,19 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
             f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}/messages?page=1&page_size=200&order=asc",
             timeout=30,
         )
-        final_answer = _final_assistant_answer(messages, final_task_id)
+        message = _final_assistant_message(messages, final_task_id)
+        final_answer = str(message.get("content") or "").strip()
         status = str(task.get("task_status") or "").lower()
         if status and status not in SUCCESS_STATUSES:
             errors.append({"code": status, "message": json.dumps(task.get("error") or {}, ensure_ascii=False)})
     except EvalRunnerError as exc:
         errors.append({"code": "runner_error", "message": str(exc)})
 
-    blocks, stream_usage = _project_sdk_blocks(records)
+    blocks = message.get("blocks") if isinstance(message.get("blocks"), list) else []
     tool_names = _collect_tool_names(blocks)
     sql_outputs = _extract_sql_outputs(blocks, final_answer)
     chart_outputs = _extract_chart_outputs(blocks)
-    usage = _collect_usage(task, messages, stream_usage)
+    usage = _collect_usage(task, message)
     rule_check = auto_rule_check(case, final_answer=final_answer, blocks=blocks, sql_outputs=sql_outputs, tool_names=tool_names)
     judge_payload = {
         "case": _case_for_judge(case),

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -270,59 +270,208 @@ def _flatten_strings(value: Any) -> list[str]:
     return []
 
 
-def _collect_tool_names(events: list[dict[str, Any]]) -> list[str]:
+def _project_sdk_blocks(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Replay Chat V2 SDK records into rendered blocks.
+
+    Mirrors the backend ``topic_task_store._project_sdk_records`` and the frontend
+    ``v2StreamParser.js`` so eval evidence matches what Chat V2 renders/persists.
+    Returns ``(blocks, usage)`` where each block is
+    ``{type: 'thinking'|'main_text'|'tool_use', text, tool_id, tool_name, input,
+    output, is_error, seq_id}`` and usage is the accumulated token usage.
+    """
+    ordered: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] | None = None
+    by_index: dict[int, dict[str, Any]] = {}
+    by_tool_id: dict[str, dict[str, Any]] = {}
+    usage: dict[str, Any] = {}
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        seq_id = int(record.get("seq_id") or 0)
+        record_type = str(record.get("record_type") or "")
+        data = record.get("data") if isinstance(record.get("data"), dict) else {}
+
+        if record_type == "stream":
+            etype = str(data.get("type") or "")
+            if etype == "message_start":
+                current = []
+                by_index = {}
+                message = data.get("message") if isinstance(data.get("message"), dict) else {}
+                if isinstance(message.get("usage"), dict):
+                    usage.update(message["usage"])
+            elif etype == "content_block_start" and current is not None:
+                cb = data.get("content_block") if isinstance(data.get("content_block"), dict) else {}
+                block_type = str(cb.get("type") or "text")
+                raw_index = data.get("index")
+                index = raw_index if isinstance(raw_index, int) else len(current)
+                if block_type == "thinking":
+                    block: dict[str, Any] = {"type": "thinking", "text": "", "seq_id": seq_id}
+                elif block_type == "tool_use":
+                    tool_id = str(cb.get("id") or "")
+                    block = {
+                        "type": "tool_use",
+                        "tool_id": tool_id,
+                        "tool_name": str(cb.get("name") or "Tool"),
+                        "_input_json": "",
+                        "input": None,
+                        "output": None,
+                        "is_error": False,
+                        "seq_id": seq_id,
+                    }
+                    if tool_id:
+                        by_tool_id[tool_id] = block
+                else:
+                    block = {"type": "main_text", "text": "", "seq_id": seq_id}
+                current.append(block)
+                by_index[index] = block
+                ordered.append(block)
+            elif etype == "content_block_delta" and current is not None:
+                raw_index = data.get("index")
+                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
+                if block:
+                    delta = data.get("delta") if isinstance(data.get("delta"), dict) else {}
+                    dtype = str(delta.get("type") or "")
+                    if dtype == "thinking_delta":
+                        block["text"] = str(block.get("text") or "") + str(delta.get("thinking") or "")
+                    elif dtype == "text_delta":
+                        block["text"] = str(block.get("text") or "") + str(delta.get("text") or "")
+                    elif dtype == "input_json_delta":
+                        block["_input_json"] = str(block.get("_input_json") or "") + str(delta.get("partial_json") or "")
+            elif etype == "content_block_stop" and current is not None:
+                raw_index = data.get("index")
+                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
+                if block and block.get("type") == "tool_use":
+                    input_json = str(block.get("_input_json") or "")
+                    if input_json:
+                        try:
+                            block["input"] = json.loads(input_json)
+                        except Exception:
+                            block["input"] = input_json
+            elif etype == "message_delta":
+                if isinstance(data.get("usage"), dict):
+                    usage.update(data["usage"])
+        elif record_type == "tool_result":
+            tool_use_id = str(data.get("tool_use_id") or "")
+            block = by_tool_id.get(tool_use_id)
+            if block is not None:
+                block["output"] = data.get("content")
+                block["is_error"] = bool(data.get("is_error"))
+
+    blocks = [{k: v for k, v in block.items() if not k.startswith("_")} for block in ordered]
+    return blocks, usage
+
+
+def _collect_tool_names(blocks: list[dict[str, Any]]) -> list[str]:
     names: list[str] = []
-    for event in events:
-        data = event.get("data") if isinstance(event, dict) else {}
-        candidates = []
-        if isinstance(event, dict):
-            candidates.extend([event.get("tool_name"), event.get("name"), event.get("tool")])
-        if isinstance(data, dict):
-            candidates.extend([data.get("tool_name"), data.get("name"), data.get("tool")])
-        for candidate in candidates:
-            if isinstance(candidate, dict):
-                candidate = candidate.get("name")
-            text = str(candidate or "").strip()
-            if text and text not in names:
-                names.append(text)
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        text = str(block.get("tool_name") or "").strip()
+        if text and text not in names:
+            names.append(text)
     return names
 
 
-def _extract_sql_outputs(events: list[dict[str, Any]], final_answer: str) -> list[str]:
-    combined = "\n".join(_flatten_strings(events) + [final_answer])
-    sqls: list[str] = []
-    fenced = re.findall(r"```sql\s*(.*?)```", combined, flags=re.IGNORECASE | re.DOTALL)
-    sqls.extend(item.strip() for item in fenced if item.strip())
-    for match in re.findall(r"(?is)\b(?:select|with)\b.+?(?:;|\n\n|$)", combined):
-        text = re.sub(r"\s+", " ", match).strip().rstrip(";")
-        if text and text not in sqls:
-            sqls.append(text)
+def _looks_like_sql(text: str) -> bool:
+    return bool(re.match(r"(?is)^\s*(?:select|with)\b", str(text or "")))
+
+
+def _normalise_sql(text: str) -> str:
+    return re.sub(r"\s+", " ", str(text or "").strip()).rstrip(";")
+
+
+def _collect_structured_sql(value: Any) -> list[str]:
+    if isinstance(value, list):
+        sqls: list[str] = []
+        for item in value:
+            sqls.extend(_collect_structured_sql(item))
+        return sqls
+    if not isinstance(value, dict):
+        return []
+    sqls = []
+    for key, item in value.items():
+        key_text = str(key or "").lower()
+        if key_text in {"sql", "query"} and isinstance(item, str) and _looks_like_sql(item):
+            sqls.append(_normalise_sql(item))
+            continue
+        sqls.extend(_collect_structured_sql(item))
     return sqls
 
 
-def _extract_chart_outputs(events: list[dict[str, Any]]) -> list[Any]:
+def _truncate_for_judge(value: Any, *, max_text: int = 2000, max_rows: int = 20) -> Any:
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if len(text) <= max_text:
+            return text
+        return text[:max_text] + f"...[truncated {len(text) - max_text} chars]"
+    if isinstance(value, list):
+        return [_truncate_for_judge(item, max_text=max_text, max_rows=max_rows) for item in value[:max_rows]]
+    if isinstance(value, dict):
+        return {str(key): _truncate_for_judge(item, max_text=max_text, max_rows=max_rows) for key, item in value.items()}
+    return str(value)
+
+
+def _extract_sql_outputs(blocks: list[dict[str, Any]], final_answer: str) -> list[str]:
+    sqls: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        sqls.extend(_collect_structured_sql(block.get("input")))
+        sqls.extend(_collect_structured_sql(block.get("output")))
+    fenced = re.findall(r"```sql\s*(.*?)```", str(final_answer or ""), flags=re.IGNORECASE | re.DOTALL)
+    sqls.extend(_normalise_sql(item) for item in fenced if _looks_like_sql(item))
+    result: list[str] = []
+    for text in sqls:
+        if text and text not in result:
+            result.append(text)
+    return result
+
+
+def _extract_chart_outputs(blocks: list[dict[str, Any]]) -> list[Any]:
     charts: list[Any] = []
-    for event in events:
-        for key in ("chart", "chart_spec", "echarts", "spec"):
-            value = event.get(key) if isinstance(event, dict) else None
-            if value is None and isinstance(event.get("data") if isinstance(event, dict) else None, dict):
-                value = event["data"].get(key)
-            if value is not None:
-                charts.append(value)
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        for source in (block.get("input"), block.get("output")):
+            if isinstance(source, dict):
+                for key in ("chart", "chart_spec", "echarts", "spec"):
+                    value = source.get(key)
+                    if value is not None:
+                        charts.append(value)
     return charts
 
 
-def _collect_usage(task: dict[str, Any], messages: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summarized: list[dict[str, Any]] = []
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        item: dict[str, Any] = {
+            "seq_id": block.get("seq_id"),
+            "tool_name": str(block.get("tool_name") or ""),
+        }
+        if block.get("input") not in (None, ""):
+            item["input"] = _truncate_for_judge(block.get("input"))
+        if block.get("output") not in (None, ""):
+            item["output"] = _truncate_for_judge(block.get("output"))
+        if block.get("is_error"):
+            item["is_error"] = True
+        summarized.append({key: value for key, value in item.items() if value not in (None, "")})
+    return summarized
+
+
+def _collect_usage(task: dict[str, Any], messages: dict[str, Any], stream_usage: dict[str, Any]) -> dict[str, Any]:
     usage: dict[str, Any] = {}
+    if isinstance(stream_usage, dict):
+        usage.update(stream_usage)
     if isinstance(task.get("usage"), dict):
         usage.update(task["usage"])
     for message in messages.get("items") or []:
         if isinstance(message, dict) and isinstance(message.get("usage"), dict):
             usage.update(message["usage"])
-    for event in events:
-        data = event.get("data") if isinstance(event, dict) else None
-        if isinstance(data, dict) and isinstance(data.get("usage"), dict):
-            usage.update(data["usage"])
     return usage
 
 
@@ -364,8 +513,8 @@ def _auto_failure_attribution(
     return _dedupe(failures)
 
 
-def auto_rule_check(case: dict[str, Any], *, final_answer: str, events: list[dict[str, Any]], sql_outputs: list[str], tool_names: list[str]) -> dict[str, Any]:
-    combined = "\n".join(_flatten_strings(events) + sql_outputs + [final_answer])
+def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dict[str, Any]], sql_outputs: list[str], tool_names: list[str]) -> dict[str, Any]:
+    combined = "\n".join(_flatten_strings(blocks) + sql_outputs + [final_answer])
     missing_sql_fragments = [
         fragment
         for fragment in case.get("required_sql_fragments") or []
@@ -478,6 +627,26 @@ def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any
     return ""
 
 
+def _fetch_sdk_records(base_url: str, task_id: str, after_id: int) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
+    """Page through the Chat V2 SDK-event interface, draining ``has_more``."""
+    collected: list[dict[str, Any]] = []
+    cursor = max(0, after_id)
+    last_page: dict[str, Any] = {}
+    while True:
+        page = http_json(
+            "GET",
+            f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/sdk-events?after_id={cursor}&limit=500",
+            timeout=60,
+        )
+        last_page = page
+        records = [item for item in page.get("records") or [] if isinstance(item, dict)]
+        collected.extend(records)
+        cursor = max(cursor, int(page.get("next_after_id") or cursor))
+        if not page.get("has_more"):
+            break
+    return collected, cursor, last_page
+
+
 def _poll_task(
     base_url: str,
     task_id: str,
@@ -488,8 +657,8 @@ def _poll_task(
     deadline = time.time() + max(1, timeout_seconds)
     current_task_id = task_id
     seen_task_ids = {task_id}
-    after_seq = 0
-    all_events: list[dict[str, Any]] = []
+    after_id = 0
+    all_records: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     last_task: dict[str, Any] = {}
     last_poll_error = ""
@@ -503,14 +672,8 @@ def _poll_task(
 
         status = str(last_task.get("task_status") or "").lower()
         try:
-            page = http_json(
-                "GET",
-                f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(current_task_id)}/events?after_seq={after_seq}&limit=1000",
-                timeout=60,
-            )
-            events = [item for item in page.get("events") or [] if isinstance(item, dict)]
-            all_events.extend(events)
-            after_seq = max(after_seq, int(page.get("next_after_seq") or after_seq))
+            records, after_id, page = _fetch_sdk_records(base_url, current_task_id, after_id)
+            all_records.extend(records)
             status = str(last_task.get("task_status") or page.get("task_status") or "").lower()
         except EvalRunnerError as exc:
             last_poll_error = str(exc)
@@ -521,16 +684,16 @@ def _poll_task(
                 if recovered_task_id and recovered_task_id not in seen_task_ids:
                     current_task_id = recovered_task_id
                     seen_task_ids.add(recovered_task_id)
-                    after_seq = 0
+                    after_id = 0
                     continue
-            return last_task, all_events, errors
+            return last_task, all_records, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
         errors.append({"code": "poll_error", "message": last_poll_error})
     last_task = dict(last_task or {"task_id": current_task_id})
     last_task["task_status"] = str(last_task.get("task_status") or "timeout")
-    return last_task, all_events, errors
+    return last_task, all_records, errors
 
 
 def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -539,14 +702,14 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
     topic_id = ""
     task_id = ""
     task: dict[str, Any] = {}
-    events: list[dict[str, Any]] = []
+    records: list[dict[str, Any]] = []
     messages: dict[str, Any] = {}
     final_answer = ""
     try:
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, events, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
+        task, records, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
         final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
@@ -561,11 +724,12 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
     except EvalRunnerError as exc:
         errors.append({"code": "runner_error", "message": str(exc)})
 
-    tool_names = _collect_tool_names(events)
-    sql_outputs = _extract_sql_outputs(events, final_answer)
-    chart_outputs = _extract_chart_outputs(events)
-    usage = _collect_usage(task, messages, events)
-    rule_check = auto_rule_check(case, final_answer=final_answer, events=events, sql_outputs=sql_outputs, tool_names=tool_names)
+    blocks, stream_usage = _project_sdk_blocks(records)
+    tool_names = _collect_tool_names(blocks)
+    sql_outputs = _extract_sql_outputs(blocks, final_answer)
+    chart_outputs = _extract_chart_outputs(blocks)
+    usage = _collect_usage(task, messages, stream_usage)
+    rule_check = auto_rule_check(case, final_answer=final_answer, blocks=blocks, sql_outputs=sql_outputs, tool_names=tool_names)
     return {
         "case_id": case.get("case_id"),
         "category": case.get("category"),
@@ -578,6 +742,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
         "tool_names": tool_names,
         "sql_outputs": sql_outputs,
         "chart_outputs": chart_outputs,
+        "tool_events": _summarize_tool_events(blocks),
         "usage": usage,
         "duration_seconds": round(time.time() - started, 3),
         "auto_rule_check": rule_check,

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -289,21 +289,42 @@ def _normalise_sql(text: str) -> str:
     return re.sub(r"\s+", " ", str(text or "").strip()).rstrip(";")
 
 
-def _collect_structured_sql(value: Any) -> list[str]:
+def _parse_json_text(value: str) -> Any | None:
+    text = str(value or "").strip()
+    if not text or text[0] not in "[{":
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _iter_structured_evidence(value: Any) -> list[Any]:
+    values = [value]
+    if isinstance(value, str):
+        parsed = _parse_json_text(value)
+        if parsed is not None:
+            values.extend(_iter_structured_evidence(parsed))
+        return values
     if isinstance(value, list):
-        sqls: list[str] = []
         for item in value:
-            sqls.extend(_collect_structured_sql(item))
-        return sqls
-    if not isinstance(value, dict):
-        return []
-    sqls = []
-    for key, item in value.items():
-        key_text = str(key or "").lower()
-        if key_text in {"sql", "query"} and isinstance(item, str) and _looks_like_sql(item):
-            sqls.append(_normalise_sql(item))
+            values.extend(_iter_structured_evidence(item))
+        return values
+    if isinstance(value, dict):
+        for item in value.values():
+            values.extend(_iter_structured_evidence(item))
+    return values
+
+
+def _collect_structured_sql(value: Any) -> list[str]:
+    sqls: list[str] = []
+    for item in _iter_structured_evidence(value):
+        if not isinstance(item, dict):
             continue
-        sqls.extend(_collect_structured_sql(item))
+        for key, field in item.items():
+            key_text = str(key or "").lower()
+            if key_text in {"sql", "query"} and isinstance(field, str) and _looks_like_sql(field):
+                sqls.append(_normalise_sql(field))
     return sqls
 
 
@@ -340,15 +361,30 @@ def _extract_sql_outputs(blocks: list[dict[str, Any]], final_answer: str) -> lis
 
 def _extract_chart_outputs(blocks: list[dict[str, Any]]) -> list[Any]:
     charts: list[Any] = []
+    seen: set[str] = set()
+
+    def add_chart(value: Any) -> None:
+        try:
+            key = json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+        except TypeError:
+            key = repr(value)
+        if key not in seen:
+            seen.add(key)
+            charts.append(value)
+
     for block in blocks:
         if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
         for source in (block.get("input"), block.get("output")):
-            if isinstance(source, dict):
+            for item in _iter_structured_evidence(source):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("kind") == "chart_spec":
+                    add_chart(item)
                 for key in ("chart", "chart_spec", "echarts", "spec"):
-                    value = source.get(key)
+                    value = item.get(key)
                     if value is not None:
-                        charts.append(value)
+                        add_chart(value)
     return charts
 
 

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -270,98 +270,6 @@ def _flatten_strings(value: Any) -> list[str]:
     return []
 
 
-def _project_sdk_blocks(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Replay Chat V2 SDK records into rendered blocks.
-
-    Mirrors the backend ``topic_task_store._project_sdk_records`` and the frontend
-    ``v2StreamParser.js`` so eval evidence matches what Chat V2 renders/persists.
-    Returns ``(blocks, usage)`` where each block is
-    ``{type: 'thinking'|'main_text'|'tool_use', text, tool_id, tool_name, input,
-    output, is_error, seq_id}`` and usage is the accumulated token usage.
-    """
-    ordered: list[dict[str, Any]] = []
-    current: list[dict[str, Any]] | None = None
-    by_index: dict[int, dict[str, Any]] = {}
-    by_tool_id: dict[str, dict[str, Any]] = {}
-    usage: dict[str, Any] = {}
-
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        seq_id = int(record.get("seq_id") or 0)
-        record_type = str(record.get("record_type") or "")
-        data = record.get("data") if isinstance(record.get("data"), dict) else {}
-
-        if record_type == "stream":
-            etype = str(data.get("type") or "")
-            if etype == "message_start":
-                current = []
-                by_index = {}
-                message = data.get("message") if isinstance(data.get("message"), dict) else {}
-                if isinstance(message.get("usage"), dict):
-                    usage.update(message["usage"])
-            elif etype == "content_block_start" and current is not None:
-                cb = data.get("content_block") if isinstance(data.get("content_block"), dict) else {}
-                block_type = str(cb.get("type") or "text")
-                raw_index = data.get("index")
-                index = raw_index if isinstance(raw_index, int) else len(current)
-                if block_type == "thinking":
-                    block: dict[str, Any] = {"type": "thinking", "text": "", "seq_id": seq_id}
-                elif block_type == "tool_use":
-                    tool_id = str(cb.get("id") or "")
-                    block = {
-                        "type": "tool_use",
-                        "tool_id": tool_id,
-                        "tool_name": str(cb.get("name") or "Tool"),
-                        "_input_json": "",
-                        "input": None,
-                        "output": None,
-                        "is_error": False,
-                        "seq_id": seq_id,
-                    }
-                    if tool_id:
-                        by_tool_id[tool_id] = block
-                else:
-                    block = {"type": "main_text", "text": "", "seq_id": seq_id}
-                current.append(block)
-                by_index[index] = block
-                ordered.append(block)
-            elif etype == "content_block_delta" and current is not None:
-                raw_index = data.get("index")
-                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
-                if block:
-                    delta = data.get("delta") if isinstance(data.get("delta"), dict) else {}
-                    dtype = str(delta.get("type") or "")
-                    if dtype == "thinking_delta":
-                        block["text"] = str(block.get("text") or "") + str(delta.get("thinking") or "")
-                    elif dtype == "text_delta":
-                        block["text"] = str(block.get("text") or "") + str(delta.get("text") or "")
-                    elif dtype == "input_json_delta":
-                        block["_input_json"] = str(block.get("_input_json") or "") + str(delta.get("partial_json") or "")
-            elif etype == "content_block_stop" and current is not None:
-                raw_index = data.get("index")
-                block = by_index.get(raw_index) if isinstance(raw_index, int) else (current[-1] if current else None)
-                if block and block.get("type") == "tool_use":
-                    input_json = str(block.get("_input_json") or "")
-                    if input_json:
-                        try:
-                            block["input"] = json.loads(input_json)
-                        except Exception:
-                            block["input"] = input_json
-            elif etype == "message_delta":
-                if isinstance(data.get("usage"), dict):
-                    usage.update(data["usage"])
-        elif record_type == "tool_result":
-            tool_use_id = str(data.get("tool_use_id") or "")
-            block = by_tool_id.get(tool_use_id)
-            if block is not None:
-                block["output"] = data.get("content")
-                block["is_error"] = bool(data.get("is_error"))
-
-    blocks = [{k: v for k, v in block.items() if not k.startswith("_")} for block in ordered]
-    return blocks, usage
-
-
 def _collect_tool_names(blocks: list[dict[str, Any]]) -> list[str]:
     names: list[str] = []
     for block in blocks:
@@ -446,11 +354,13 @@ def _extract_chart_outputs(blocks: list[dict[str, Any]]) -> list[Any]:
 
 def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     summarized: list[dict[str, Any]] = []
+    seq = 0
     for block in blocks:
         if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
+        seq += 1
         item: dict[str, Any] = {
-            "seq_id": block.get("seq_id"),
+            "seq_id": seq,
             "tool_name": str(block.get("tool_name") or ""),
         }
         if block.get("input") not in (None, ""):
@@ -463,15 +373,12 @@ def _summarize_tool_events(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]
     return summarized
 
 
-def _collect_usage(task: dict[str, Any], messages: dict[str, Any], stream_usage: dict[str, Any]) -> dict[str, Any]:
+def _collect_usage(task: dict[str, Any], message: dict[str, Any]) -> dict[str, Any]:
     usage: dict[str, Any] = {}
-    if isinstance(stream_usage, dict):
-        usage.update(stream_usage)
     if isinstance(task.get("usage"), dict):
         usage.update(task["usage"])
-    for message in messages.get("items") or []:
-        if isinstance(message, dict) and isinstance(message.get("usage"), dict):
-            usage.update(message["usage"])
+    if isinstance(message.get("usage"), dict):
+        usage.update(message["usage"])
     return usage
 
 
@@ -552,7 +459,8 @@ def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dic
     }
 
 
-def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
+def _final_assistant_message(messages: dict[str, Any], task_id: str) -> dict[str, Any]:
+    """Pick the last assistant message for ``task_id`` (Chat V2 projected blocks)."""
     candidates = []
     for message in messages.get("items") or []:
         if not isinstance(message, dict):
@@ -566,7 +474,7 @@ def _final_assistant_answer(messages: dict[str, Any], task_id: str) -> str:
         for message in messages.get("items") or []:
             if isinstance(message, dict) and str(message.get("sender_type") or "") == "assistant":
                 candidates.append(message)
-    return str((candidates[-1] if candidates else {}).get("content") or "").strip()
+    return candidates[-1] if candidates else {}
 
 
 def _create_topic(base_url: str, case: dict[str, Any], agent_id: str) -> str:
@@ -627,38 +535,21 @@ def _resolve_recovered_task_id(base_url: str, topic_id: str, task: dict[str, Any
     return ""
 
 
-def _fetch_sdk_records(base_url: str, task_id: str, after_id: int) -> tuple[list[dict[str, Any]], int, dict[str, Any]]:
-    """Page through the Chat V2 SDK-event interface, draining ``has_more``."""
-    collected: list[dict[str, Any]] = []
-    cursor = max(0, after_id)
-    last_page: dict[str, Any] = {}
-    while True:
-        page = http_json(
-            "GET",
-            f"{base_url}/api/v1/nl2sql/tasks/{urllib.parse.quote(task_id)}/sdk-events?after_id={cursor}&limit=500",
-            timeout=60,
-        )
-        last_page = page
-        records = [item for item in page.get("records") or [] if isinstance(item, dict)]
-        collected.extend(records)
-        cursor = max(cursor, int(page.get("next_after_id") or cursor))
-        if not page.get("has_more"):
-            break
-    return collected, cursor, last_page
-
-
 def _poll_task(
     base_url: str,
     task_id: str,
     timeout_seconds: int,
     *,
     topic_id: str = "",
-) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Poll task status until terminal, following recovered/replacement tasks.
+
+    Run evidence is read afterwards from the Chat V2 server-projected ``blocks``
+    in ``GET /topics/{id}/messages`` (the same projection the Chat V2 history uses).
+    """
     deadline = time.time() + max(1, timeout_seconds)
     current_task_id = task_id
     seen_task_ids = {task_id}
-    after_id = 0
-    all_records: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     last_task: dict[str, Any] = {}
     last_poll_error = ""
@@ -671,29 +562,21 @@ def _poll_task(
             continue
 
         status = str(last_task.get("task_status") or "").lower()
-        try:
-            records, after_id, page = _fetch_sdk_records(base_url, current_task_id, after_id)
-            all_records.extend(records)
-            status = str(last_task.get("task_status") or page.get("task_status") or "").lower()
-        except EvalRunnerError as exc:
-            last_poll_error = str(exc)
-
         if status in TERMINAL_STATUSES:
             if _is_recovered_task(last_task):
                 recovered_task_id = _resolve_recovered_task_id(base_url, topic_id, last_task)
                 if recovered_task_id and recovered_task_id not in seen_task_ids:
                     current_task_id = recovered_task_id
                     seen_task_ids.add(recovered_task_id)
-                    after_id = 0
                     continue
-            return last_task, all_records, errors
+            return last_task, errors
         time.sleep(0.2)
     errors.append({"code": "timeout", "message": f"task did not finish within {timeout_seconds}s"})
     if last_poll_error:
         errors.append({"code": "poll_error", "message": last_poll_error})
     last_task = dict(last_task or {"task_id": current_task_id})
     last_task["task_status"] = str(last_task.get("task_status") or "timeout")
-    return last_task, all_records, errors
+    return last_task, errors
 
 
 def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -702,14 +585,13 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
     topic_id = ""
     task_id = ""
     task: dict[str, Any] = {}
-    records: list[dict[str, Any]] = []
-    messages: dict[str, Any] = {}
+    message: dict[str, Any] = {}
     final_answer = ""
     try:
         topic_id = _create_topic(base_url, case, str(args.agent_id or "").strip())
         task_id = _submit_task(base_url, topic_id, case, args)
         case_timeout = min(max(1, args.timeout_seconds), int(case.get("max_wait_seconds") or args.timeout_seconds or 900))
-        task, records, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
+        task, poll_errors = _poll_task(base_url, task_id, case_timeout, topic_id=topic_id)
         errors.extend(poll_errors)
         final_task_id = str(task.get("task_id") or task_id).strip() or task_id
         messages = http_json(
@@ -717,18 +599,19 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace) -> d
             f"{base_url}/api/v1/nl2sql/topics/{urllib.parse.quote(topic_id)}/messages?page=1&page_size=200&order=asc",
             timeout=30,
         )
-        final_answer = _final_assistant_answer(messages, final_task_id)
+        message = _final_assistant_message(messages, final_task_id)
+        final_answer = str(message.get("content") or "").strip()
         status = str(task.get("task_status") or "").lower()
         if status and status not in SUCCESS_STATUSES:
             errors.append({"code": status, "message": json.dumps(task.get("error") or {}, ensure_ascii=False)})
     except EvalRunnerError as exc:
         errors.append({"code": "runner_error", "message": str(exc)})
 
-    blocks, stream_usage = _project_sdk_blocks(records)
+    blocks = message.get("blocks") if isinstance(message.get("blocks"), list) else []
     tool_names = _collect_tool_names(blocks)
     sql_outputs = _extract_sql_outputs(blocks, final_answer)
     chart_outputs = _extract_chart_outputs(blocks)
-    usage = _collect_usage(task, messages, stream_usage)
+    usage = _collect_usage(task, message)
     rule_check = auto_rule_check(case, final_answer=final_answer, blocks=blocks, sql_outputs=sql_outputs, tool_names=tool_names)
     return {
         "case_id": case.get("case_id"),


### PR DESCRIPTION
## Summary

Migrate both DataAgent evaluation runners (`builtin` and `deepeval`) from consuming the V1 magic-event task stream (`/tasks/{id}/events`) to sourcing run evidence from Chat V2 server-projected assistant message blocks in `GET /topics/{id}/messages`. This removes the eval tool's own copy of the block projection logic and aligns evidence sourcing with what the product actually renders and persists.

## Key Changes

- **Simplified task polling**: `_poll_task()` now returns `(task, errors)` instead of `(task, events, errors)`. It polls only task status via `GET /tasks/{id}`, following recovered/replacement tasks, without fetching the raw SDK-event stream.

- **Evidence sourcing from projected blocks**: After polling to terminal state, runners fetch `/topics/{id}/messages` once and extract the last assistant message's `blocks` field (Chat V2's server-projected block list). This replaces the prior re-derivation of blocks from raw events.

- **Updated evidence helpers**: 
  - `_collect_tool_names()`, `_extract_sql_outputs()`, `_extract_chart_outputs()` now operate on the projected `blocks` list (filtering for `type: "tool_use"`) instead of parsing raw events.
  - `_summarize_tool_events()` reorders by tool ordinal (seq_id is now the tool's position among `tool_use` blocks, not the raw record seq).
  - `_collect_usage()` simplified to merge `task.usage` with a single assistant `message.usage`.

- **Message selection**: Replaced `_final_assistant_answer()` with `_final_assistant_message()`, which returns the full assistant message dict (containing `blocks`, `content`, `usage`) rather than just the answer text.

- **Projection contract fixtures** (new):
  - `dataagent/contracts/sdk-block-projection/cases.json` — shared golden test cases encoding `records → expected canonical blocks`.
  - `dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py` — backend contract test locking `_project_sdk_records` output.
  - `dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js` — frontend contract test locking `v2StreamParser.processV2Record` output.
  - Both normalize to a canonical shape and assert against the same fixtures, ensuring the two remaining projection implementations (backend and frontend) cannot silently diverge.

- **Test updates**: Removed `/events` endpoint handlers from test fakes; updated `_poll_task`, `_summarize_tool_events`, and full HTTP scenario tests to work with the new message-blocks interface.

## Implementation Details

- The projected blocks are already in render order; no re-sequencing is needed.
- Empty `thinking` and `main_text` blocks are dropped during canonicalization.
- SQL extraction now reads structured `input`/`output` fields in `tool_use` blocks, plus fenced ```sql blocks in the final answer.
- Chart extraction searches `tool_use` input/output for `chart`, `chart_spec`, `echarts`, or `spec` keys.
- No change to final-answer sourcing, judge call, scoring gates, or report shape.

## Design Document

See `docs/design/2026-06-04-eval-chatv2-interface-design.md` for full rationale, interface changes, and risk analysis.

https://claude.ai/code/session_01QAk1o7n8qvrWPMchBi6PPs