### PR TITLE
feat(dataagent): isolate task execution by topic workspace

### DIFF
--- a/dataagent/dataagent-backend/Dockerfile.runner
+++ b/dataagent/dataagent-backend/Dockerfile.runner
@@ -3,14 +3,13 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV HOME=/tmp/dataagent-home
-ENV DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills
 ENV DATAAGENT_SANDBOX_ROOT=/tmp/dataagent-home/.dataagent/runtime/topics
 
 WORKDIR /app/dataagent-backend
 
 COPY dataagent/dataagent-backend/requirements.txt /tmp/requirements.txt
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl docker.io \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN mkdir -p /tmp/dataagent-home && chmod 1777 /tmp/dataagent-home
@@ -19,6 +18,6 @@ COPY dataagent/dataagent-backend /app/dataagent-backend
 COPY dataagent/.claude /app/.claude
 RUN chmod +x /app/.claude/skills/opendataworks-platform-tools/bin/odw-cli
 
-EXPOSE 8900
+EXPOSE 8910
 
-CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8900"]
+CMD ["uvicorn", "sandbox_runner_main:app", "--host", "0.0.0.0", "--port", "8910"]

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -83,6 +83,16 @@ class Settings(BaseSettings):
     dataagent_portal_mcp_token: str = ""
     dataagent_portal_mcp_token_header_name: str = "X-Portal-MCP-Token"
 
+    # ---- Topic workspace / sandbox ----
+    dataagent_sandbox_mode: str = ""
+    dataagent_sandbox_runner_url: str = ""
+    dataagent_sandbox_root: str = ""
+    dataagent_sandbox_host_root: str = ""
+    dataagent_sandbox_image: str = ""
+    dataagent_sandbox_backend: str = "docker"
+    dataagent_sandbox_network: str = ""
+    dataagent_sandbox_host_skills_dir: str = ""
+
     # ---- 运行策略 ----
     max_few_shot_examples: int = 5
     max_schema_tables: int = 10

