### PR TITLE
Use runtime config for provider settings instead of admin API

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -358,7 +358,7 @@ const route = useRoute()
 const router = useRouter()
 
 const api = createNl2SqlApiClient({ timeout: 300000 })
-const { topicApi, adminApi, agentApi } = api
+const { topicApi, agentApi } = api
 
 // ── State ────────────────────────────────────────────────────────────────────
 const agents = ref([])
@@ -385,6 +385,7 @@ const {
   availableModels, canSend, isBusy: isStreaming, activeTaskId,
   thinkingExpanded, toggleThinking,
   send: engineSend, cancel: engineCancel, detach,
+  loadConfig,
 } = chat
 const { handleCopyMessage, toggleMessageFeedback } = useChatMessageActions({
   api,
@@ -608,18 +609,17 @@ function focusMessage(messageId) {
 // ── Data loading ───────────────────────────────────────────────────────────
 async function loadSettings() {
   try {
-    const data = await adminApi.getSettings()
-    settings.providers = Array.isArray(data?.providers) ? data.providers : []
-    settings.default_provider_id = String(data?.default_provider_id || '')
-    settings.default_model = String(data?.default_model || '')
-    // Mirror into the engine so its model-validity guard sees real providers.
-    providers.value = settings.providers
-    defaultProviderId.value = settings.default_provider_id
-    defaultModel.value = settings.default_model
-    if (!selectedModel.value) {
-      selectedProvider.value = settings.default_provider_id
-      selectedModel.value = settings.default_model
-    }
+    // Use the runtime-config path: it returns only enabled providers and a
+    // default already repaired to an enabled provider/model. Deriving the
+    // default from admin settings instead would surface disabled providers
+    // and a stale default pointing at a provider the user has not enabled.
+    const config = await loadConfig()
+    const enabledProviders = Array.isArray(config?.providers)
+      ? config.providers.filter((p) => p?.enabled !== false && Array.isArray(p?.models) && p.models.length)
+      : []
+    settings.providers = enabledProviders
+    settings.default_provider_id = defaultProviderId.value
+    settings.default_model = defaultModel.value
   } catch {
     // non-fatal
   }


### PR DESCRIPTION
## Summary
Refactored the settings loading logic to use the runtime configuration endpoint (`loadConfig()`) instead of the admin API. This ensures only enabled providers are displayed and prevents stale default provider/model selections.

## Key Changes
- Removed `adminApi` from the destructured API client (no longer needed)
- Added `loadConfig` to the destructured chat engine exports
- Replaced `adminApi.getSettings()` call with `loadConfig()` in `loadSettings()`
- Added filtering to only include enabled providers with available models
- Simplified settings assignment to use values already set by `loadConfig()`

## Implementation Details
The runtime config endpoint provides a better source of truth for provider settings because it:
- Returns only enabled providers (filters out disabled ones)
- Ensures the default provider/model selection points to an enabled provider
- Prevents surfacing stale defaults that may reference disabled providers

This change improves the user experience by preventing selection of unavailable providers and ensures consistency between the UI state and actual available options.

https://claude.ai/code/session_01J49NxQxywkQNgpFiBFmW2B