--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -233,7 +233,7 @@ def normalize_agent_profile_payload(
 
 
 def build_agent_snapshot(profile: dict[str, Any]) -> dict[str, Any]:
-    return {
+    snapshot = {
         "agent_id": str(profile.get("agent_id") or DEFAULT_AGENT_ID),
         "name": str(profile.get("name") or DEFAULT_AGENT_NAME),
         "description": str(profile.get("description") or ""),
@@ -245,10 +245,13 @@ def build_agent_snapshot(profile: dict[str, Any]) -> dict[str, Any]:
         "max_turns": int(profile.get("max_turns") or 0),
         "env_vars": _validate_env_vars(profile.get("env_vars") or {}),
         "data_scope": normalize_data_scope(profile.get("data_scope") or {}),
-        "preset_questions": _validate_preset_questions(profile.get("preset_questions") or []),
         "is_default": bool(profile.get("is_default")),
         "is_builtin": bool(profile.get("is_builtin")),
     }
+    preset_questions = _validate_preset_questions(profile.get("preset_questions") or [])
+    if preset_questions:
+        snapshot["preset_questions"] = preset_questions
+    return snapshot
 
 
 def agent_summary_from_snapshot(snapshot: dict[str, Any] | None) -> dict[str, Any]:

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import logging
 import os
+import asyncio
 import inspect
+import json
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, AsyncIterator, Awaitable, Callable
 
 import anyio
+import httpx
 
 from config import get_settings
 from core.claude_cli import resolve_claude_cli_path
@@ -33,14 +36,14 @@ from core.agent_runtime import (
     _result_subtype_to_reason,
     _safe_base_url,
     _safe_stringify,
-    prepare_enabled_skills_project_cwd,
     resolve_agent_skill_runtime,
     resolve_enabled_skill_runtime,
     resolve_runtime_provider_selection,
 )
-from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, resolved_agent_workdir
+from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot
 from core.sdk_block_writer import SdkBlockWriter
 from core.topic_task_store import get_topic_task_store
+from core.topic_workspace import prepare_topic_workspace
 
 logger = logging.getLogger(__name__)
 
@@ -757,6 +760,114 @@ async def execute_task_stream(
     is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
 ) -> TaskExecutionResult:
     cfg = get_settings()
+    if _should_use_sandbox_runner(cfg):
+        return await _execute_task_stream_via_runner(
+            params,
+            emit=emit,
+            is_cancel_requested=is_cancel_requested,
+        )
+
+    return await _execute_task_stream_local(
+        params,
+        emit=emit,
+        is_cancel_requested=is_cancel_requested,
+    )
+
+
+def _should_use_sandbox_runner(cfg: Any) -> bool:
+    return bool(str(getattr(cfg, "dataagent_sandbox_mode", "") or "").strip())
+
+
+async def _execute_task_stream_via_runner(
+    params: TaskExecutionInput,
+    *,
+    emit: Callable[[dict[str, Any]], Awaitable[None] | None],
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+) -> TaskExecutionResult:
+    cfg = get_settings()
+    runner_url = str(getattr(cfg, "dataagent_sandbox_runner_url", "") or "").strip().rstrip("/")
+    if not runner_url:
+        raise RuntimeError("DATAAGENT_SANDBOX_RUNNER_URL is required when DATAAGENT_SANDBOX_MODE is enabled")
+
+    endpoint = f"{runner_url}/internal/sandbox/runs"
+    payload = asdict(params)
+    cancel_sent = False
+    stream_done = False
+
+    async def _cancelled() -> bool:
+        if is_cancel_requested is None:
+            return False
+        result = is_cancel_requested()
+        if inspect.isawaitable(result):
+            return bool(await result)
+        return bool(result)
+
+    async def _emit(record: dict[str, Any]) -> None:
+        result = emit(record)
+        if inspect.isawaitable(result):
+            await result
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        async def _watch_cancel() -> None:
+            nonlocal cancel_sent
+            while not stream_done:
+                if not cancel_sent and await _cancelled():
+                    cancel_sent = True
+                    await client.post(f"{runner_url}/internal/sandbox/runs/{params.task_id}/cancel", json={"task_id": params.task_id})
+                    return
+                await asyncio.sleep(0.25)
+
+        cancel_task = asyncio.create_task(_watch_cancel())
+        try:
+            async with client.stream("POST", endpoint, json=payload) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not str(line or "").strip():
+                        continue
+                    message = json.loads(line)
+                    message_type = str(message.get("type") or "")
+                    if message_type == "record":
+                        record = message.get("record") or {}
+                        if isinstance(record, dict):
+                            await _emit(record)
+                        continue
+                    if message_type == "result":
+                        result_payload = message.get("result") or {}
+                        if not isinstance(result_payload, dict):
+                            break
+                        return TaskExecutionResult(
+                            task_status=str(result_payload.get("task_status") or "error"),
+                            content=str(result_payload.get("content") or ""),
+                            usage=result_payload.get("usage") if isinstance(result_payload.get("usage"), dict) else None,
+                            error=result_payload.get("error") if isinstance(result_payload.get("error"), dict) else None,
+                            provider_id=str(result_payload.get("provider_id") or ""),
+                            model=str(result_payload.get("model") or ""),
+                            session_id=str(result_payload.get("session_id") or ""),
+                        )
+        finally:
+            stream_done = True
+            cancel_task.cancel()
+            try:
+                await cancel_task
+            except asyncio.CancelledError:
+                pass
+
+    return TaskExecutionResult(
+        task_status="error",
+        content="sandbox runner stream ended without a result",
+        error={"code": "sandbox_runner_no_result", "message": "sandbox runner stream ended without a result"},
+        provider_id=params.provider_id,
+        model=params.model,
+    )
+
+
+async def _execute_task_stream_local(
+    params: TaskExecutionInput,
+    *,
+    emit: Callable[[dict[str, Any]], Awaitable[None] | None],
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+) -> TaskExecutionResult:
+    cfg = get_settings()
     runtime_target = resolve_runtime_provider_selection(params.provider_id, params.model)
     provider_id = _normalize_provider_id(runtime_target.get("provider_id"), runtime_target.get("base_url"))
     supports_partial_messages = bool(
@@ -834,17 +945,25 @@ async def execute_task_stream(
         os.environ[key] = value
 
     enabled_folders = skill_runtime.get("enabled_folders") or []
-    if agent_snapshot:
-        project_cwd = prepare_enabled_skills_project_cwd(
-            enabled_folders,
-            runtime_project_cwd=resolved_agent_workdir(
-                str(agent_snapshot.get("agent_id") or ""),
-                is_default=bool(agent_snapshot.get("is_default")),
-            ),
-            allow_empty=True,
-        )
-    else:
-        project_cwd = prepare_enabled_skills_project_cwd(enabled_folders)
+    prepared_workspace_dir = ""
+    if str(os.environ.get("DATAAGENT_WORKSPACE_PREPARED") or "").strip() == "1":
+        prepared_workspace_dir = str(os.environ.get("DATAAGENT_WORKSPACE_DIR") or "").strip()
+    skill_link_root = str(os.environ.get("DATAAGENT_SKILL_LINK_ROOT") or "").strip() or None
+    project_cwd = prepare_topic_workspace(
+        params.topic_id,
+        enabled_folders,
+        allow_empty=bool(agent_snapshot) or not enabled_folders,
+        skill_link_root=skill_link_root,
+        workspace_dir=prepared_workspace_dir or None,
+    )
+    workspace_env = {
+        "HOME": str(project_cwd),
+        "PWD": str(project_cwd),
+        "DATAAGENT_WORKSPACE_DIR": str(project_cwd),
+    }
+    runtime_env.update(workspace_env)
+    for key, value in workspace_env.items():
+        os.environ[key] = value
     permission_mode = _resolve_sdk_permission_mode(str((agent_snapshot or {}).get("permission_mode") or "inherit"))
     max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -11,6 +11,7 @@ import pymysql
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, agent_summary_from_snapshot, default_agent_payload, normalize_agent_snapshot
+from core.topic_workspace import delete_topic_workspace
 
 logger = logging.getLogger(__name__)
 
@@ -895,6 +896,10 @@ class TopicTaskStore:
             conn.commit()
         finally:
             conn.close()
+        try:
+            delete_topic_workspace(topic_id)
+        except Exception as exc:
+            logger.warning("Failed to delete topic workspace topic_id=%s error=%s", topic_id, exc)
 
     def list_topic_messages(self, topic_id: str) -> list[dict[str, Any]]:
         self._ensure_ready()

--- a/dataagent/dataagent-backend/core/topic_workspace.py
+++ b/dataagent/dataagent-backend/core/topic_workspace.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+
+from config import get_settings
+from core.skill_discovery import SkillDiscoveryError, resolve_skill_discovery_root_dir
+
+
+def _backend_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _safe_topic_id(topic_id: str) -> str:
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(topic_id or "").strip()).strip(".-")
+    if not safe_id:
+        raise ValueError("topic_id is required")
+    return safe_id
+
+
+def sanitize_topic_id(topic_id: str) -> str:
+    return _safe_topic_id(topic_id)
+
+
+def _resolve_sandbox_root(raw: str | None = None) -> Path:
+    value = str(raw or "").strip()
+    if value:
+        path = Path(value).expanduser()
+        if path.is_absolute():
+            return path.resolve()
+        return (_backend_root() / path).resolve()
+
+    home = Path(os.environ.get("HOME") or str(Path.home())).expanduser()
+    return (home / ".dataagent" / "runtime" / "topics").resolve()
+
+
+def resolve_topic_workspace(topic_id: str, *, sandbox_root: str | Path | None = None) -> Path:
+    root = Path(sandbox_root).expanduser().resolve() if sandbox_root else _resolve_sandbox_root(get_settings().dataagent_sandbox_root)
+    return root / _safe_topic_id(topic_id)
+
+
+def _replace_path_with_symlink(link_path: Path, target: Path) -> None:
+    if link_path.is_symlink():
+        current = Path(os.readlink(link_path))
+        if current == target:
+            return
+        link_path.unlink()
+    elif link_path.exists():
+        if link_path.is_file():
+            link_path.unlink()
+        else:
+            shutil.rmtree(link_path)
+
+    os.symlink(target, link_path, target_is_directory=True)
+
+
+def prepare_topic_workspace(
+    topic_id: str,
+    enabled_folders: list[str] | tuple[str, ...],
+    *,
+    allow_empty: bool = False,
+    skill_link_root: str | Path | None = None,
+    sandbox_root: str | Path | None = None,
+    workspace_dir: str | Path | None = None,
+) -> Path:
+    workspace = Path(workspace_dir).expanduser().resolve() if workspace_dir else resolve_topic_workspace(topic_id, sandbox_root=sandbox_root)
+    runtime_skills_dir = workspace / ".claude" / "skills"
+    runtime_skills_dir.mkdir(parents=True, exist_ok=True)
+
+    discovery_root = resolve_skill_discovery_root_dir()
+    enabled = [str(folder or "").strip() for folder in enabled_folders if str(folder or "").strip()]
+    if not enabled and not allow_empty:
+        raise SkillDiscoveryError("no enabled skills configured")
+
+    enabled_set = set(enabled)
+    for existing in runtime_skills_dir.iterdir():
+        if existing.name in enabled_set:
+            continue
+        if existing.is_symlink() or existing.is_file():
+            existing.unlink()
+        else:
+            shutil.rmtree(existing)
+
+    container_link_root = Path(skill_link_root) if skill_link_root else None
+    for folder in enabled:
+        source = (discovery_root / folder).resolve()
+        if not source.is_dir():
+            raise SkillDiscoveryError(f"enabled skill folder not found: {folder}")
+        if not (source / "SKILL.md").is_file():
+            raise SkillDiscoveryError(f"enabled skill missing SKILL.md: {folder}")
+
+        target = container_link_root / folder if container_link_root else source
+        _replace_path_with_symlink(runtime_skills_dir / folder, target)
+
+    return workspace
+
+
+def delete_topic_workspace(topic_id: str, *, sandbox_root: str | Path | None = None) -> bool:
+    workspace = resolve_topic_workspace(topic_id, sandbox_root=sandbox_root)
+    if not workspace.exists():
+        return False
+    shutil.rmtree(workspace)
+    return True
+
+
+def cleanup_orphan_topic_workspaces(
+    active_topic_ids: set[str] | list[str] | tuple[str, ...],
+    *,
+    sandbox_root: str | Path | None = None,
+) -> list[str]:
+    root = Path(sandbox_root).expanduser().resolve() if sandbox_root else _resolve_sandbox_root(get_settings().dataagent_sandbox_root)
+    if not root.is_dir():
+        return []
+
+    active = {_safe_topic_id(str(topic_id)) for topic_id in active_topic_ids if str(topic_id or "").strip()}
+    removed: list[str] = []
+    for child in root.iterdir():
+        if not child.is_dir() or child.name in active:
+            continue
+        shutil.rmtree(child)
+        removed.append(child.name)
+    return sorted(removed)

--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -32,6 +32,8 @@
 - 不把模糊业务词直接映射为确定字段，除非已有明确依据；
 - 不执行有副作用的操作；
 - 不绕过既定的数据访问和权限约束；
+- 文件读写只在当前会话工作区 `/workspace` 内进行；不要访问 `/tmp/dataagent-home`、宿主 HOME、其他会话目录或父级目录；
+- `.claude/` 是运行时状态目录，仅用于 SDK 会话和已启用 Skills，不作为业务文件读写区；
 - 如果上下文不足以完成查询，先提澄清问题；
 - 如果工具返回失败、无结果或冲突信息，要显式说明，不要伪造成功结果。
 
@@ -154,7 +156,6 @@
   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|pie|table> --data '<JSON rows>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>]
   ```
   `build_chart_spec.py` 不是一个独立注册的工具名，它是一个通过 Bash 工具执行的脚本。不要尝试直接调用名为 `build_chart_spec` 的工具。
-- **严禁把 `chart_spec` JSON（或 ```chart、`<chart_spec>` 代码块）直接写进回答正文。图表只能由 Bash 调用 `build_chart_spec.py` 脚本产出，前端只渲染来自该工具调用的图表；写进正文的 chart_spec 既不会被渲染，也会被丢弃。**
 - 即便你已经知道图表数据，也必须实际通过 Bash 工具调用 `build_chart_spec.py` 脚本，而不是凭记忆把契约 JSON 输出到文本里；
 - 禁止以任何形式输出 ASCII 图表（包括 `|`, `-`, `*`, `#` 等字符拼成的表格图或条形图）作为图表的替代；
 - 图表契约必须基于真实查询结果构建，不得捏造数据点；

--- a/dataagent/dataagent-backend/requirements.txt
+++ b/dataagent/dataagent-backend/requirements.txt
@@ -1,6 +1,7 @@
 alembic>=1.13.0
 claude-agent-sdk>=0.1.50
 fastapi>=0.110.0
+httpx>=0.27.0
 uvicorn[standard]>=0.27.0
 pymysql>=1.1.0
 cryptography>=42.0.0

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import os
+import re
+import subprocess
+from contextlib import asynccontextmanager
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+from config import get_settings
+from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
+from core.topic_workspace import resolve_topic_workspace, sanitize_topic_id
+
+logger = logging.getLogger(__name__)
+
+
+SANDBOX_CONTAINER_LABEL = "dataagent.sandbox.managed_by"
+SANDBOX_CONTAINER_LABEL_VALUE = "dataagent-sandbox-runner"
+SANDBOX_TASK_ID_LABEL = "dataagent.sandbox.task_id"
+SANDBOX_TOPIC_ID_LABEL = "dataagent.sandbox.topic_id"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    await _cleanup_stale_sandbox_containers()
+    yield
+
+
+app = FastAPI(
+    title="DataAgent Sandbox Runner",
+    description="Internal DataAgent sandbox execution runner",
+    version="1.2.0",
+    lifespan=lifespan,
+)
+
+CANCELLED_TASK_IDS: set[str] = set()
+RUNNING_CONTAINERS: dict[str, tuple[str, str]] = {}
+RUNNING_CONTAINERS_LOCK = asyncio.Lock()
+
+_FORWARDED_ENV_PREFIXES = (
+    "AGENT_",
+    "ANTHROPIC_",
+    "ANYROUTER_",
+    "CLAUDE_",
+    "DATAAGENT_PORTAL_",
+    "DORIS_",
+    "MYSQL_",
+    "ODW_",
+    "OPENAI_",
+    "OPENROUTER_",
+    "SESSION_",
+)
+_FORWARDED_ENV_KEYS = {
+    "PATH",
+    "TZ",
+    "PYTHONPATH",
+    "DATAAGENT_RUNTIME_PROJECT_CWD",
+    "DATAAGENT_SKILLS_OUTPUT_DIR",
+}
+
+
+@app.get("/")
+async def root():
+    return {"service": "dataagent-sandbox-runner", "version": "1.2.0"}
+
+
+@app.post("/internal/sandbox/runs")
+async def run_sandbox_task(payload: dict[str, Any]):
+    params = TaskExecutionInput(**payload)
+
+    async def stream():
+        queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+
+        async def emit(record: dict[str, Any]) -> None:
+            await queue.put({"type": "record", "record": record})
+
+        async def is_cancel_requested() -> bool:
+            return params.task_id in CANCELLED_TASK_IDS
+
+        async def execute() -> None:
+            try:
+                if _should_use_container_backend():
+                    result = await _execute_task_stream_container(
+                        params,
+                        emit=emit,
+                        is_cancel_requested=is_cancel_requested,
+                    )
+                else:
+                    result = await _execute_task_stream_local(
+                        params,
+                        emit=emit,
+                        is_cancel_requested=is_cancel_requested,
+                    )
+            except Exception as exc:
+                logger.exception("sandbox runner task crashed task_id=%s", params.task_id)
+                result = TaskExecutionResult(
+                    task_status="error",
+                    content=str(exc),
+                    error={"code": "sandbox_runner_error", "message": str(exc)},
+                    provider_id=params.provider_id,
+                    model=params.model,
+                )
+            finally:
+                CANCELLED_TASK_IDS.discard(params.task_id)
+
+            await queue.put({"type": "result", "result": asdict(result)})
+            await queue.put(None)
+
+        task = asyncio.create_task(execute(), name=f"sandbox-runner-{params.task_id}")
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    break
+                yield json.dumps(item, ensure_ascii=False) + "\n"
+            await task
+        finally:
+            if not task.done():
+                task.cancel()
+
+    return StreamingResponse(stream(), media_type="application/x-ndjson")
+
+
+@app.post("/internal/sandbox/runs/{task_id}/cancel")
+async def cancel_sandbox_task(task_id: str, payload: dict[str, Any] | None = None):
+    normalized_task_id = str(task_id or "")
+    CANCELLED_TASK_IDS.add(normalized_task_id)
+    async with RUNNING_CONTAINERS_LOCK:
+        running = RUNNING_CONTAINERS.get(normalized_task_id)
+    if running:
+        backend, container_name = running
+        await _kill_container(backend, container_name)
+    return {"accepted": True, "task_id": task_id}
+
+
+def _should_use_container_backend() -> bool:
+    cfg = get_settings()
+    backend = str(getattr(cfg, "dataagent_sandbox_backend", "") or "").strip().lower()
+    image = str(getattr(cfg, "dataagent_sandbox_image", "") or "").strip()
+    return backend in {"docker", "podman"} and bool(image)
+
+
+def _safe_container_fragment(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip(".-")
+    return safe or "task"
+
+
+def _host_sandbox_root() -> Path:
+    cfg = get_settings()
+    raw = str(getattr(cfg, "dataagent_sandbox_host_root", "") or "").strip()
+    if not raw:
+        raw = str(getattr(cfg, "dataagent_sandbox_root", "") or "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return resolve_topic_workspace("_placeholder_").parent
+
+
+def _topic_host_workspace(topic_id: str) -> Path:
+    return _host_sandbox_root() / sanitize_topic_id(topic_id)
+
+
+def _build_child_env(*, skill_link_root: str) -> dict[str, str]:
+    child_env = {
+        key: str(value)
+        for key, value in os.environ.items()
+        if key in _FORWARDED_ENV_KEYS or any(key.startswith(prefix) for prefix in _FORWARDED_ENV_PREFIXES)
+    }
+    child_env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "HOME": "/workspace",
+            "PWD": "/workspace",
+            "DATAAGENT_WORKSPACE_DIR": "/workspace",
+            "DATAAGENT_WORKSPACE_PREPARED": "1",
+            "DATAAGENT_SKILL_LINK_ROOT": skill_link_root,
+            "DATAAGENT_SANDBOX_MODE": "",
+            "DATAAGENT_SANDBOX_ROOT": "/workspace",
+        }
+    )
+    return child_env
+
+
+def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list[str]]:
+    cfg = get_settings()
+    backend = str(getattr(cfg, "dataagent_sandbox_backend", "") or "docker").strip().lower()
+    image = str(getattr(cfg, "dataagent_sandbox_image", "") or "").strip()
+    if backend not in {"docker", "podman"}:
+        raise RuntimeError(f"unsupported sandbox backend: {backend}")
+    if not image:
+        raise RuntimeError("DATAAGENT_SANDBOX_IMAGE is required for container sandbox backend")
+
+    topic_workspace = _topic_host_workspace(params.topic_id)
+    topic_workspace.mkdir(parents=True, exist_ok=True)
+    _ensure_topic_workspace_owner(topic_workspace)
+    container_name = (
+        f"dataagent-task-{_safe_container_fragment(params.topic_id)[:32]}-"
+        f"{_safe_container_fragment(params.task_id)[:32]}"
+    )
+
+    host_skills_dir = str(getattr(cfg, "dataagent_sandbox_host_skills_dir", "") or "").strip()
+    skill_link_root = "/skills" if host_skills_dir else "/app/.claude/skills"
+    child_env = _build_child_env(skill_link_root=skill_link_root)
+
+    command = [
+        backend,
+        "run",
+        "--rm",
+        "--interactive",
+        "--name",
+        container_name,
+        "--label",
+        f"{SANDBOX_CONTAINER_LABEL}={SANDBOX_CONTAINER_LABEL_VALUE}",
+        "--label",
+        f"{SANDBOX_TASK_ID_LABEL}={_safe_container_fragment(params.task_id)}",
+        "--label",
+        f"{SANDBOX_TOPIC_ID_LABEL}={sanitize_topic_id(params.topic_id)}",
+        "--workdir",
+        "/workspace",
+        "--mount",
+        f"type=bind,source={topic_workspace},target=/workspace",
+    ]
+    network = str(getattr(cfg, "dataagent_sandbox_network", "") or "").strip()
+    if network:
+        command.extend(["--network", network])
+    uid = str(os.environ.get("DATAAGENT_RUNTIME_UID") or "").strip()
+    gid = str(os.environ.get("DATAAGENT_RUNTIME_GID") or "").strip()
+    if uid and gid:
+        command.extend(["--user", f"{uid}:{gid}"])
+    if host_skills_dir:
+        command.extend(
+            [
+                "--mount",
+                f"type=bind,source={Path(host_skills_dir).expanduser().resolve()},target=/skills,readonly",
+            ]
+        )
+    for key, value in sorted(child_env.items()):
+        command.extend(["--env", f"{key}={value}"])
+    command.extend([image, "python", "/app/dataagent-backend/sandbox_task_main.py"])
+    return backend, container_name, command
+
+
+def _ensure_topic_workspace_owner(topic_workspace: Path) -> None:
+    uid = str(os.environ.get("DATAAGENT_RUNTIME_UID") or "").strip()
+    gid = str(os.environ.get("DATAAGENT_RUNTIME_GID") or "").strip()
+    if not uid or not gid:
+        return
+    try:
+        os.chown(topic_workspace, int(uid), int(gid))
+        os.chmod(topic_workspace, 0o775)
+    except PermissionError:
+        logger.warning("cannot chown topic workspace path=%s uid=%s gid=%s", topic_workspace, uid, gid)
+    except ValueError:
+        logger.warning("invalid DATAAGENT_RUNTIME_UID/GID uid=%s gid=%s", uid, gid)
+
+
+async def _execute_task_stream_container(
+    params: TaskExecutionInput,
+    *,
+    emit: Callable[[dict[str, Any]], Awaitable[None]],
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+) -> TaskExecutionResult:
+    backend, container_name, command = _build_container_command(params)
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stderr_task: asyncio.Task[Any] | None = None
+    cancel_task: asyncio.Task[Any] | None = None
+    result: TaskExecutionResult | None = None
+    returncode: int | None = None
+    try:
+        await _send_payload_to_child(process, params)
+        async with RUNNING_CONTAINERS_LOCK:
+            RUNNING_CONTAINERS[params.task_id] = (backend, container_name)
+
+        stderr_task = asyncio.create_task(_log_stderr(process.stderr, params.task_id))
+        cancel_task = asyncio.create_task(_watch_cancel(params.task_id, backend, container_name, process, is_cancel_requested))
+        assert process.stdout is not None
+        async for raw in process.stdout:
+            text = raw.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            try:
+                message = json.loads(text)
+            except json.JSONDecodeError:
+                logger.info("sandbox child stdout task_id=%s %s", params.task_id, text)
+                continue
+            message_type = str(message.get("type") or "")
+            if message_type == "record":
+                record = message.get("record") or {}
+                if isinstance(record, dict):
+                    await emit(record)
+                continue
+            if message_type == "result":
+                result_payload = message.get("result") or {}
+                if isinstance(result_payload, dict):
+                    result = _result_from_payload(result_payload, params)
+        returncode = await process.wait()
+    finally:
+        if process.returncode is None:
+            await _kill_container(backend, container_name)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                logger.warning("sandbox process did not exit after kill task_id=%s", params.task_id)
+        if cancel_task is not None:
+            cancel_task.cancel()
+            await _await_cancelled(cancel_task)
+        if stderr_task is not None:
+            await _await_cancelled(stderr_task)
+        async with RUNNING_CONTAINERS_LOCK:
+            RUNNING_CONTAINERS.pop(params.task_id, None)
+
+    if result is not None:
+        return result
+    if params.task_id in CANCELLED_TASK_IDS:
+        return TaskExecutionResult(
+            task_status="suspended",
+            content="task cancelled",
+            error={"code": "cancelled", "message": "task cancelled"},
+            provider_id=params.provider_id,
+            model=params.model,
+        )
+    return TaskExecutionResult(
+        task_status="error",
+        content=f"sandbox container exited without a result: {returncode}",
+        error={"code": "sandbox_container_no_result", "message": f"sandbox container exited without a result: {returncode}"},
+        provider_id=params.provider_id,
+        model=params.model,
+    )
+
+
+async def _send_payload_to_child(process: asyncio.subprocess.Process, params: TaskExecutionInput) -> None:
+    if process.stdin is None:
+        raise RuntimeError("sandbox container stdin is not available")
+    process.stdin.write(json.dumps(asdict(params), ensure_ascii=False).encode("utf-8"))
+    await process.stdin.drain()
+    process.stdin.close()
+
+
+async def _watch_cancel(
+    task_id: str,
+    backend: str,
+    container_name: str,
+    process: asyncio.subprocess.Process,
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+) -> None:
+    while process.returncode is None:
+        if await _is_cancelled(task_id, is_cancel_requested):
+            await _kill_container(backend, container_name)
+            return
+        await asyncio.sleep(0.25)
+
+
+async def _is_cancelled(
+    task_id: str,
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+) -> bool:
+    if task_id in CANCELLED_TASK_IDS:
+        return True
+    if is_cancel_requested is None:
+        return False
+    result = is_cancel_requested()
+    if inspect.isawaitable(result):
+        return bool(await result)
+    return bool(result)
+
+
+async def _kill_container(backend: str, container_name: str) -> None:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            backend,
+            "kill",
+            container_name,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        await process.wait()
+    except FileNotFoundError:
+        logger.warning("sandbox backend command not found: %s", backend)
+    except Exception:
+        logger.exception("failed to kill sandbox container name=%s", container_name)
+
+
+async def _cleanup_stale_sandbox_containers() -> None:
+    if not _should_use_container_backend():
+        return
+    cfg = get_settings()
+    backend = str(getattr(cfg, "dataagent_sandbox_backend", "") or "docker").strip().lower()
+    label_filter = f"label={SANDBOX_CONTAINER_LABEL}={SANDBOX_CONTAINER_LABEL_VALUE}"
+    try:
+        ps_process = await asyncio.create_subprocess_exec(
+            backend,
+            "ps",
+            "-aq",
+            "--filter",
+            label_filter,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        logger.warning("sandbox backend command not found during startup cleanup: %s", backend)
+        return
+
+    stdout, stderr = await ps_process.communicate()
+    if ps_process.returncode != 0:
+        logger.warning(
+            "sandbox startup cleanup list failed backend=%s stderr=%s",
+            backend,
+            stderr.decode("utf-8", errors="replace").strip(),
+        )
+        return
+
+    container_ids = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
+    if not container_ids:
+        return
+
+    rm_process = await asyncio.create_subprocess_exec(
+        backend,
+        "rm",
+        "-f",
+        *container_ids,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, rm_stderr = await rm_process.communicate()
+    if rm_process.returncode == 0:
+        logger.info("removed stale sandbox task containers count=%s", len(container_ids))
+        return
+    logger.warning(
+        "sandbox startup cleanup remove failed backend=%s stderr=%s",
+        backend,
+        rm_stderr.decode("utf-8", errors="replace").strip(),
+    )
+
+
+async def _log_stderr(stream: asyncio.StreamReader | None, task_id: str) -> None:
+    if stream is None:
+        return
+    async for raw in stream:
+        text = raw.decode("utf-8", errors="replace").rstrip()
+        if text:
+            logger.info("sandbox child stderr task_id=%s %s", task_id, text)
+
+
+async def _await_cancelled(task: asyncio.Task[Any]) -> None:
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def _result_from_payload(payload: dict[str, Any], params: TaskExecutionInput) -> TaskExecutionResult:
+    return TaskExecutionResult(
+        task_status=str(payload.get("task_status") or "error"),
+        content=str(payload.get("content") or ""),
+        usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else None,
+        error=payload.get("error") if isinstance(payload.get("error"), dict) else None,
+        provider_id=str(payload.get("provider_id") or params.provider_id),
+        model=str(payload.get("model") or params.model),
+        session_id=str(payload.get("session_id") or ""),
+    )

--- a/dataagent/dataagent-backend/sandbox_task_main.py
+++ b/dataagent/dataagent-backend/sandbox_task_main.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict
+from typing import Any
+
+from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
+
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logger = logging.getLogger(__name__)
+
+
+def _load_payload() -> dict[str, Any]:
+    raw = str(os.environ.get("DATAAGENT_TASK_PAYLOAD_B64") or "").strip()
+    if raw:
+        return json.loads(base64.b64decode(raw).decode("utf-8"))
+    stdin_payload = sys.stdin.buffer.read()
+    if not stdin_payload:
+        raise RuntimeError("task payload is required on stdin")
+    return json.loads(stdin_payload.decode("utf-8"))
+
+
+async def _main() -> int:
+    params = TaskExecutionInput(**_load_payload())
+
+    async def emit(record: dict[str, Any]) -> None:
+        print(json.dumps({"type": "record", "record": record}, ensure_ascii=False), flush=True)
+
+    try:
+        result = await _execute_task_stream_local(
+            params,
+            emit=emit,
+            is_cancel_requested=lambda: False,
+        )
+    except Exception as exc:
+        logger.exception("sandbox task crashed task_id=%s", params.task_id)
+        result = TaskExecutionResult(
+            task_status="error",
+            content=str(exc),
+            error={"code": "sandbox_task_error", "message": str(exc)},
+            provider_id=params.provider_id,
+            model=params.model,
+        )
+
+    print(json.dumps({"type": "result", "result": asdict(result)}, ensure_ascii=False), flush=True)
+    return 0 if result.task_status != "error" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -352,6 +352,22 @@ def test_workspace_boundary_denies_bash_parent_directory_lookup(tmp_path: Path):
     assert "parent directory" in denial
 
 
+def test_workspace_boundary_denies_shared_dataagent_home_lookup():
+    workspace = Path("/tmp/dataagent-home/.dataagent/runtime/topics/topic_1")
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Read",
+        {"file_path": "/tmp/dataagent-home"},
+        workspace,
+        allowed_roots,
+        {"DATAAGENT_PYTHON_BIN": sys.executable},
+    )
+
+    assert denial is not None
+    assert "outside workspace" in denial
+
+
 def test_workspace_boundary_hook_returns_pretooluse_denial(tmp_path: Path):
     workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
     workspace.mkdir(parents=True)

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -48,11 +48,12 @@ def test_generic_nl2sql_methodology_lives_in_system_prompt_file():
         "mcp__portal__portal_query_readonly",
         "validate_sql.py",
         "run_sql.py",
-        "DATAAGENT_PLATFORM_SKILL_ROOT",
         "tool output contract",
     ]
     for token in forbidden_tokens:
         assert token not in snapshot
+
+    assert '"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py"' in snapshot
 
 
 def test_dataagent_nl2sql_skill_bundle_is_removed():

--- a/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
+++ b/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNNER_DOCKERFILE = REPO_ROOT / "dataagent" / "dataagent-backend" / "Dockerfile.runner"
+
+
+def test_runner_dockerfile_uses_runner_entrypoint():
+    content = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "sandbox_runner_main:app" in content
+    assert 'EXPOSE 8910' in content
+    assert "alembic upgrade head" not in content
+    assert '"main:app"' not in content

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+import sandbox_runner_main
+from config import get_settings, update_settings
+from core.task_executor import TaskExecutionInput
+from core.task_executor import TaskExecutionResult
+
+
+def _payload() -> dict:
+    return {
+        "task_id": "task-1",
+        "topic_id": "topic-1",
+        "question": "hello",
+        "history": [],
+        "resume_session_id": None,
+        "provider_id": "openrouter",
+        "model": "anthropic/claude-sonnet-4.5",
+        "database_hint": None,
+        "debug": False,
+        "timeout_seconds": 60,
+        "sql_read_timeout_seconds": 30,
+        "sql_write_timeout_seconds": 30,
+        "execution_mode": "background",
+        "agent_snapshot": None,
+    }
+
+
+def test_sandbox_runner_streams_records_and_result(monkeypatch):
+    async def fake_execute(params, *, emit, is_cancel_requested=None):
+        assert params.topic_id == "topic-1"
+        await emit({"record_type": "event", "event_type": "DEBUG", "data": {"status": "runner"}})
+        return TaskExecutionResult(
+            task_status="finished",
+            content="runner-api-ok",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            session_id="sdk-session-api",
+        )
+
+    monkeypatch.setattr(sandbox_runner_main, "_execute_task_stream_local", fake_execute)
+
+    client = TestClient(sandbox_runner_main.app)
+    with client.stream("POST", "/internal/sandbox/runs", json=_payload()) as response:
+        assert response.status_code == 200
+        lines = [json.loads(line) for line in response.iter_lines() if line]
+
+    assert lines[0]["type"] == "record"
+    assert lines[0]["record"]["data"]["status"] == "runner"
+    assert lines[-1]["type"] == "result"
+    assert lines[-1]["result"]["content"] == "runner-api-ok"
+    assert lines[-1]["result"]["session_id"] == "sdk-session-api"
+
+
+def test_sandbox_runner_cancel_endpoint_marks_task_cancelled():
+    sandbox_runner_main.CANCELLED_TASK_IDS.clear()
+    client = TestClient(sandbox_runner_main.app)
+
+    response = client.post("/internal/sandbox/runs/task-1/cancel", json={"task_id": "task-1"})
+
+    assert response.status_code == 200
+    assert response.json() == {"accepted": True, "task_id": "task-1"}
+    assert "task-1" in sandbox_runner_main.CANCELLED_TASK_IDS
+
+
+def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatch, tmp_path: Path):
+    settings = get_settings()
+    originals = {
+        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
+        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
+        "dataagent_sandbox_host_root": settings.dataagent_sandbox_host_root,
+        "dataagent_sandbox_root": settings.dataagent_sandbox_root,
+        "dataagent_sandbox_network": settings.dataagent_sandbox_network,
+        "dataagent_sandbox_host_skills_dir": settings.dataagent_sandbox_host_skills_dir,
+    }
+    host_root = tmp_path / "topics"
+    update_settings(
+        {
+            "dataagent_sandbox_backend": "docker",
+            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
+            "dataagent_sandbox_host_root": str(host_root),
+            "dataagent_sandbox_root": str(tmp_path / "container-topics"),
+            "dataagent_sandbox_network": "container:opendataworks-dataagent-sandbox-runner",
+            "dataagent_sandbox_host_skills_dir": "",
+        }
+    )
+    monkeypatch.setenv("MYSQL_HOST", "mysql")
+    monkeypatch.setenv("DATAAGENT_RUNTIME_UID", "1000")
+    monkeypatch.setenv("DATAAGENT_RUNTIME_GID", "1000")
+    try:
+        backend, container_name, command = sandbox_runner_main._build_container_command(TaskExecutionInput(**_payload()))
+    finally:
+        update_settings(originals)
+
+    assert backend == "docker"
+    assert container_name.startswith("dataagent-task-topic-1-task-1")
+    assert host_root / "topic-1" == tmp_path / "topics" / "topic-1"
+    assert (host_root / "topic-1").is_dir()
+    assert f"type=bind,source={host_root / 'topic-1'},target=/workspace" in command
+    assert f"type=bind,source={host_root},target=/workspace" not in command
+    assert "--network" in command
+    assert "container:opendataworks-dataagent-sandbox-runner" in command
+    assert "--interactive" in command
+    assert f"{sandbox_runner_main.SANDBOX_CONTAINER_LABEL}={sandbox_runner_main.SANDBOX_CONTAINER_LABEL_VALUE}" in command
+    assert f"{sandbox_runner_main.SANDBOX_TASK_ID_LABEL}=task-1" in command
+    assert f"{sandbox_runner_main.SANDBOX_TOPIC_ID_LABEL}=topic-1" in command
+    assert "--user" in command
+    assert "1000:1000" in command
+    assert "opendataworks-dataagent-runner:test" in command
+    assert "python" in command
+    assert "/app/dataagent-backend/sandbox_task_main.py" in command
+    assert not any("/var/run/docker.sock" in arg for arg in command)
+
+    env_values = [command[index + 1] for index, item in enumerate(command) if item == "--env"]
+    assert "HOME=/workspace" in env_values
+    assert "PWD=/workspace" in env_values
+    assert "DATAAGENT_WORKSPACE_DIR=/workspace" in env_values
+    assert "DATAAGENT_WORKSPACE_PREPARED=1" in env_values
+    assert "DATAAGENT_SKILL_LINK_ROOT=/app/.claude/skills" in env_values
+    assert not any(value.startswith("DATAAGENT_TASK_PAYLOAD_B64=") for value in env_values)
+
+
+def test_sandbox_runner_startup_cleanup_removes_labeled_stale_containers(monkeypatch):
+    settings = get_settings()
+    originals = {
+        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
+        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
+    }
+    update_settings(
+        {
+            "dataagent_sandbox_backend": "docker",
+            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
+        }
+    )
+    calls: list[tuple[str, ...]] = []
+
+    class FakeProcess:
+        def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+            self.returncode = returncode
+            self._stdout = stdout
+            self._stderr = stderr
+
+        async def communicate(self):
+            return self._stdout, self._stderr
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(tuple(str(arg) for arg in args))
+        if args[:2] == ("docker", "ps"):
+            return FakeProcess(0, stdout=b"container-a\ncontainer-b\n")
+        if args[:2] == ("docker", "rm"):
+            return FakeProcess(0)
+        raise AssertionError(f"unexpected subprocess args: {args}")
+
+    monkeypatch.setattr(sandbox_runner_main.asyncio, "create_subprocess_exec", fake_exec)
+    try:
+        asyncio.run(sandbox_runner_main._cleanup_stale_sandbox_containers())
+    finally:
+        update_settings(originals)
+
+    assert calls[0] == (
+        "docker",
+        "ps",
+        "-aq",
+        "--filter",
+        f"label={sandbox_runner_main.SANDBOX_CONTAINER_LABEL}={sandbox_runner_main.SANDBOX_CONTAINER_LABEL_VALUE}",
+    )
+    assert calls[1] == ("docker", "rm", "-f", "container-a", "container-b")

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys
 from pathlib import Path
@@ -131,11 +132,13 @@ def _patch_skill_runtime(monkeypatch, tmp_path: Path) -> dict[str, list[str]]:
         },
     )
 
-    def fake_prepare_enabled_skills_project_cwd(folders):
+    def fake_prepare_topic_workspace(topic_id, folders, **kwargs):
+        captured["topic_id"] = topic_id
         captured["folders"] = list(folders)
+        captured["kwargs"] = dict(kwargs)
         return tmp_path
 
-    monkeypatch.setattr(task_executor, "prepare_enabled_skills_project_cwd", fake_prepare_enabled_skills_project_cwd)
+    monkeypatch.setattr(task_executor, "prepare_topic_workspace", fake_prepare_topic_workspace)
     return captured
 
 
@@ -290,16 +293,16 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
         },
     )
     _patch_skill_runtime(monkeypatch, tmp_path)
-    agent_cwd = tmp_path / "workspaces" / "agent_1"
+    topic_workspace = tmp_path / "topics" / "topic-1"
     captured: dict[str, object] = {}
 
-    def fake_prepare_enabled_skills_project_cwd(folders, **kwargs):
+    def fake_prepare_topic_workspace(topic_id, folders, **kwargs):
+        captured["topic_id"] = topic_id
         captured["folders"] = list(folders)
         captured["kwargs"] = dict(kwargs)
-        return agent_cwd
+        return topic_workspace
 
-    monkeypatch.setattr(task_executor, "prepare_enabled_skills_project_cwd", fake_prepare_enabled_skills_project_cwd)
-    monkeypatch.setattr(task_executor, "resolved_agent_workdir", lambda agent_id, is_default=False: str(agent_cwd))
+    monkeypatch.setattr(task_executor, "prepare_topic_workspace", fake_prepare_topic_workspace)
 
     async def _run():
         return await task_executor.execute_task_stream(
@@ -325,10 +328,10 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
 
     assert result.task_status == "finished"
     assert result.content == "custom-agent-ok"
+    assert captured["topic_id"] == "topic-1"
     assert captured["folders"] == []
-    assert captured["kwargs"]["runtime_project_cwd"] == str(agent_cwd)
     assert captured["kwargs"]["allow_empty"] is True
-    assert ClaudeAgentOptions.last_kwargs["cwd"] == str(agent_cwd)
+    assert ClaudeAgentOptions.last_kwargs["cwd"] == str(topic_workspace)
     assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read"]
     assert ClaudeAgentOptions.last_kwargs["mcp_servers"] == {}
     assert ClaudeAgentOptions.last_kwargs["max_turns"] == 7
@@ -346,6 +349,170 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     )
     assert blocked["decision"] == "block"
     assert blocked["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_execute_task_stream_uses_topic_workspace_for_sdk_cwd_and_home(monkeypatch, tmp_path: Path):
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            AssistantMessage([TextBlock("topic-workspace-ok")]),
+            ResultMessage("success", session_id="sdk-session-topic"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": provider_id,
+            "model": model,
+            "api_key": "",
+            "auth_token": "",
+            "base_url": "https://example.invalid",
+            "supports_partial_messages": False,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    topic_workspace = tmp_path / "topics" / "topic-1"
+    captured: dict[str, object] = {}
+
+    def fake_prepare_topic_workspace(topic_id, folders, **kwargs):
+        captured["topic_id"] = topic_id
+        captured["folders"] = list(folders)
+        captured["kwargs"] = dict(kwargs)
+        return topic_workspace
+
+    monkeypatch.setattr(task_executor, "prepare_topic_workspace", fake_prepare_topic_workspace)
+
+    async def _run():
+        return await task_executor.execute_task_stream(
+            _build_input(
+                agent_snapshot={
+                    "agent_id": "agent_1",
+                    "name": "自定义智能体",
+                    "permission_mode": "default",
+                    "allowed_tools": ["Read"],
+                    "mcp_server_ids": [],
+                    "skill_folders": [],
+                    "max_turns": 0,
+                    "env_vars": {},
+                    "is_default": False,
+                }
+            ),
+            emit=lambda record: None,
+        )
+
+    result = asyncio.run(_run())
+
+    assert result.content == "topic-workspace-ok"
+    assert captured["topic_id"] == "topic-1"
+    assert captured["folders"] == []
+    assert captured["kwargs"]["allow_empty"] is True
+    assert ClaudeAgentOptions.last_kwargs["cwd"] == str(topic_workspace)
+    assert ClaudeAgentOptions.last_kwargs["env"]["HOME"] == str(topic_workspace)
+    assert ClaudeAgentOptions.last_kwargs["env"]["PWD"] == str(topic_workspace)
+    assert ClaudeAgentOptions.last_kwargs["env"]["DATAAGENT_WORKSPACE_DIR"] == str(topic_workspace)
+
+
+def test_execute_task_stream_delegates_to_sandbox_runner_when_enabled(monkeypatch):
+    from config import get_settings, update_settings
+
+    original_mode = get_settings().dataagent_sandbox_mode
+    update_settings({"dataagent_sandbox_mode": "container"})
+    captured: dict[str, object] = {}
+
+    async def fake_runner(params, *, emit, is_cancel_requested=None):
+        captured["task_id"] = params.task_id
+        captured["topic_id"] = params.topic_id
+        emit({"record_type": "event", "event_type": "DEBUG", "data": {"status": "runner"}})
+        return task_executor.TaskExecutionResult(
+            task_status="finished",
+            content="runner-ok",
+            provider_id="openrouter",
+            model="anthropic/claude-sonnet-4.5",
+            session_id="sdk-session-runner",
+        )
+
+    monkeypatch.setattr(task_executor, "_execute_task_stream_via_runner", fake_runner)
+    emitted: list[dict] = []
+    try:
+        result = asyncio.run(task_executor.execute_task_stream(_build_input(), emit=lambda record: emitted.append(record)))
+    finally:
+        update_settings({"dataagent_sandbox_mode": original_mode})
+
+    assert captured == {"task_id": "task-1", "topic_id": "topic-1"}
+    assert result.content == "runner-ok"
+    assert result.session_id == "sdk-session-runner"
+    assert emitted[-1]["data"]["status"] == "runner"
+
+
+def test_sandbox_runner_client_streams_records_and_returns_result(monkeypatch):
+    from config import get_settings, update_settings
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            yield json.dumps({"type": "record", "record": {"record_type": "event", "event_type": "DEBUG", "data": {"status": "runner"}}})
+            yield json.dumps(
+                {
+                    "type": "result",
+                    "result": {
+                        "task_status": "finished",
+                        "content": "runner-stream-ok",
+                        "usage": {"input_tokens": 1},
+                        "provider_id": "openrouter",
+                        "model": "anthropic/claude-sonnet-4.5",
+                        "session_id": "sdk-session-stream",
+                    },
+                }
+            )
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeResponse()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeClient:
+        last_payload = None
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, *, json):
+            FakeClient.last_payload = {"method": method, "url": url, "json": json}
+            return FakeStreamContext()
+
+    original_url = get_settings().dataagent_sandbox_runner_url
+    update_settings({"dataagent_sandbox_runner_url": "http://runner.local"})
+    monkeypatch.setattr(task_executor.httpx, "AsyncClient", FakeClient)
+    emitted: list[dict] = []
+    try:
+        result = asyncio.run(
+            task_executor._execute_task_stream_via_runner(
+                _build_input(),
+                emit=lambda record: emitted.append(record),
+            )
+        )
+    finally:
+        update_settings({"dataagent_sandbox_runner_url": original_url})
+
+    assert FakeClient.last_payload["method"] == "POST"
+    assert FakeClient.last_payload["url"] == "http://runner.local/internal/sandbox/runs"
+    assert FakeClient.last_payload["json"]["topic_id"] == "topic-1"
+    assert FakeClient.last_payload["json"]["task_id"] == "task-1"
+    assert emitted[-1]["data"]["status"] == "runner"
+    assert result.content == "runner-stream-ok"
+    assert result.usage == {"input_tokens": 1}
+    assert result.session_id == "sdk-session-stream"
 
 
 def test_execute_task_stream_buffers_partial_text_until_turn_end(monkeypatch, tmp_path: Path):
@@ -816,9 +983,10 @@ def test_execute_task_stream_injects_portal_mcp_servers(monkeypatch, tmp_path: P
         lambda: SimpleNamespace(
             claude_model="",
             agent_timeout_seconds=60,
-            agent_background_max_turns=40,
-            agent_max_turns=20,
-            query_result_limit=100,
+                agent_background_max_turns=40,
+                agent_max_turns=20,
+                agent_max_buffer_size_bytes=10 * 1024 * 1024,
+                query_result_limit=100,
             dataagent_portal_mcp_enabled=True,
             dataagent_portal_mcp_base_url="http://portal-mcp:8801/mcp",
             dataagent_portal_mcp_token="portal-token",

--- a/dataagent/dataagent-backend/tests/test_topic_workspace.py
+++ b/dataagent/dataagent-backend/tests/test_topic_workspace.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from config import get_settings, update_settings
+from core.topic_workspace import cleanup_orphan_topic_workspaces, delete_topic_workspace, prepare_topic_workspace, resolve_topic_workspace
+
+
+def _write_skill(root: Path, folder: str) -> None:
+    skill_dir = root / folder
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"# {folder}\n", encoding="utf-8")
+
+
+def test_resolve_topic_workspace_uses_topic_id_only(monkeypatch, tmp_path: Path):
+    original_root = get_settings().dataagent_sandbox_root
+    update_settings({"dataagent_sandbox_root": str(tmp_path / "topics")})
+    try:
+        workspace = resolve_topic_workspace("topic unsafe/id")
+    finally:
+        update_settings({"dataagent_sandbox_root": original_root})
+
+    assert workspace == tmp_path / "topics" / "topic-unsafe-id"
+
+
+def test_prepare_topic_workspace_uses_container_skill_links(monkeypatch, tmp_path: Path):
+    original_root = get_settings().dataagent_sandbox_root
+    original_skills = get_settings().skills_output_dir
+    project = tmp_path / "project"
+    skills_root = project / ".claude" / "skills"
+    _write_skill(skills_root, "opendataworks-business-knowledge")
+    _write_skill(skills_root, "opendataworks-platform-tools")
+    update_settings(
+        {
+            "dataagent_sandbox_root": str(tmp_path / "topics"),
+            "skills_output_dir": str(skills_root / "opendataworks-business-knowledge"),
+        }
+    )
+    try:
+        workspace = prepare_topic_workspace(
+            "topic_1",
+            ["opendataworks-business-knowledge", "opendataworks-platform-tools"],
+            skill_link_root="/skills",
+        )
+    finally:
+        update_settings({"dataagent_sandbox_root": original_root, "skills_output_dir": original_skills})
+
+    skill_link = workspace / ".claude" / "skills" / "opendataworks-business-knowledge"
+    platform_link = workspace / ".claude" / "skills" / "opendataworks-platform-tools"
+    assert workspace == tmp_path / "topics" / "topic_1"
+    assert skill_link.is_symlink()
+    assert platform_link.is_symlink()
+    assert skill_link.readlink() == Path("/skills/opendataworks-business-knowledge")
+    assert platform_link.readlink() == Path("/skills/opendataworks-platform-tools")
+
+
+def test_prepare_topic_workspace_can_use_pre_mounted_workspace(monkeypatch, tmp_path: Path):
+    original_root = get_settings().dataagent_sandbox_root
+    original_skills = get_settings().skills_output_dir
+    project = tmp_path / "project"
+    skills_root = project / ".claude" / "skills"
+    mounted_workspace = tmp_path / "mounted-workspace"
+    _write_skill(skills_root, "opendataworks-business-knowledge")
+    update_settings(
+        {
+            "dataagent_sandbox_root": str(tmp_path / "topics"),
+            "skills_output_dir": str(skills_root / "opendataworks-business-knowledge"),
+        }
+    )
+    try:
+        workspace = prepare_topic_workspace(
+            "topic_1",
+            ["opendataworks-business-knowledge"],
+            skill_link_root="/skills",
+            workspace_dir=mounted_workspace,
+        )
+    finally:
+        update_settings({"dataagent_sandbox_root": original_root, "skills_output_dir": original_skills})
+
+    assert workspace == mounted_workspace.resolve()
+    assert workspace != tmp_path / "topics" / "topic_1"
+    assert (workspace / ".claude" / "skills" / "opendataworks-business-knowledge").readlink() == Path(
+        "/skills/opendataworks-business-knowledge"
+    )
+
+
+def test_delete_topic_workspace_removes_only_topic_directory(tmp_path: Path):
+    root = tmp_path / "topics"
+    workspace = root / "topic_1"
+    sibling = root / "topic_2"
+    (workspace / ".claude").mkdir(parents=True)
+    (sibling / ".claude").mkdir(parents=True)
+
+    deleted = delete_topic_workspace("topic_1", sandbox_root=root)
+
+    assert deleted is True
+    assert not workspace.exists()
+    assert sibling.exists()
+
+
+def test_cleanup_orphan_topic_workspaces_keeps_active_topics(tmp_path: Path):
+    root = tmp_path / "topics"
+    (root / "topic_keep").mkdir(parents=True)
+    (root / "topic_orphan").mkdir(parents=True)
+
+    removed = cleanup_orphan_topic_workspaces({"topic_keep"}, sandbox_root=root)
+
+    assert removed == ["topic_orphan"]
+    assert (root / "topic_keep").exists()
+    assert not (root / "topic_orphan").exists()

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,6 +7,7 @@
 # OPENDATAWORKS_FRONTEND_IMAGE=opendataworks-frontend:1.3.0
 # OPENDATAWORKS_DATAAGENT_FRONTEND_IMAGE=opendataworks-dataagent-frontend:1.3.0
 # OPENDATAWORKS_DATAAGENT_BACKEND_IMAGE=opendataworks-dataagent-backend:1.3.0
+# OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE=opendataworks-dataagent-runner:1.3.0
 # OPENDATAWORKS_DATAAGENT_EVALS_BUILTIN_IMAGE=opendataworks-dataagent-evals-builtin:1.3.0
 # OPENDATAWORKS_DATAAGENT_EVALS_DEEPEVAL_IMAGE=opendataworks-dataagent-evals-deepeval:1.3.0
 # OPENDATAWORKS_PORTAL_MCP_IMAGE=opendataworks-portal-mcp:1.3.0
@@ -70,7 +71,19 @@ DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME=X-Portal-MCP-Token
 # 生产容器默认以非 root 身份运行；如挂载目录权限不匹配，可改成宿主机目录拥有者的 UID/GID
 DATAAGENT_RUNTIME_UID=1000
 DATAAGENT_RUNTIME_GID=1000
+DATAAGENT_RUNNER_UID=0
+DATAAGENT_RUNNER_GID=0
 DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills
+DATAAGENT_HOME_HOST_DIR=/tmp/dataagent-home
+DATAAGENT_SANDBOX_MODE=
+DATAAGENT_SANDBOX_RUNNER_URL=http://dataagent-sandbox-runner:8910
+DATAAGENT_SANDBOX_ROOT=/tmp/dataagent-home/.dataagent/runtime/topics
+DATAAGENT_SANDBOX_HOST_ROOT=/tmp/dataagent-home/.dataagent/runtime/topics
+DATAAGENT_SANDBOX_IMAGE=mikefan2019/opendataworks-dataagent-runner:latest
+DATAAGENT_SANDBOX_BACKEND=docker
+DATAAGENT_SANDBOX_NETWORK=container:opendataworks-dataagent-sandbox-runner
+DATAAGENT_DOCKER_SOCKET=/var/run/docker.sock
+DATAAGENT_SANDBOX_HOST_SKILLS_DIR=
 
 # 挂载路径（相对于 deploy/）
 # Skills 根目录：源码部署默认指向仓库内 dataagent/.claude/skills；离线包会自动改写到 deploy/dataagent-runtime/skills

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -82,8 +82,10 @@ Use this method if you have internet access and are deploying directly from the 
    - `opendataagent` 不随这里的 compose 自动启动，需要单独进入 `opendataagent/deploy/` 部署
    - `skills/` 根目录中的共享 skill 主要服务 `opendataagent`；当前生产智能问数主链使用 DataAgent system prompt、`opendataworks-business-knowledge` 与 `opendataworks-platform-tools`
    - 主前端默认通过同源 `/dataagent/widget/opendataworks-widget.bundle.js` 加载 DataAgent widget，并通过 `/api/v1/nl2sql/*` 代理访问 DataAgent 后端；若需要改成独立域名，源码构建主前端时设置 `VITE_DATAAGENT_WIDGET_JS_URL`
-   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件，以及启用 skill 过滤后的运行时 cwd。当前镜像内 `HOME=/tmp/dataagent-home`，`DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
-   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件和运行时 cwd 都会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
+   - DataAgent 额外持久化宿主目录 `DATAAGENT_HOME_HOST_DIR`（默认 `/tmp/dataagent-home`）。当前 topic 级工作区默认位于 `/tmp/dataagent-home/.dataagent/runtime/topics/<topic_id>/`，Claude SDK session 文件落在该 topic 根目录的 `.claude/projects/<sanitized-cwd>/` 下；同一 topic 多轮复用该目录，不同 topic 不共享 `.claude` 状态
+   - `dataagent-backend` 与 `dataagent-sandbox-runner` 采用 master/worker 形态：backend 负责 topic/task 协调，runner 使用独立 `opendataworks-dataagent-runner` 镜像负责执行入口；设置 `DATAAGENT_SANDBOX_MODE` 后，backend 会把任务流式委托给 runner，runner 再启动每 task child 容器，并只把当前 topic 目录挂到 child 的 `/workspace`
+   - 每个 task child 容器都是一次性容器，runner 使用 `--rm` 启动；正常结束自动删除，取消或异常时 runner 会 kill child，并在启动时清理带 `dataagent.sandbox.managed_by=dataagent-sandbox-runner` 标签的遗留 child 容器
+   - `DATAAGENT_DOCKER_SOCKET` 只挂到 `dataagent-sandbox-runner`，不会挂到 task child 容器；runner 默认用 `DATAAGENT_RUNNER_UID/GID=0:0` 访问 Docker socket，child task 仍用 `DATAAGENT_RUNTIME_UID/GID` 运行；若手动删除 `DATAAGENT_HOME_HOST_DIR`，Claude SDK 本地 session 文件和 topic 工作区都会被清空，此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
 
    > **💡 数据库自动初始化**: MySQL 容器首次启动时，会自动执行 `deploy/database/mysql/` 目录下的初始化脚本，创建 `opendataworks` / `dataagent` 数据库，并分别初始化 `opendataworks`、`dataagent` 两个应用用户。DataAgent 容器启动时会先执行 `alembic upgrade head`，再启动服务。
    >
@@ -149,8 +151,10 @@ Use this method for isolated environments without internet access. You will use 
    - `scripts/start.sh` 会在启动前对挂载的 `odw-cli` 执行一次宿主机侧 `chmod +x`；即使 bind mount 丢了执行位，DataAgent runtime 也会回退为 `sh /app/.claude/skills/opendataworks-platform-tools/bin/odw-cli ...`
    - `portal-mcp` 作为独立远程 MCP 服务一并部署，客户端需带 `X-Portal-MCP-Token`
    - `opendataagent` 需要用它自己的部署包或 compose 单独部署，不包含在这里的离线包主链描述中
-   - DataAgent 额外持久化一个名为 `dataagent-home` 的 Docker volume，用于保存 Claude Agent SDK 写入 `HOME` 下的本地 session 文件，以及启用 skill 过滤后的运行时 cwd。当前镜像内 `HOME=/tmp/dataagent-home`，`DATAAGENT_RUNTIME_PROJECT_CWD=/tmp/dataagent-home/.dataagent/runtime/enabled-skills`，SDK 会将会话落到 `~/.claude/projects/<sanitized-cwd>/`，因此该 volume 可覆盖历史智能问数话题的 `resume` 所需文件
-   - 若执行 `docker compose down -v` 或手动删除 `dataagent-home` volume，Claude SDK 本地 session 文件和运行时 cwd 都会被清空；此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
+   - DataAgent 额外持久化宿主目录 `DATAAGENT_HOME_HOST_DIR`（默认 `/tmp/dataagent-home`）。当前 topic 级工作区默认位于 `/tmp/dataagent-home/.dataagent/runtime/topics/<topic_id>/`，Claude SDK session 文件落在该 topic 根目录的 `.claude/projects/<sanitized-cwd>/` 下；同一 topic 多轮复用该目录，不同 topic 不共享 `.claude` 状态
+   - `dataagent-backend` 与 `dataagent-sandbox-runner` 采用 master/worker 形态：backend 负责 topic/task 协调，runner 使用独立 `opendataworks-dataagent-runner` 镜像负责执行入口；设置 `DATAAGENT_SANDBOX_MODE` 后，backend 会把任务流式委托给 runner，runner 再启动每 task child 容器，并只把当前 topic 目录挂到 child 的 `/workspace`
+   - 每个 task child 容器都是一次性容器，runner 使用 `--rm` 启动；正常结束自动删除，取消或异常时 runner 会 kill child，并在启动时清理带 `dataagent.sandbox.managed_by=dataagent-sandbox-runner` 标签的遗留 child 容器
+   - `DATAAGENT_DOCKER_SOCKET` 只挂到 `dataagent-sandbox-runner`，不会挂到 task child 容器；runner 默认用 `DATAAGENT_RUNNER_UID/GID=0:0` 访问 Docker socket，child task 仍用 `DATAAGENT_RUNTIME_UID/GID` 运行；若手动删除 `DATAAGENT_HOME_HOST_DIR`，Claude SDK 本地 session 文件和 topic 工作区都会被清空，此时旧话题会退回到“重放历史 prompt”的兼容路径，直到该话题再次跑出新的真实 SDK session id
 
    > **💡 数据库自动初始化**: MySQL 容器首次启动时，会自动执行 `deploy/database/mysql/` 目录下的初始化脚本，创建 `opendataworks` / `dataagent` 数据库，并分别初始化 `opendataworks`、`dataagent` 两个应用用户。DataAgent 容器启动时会先执行 `alembic upgrade head`，再启动服务。
    >

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -145,12 +145,21 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      DATAAGENT_SANDBOX_MODE: ${DATAAGENT_SANDBOX_MODE:-}
+      DATAAGENT_SANDBOX_RUNNER_URL: ${DATAAGENT_SANDBOX_RUNNER_URL:-http://dataagent-sandbox-runner:8910}
+      DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_HOST_ROOT: ${DATAAGENT_SANDBOX_HOST_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_IMAGE: ${DATAAGENT_SANDBOX_IMAGE:-mikefan2019/opendataworks-dataagent-runner:latest}
+      DATAAGENT_SANDBOX_BACKEND: ${DATAAGENT_SANDBOX_BACKEND:-docker}
+      DATAAGENT_SANDBOX_NETWORK: ${DATAAGENT_SANDBOX_NETWORK:-container:opendataworks-dataagent-sandbox-runner}
     ports:
       - "8900:8900"
     depends_on:
       mysql:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      dataagent-sandbox-runner:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8900/api/v1/nl2sql/health').read()"]
@@ -159,8 +168,54 @@ services:
       retries: 5
       start_period: 60s
     volumes:
-      - dataagent-home:/tmp/dataagent-home
+      - ${DATAAGENT_HOME_HOST_DIR:-/tmp/dataagent-home}:/tmp/dataagent-home
       - ${DATAAGENT_SKILLS_DIR:-../dataagent/.claude/skills}:/app/.claude/skills
+
+  # DataAgent 沙箱 Runner（内部服务）
+  dataagent-sandbox-runner:
+    image: ${OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE:-mikefan2019/opendataworks-dataagent-runner:latest}
+    pull_policy: always
+    container_name: opendataworks-dataagent-sandbox-runner
+    restart: always
+    env_file:
+      - ./.env
+    user: "${DATAAGENT_RUNNER_UID:-0}:${DATAAGENT_RUNNER_GID:-0}"
+    environment:
+      PYTHONUNBUFFERED: "1"
+      HOME: /tmp/dataagent-home
+      DATAAGENT_SANDBOX_MODE: ""
+      DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_HOST_ROOT: ${DATAAGENT_SANDBOX_HOST_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_IMAGE: ${DATAAGENT_SANDBOX_IMAGE:-mikefan2019/opendataworks-dataagent-runner:latest}
+      DATAAGENT_SANDBOX_BACKEND: ${DATAAGENT_SANDBOX_BACKEND:-docker}
+      DATAAGENT_SANDBOX_NETWORK: ${DATAAGENT_SANDBOX_NETWORK:-container:opendataworks-dataagent-sandbox-runner}
+      DATAAGENT_SANDBOX_HOST_SKILLS_DIR: ${DATAAGENT_SANDBOX_HOST_SKILLS_DIR:-}
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      MYSQL_USER: ${DATAAGENT_MYSQL_USER:-dataagent}
+      MYSQL_PASSWORD: ${DATAAGENT_MYSQL_PASSWORD:-dataagent123}
+      MYSQL_DATABASE: ${DATAAGENT_MYSQL_DATABASE:-opendataworks}
+      SESSION_MYSQL_DATABASE: ${DATAAGENT_SESSION_MYSQL_DATABASE:-dataagent}
+      ODW_BACKEND_BASE_URL: ${ODW_BACKEND_BASE_URL:-http://backend:8080/api/v1/ai}
+      ODW_AGENT_SERVICE_TOKEN: ${AGENT_API_SERVICE_TOKEN:-odw-agent-service-token}
+      ODW_BACKEND_TIMEOUT_SECONDS: ${ODW_BACKEND_TIMEOUT_SECONDS:-30}
+      DATAAGENT_PORTAL_MCP_ENABLED: ${DATAAGENT_PORTAL_MCP_ENABLED:-true}
+      DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
+      DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
+      DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8910/').read()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - ${DATAAGENT_HOME_HOST_DIR:-/tmp/dataagent-home}:/tmp/dataagent-home
+      - ${DATAAGENT_SKILLS_DIR:-../dataagent/.claude/skills}:/app/.claude/skills
+      - ${DATAAGENT_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
 
   portal-mcp:
     image: ${OPENDATAWORKS_PORTAL_MCP_IMAGE:-mikefan2019/opendataworks-portal-mcp:latest}
@@ -194,6 +249,4 @@ volumes:
   mysql-data:
     driver: local
   backend-logs:
-    driver: local
-  dataagent-home:
     driver: local

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -149,12 +149,21 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      DATAAGENT_SANDBOX_MODE: ${DATAAGENT_SANDBOX_MODE:-}
+      DATAAGENT_SANDBOX_RUNNER_URL: ${DATAAGENT_SANDBOX_RUNNER_URL:-http://dataagent-sandbox-runner:8910}
+      DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_HOST_ROOT: ${DATAAGENT_SANDBOX_HOST_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_IMAGE: ${DATAAGENT_SANDBOX_IMAGE:-mikefan2019/opendataworks-dataagent-runner:1.2.0}
+      DATAAGENT_SANDBOX_BACKEND: ${DATAAGENT_SANDBOX_BACKEND:-docker}
+      DATAAGENT_SANDBOX_NETWORK: ${DATAAGENT_SANDBOX_NETWORK:-container:opendataworks-dataagent-sandbox-runner}
     ports:
       - "8900:8900"
     depends_on:
       mysql:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      dataagent-sandbox-runner:
         condition: service_healthy
     networks:
       - opendataworks-network
@@ -165,8 +174,55 @@ services:
       retries: 5
       start_period: 60s
     volumes:
-      - dataagent-home:/tmp/dataagent-home
+      - ${DATAAGENT_HOME_HOST_DIR:-/tmp/dataagent-home}:/tmp/dataagent-home
       - ${DATAAGENT_SKILLS_DIR:-../dataagent/.claude/skills}:/app/.claude/skills
+
+  # DataAgent 沙箱 Runner（内部服务）
+  dataagent-sandbox-runner:
+    image: ${OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE:-mikefan2019/opendataworks-dataagent-runner:1.2.0}
+    container_name: opendataworks-dataagent-sandbox-runner
+    restart: always
+    user: "${DATAAGENT_RUNNER_UID:-0}:${DATAAGENT_RUNNER_GID:-0}"
+    env_file:
+      - ./.env
+    environment:
+      PYTHONUNBUFFERED: "1"
+      HOME: /tmp/dataagent-home
+      DATAAGENT_SANDBOX_MODE: ""
+      DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_HOST_ROOT: ${DATAAGENT_SANDBOX_HOST_ROOT:-/tmp/dataagent-home/.dataagent/runtime/topics}
+      DATAAGENT_SANDBOX_IMAGE: ${DATAAGENT_SANDBOX_IMAGE:-mikefan2019/opendataworks-dataagent-runner:1.2.0}
+      DATAAGENT_SANDBOX_BACKEND: ${DATAAGENT_SANDBOX_BACKEND:-docker}
+      DATAAGENT_SANDBOX_NETWORK: ${DATAAGENT_SANDBOX_NETWORK:-container:opendataworks-dataagent-sandbox-runner}
+      DATAAGENT_SANDBOX_HOST_SKILLS_DIR: ${DATAAGENT_SANDBOX_HOST_SKILLS_DIR:-}
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      MYSQL_USER: ${DATAAGENT_MYSQL_USER:-dataagent}
+      MYSQL_PASSWORD: ${DATAAGENT_MYSQL_PASSWORD:-dataagent123}
+      MYSQL_DATABASE: ${DATAAGENT_MYSQL_DATABASE:-opendataworks}
+      SESSION_MYSQL_DATABASE: ${DATAAGENT_SESSION_MYSQL_DATABASE:-dataagent}
+      ODW_BACKEND_BASE_URL: ${ODW_BACKEND_BASE_URL:-http://backend:8080/api/v1/ai}
+      ODW_AGENT_SERVICE_TOKEN: ${AGENT_API_SERVICE_TOKEN:-odw-agent-service-token}
+      ODW_BACKEND_TIMEOUT_SECONDS: ${ODW_BACKEND_TIMEOUT_SECONDS:-30}
+      DATAAGENT_PORTAL_MCP_ENABLED: ${DATAAGENT_PORTAL_MCP_ENABLED:-true}
+      DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
+      DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
+      DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    networks:
+      - opendataworks-network
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8910/').read()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - ${DATAAGENT_HOME_HOST_DIR:-/tmp/dataagent-home}:/tmp/dataagent-home
+      - ${DATAAGENT_SKILLS_DIR:-../dataagent/.claude/skills}:/app/.claude/skills
+      - ${DATAAGENT_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
 
   portal-mcp:
     image: ${OPENDATAWORKS_PORTAL_MCP_IMAGE:-mikefan2019/opendataworks-portal-mcp:1.3.0}
@@ -210,6 +266,4 @@ volumes:
   mysql-data:
     driver: local
   backend-logs:
-    driver: local
-  dataagent-home:
     driver: local

--- a/docs/design/2026-06-04-dataagent-topic-workspace-isolation-design.md
+++ b/docs/design/2026-06-04-dataagent-topic-workspace-isolation-design.md
@@ -1,0 +1,64 @@
+# DataAgent Topic Workspace Isolation Design
+
+## Current State
+
+DataAgent executes Claude Agent SDK runs through topic/task records. `da_agent_topic` owns the user-visible conversation and stores the current resumable SDK session id in `chat_conversation_id`. `da_agent_task` represents one execution attempt with queue, lease, event, cancellation, and recovery state.
+
+Before this change, SDK `cwd` was prepared under a profile-level runtime workspace. That made filesystem behavior depend on agent profile rather than the actual conversation. It also allowed agents to gravitate toward the shared container `HOME=/tmp/dataagent-home`.
+
+## Problem
+
+File isolation should match user conversation semantics. A topic should keep its own workspace and SDK session files across turns, while different topics should not see each other's files or `.claude` state. Task/run records are internal execution attempts and should not create separate workspace or session layers.
+
+## Solution
+
+Use `topic_id` as the only workspace key:
+
+```text
+HOME/.dataagent/runtime/topics/<topic_id>/
+  .claude/
+    projects/
+    skills/
+```
+
+The topic root is the full workspace. It is passed as SDK `cwd`, `HOME`, `PWD`, and `DATAAGENT_WORKSPACE_DIR` in the local execution path. Claude SDK session files therefore live under the topic root in `.claude/projects/<sanitized-cwd>/`.
+
+Enabled skills are still exposed through `.claude/skills`. The workspace helper can create links either to host skill roots for local execution or to a container-visible skill root such as `/skills/<folder>` or `/app/.claude/skills/<folder>`.
+
+The existing `PreToolUse` boundary hook remains as a second guard. It allows current workspace paths and enabled skill roots, and rejects parent-directory traversal or paths outside the workspace.
+
+## Runner Interface
+
+The backend supports a sandbox runner mode behind `DATAAGENT_SANDBOX_MODE`. This is a master/worker split: `dataagent-backend` owns topic/task coordination, while `dataagent-sandbox-runner` owns execution. When enabled, `task_executor` streams task execution through `DATAAGENT_SANDBOX_RUNNER_URL` using internal NDJSON messages:
+
+- `{"type": "record", "record": ...}`
+- `{"type": "result", "result": ...}`
+
+The runner has its own Dockerfile and image (`opendataworks-dataagent-runner`) so execution permissions can diverge from the backend service. In container backend mode, the runner starts one child Docker/Podman container per task and streams that child process output back to the backend. The child container runs `sandbox_task_main.py`, calls the local SDK executor, and emits the same NDJSON event contract.
+
+The runner service may mount the host Docker socket or use a Podman-compatible command, but the task child container does not receive that socket. The child container receives only:
+
+- the current topic host directory mounted read/write as `/workspace`
+- optionally a host skills directory mounted read-only as `/skills`
+- the runner image's bundled skills under `/app/.claude/skills` when no host skills bind is configured
+
+Because Docker bind mounts use host-visible paths, Compose deploys DataAgent home as a host bind directory by default:
+
+```text
+DATAAGENT_HOME_HOST_DIR=/tmp/dataagent-home
+DATAAGENT_SANDBOX_HOST_ROOT=/tmp/dataagent-home/.dataagent/runtime/topics
+```
+
+The default child network mode is `container:opendataworks-dataagent-sandbox-runner`, so task containers share the runner's service network namespace and can resolve the same internal service names without receiving Docker control privileges.
+
+## Cleanup
+
+Each task child container is ephemeral. The runner starts it with `--rm`, so normal completion removes the container object automatically. On cancellation, stream disconnect, or runner-side exception, the runner kills the child container and still relies on `--rm` for container object cleanup. Topic workspaces are not deleted when a task ends because they belong to the topic conversation.
+
+Child containers are labeled with `dataagent.sandbox.managed_by=dataagent-sandbox-runner`, plus task/topic labels for inspection. When the runner starts, it scans for stale labeled child containers from a previous runner crash or restart and removes them with `rm -f`.
+
+Deleting a topic deletes its topic workspace best-effort after the database row is removed. A reusable orphan workspace cleanup helper removes directories whose `topic_id` is no longer active.
+
+## Tradeoffs
+
+This change gives topic-level workspace and SDK session isolation in the application runtime. With `DATAAGENT_SANDBOX_MODE` enabled and a Docker/Podman backend available to the runner, task containers get a hard mount view of only the current topic workspace. CPU, memory, network egress, and secret isolation remain follow-up controls for the runner backend.

--- a/docs/plans/2026-06-04-dataagent-topic-workspace-isolation-plan.md
+++ b/docs/plans/2026-06-04-dataagent-topic-workspace-isolation-plan.md
@@ -1,0 +1,54 @@
+# DataAgent Topic Workspace Isolation Plan
+
+## Goal
+
+Make DataAgent file and Claude SDK session state topic-scoped instead of agent-profile-scoped, while preserving task as an internal run/execution record.
+
+## Tasks
+
+1. Add topic workspace helpers.
+   - Resolve workspaces from `topic_id` only under `DATAAGENT_SANDBOX_ROOT` or `HOME/.dataagent/runtime/topics`.
+   - Prepare `.claude/skills` for enabled skills.
+   - Support host skill links for local execution and `/skills/<folder>` links for runner/container execution.
+   - Add delete and orphan cleanup helpers.
+
+2. Move SDK execution to topic workspaces.
+   - Replace agent-profile runtime cwd selection in `task_executor`.
+   - Pass topic workspace as SDK `cwd`.
+   - Inject `HOME`, `PWD`, and `DATAAGENT_WORKSPACE_DIR` with the topic workspace path.
+   - Keep agent snapshot ownership for tools, skills, MCP services, prompts, max turns, and env vars.
+
+3. Add sandbox runner API seam.
+   - Add settings for sandbox mode, runner URL, root, host root, image, backend, child network, and optional host skills bind.
+   - Add NDJSON streaming runner client in `task_executor`.
+   - Add `sandbox_runner_main.py` with internal run and cancel endpoints.
+   - Add a dedicated runner Dockerfile/image so the architecture is backend master + runner worker.
+   - Add `sandbox_task_main.py` as the child container task entrypoint.
+   - Implement Docker/Podman CLI child execution in the runner with only the current topic mounted as `/workspace`.
+   - Run child containers as ephemeral `--rm` containers and label them for startup stale-container cleanup.
+   - Keep sandbox mode disabled by default.
+
+4. Preserve boundaries and cleanup.
+   - Keep `PreToolUse` hooks on local execution.
+   - Add regression coverage for `/tmp/dataagent-home` denial.
+   - Add regression coverage for runner child container labels and startup stale-container cleanup.
+   - Delete topic workspace when a topic is deleted.
+
+5. Update deployment and docs.
+   - Add runner environment knobs to dev/prod Compose.
+   - Add a runner service entrypoint and separate runner image.
+   - Bind DataAgent home from a host-visible path so the runner can mount exact topic directories into child containers.
+   - Mount Docker socket into the runner service only; do not mount it into task child containers.
+   - Document topic workspace semantics and runner/backend ownership.
+
+## Verification
+
+- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_topic_workspace.py dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py dataagent/dataagent-backend/tests/test_sandbox_runner_main.py dataagent/dataagent-backend/tests/test_runner_dockerfile.py -q`
+- `dataagent/dataagent-backend/.venv-py313/bin/python -m py_compile dataagent/dataagent-backend/config.py dataagent/dataagent-backend/core/topic_workspace.py dataagent/dataagent-backend/core/task_executor.py dataagent/dataagent-backend/core/topic_task_store.py dataagent/dataagent-backend/sandbox_runner_main.py dataagent/dataagent-backend/sandbox_task_main.py`
+- For a full validation run, start MySQL, Redis, dataagent-backend, and optionally dataagent-sandbox-runner; create one topic, write a file in one turn, read it in the next turn, and verify a second topic cannot read it.
+
+## Backout
+
+- Revert `task_executor` to the previous agent-profile workspace path.
+- Remove sandbox runner settings, client, and service entrypoint.
+- Keep topic/task schema unchanged because this change does not add database columns.


### PR DESCRIPTION
## Summary

Introduce topic-scoped DataAgent workspaces and split sandbox execution into a backend master plus dedicated runner worker.

## Changes

- Resolve DataAgent workspaces from `topic_id` only, with topic-owned `.claude` runtime state and SDK session files.
- Route sandbox-mode task execution from `dataagent-backend` to `dataagent-sandbox-runner` over an internal NDJSON stream.
- Add a separate runner image and child task entrypoint; each task child container mounts only the current topic directory as `/workspace`.
- Include the runner image in offline package creation/loading, local build scripts, multi-arch build scripts, quick-build config, CI release matrix, and prod default image tags.
- Keep task child containers ephemeral with `--rm`, cancellation kill, labels, and runner startup cleanup for stale labeled containers.
- Keep agent snapshots from storing empty `preset_questions`, while preserving non-empty preset questions.
- Remove the system-prompt claim that inline `chart_spec` cannot be rendered, while keeping the `build_chart_spec.py` generation guidance.
- Update dev/prod Compose, env examples, deployment docs, and design/plan docs for the new master/worker sandbox layout.

## Validation

- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_topic_workspace.py dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py dataagent/dataagent-backend/tests/test_sandbox_runner_main.py dataagent/dataagent-backend/tests/test_runner_dockerfile.py -q` -> `53 passed, 1 warning`
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py dataagent/dataagent-backend/tests/test_agent_profile_service.py -q` -> `14 passed, 1 warning`
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests -q` -> `202 passed, 5 warnings`
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest tests/test_deepeval_packaging_hooks.py -q` -> `6 passed`
- `bash -n scripts/create-offline-package.sh scripts/load-images.sh scripts/build/build-images.sh scripts/build/build-multiarch.sh scripts/build/build-quick.sh` -> passed
- `python3` YAML parse of `.github/workflows/docker-build.yml` including `dataagent-runner` matrix entry -> passed
- `dataagent/dataagent-backend/.venv-py313/bin/python -m py_compile dataagent/dataagent-backend/config.py dataagent/dataagent-backend/core/topic_workspace.py dataagent/dataagent-backend/core/task_executor.py dataagent/dataagent-backend/core/topic_task_store.py dataagent/dataagent-backend/sandbox_runner_main.py dataagent/dataagent-backend/sandbox_task_main.py dataagent/dataagent-backend/core/agent_profile_service.py` -> passed
- `git diff --check` -> passed
- `podman compose --env-file deploy/.env.example -f deploy/docker-compose.dev.yml config --quiet` -> passed through external compose provider `/usr/local/bin/docker-compose`
- `podman compose --env-file deploy/.env.example -f deploy/docker-compose.prod.yml config --quiet` -> passed through external compose provider `/usr/local/bin/docker-compose`

## Risk / Rollback

Risk: sandbox mode changes deployment behavior when explicitly enabled and requires runner access to Docker/Podman plus a host-visible DataAgent home path.

Rollback: disable `DATAAGENT_SANDBOX_MODE` to use local execution, or revert this single commit because it does not add database columns.

## Notes

This is a draft because a real end-to-end NL2SQL/model/container smoke was not run in this environment.