### PR TITLE
Slim offline package: split evals, merge images, use xz compression

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -162,6 +162,13 @@ jobs:
             --output "opendataworks-deployment-${VERSION}.tar.xz" \
             --platform linux/amd64
           echo "PACKAGE_PATH=opendataworks-deployment-${VERSION}.tar.xz" >> $GITHUB_ENV
+          chmod +x scripts/create-evals-offline-package.sh
+          scripts/create-evals-offline-package.sh \
+            --namespace "${{ secrets.DOCKER_USERNAME }}" \
+            --tag "$VERSION" \
+            --output "opendataworks-evals-offline-${VERSION}.tar.xz" \
+            --platform linux/amd64
+          echo "EVALS_PACKAGE_PATH=opendataworks-evals-offline-${VERSION}.tar.xz" >> $GITHUB_ENV
           chmod +x opendataagent/scripts/create-offline-package.sh
           opendataagent/scripts/create-offline-package.sh \
             --tag "$VERSION" \
@@ -173,6 +180,8 @@ jobs:
         run: |
           sha256sum "$PACKAGE_PATH" > "${PACKAGE_PATH}.sha256"
           echo "PACKAGE_SHA=${PACKAGE_PATH}.sha256" >> $GITHUB_ENV
+          sha256sum "$EVALS_PACKAGE_PATH" > "${EVALS_PACKAGE_PATH}.sha256"
+          echo "EVALS_PACKAGE_SHA=${EVALS_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
           sha256sum "$ODA_PACKAGE_PATH" > "${ODA_PACKAGE_PATH}.sha256"
           echo "ODA_PACKAGE_SHA=${ODA_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
 
@@ -190,6 +199,8 @@ jobs:
             echo "### 离线部署包 (Offline Deployment Package)"
             echo "- **[opendataworks-deployment-${VERSION}.tar.xz](https://github.com/${REPO}/releases/download/${TAG}/opendataworks-deployment-${VERSION}.tar.xz)** - 适用于无外网环境（需 xz 解压：tar -xJf）"
             echo "- 校验和: \`opendataworks-deployment-${VERSION}.tar.xz.sha256\`"
+            echo "- **[opendataworks-evals-offline-${VERSION}.tar.xz](https://github.com/${REPO}/releases/download/${TAG}/opendataworks-evals-offline-${VERSION}.tar.xz)** - 可选评测附加包（仅在需要在线评测时下载）"
+            echo "- 校验和: \`opendataworks-evals-offline-${VERSION}.tar.xz.sha256\`"
             echo "- **[opendataagent-deployment-${VERSION}.tar.gz](https://github.com/${REPO}/releases/download/${TAG}/opendataagent-deployment-${VERSION}.tar.gz)** - 独立 `opendataagent` 离线部署包"
             echo "- 校验和: \`opendataagent-deployment-${VERSION}.tar.gz.sha256\`"
             echo ""
@@ -228,6 +239,8 @@ jobs:
           files: |
             ${{ env.PACKAGE_PATH }}
             ${{ env.PACKAGE_SHA }}
+            ${{ env.EVALS_PACKAGE_PATH }}
+            ${{ env.EVALS_PACKAGE_SHA }}
             ${{ env.ODA_PACKAGE_PATH }}
             ${{ env.ODA_PACKAGE_SHA }}
 
@@ -255,6 +268,13 @@ jobs:
             --output "opendataworks-deployment-${RELEASE_TAG}.tar.xz" \
             --platform linux/amd64
           echo "PACKAGE_PATH=opendataworks-deployment-${RELEASE_TAG}.tar.xz" >> $GITHUB_ENV
+          chmod +x scripts/create-evals-offline-package.sh
+          scripts/create-evals-offline-package.sh \
+            --namespace "${{ secrets.DOCKER_USERNAME }}" \
+            --tag "${IMAGE_TAG}" \
+            --output "opendataworks-evals-offline-${RELEASE_TAG}.tar.xz" \
+            --platform linux/amd64
+          echo "EVALS_PACKAGE_PATH=opendataworks-evals-offline-${RELEASE_TAG}.tar.xz" >> $GITHUB_ENV
           chmod +x opendataagent/scripts/create-offline-package.sh
           opendataagent/scripts/create-offline-package.sh \
             --tag "${IMAGE_TAG}" \
@@ -265,6 +285,8 @@ jobs:
         run: |
           sha256sum "$PACKAGE_PATH" > "${PACKAGE_PATH}.sha256"
           echo "PACKAGE_SHA=${PACKAGE_PATH}.sha256" >> $GITHUB_ENV
+          sha256sum "$EVALS_PACKAGE_PATH" > "${EVALS_PACKAGE_PATH}.sha256"
+          echo "EVALS_PACKAGE_SHA=${EVALS_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
           sha256sum "$ODA_PACKAGE_PATH" > "${ODA_PACKAGE_PATH}.sha256"
           echo "ODA_PACKAGE_SHA=${ODA_PACKAGE_PATH}.sha256" >> $GITHUB_ENV
 
@@ -281,8 +303,10 @@ jobs:
             echo "## 📦 下载 / Downloads"
             echo ""
             echo "### 离线部署包 (Offline Deployment Package)"
-            echo "- **[${PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${PACKAGE_PATH})**"
+            echo "- **[${PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${PACKAGE_PATH})**（需 xz 解压：tar -xJf）"
             echo "- 校验和: \`${PACKAGE_PATH}.sha256\`"
+            echo "- **[${EVALS_PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${EVALS_PACKAGE_PATH})** - 可选评测附加包"
+            echo "- 校验和: \`${EVALS_PACKAGE_PATH}.sha256\`"
             echo "- **[${ODA_PACKAGE_PATH}](https://github.com/${REPO}/releases/download/${TAG}/${ODA_PACKAGE_PATH})**"
             echo "- 校验和: \`${ODA_PACKAGE_PATH}.sha256\`"
             echo ""
@@ -336,6 +360,8 @@ jobs:
           files: |
             ${{ env.PACKAGE_PATH }}
             ${{ env.PACKAGE_SHA }}
+            ${{ env.EVALS_PACKAGE_PATH }}
+            ${{ env.EVALS_PACKAGE_SHA }}
             ${{ env.ODA_PACKAGE_PATH }}
             ${{ env.ODA_PACKAGE_SHA }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -159,9 +159,9 @@ jobs:
           scripts/create-offline-package.sh \
             --namespace "${{ secrets.DOCKER_USERNAME }}" \
             --tag "$VERSION" \
-            --output "opendataworks-deployment-${VERSION}.tar.gz" \
+            --output "opendataworks-deployment-${VERSION}.tar.xz" \
             --platform linux/amd64
-          echo "PACKAGE_PATH=opendataworks-deployment-${VERSION}.tar.gz" >> $GITHUB_ENV
+          echo "PACKAGE_PATH=opendataworks-deployment-${VERSION}.tar.xz" >> $GITHUB_ENV
           chmod +x opendataagent/scripts/create-offline-package.sh
           opendataagent/scripts/create-offline-package.sh \
             --tag "$VERSION" \
@@ -188,8 +188,8 @@ jobs:
             echo "## 📦 下载 / Downloads"
             echo ""
             echo "### 离线部署包 (Offline Deployment Package)"
-            echo "- **[opendataworks-deployment-${VERSION}.tar.gz](https://github.com/${REPO}/releases/download/${TAG}/opendataworks-deployment-${VERSION}.tar.gz)** - 适用于无外网环境"
-            echo "- 校验和: \`opendataworks-deployment-${VERSION}.tar.gz.sha256\`"
+            echo "- **[opendataworks-deployment-${VERSION}.tar.xz](https://github.com/${REPO}/releases/download/${TAG}/opendataworks-deployment-${VERSION}.tar.xz)** - 适用于无外网环境（需 xz 解压：tar -xJf）"
+            echo "- 校验和: \`opendataworks-deployment-${VERSION}.tar.xz.sha256\`"
             echo "- **[opendataagent-deployment-${VERSION}.tar.gz](https://github.com/${REPO}/releases/download/${TAG}/opendataagent-deployment-${VERSION}.tar.gz)** - 独立 `opendataagent` 离线部署包"
             echo "- 校验和: \`opendataagent-deployment-${VERSION}.tar.gz.sha256\`"
             echo ""
@@ -252,9 +252,9 @@ jobs:
           scripts/create-offline-package.sh \
             --namespace "${{ secrets.DOCKER_USERNAME }}" \
             --tag "${IMAGE_TAG}" \
-            --output "opendataworks-deployment-${RELEASE_TAG}.tar.gz" \
+            --output "opendataworks-deployment-${RELEASE_TAG}.tar.xz" \
             --platform linux/amd64
-          echo "PACKAGE_PATH=opendataworks-deployment-${RELEASE_TAG}.tar.gz" >> $GITHUB_ENV
+          echo "PACKAGE_PATH=opendataworks-deployment-${RELEASE_TAG}.tar.xz" >> $GITHUB_ENV
           chmod +x opendataagent/scripts/create-offline-package.sh
           opendataagent/scripts/create-offline-package.sh \
             --tag "${IMAGE_TAG}" \

--- a/dataagent/dataagent-backend/Dockerfile.runner
+++ b/dataagent/dataagent-backend/Dockerfile.runner
@@ -7,9 +7,13 @@ ENV DATAAGENT_SANDBOX_ROOT=/tmp/dataagent-home/.dataagent/runtime/topics
 
 WORKDIR /app/dataagent-backend
 
+# runner 仅通过挂载的 docker socket 调 `docker run/ps/rm` 启动子容器，只需 docker 客户端，
+# 不需要 docker.io 带来的守护进程 + containerd + runc。从官方 docker CLI 镜像拷静态二进制。
+COPY --from=docker:27-cli /usr/local/bin/docker /usr/local/bin/docker
+
 COPY dataagent/dataagent-backend/requirements.txt /tmp/requirements.txt
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl docker.io \
+    && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN mkdir -p /tmp/dataagent-home && chmod 1777 /tmp/dataagent-home

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -97,21 +97,25 @@ Use this method if you have internet access and are deploying directly from the 
 
 ## 2. Offline Deployment (Using Package)
 
-Use this method for isolated environments without internet access. You will use the `opendataworks-deployment-*.tar.gz` package.
+Use this method for isolated environments without internet access. You will use the `opendataworks-deployment-*.tar.xz` package.
 
 ### Prerequisites
 - Docker or Podman installed on the target machine.
-- The offline deployment package (`opendataworks-deployment-*.tar.gz`).
+- `xz`/`xz-utils` installed on the target machine (used to decompress the package).
+- The offline deployment package (`opendataworks-deployment-*.tar.xz`).
 
 ### Steps
 1. **Extract Package**:
    ```bash
-   tar -xzf opendataworks-deployment-*.tar.gz
+   # 新版离线包为 xz 压缩
+   tar -xJf opendataworks-deployment-*.tar.xz
+   # 若某些精简系统的 tar 未链接 xz，可改用管道：
+   #   xz -dc opendataworks-deployment-*.tar.xz | tar -xf -
    cd opendataworks-deployment
    ```
 
 2. **Load Images**:
-   This loads all required Docker images from the local archive.
+   This loads all required Docker images from the local archive. 新版离线包将全部镜像去重保存为单个 `deploy/docker-images/all-images.tar`，加载脚本会自动识别（旧版逐镜像 `*.tar` 也兼容）。
    ```bash
    scripts/load-images.sh
    ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -170,7 +170,15 @@ Use this method for isolated environments without internet access. You will use 
 
 ## 3. DataAgent Online Evaluation
 
-离线包内置 DataAgent 通用问数评测工具，部署完成并配置可用模型后，可手动运行在线评测。builtin 与 DeepEval 是两个并列评测引擎，均位于离线包根目录 `tools/dataagent-evals/`，且均独立于 DataAgent runtime。私有评测集不随 GitHub 或离线包内置，运行时必须通过 `--dataset` 或 `DATAAGENT_EVAL_DATASET` 指定。
+DataAgent 通用问数评测工具用于部署完成并配置可用模型后手动运行在线评测。builtin 与 DeepEval 是两个并列评测引擎，均位于 `tools/dataagent-evals/`，且均独立于 DataAgent runtime。私有评测集不随 GitHub 或离线包内置，运行时必须通过 `--dataset` 或 `DATAAGENT_EVAL_DATASET` 指定。
+
+> **📦 评测镜像改由独立附加包提供**：评测镜像默认不随服务启动，且 `deepeval` 依赖较重，已从主离线包拆出，单独发布为 `opendataworks-evals-offline-*.tar.xz`。需要在线评测时单独下载该附加包并加载：
+> ```bash
+> tar -xJf opendataworks-evals-offline-*.tar.xz
+> cd opendataworks-evals-offline
+> scripts/load-evals-images.sh
+> ```
+> 主离线包仍保留 `scripts/run-dataagent-evals.sh` / `run-dataagent-deepeval-evals.sh` 与 `tools/dataagent-evals/`，加载附加包镜像后即可直接运行。
 
 ```bash
 DATAAGENT_EVAL_JUDGE_BASE_URL=https://api.example.com \

--- a/docs/design/2026-06-04-offline-package-slimming-design.md
+++ b/docs/design/2026-06-04-offline-package-slimming-design.md
@@ -1,0 +1,41 @@
+# 离线部署包瘦身设计
+
+- 日期: 2026-06-04
+- 主题 slug: `offline-package-slimming`
+- 影响栈: 部署/打包脚本（`scripts/`）、镜像构建（`Dockerfile.runner`）、CI 发布流程（`.github/workflows/docker-build.yml`）、运维文档
+
+## 现状
+
+主系统离线包由 `scripts/create-offline-package.sh` 生成，内容几乎全部是 `deploy/docker-images/` 下的镜像归档：
+
+- 8 个自建镜像 + `mysql:8.0` + `redis:7.2-alpine`，每个镜像单独 `docker save` 成一个 `*.tar`，最后用 `tar -czf`（gzip 默认级别）压成 `*.tar.gz`。
+- 5 个镜像共用 `python:3.11-slim` 基础层、2 个前端共用 `nginx:alpine`；逐个 save 时这些共享层在每个 tar 里各存一份，无法跨镜像去重。
+- `opendataworks-dataagent-runner` 镜像通过 `apt-get install docker.io` 安装整套 Docker 引擎（守护进程 + containerd + runc），但它只通过挂载的 socket 调 `docker run/ps/rm`，仅需客户端。
+- `opendataworks-dataagent-evals-builtin` / `opendataworks-dataagent-evals-deepeval` 两个评测镜像默认不随服务启动，`deepeval` 还会引入很重的 ML 依赖，却被打进每个主包。
+
+## 问题
+
+离线包体积偏大，主要来自：共享层重复存储、gzip 压缩率一般、runner 携带无用的 Docker 守护进程、以及大多数部署用不到的评测镜像。
+
+## 方案
+
+四个相互独立的优化点：
+
+1. **镜像合并去重**：所有镜像一次性 `docker save`（Podman 用 `--multi-image-archive`）保存到单个 `deploy/docker-images/all-images.tar`，共享 base 层只存一份。
+2. **xz 压缩**：整包用 `xz -T0`（多线程）替代 gzip，压缩级别可经 `OPENDATAWORKS_XZ_LEVEL` 覆盖（默认 6），输出名改为 `*.tar.xz`。目标机用 `tar -xJf` 解压（`xz`/`xz-utils` 为常见预装组件）。
+3. **runner 去 `docker.io`**：改为从官方 `docker:27-cli` 镜像 `COPY` 静态 docker 客户端二进制，去掉守护进程依赖。
+4. **evals 拆为独立附加包**：主包不再包含两个评测镜像；新增 `scripts/create-evals-offline-package.sh` 生成 `opendataworks-evals-offline-<tag>.tar.xz` 附加包，内含两个评测镜像（合并去重 + xz）与 `scripts/load-evals-images.sh` 加载器。需要在线评测的部署单独下载并加载该附加包。
+
+## 接口与兼容
+
+- `scripts/load-images.sh`：优先加载 `all-images.tar`，找不到时回退逐镜像 `*.tar`（兼容旧包）。不再把评测镜像列为必需。
+- `scripts/load-package-and-start.sh`：接受 `.tar.xz`（`tar -xJf`），保留 `.tar.gz` 兼容。
+- 评测运行脚本 `scripts/run-dataagent-evals.sh` / `run-dataagent-deepeval-evals.sh` 不变：仍按镜像 env 变量执行；只是镜像改由评测附加包提供。
+- CI 发布同时产出主包 `opendataworks-deployment-<tag>.tar.xz` 与评测附加包 `opendataworks-evals-offline-<tag>.tar.xz`。
+- 独立 `opendataagent` 离线包使用各自脚本，保持 `.tar.gz`，本设计不涉及。
+
+## 取舍
+
+- 评测镜像拆分会让需要评测的用户多下载一个附加包，但显著减小主包，对绝大多数只部署主链路的用户更友好。
+- 未将 runner 改为 `FROM` backend：当前 CI 为 matrix 并行、各镜像独立构建，runner 构建时拿不到 backend 镜像，改造需引入串行依赖与镜像引用传参，风险高于收益；合并去重已回收两者共享基础层的大部分重复成本。
+- xz 压缩慢于 gzip，但离线包“压一次解多次”，且 `-T0` 多线程已缓解打包耗时。

--- a/docs/handbook/operations-guide.md
+++ b/docs/handbook/operations-guide.md
@@ -56,8 +56,8 @@ bash ../scripts/start.sh
 
 ## 离线部署
 
-1. 执行 `scripts/create-offline-package.sh`，生成 `opendataworks-deployment-*.tar.gz`（可指定 `--platform` 或镜像标签）。
-2. 目标机器解压后包含：`deploy/docker-compose*.yml`、`deploy/.env.example`、`deploy/dataagent-runtime/`、`scripts/` 控制脚本、`deploy/docker-images/*.tar`。
+1. 执行 `scripts/create-offline-package.sh`，生成 `opendataworks-deployment-*.tar.xz`（可指定 `--platform` 或镜像标签；压缩级别可用 `OPENDATAWORKS_XZ_LEVEL` 覆盖，默认 6）。全部镜像会去重保存为单个 `deploy/docker-images/all-images.tar`，再用 `xz -T0` 压缩整包。
+2. 目标机器需安装 `xz`/`xz-utils`，解压（`tar -xJf opendataworks-deployment-*.tar.xz`）后包含：`deploy/docker-compose*.yml`、`deploy/.env.example`、`deploy/dataagent-runtime/`、`scripts/` 控制脚本、`deploy/docker-images/all-images.tar`。
 3. 在解压目录内执行 `scripts/load-package-and-start.sh --package .`，加载镜像并启动。
 
 ## 裸机部署 (systemd)

--- a/docs/handbook/operations-guide.md
+++ b/docs/handbook/operations-guide.md
@@ -59,6 +59,7 @@ bash ../scripts/start.sh
 1. 执行 `scripts/create-offline-package.sh`，生成 `opendataworks-deployment-*.tar.xz`（可指定 `--platform` 或镜像标签；压缩级别可用 `OPENDATAWORKS_XZ_LEVEL` 覆盖，默认 6）。全部镜像会去重保存为单个 `deploy/docker-images/all-images.tar`，再用 `xz -T0` 压缩整包。
 2. 目标机器需安装 `xz`/`xz-utils`，解压（`tar -xJf opendataworks-deployment-*.tar.xz`）后包含：`deploy/docker-compose*.yml`、`deploy/.env.example`、`deploy/dataagent-runtime/`、`scripts/` 控制脚本、`deploy/docker-images/all-images.tar`。
 3. 在解压目录内执行 `scripts/load-package-and-start.sh --package .`，加载镜像并启动。
+4. 评测镜像已拆为独立附加包 `opendataworks-evals-offline-*.tar.xz`（由 `scripts/create-evals-offline-package.sh` 生成）；仅在需要在线评测时下载，`tar -xJf` 解压后执行 `scripts/load-evals-images.sh` 加载。
 
 ## 裸机部署 (systemd)
 

--- a/docs/handbook/release-process.md
+++ b/docs/handbook/release-process.md
@@ -115,9 +115,11 @@ GitHub Release 中应包含：
 - **下载区块**：由工作流写入 Release 正文，包含 Docker 镜像拉取命令与两份离线包链接
 - **Docker 镜像区块**：包含 `opendataworks-*` 和 `opendataagent-*` 的 Docker Hub 链接与 `docker pull` 示例
 - **附件**：
-  - `opendataworks-deployment-1.0.0.tar.xz`（离线部署包）
+  - `opendataworks-deployment-1.0.0.tar.xz`（主离线部署包）
+  - `opendataworks-evals-offline-1.0.0.tar.xz`（可选评测附加包，含两个评测镜像）
   - `opendataagent-deployment-1.0.0.tar.gz`（独立 `opendataagent` 离线部署包）
   - 可选：`opendataworks-deployment-1.0.0.tar.xz.sha256`（校验和）
+  - 可选：`opendataworks-evals-offline-1.0.0.tar.xz.sha256`（校验和）
   - 可选：`opendataagent-deployment-1.0.0.tar.gz.sha256`（校验和）
 
 Gitee Release 复用同一组离线包附件，但不能复用 GitHub 下载 URL。同步步骤会先创建占位正文，上传附件后根据 Gitee 返回的 `attach_files/{id}/download` 地址生成最终正文并 PATCH 回 Release。

--- a/docs/handbook/release-process.md
+++ b/docs/handbook/release-process.md
@@ -100,11 +100,12 @@ git push origin v1.0.0
 ### 4.1 离线包生成（CI 中执行）
 
 ```bash
-scripts/create-offline-package.sh --tag 1.0.0 --output opendataworks-deployment-1.0.0.tar.gz
+scripts/create-offline-package.sh --tag 1.0.0 --output opendataworks-deployment-1.0.0.tar.xz
 ```
 
 - 使用 `--tag` 指定版本，对应 Docker Hub 上的镜像 tag
-- 输出文件名建议为 `opendataworks-deployment-{version}.tar.gz`
+- 输出文件名建议为 `opendataworks-deployment-{version}.tar.xz`（xz 压缩，全部镜像去重合并为单个 `all-images.tar`）
+- 目标机器需安装 `xz`/`xz-utils`，解压使用 `tar -xJf`
 
 ### 4.2 Release 内容
 
@@ -114,9 +115,9 @@ GitHub Release 中应包含：
 - **下载区块**：由工作流写入 Release 正文，包含 Docker 镜像拉取命令与两份离线包链接
 - **Docker 镜像区块**：包含 `opendataworks-*` 和 `opendataagent-*` 的 Docker Hub 链接与 `docker pull` 示例
 - **附件**：
-  - `opendataworks-deployment-1.0.0.tar.gz`（离线部署包）
+  - `opendataworks-deployment-1.0.0.tar.xz`（离线部署包）
   - `opendataagent-deployment-1.0.0.tar.gz`（独立 `opendataagent` 离线部署包）
-  - 可选：`opendataworks-deployment-1.0.0.tar.gz.sha256`（校验和）
+  - 可选：`opendataworks-deployment-1.0.0.tar.xz.sha256`（校验和）
   - 可选：`opendataagent-deployment-1.0.0.tar.gz.sha256`（校验和）
 
 Gitee Release 复用同一组离线包附件，但不能复用 GitHub 下载 URL。同步步骤会先创建占位正文，上传附件后根据 Gitee 返回的 `attach_files/{id}/download` 地址生成最终正文并 PATCH 回 Release。
@@ -135,7 +136,7 @@ Gitee Release 复用同一组离线包附件，但不能复用 GitHub 下载 URL
    docker pull mikefan2019/opendataagent-web:1.0.0
    ```
 
-2. **主系统离线部署包**：在 Release 页面下载 `opendataworks-deployment-1.0.0.tar.gz`，按 [deploy/README.md](../../deploy/README.md) 进行离线部署。
+2. **主系统离线部署包**：在 Release 页面下载 `opendataworks-deployment-1.0.0.tar.xz`，按 [deploy/README.md](../../deploy/README.md) 进行离线部署。
 3. **Opendataagent 离线部署包**：在 Release 页面下载 `opendataagent-deployment-1.0.0.tar.gz`，按 [opendataagent/deploy/README.md](../../opendataagent/deploy/README.md) 进行离线部署。
 
 ---

--- a/docs/plans/2026-06-04-offline-package-slimming-plan.md
+++ b/docs/plans/2026-06-04-offline-package-slimming-plan.md
@@ -1,0 +1,44 @@
+# 离线部署包瘦身计划
+
+- 日期: 2026-06-04
+- 主题 slug: `offline-package-slimming`
+- 关联设计: [docs/design/2026-06-04-offline-package-slimming-design.md](../design/2026-06-04-offline-package-slimming-design.md)
+
+## 任务与触达文件
+
+### 已完成
+
+1. 镜像合并去重 + xz 压缩
+   - `scripts/create-offline-package.sh`：一次性 `save_images` 到 `all-images.tar`，`tar | xz -T0` 输出 `.tar.xz`
+   - `scripts/build/build-images.sh`：导出合并归档 `all-images.tar`
+   - `scripts/load-images.sh`：优先加载 `all-images.tar`，回退逐镜像
+   - `scripts/load-package-and-start.sh`：接受 `.tar.xz` / `.tar.gz`
+   - 文档：`deploy/README.md`、`docs/handbook/operations-guide.md`
+2. runner 去 `docker.io`
+   - `dataagent/dataagent-backend/Dockerfile.runner`：`COPY --from=docker:27-cli` 静态客户端
+3. 发布产物命名修正
+   - `.github/workflows/docker-build.yml`、`docs/handbook/release-process.md`：主包改 `.tar.xz`
+
+### 本次执行（evals 拆分）
+
+4. 主包剔除评测镜像
+   - `scripts/create-offline-package.sh`：从合并 save 列表移除两个 evals 镜像；env 重写保留评测镜像名（供附加包加载后使用）
+5. 新增评测附加包生成器
+   - `scripts/create-evals-offline-package.sh`：拉取两个 evals 镜像 → `evals-images.tar`（合并去重）→ `xz` → `opendataworks-evals-offline-<tag>.tar.xz`，内含加载器与评测工具脚本
+6. 新增评测附加包加载器
+   - `scripts/load-evals-images.sh`：`docker/podman load -i evals-images.tar`
+7. CI 产出并附加评测附加包
+   - `.github/workflows/docker-build.yml`：`create-release` 与 `create-latest-release` 增加生成与上传 `opendataworks-evals-offline-*.tar.xz`
+8. 文档
+   - `deploy/README.md` 第 3 节、`docs/handbook/operations-guide.md`、`docs/handbook/release-process.md`：说明评测镜像改由附加包提供
+
+## 验证
+
+- `bash -n` 校验所有改动脚本
+- `python3 -c "import yaml; ..."` 校验工作流 YAML
+- 无 Docker 守护进程，无法本地实跑打包/加载端到端；在交付说明中明确标注需在构建机实测：主包与评测附加包均能生成、`tar -xJf` 解包、`load-images.sh` / `load-evals-images.sh` 成功加载
+
+## 回滚
+
+- 各项改动彼此独立，按 commit 粒度可单独 revert
+- 评测拆分回滚：恢复 `create-offline-package.sh` 中两个 evals 镜像条目、删除附加包脚本与 CI 步骤即可

--- a/scripts/build/build-images.sh
+++ b/scripts/build/build-images.sh
@@ -110,27 +110,26 @@ $CONTAINER_CMD pull --platform linux/amd64 $REDIS_IMAGE
 echo "✅ Redis 镜像拉取完成"
 echo ""
 
-echo "📦 导出镜像为 tar 包..."
-echo "  - 导出前端镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-frontend.tar" $FRONTEND_IMAGE
-echo "  - 导出后端镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-backend.tar" $BACKEND_IMAGE
-echo "  - 导出 DataAgent 前端镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-dataagent-frontend.tar" $DATAAGENT_FRONTEND_IMAGE
-echo "  - 导出 DataAgent 后端镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-dataagent-backend.tar" $DATAAGENT_BACKEND_IMAGE
-echo "  - 导出 DataAgent Runner 镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-dataagent-runner.tar" $DATAAGENT_RUNNER_IMAGE
-echo "  - 导出 DataAgent builtin 评测镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-dataagent-evals-builtin.tar" $DATAAGENT_EVALS_BUILTIN_IMAGE
-echo "  - 导出 DataAgent DeepEval 评测镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-dataagent-evals-deepeval.tar" $DATAAGENT_EVALS_DEEPEVAL_IMAGE
-echo "  - 导出 Portal MCP 镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/opendataworks-portal-mcp.tar" $PORTAL_MCP_IMAGE
-echo "  - 导出 Redis 镜像..."
-$CONTAINER_CMD save -o "$OUTPUT_DIR/redis-7.2-alpine.tar" $REDIS_IMAGE
+echo "📦 导出镜像为去重合并归档 all-images.tar ..."
+# 一次性保存全部镜像，使共享 base layer（python:3.11-slim、nginx:alpine 等）去重
+ALL_IMAGES=(
+    "$FRONTEND_IMAGE"
+    "$BACKEND_IMAGE"
+    "$DATAAGENT_FRONTEND_IMAGE"
+    "$DATAAGENT_BACKEND_IMAGE"
+    "$DATAAGENT_RUNNER_IMAGE"
+    "$DATAAGENT_EVALS_BUILTIN_IMAGE"
+    "$DATAAGENT_EVALS_DEEPEVAL_IMAGE"
+    "$PORTAL_MCP_IMAGE"
+    "$REDIS_IMAGE"
+)
+if [ "$CONTAINER_CMD" = "podman" ]; then
+    $CONTAINER_CMD save --multi-image-archive -o "$OUTPUT_DIR/all-images.tar" "${ALL_IMAGES[@]}"
+else
+    $CONTAINER_CMD save -o "$OUTPUT_DIR/all-images.tar" "${ALL_IMAGES[@]}"
+fi
 
-echo "✅ 所有镜像导出完成"
+echo "✅ 所有镜像导出完成 -> $OUTPUT_DIR/all-images.tar"
 echo ""
 
 echo "========================================="

--- a/scripts/create-evals-offline-package.sh
+++ b/scripts/create-evals-offline-package.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 生成 DataAgent 评测离线附加包。
+# 评测镜像（evals-builtin / evals-deepeval）默认不随服务启动，且 deepeval 依赖很重，
+# 因此从主离线包拆出，单独打包供需要在线评测的部署按需下载与加载。
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PACKAGE_NAME="opendataworks-evals-offline"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/create-evals-offline-package.sh [options]
+
+Options:
+  --registry <registry>     Remote registry host (default: docker.io)
+  --namespace <namespace>   Docker Hub namespace for opendataworks images (default: mikefan2019)
+  --tag <tag>               Image tag to pull (default: latest)
+  --output <path>           Output tar.xz path (default: ./opendataworks-evals-offline-<timestamp>.tar.xz)
+  --platform <platform>     Optional pull platform (e.g. linux/amd64)
+  --keep-workdir            Do not delete temporary build directory (for debugging)
+  -h, --help                Show this help
+
+Environment overrides:
+  OPENDATAWORKS_REGISTRY, OPENDATAWORKS_NAMESPACE, OPENDATAWORKS_TAG,
+  OPENDATAWORKS_PLATFORM, OPENDATAWORKS_XZ_LEVEL (default: 6)
+
+The add-on package contains the two evaluation images saved into a single
+deduplicated archive plus the eval tooling and a loader script.
+EOF
+}
+
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+detect_container_cmd() {
+    if command -v docker >/dev/null 2>&1; then
+        echo docker
+    elif command -v podman >/dev/null 2>&1; then
+        echo podman
+    else
+        die "docker or podman is required"
+    fi
+}
+
+PARSER_REGISTRY="${OPENDATAWORKS_REGISTRY:-docker.io}"
+PARSER_NAMESPACE="${OPENDATAWORKS_NAMESPACE:-mikefan2019}"
+PARSER_TAG="${OPENDATAWORKS_TAG:-latest}"
+PARSER_PLATFORM="${OPENDATAWORKS_PLATFORM:-}"
+OUTPUT_PATH=""
+KEEP_WORKDIR=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --registry) PARSER_REGISTRY="$2"; shift 2 ;;
+        --namespace) PARSER_NAMESPACE="$2"; shift 2 ;;
+        --tag) PARSER_TAG="$2"; shift 2 ;;
+        --output) OUTPUT_PATH="$2"; shift 2 ;;
+        --platform) PARSER_PLATFORM="$2"; shift 2 ;;
+        --keep-workdir) KEEP_WORKDIR=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) die "unknown option: $1" ;;
+    esac
+done
+
+CONTAINER_CMD=$(detect_container_cmd)
+log "Using container runtime: $CONTAINER_CMD"
+
+command -v xz >/dev/null 2>&1 || die "xz is required to compress the offline package (install xz-utils)"
+XZ_LEVEL="${OPENDATAWORKS_XZ_LEVEL:-6}"
+
+if [[ -z "$OUTPUT_PATH" ]]; then
+    OUTPUT_PATH="opendataworks-evals-offline-$(date '+%Y%m%d-%H%M%S').tar.xz"
+fi
+[[ -e "$OUTPUT_PATH" ]] && die "output path already exists: $OUTPUT_PATH"
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/opendataworks-evals-package.XXXXXXXX")
+PACKAGE_ROOT="$WORKDIR/$PACKAGE_NAME"
+trap '[[ "$KEEP_WORKDIR" = true ]] || rm -rf "$WORKDIR"' EXIT
+
+DEPLOY_IMAGE_DIR="$PACKAGE_ROOT/docker-images"
+PACKAGED_SCRIPTS_DIR="$PACKAGE_ROOT/scripts"
+PACKAGED_TOOLS_DIR="$PACKAGE_ROOT/tools"
+mkdir -p "$DEPLOY_IMAGE_DIR" "$PACKAGED_SCRIPTS_DIR" "$PACKAGED_TOOLS_DIR"
+
+log "Copying eval tooling and run scripts"
+if [[ -d "$REPO_ROOT/tools/dataagent-evals" ]]; then
+    mkdir -p "$PACKAGED_TOOLS_DIR/dataagent-evals"
+    tar -C "$REPO_ROOT/tools/dataagent-evals" -cf - . | tar -C "$PACKAGED_TOOLS_DIR/dataagent-evals" -xf -
+fi
+for f in run-dataagent-evals.sh run-dataagent-evals.py run-dataagent-deepeval-evals.sh load-evals-images.sh; do
+    [[ -f "$REPO_ROOT/scripts/$f" ]] && cp "$REPO_ROOT/scripts/$f" "$PACKAGED_SCRIPTS_DIR/$f"
+done
+
+OP_TAG="$PARSER_TAG"
+COMBINED_ARCHIVE="evals-images.tar"
+declare -a SAVE_TARGETS=()
+declare -a MANIFEST_RAW=()
+
+EVAL_IMAGES=(
+    "${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-evals-builtin:${OP_TAG}|opendataworks-dataagent-evals-builtin:${OP_TAG}"
+    "${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-evals-deepeval:${OP_TAG}|opendataworks-dataagent-evals-deepeval:${OP_TAG}"
+)
+
+pull_image() {
+    if [[ -n "$PARSER_PLATFORM" ]]; then
+        "$CONTAINER_CMD" pull --platform "$PARSER_PLATFORM" "$1"
+    else
+        "$CONTAINER_CMD" pull "$1"
+    fi
+}
+
+log "Pulling eval images from ${PARSER_REGISTRY}/${PARSER_NAMESPACE} tag ${OP_TAG}"
+for entry in "${EVAL_IMAGES[@]}"; do
+    IFS='|' read -r source target <<<"$entry"
+    log "Pulling $source"
+    pull_image "$source"
+    [[ "$source" != "$target" ]] && "$CONTAINER_CMD" tag "$source" "$target"
+    SAVE_TARGETS+=("$target")
+    digest=$("$CONTAINER_CMD" image inspect --format='{{index .RepoDigests 0}}' "$source" 2>/dev/null || true)
+    MANIFEST_RAW+=("$COMBINED_ARCHIVE|$source|$target|$digest")
+done
+
+log "Saving ${#SAVE_TARGETS[@]} eval images into deduplicated archive docker-images/$COMBINED_ARCHIVE"
+if [[ "$CONTAINER_CMD" == "podman" ]]; then
+    "$CONTAINER_CMD" save --multi-image-archive -o "$DEPLOY_IMAGE_DIR/$COMBINED_ARCHIVE" "${SAVE_TARGETS[@]}"
+else
+    "$CONTAINER_CMD" save -o "$DEPLOY_IMAGE_DIR/$COMBINED_ARCHIVE" "${SAVE_TARGETS[@]}"
+fi
+
+MANIFEST_FILE="$DEPLOY_IMAGE_DIR/manifest.json"
+{
+    printf '[\n'
+    for i in "${!MANIFEST_RAW[@]}"; do
+        IFS='|' read -r archive source target digest <<<"${MANIFEST_RAW[$i]}"
+        printf '  {\n'
+        printf '    "archive": "%s",\n' "$archive"
+        printf '    "source": "%s",\n' "$source"
+        printf '    "target": "%s"' "$target"
+        if [[ -n "$digest" ]]; then printf ',\n    "digest": "%s"\n' "$digest"; else printf '\n'; fi
+        if [[ "$i" -lt $((${#MANIFEST_RAW[@]} - 1)) ]]; then printf '  },\n'; else printf '  }\n'; fi
+    done
+    printf ']\n'
+} > "$MANIFEST_FILE"
+
+log "Generating checksums"
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$DEPLOY_IMAGE_DIR" && sha256sum *.tar > checksums.sha256)
+elif command -v shasum >/dev/null 2>&1; then
+    (cd "$DEPLOY_IMAGE_DIR" && shasum -a 256 *.tar > checksums.sha256)
+else
+    die "sha256sum or shasum binary is required to compute checksums"
+fi
+
+cat > "$PACKAGE_ROOT/README.md" <<'EOF'
+# OpenDataWorks 评测离线附加包
+
+本附加包包含 DataAgent 评测镜像，独立于主离线包发布。
+
+## 加载
+
+```bash
+tar -xJf opendataworks-evals-offline-*.tar.xz
+cd opendataworks-evals-offline
+scripts/load-evals-images.sh
+```
+
+加载后，按主仓库 `deploy/README.md` 第 3 节运行 builtin / DeepEval 评测。
+私有评测集不随包内置，运行时通过 `--dataset` 指定。
+EOF
+
+log "Creating xz archive $OUTPUT_PATH (level ${XZ_LEVEL}, multi-threaded)"
+tar -C "$WORKDIR" -cf - "$PACKAGE_NAME" | xz -T0 "-${XZ_LEVEL}" -c > "$OUTPUT_PATH"
+
+log "Eval offline add-on package ready: $OUTPUT_PATH"

--- a/scripts/create-offline-package.sh
+++ b/scripts/create-offline-package.sh
@@ -314,14 +314,14 @@ compute_checksums() {
 
 OP_TAG="$PARSER_TAG"
 
+# 评测镜像（evals-builtin / evals-deepeval）默认不随服务启动，且 deepeval 依赖很重，
+# 已拆分到独立附加包 scripts/create-evals-offline-package.sh，不再打入主离线包。
 MAIN_IMAGES=(
     "opendataworks-frontend.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-frontend:${OP_TAG}|opendataworks-frontend:${OP_TAG}"
     "opendataworks-backend.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-backend:${OP_TAG}|opendataworks-backend:${OP_TAG}"
     "opendataworks-dataagent-frontend.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-frontend:${OP_TAG}|opendataworks-dataagent-frontend:${OP_TAG}"
     "opendataworks-dataagent-backend.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-backend:${OP_TAG}|opendataworks-dataagent-backend:${OP_TAG}"
     "opendataworks-dataagent-runner.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-runner:${OP_TAG}|opendataworks-dataagent-runner:${OP_TAG}"
-    "opendataworks-dataagent-evals-builtin.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-evals-builtin:${OP_TAG}|opendataworks-dataagent-evals-builtin:${OP_TAG}"
-    "opendataworks-dataagent-evals-deepeval.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-dataagent-evals-deepeval:${OP_TAG}|opendataworks-dataagent-evals-deepeval:${OP_TAG}"
     "opendataworks-portal-mcp.tar|${PARSER_REGISTRY}/${PARSER_NAMESPACE}/opendataworks-portal-mcp:${OP_TAG}|opendataworks-portal-mcp:${OP_TAG}"
 )
 
@@ -398,3 +398,4 @@ fi
 log "Offline deployment package ready: $OUTPUT_PATH"
 log "Included manifest: $PACKAGE_NAME/deploy/docker-images/manifest.json"
 log "Image checksums: $PACKAGE_NAME/deploy/docker-images/checksums.sha256"
+log "Evaluation images are shipped separately; build with scripts/create-evals-offline-package.sh"

--- a/scripts/create-offline-package.sh
+++ b/scripts/create-offline-package.sh
@@ -14,17 +14,18 @@ Options:
   --registry <registry>     Remote registry host (default: docker.io)
   --namespace <namespace>   Docker Hub namespace for opendataworks images (default: mikefan2019)
   --tag <tag>               Image tag to pull (default: latest)
-  --output <path>           Output tar.gz path (default: ./opendataworks-deployment-<timestamp>.tar.gz)
+  --output <path>           Output tar.xz path (default: ./opendataworks-deployment-<timestamp>.tar.xz)
   --platform <platform>     Optional pull platform (e.g. linux/amd64)
   --keep-workdir            Do not delete temporary build directory (for debugging)
   -h, --help                Show this help
 
 Environment overrides:
   OPENDATAWORKS_REGISTRY, OPENDATAWORKS_NAMESPACE, OPENDATAWORKS_TAG,
-  OPENDATAWORKS_PLATFORM
+  OPENDATAWORKS_PLATFORM, OPENDATAWORKS_XZ_LEVEL (default: 6)
 
 The script packages current scripts/ and deploy/ content, pulls required images
-from Docker Hub, retags them, and produces a compressed archive.
+from Docker Hub, retags them, saves them into a single deduplicated image
+archive, and produces an xz-compressed archive.
 EOF
 }
 
@@ -93,8 +94,11 @@ done
 CONTAINER_CMD=$(detect_container_cmd)
 log "Using container runtime: $CONTAINER_CMD"
 
+command -v xz >/dev/null 2>&1 || die "xz is required to compress the offline package (install xz-utils)"
+XZ_LEVEL="${OPENDATAWORKS_XZ_LEVEL:-6}"
+
 if [[ -z "$OUTPUT_PATH" ]]; then
-    OUTPUT_PATH="opendataworks-deployment-$(date '+%Y%m%d-%H%M%S').tar.gz"
+    OUTPUT_PATH="opendataworks-deployment-$(date '+%Y%m%d-%H%M%S').tar.xz"
 fi
 
 if [[ -e "$OUTPUT_PATH" ]]; then
@@ -273,10 +277,16 @@ pull_image() {
     fi
 }
 
-save_image() {
-    local image="$1"
-    local archive="$2"
-    "$CONTAINER_CMD" save -o "$DEPLOY_IMAGE_DIR/$archive" "$image"
+# 将多个镜像保存到同一个归档，使共享 base layer 去重（python:3.11-slim、nginx:alpine 等）。
+# Docker 的 save 原生支持多镜像；Podman 需要 --multi-image-archive。
+save_images() {
+    local archive="$1"
+    shift
+    if [[ "$CONTAINER_CMD" == "podman" ]]; then
+        "$CONTAINER_CMD" save --multi-image-archive -o "$DEPLOY_IMAGE_DIR/$archive" "$@"
+    else
+        "$CONTAINER_CMD" save -o "$DEPLOY_IMAGE_DIR/$archive" "$@"
+    fi
 }
 
 retag_image() {
@@ -320,16 +330,18 @@ EXTRA_IMAGES=(
     "redis-7.2-alpine.tar|docker.io/library/redis:7.2-alpine|redis:7.2-alpine"
 )
 
+COMBINED_ARCHIVE="all-images.tar"
+declare -a SAVE_TARGETS=()
+
 log "Pulling application images from ${PARSER_REGISTRY}/${PARSER_NAMESPACE} tag ${OP_TAG}"
 for entry in "${MAIN_IMAGES[@]}"; do
     IFS='|' read -r archive source target <<<"$entry"
     log "Pulling $source"
     pull_image "$source"
     retag_image "$source" "$target"
-    log "Saving $target to deploy/docker-images/$archive"
-    save_image "$target" "$archive"
+    SAVE_TARGETS+=("$target")
     digest=$(get_digest "$source")
-    MANIFEST_RAW+=("$archive|$source|$target|$digest")
+    MANIFEST_RAW+=("$COMBINED_ARCHIVE|$source|$target|$digest")
 done
 
 log "Pulling dependency images"
@@ -338,11 +350,14 @@ for entry in "${EXTRA_IMAGES[@]}"; do
     log "Pulling $source"
     pull_image "$source"
     retag_image "$source" "$target"
-    log "Saving $target to deploy/docker-images/$archive"
-    save_image "$target" "$archive"
+    SAVE_TARGETS+=("$target")
     digest=$(get_digest "$source")
-    MANIFEST_RAW+=("$archive|$source|$target|$digest")
+    MANIFEST_RAW+=("$COMBINED_ARCHIVE|$source|$target|$digest")
 done
+
+# 一次性保存全部镜像，使共享层去重，显著减小镜像归档体积
+log "Saving ${#SAVE_TARGETS[@]} images into deduplicated archive deploy/docker-images/$COMBINED_ARCHIVE"
+save_images "$COMBINED_ARCHIVE" "${SAVE_TARGETS[@]}"
 
 MANIFEST_FILE="$DEPLOY_IMAGE_DIR/manifest.json"
 {
@@ -371,8 +386,8 @@ checksum_file="$DEPLOY_IMAGE_DIR/checksums.sha256"
 log "Generating checksums"
 (cd "$DEPLOY_IMAGE_DIR" && compute_checksums *.tar > checksums.tmp && mv checksums.tmp "$(basename "$checksum_file")")
 
-log "Creating archive $OUTPUT_PATH"
-tar -C "$WORKDIR" -czf "$OUTPUT_PATH" "$PACKAGE_NAME"
+log "Creating xz archive $OUTPUT_PATH (level ${XZ_LEVEL}, multi-threaded)"
+tar -C "$WORKDIR" -cf - "$PACKAGE_NAME" | xz -T0 "-${XZ_LEVEL}" -c > "$OUTPUT_PATH"
 
 if [[ "$KEEP_WORKDIR" = true ]]; then
     log "Temporary workspace kept at: $WORKDIR"

--- a/scripts/load-evals-images.sh
+++ b/scripts/load-evals-images.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# OpenDataWorks 评测镜像加载脚本（评测离线附加包使用）
+# 功能：从评测附加包加载 DataAgent 评测镜像
+# 支持 Docker 和 Podman
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "========================================="
+echo "  OpenDataWorks 评测镜像加载脚本"
+echo "========================================="
+echo ""
+
+if command -v docker &> /dev/null; then
+    CONTAINER_CMD="docker"
+    echo "✓ 检测到 Docker"
+elif command -v podman &> /dev/null; then
+    CONTAINER_CMD="podman"
+    echo "✓ 检测到 Podman"
+else
+    echo "❌ 错误: 未找到 Docker 或 Podman"
+    exit 1
+fi
+echo ""
+
+# 兼容主包目录布局（deploy/docker-images）与附加包布局（docker-images）
+if [ -f "$PACKAGE_ROOT/docker-images/evals-images.tar" ]; then
+    IMAGE_DIR="$PACKAGE_ROOT/docker-images"
+elif [ -f "$PACKAGE_ROOT/deploy/docker-images/evals-images.tar" ]; then
+    IMAGE_DIR="$PACKAGE_ROOT/deploy/docker-images"
+else
+    echo "❌ 错误: 未找到 evals-images.tar"
+    echo "请在评测附加包解压目录内运行本脚本"
+    exit 1
+fi
+
+echo "📦 加载评测镜像（去重单归档）..."
+$CONTAINER_CMD load -i "$IMAGE_DIR/evals-images.tar"
+echo "✅ 评测镜像加载完成"
+echo ""
+
+# 修复 localhost 前缀问题（Podman 加载可能带 localhost/ 前缀）
+IMAGE_TAG="latest"
+if [[ -f "$IMAGE_DIR/manifest.json" ]]; then
+    _tag=$(grep -o '"target": *"opendataworks-dataagent-evals-builtin:[^"]*"' "$IMAGE_DIR/manifest.json" 2>/dev/null | sed 's/.*opendataworks-dataagent-evals-builtin://;s/"//')
+    [[ -n "$_tag" ]] && IMAGE_TAG="$_tag"
+fi
+IMAGES=(
+    "opendataworks-dataagent-evals-builtin:${IMAGE_TAG}"
+    "opendataworks-dataagent-evals-deepeval:${IMAGE_TAG}"
+    "opendataworks-dataagent-evals-builtin:latest"
+    "opendataworks-dataagent-evals-deepeval:latest"
+)
+for image in "${IMAGES[@]}"; do
+    localhost_image="localhost/$image"
+    if $CONTAINER_CMD images --format "{{.Repository}}:{{.Tag}}" | grep -q "^$localhost_image$"; then
+        echo "  🔄 修复镜像标签: $localhost_image -> $image"
+        $CONTAINER_CMD tag "$localhost_image" "$image"
+        $CONTAINER_CMD rmi "$localhost_image"
+    fi
+done
+
+echo ""
+echo "📋 已加载评测镜像："
+$CONTAINER_CMD images | grep -E "opendataworks-dataagent-evals" || true
+echo ""
+echo "📝 下一步：按 deploy/README.md 第 3 节运行 builtin / DeepEval 评测（用 --dataset 指定私有评测集）"
+echo ""

--- a/scripts/load-images.sh
+++ b/scripts/load-images.sh
@@ -38,8 +38,10 @@ if [ ! -d "$IMAGE_DIR" ]; then
     exit 1
 fi
 
-# 检查必需的镜像文件
-REQUIRED_IMAGES=(
+# 当前离线包将全部镜像去重保存到单个归档 all-images.tar。
+# 兼容旧包：若不存在合并归档，则回退加载历史的逐镜像 *.tar。
+COMBINED_ARCHIVE="$IMAGE_DIR/all-images.tar"
+LEGACY_IMAGES=(
     "opendataworks-frontend.tar"
     "opendataworks-backend.tar"
     "opendataworks-dataagent-frontend.tar"
@@ -52,76 +54,37 @@ REQUIRED_IMAGES=(
     "redis-7.2-alpine.tar"
 )
 
-echo "🔍 检查镜像文件..."
-for image_file in "${REQUIRED_IMAGES[@]}"; do
-    if [ ! -f "$IMAGE_DIR/$image_file" ]; then
-        echo "❌ 缺少镜像文件: $image_file"
-        exit 1
-    fi
-    echo "  ✓ 找到 $image_file"
-done
-echo ""
-
-echo "📦 开始加载镜像..."
-echo ""
-
-# 加载前端镜像
-echo "📦 [1/10] 加载前端镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-frontend.tar"
-echo "✅ 前端镜像加载完成"
-echo ""
-
-# 加载后端镜像
-echo "📦 [2/10] 加载后端镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-backend.tar"
-echo "✅ 后端镜像加载完成"
-echo ""
-
-# 加载 DataAgent 前端镜像
-echo "📦 [3/10] 加载 DataAgent 前端镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-dataagent-frontend.tar"
-echo "✅ DataAgent 前端镜像加载完成"
-echo ""
-
-echo "📦 [4/10] 加载 DataAgent 后端镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-dataagent-backend.tar"
-echo "✅ DataAgent 后端镜像加载完成"
-echo ""
-
-echo "📦 [5/10] 加载 DataAgent Runner 镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-dataagent-runner.tar"
-echo "✅ DataAgent Runner 镜像加载完成"
-echo ""
-
-# 加载 builtin 评测镜像
-echo "📦 [6/10] 加载 builtin 评测镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-dataagent-evals-builtin.tar"
-echo "✅ builtin 评测镜像加载完成"
-echo ""
-
-# 加载 DeepEval 评测镜像
-echo "📦 [7/10] 加载 DeepEval 评测镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-dataagent-evals-deepeval.tar"
-echo "✅ DeepEval 评测镜像加载完成"
-echo ""
-
-# 加载 Portal MCP 镜像
-echo "📦 [8/10] 加载 Portal MCP 镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/opendataworks-portal-mcp.tar"
-echo "✅ Portal MCP 镜像加载完成"
-echo ""
-
-# 加载 MySQL 镜像
-echo "📦 [9/10] 加载 MySQL 镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/mysql-8.0.tar"
-echo "✅ MySQL 镜像加载完成"
-echo ""
-
-# 加载 Redis 镜像
-echo "📦 [10/10] 加载 Redis 镜像..."
-$CONTAINER_CMD load -i "$IMAGE_DIR/redis-7.2-alpine.tar"
-echo "✅ Redis 镜像加载完成"
-echo ""
+if [ -f "$COMBINED_ARCHIVE" ]; then
+    echo "🔍 找到合并镜像归档: all-images.tar"
+    echo ""
+    echo "📦 开始加载镜像（去重单归档）..."
+    $CONTAINER_CMD load -i "$COMBINED_ARCHIVE"
+    echo "✅ 所有镜像加载完成"
+    echo ""
+else
+    echo "ℹ️  未找到 all-images.tar，回退到逐镜像加载（旧版离线包）"
+    echo ""
+    echo "🔍 检查镜像文件..."
+    for image_file in "${LEGACY_IMAGES[@]}"; do
+        if [ ! -f "$IMAGE_DIR/$image_file" ]; then
+            echo "❌ 缺少镜像文件: $image_file"
+            exit 1
+        fi
+        echo "  ✓ 找到 $image_file"
+    done
+    echo ""
+    echo "📦 开始加载镜像..."
+    echo ""
+    idx=1
+    total=${#LEGACY_IMAGES[@]}
+    for image_file in "${LEGACY_IMAGES[@]}"; do
+        echo "📦 [$idx/$total] 加载 $image_file ..."
+        $CONTAINER_CMD load -i "$IMAGE_DIR/$image_file"
+        idx=$((idx + 1))
+    done
+    echo "✅ 所有镜像加载完成"
+    echo ""
+fi
 
 echo "========================================="
 echo "  所有镜像加载完成！"

--- a/scripts/load-package-and-start.sh
+++ b/scripts/load-package-and-start.sh
@@ -7,8 +7,8 @@ usage() {
 Usage: scripts/load-package-and-start.sh [options] --package <path>
 
 Options:
-  --package <path>     Path to deployment tar.gz (from create-offline-package script) or extracted directory
-  --target-dir <path>  Target directory for extraction when --package is a tar.gz (default: ./opendataworks-deployment)
+  --package <path>     Path to deployment tar.xz/tar.gz (from create-offline-package script) or extracted directory
+  --target-dir <path>  Target directory for extraction when --package is an archive (default: ./opendataworks-deployment)
   --no-start           Load images only; skip compose up
   --no-env-copy        Do not auto-copy .env.example to .env when missing
   -h, --help           Show this help
@@ -74,11 +74,17 @@ if [[ ! -e "$PACKAGE_PATH" ]]; then
 fi
 
 if [[ -f "$PACKAGE_PATH" ]]; then
+    tar_decompress_flag=""
     case "$PACKAGE_PATH" in
+        *.tar.xz|*.txz)
+            command -v xz >/dev/null 2>&1 || die "xz is required to extract $PACKAGE_PATH (install xz-utils)"
+            tar_decompress_flag="-J"
+            ;;
         *.tar.gz|*.tgz)
+            tar_decompress_flag="-z"
             ;;
         *)
-            die "unsupported archive format: $PACKAGE_PATH (expected .tar.gz)"
+            die "unsupported archive format: $PACKAGE_PATH (expected .tar.xz or .tar.gz)"
             ;;
     esac
     mkdir -p "$TARGET_DIR"
@@ -86,7 +92,7 @@ if [[ -f "$PACKAGE_PATH" ]]; then
         die "target directory not empty: $TARGET_DIR"
     fi
     log "Extracting $PACKAGE_PATH to $TARGET_DIR"
-    tar -xzf "$PACKAGE_PATH" --strip-components=1 -C "$TARGET_DIR"
+    tar "$tar_decompress_flag" -xf "$PACKAGE_PATH" --strip-components=1 -C "$TARGET_DIR"
     PACKAGE_DIR="$TARGET_DIR"
 elif [[ -d "$PACKAGE_PATH" ]]; then
     PACKAGE_DIR="$PACKAGE_PATH"


### PR DESCRIPTION
## Summary

This PR implements a comprehensive offline deployment package optimization plan, reducing package size through image deduplication, improved compression, and separating evaluation tools into an optional add-on package.

## Key Changes

### 1. Image Merging & Deduplication
- **`scripts/create-offline-package.sh`**: Changed from saving each image individually to a single `all-images.tar` archive, allowing shared base layers (python:3.11-slim, nginx:alpine) to be deduplicated
- **`scripts/build/build-images.sh`**: Updated to export all images into merged `all-images.tar` instead of individual `*.tar` files
- **`scripts/load-images.sh`**: Enhanced to prioritize loading `all-images.tar` with fallback to legacy per-image `*.tar` files for backward compatibility

### 2. Compression Format Upgrade
- Changed from gzip (`.tar.gz`) to xz (`.tar.xz`) compression with multi-threaded support (`xz -T0`)
- Compression level configurable via `OPENDATAWORKS_XZ_LEVEL` environment variable (default: 6)
- Updated all references in CI, documentation, and deployment scripts

### 3. Evaluation Images Split into Optional Add-on Package
- **`scripts/create-evals-offline-package.sh`** (new): Generates `opendataworks-evals-offline-*.tar.xz` containing only the two evaluation images (evals-builtin and evals-deepeval) with merged deduplication
- **`scripts/load-evals-images.sh`** (new): Loader script for the evaluation add-on package with Podman/Docker compatibility and localhost prefix fixup
- Removed evaluation images from main package to reduce size for deployments that don't need evaluation features

### 4. Runner Image Optimization
- **`dataagent/dataagent-backend/Dockerfile.runner`**: Replaced `apt-get install docker.io` with static docker CLI binary copied from official `docker:27-cli` image, eliminating unnecessary daemon/containerd/runc dependencies

### 5. CI/Release Process Updates
- **`.github/workflows/docker-build.yml`**: 
  - Updated to generate both main package (`.tar.xz`) and evaluation add-on package
  - Release notes now reference both packages with appropriate download instructions
  - Generates SHA256 checksums for both packages

### 6. Documentation Updates
- **`deploy/README.md`**: Updated offline deployment instructions to use `tar -xJf` for xz extraction, documented image deduplication
- **`docs/handbook/release-process.md`**: Updated package naming and compression format
- **`docs/handbook/operations-guide.md`**: Updated offline deployment procedures
- **`scripts/load-package-and-start.sh`**: Enhanced to handle both `.tar.xz` and `.tar.gz` formats
- **Design & Plan Documents** (new): Added `docs/design/2026-06-04-offline-package-slimming-design.md` and `docs/plans/2026-06-04-offline-package-slimming-plan.md` documenting the optimization strategy

## Implementation Details

- All scripts maintain backward compatibility (legacy per-image tar loading still supported)
- Podman support includes `--multi-image-archive` flag for proper multi-image save
- Evaluation add-on package includes tooling scripts and comprehensive README
- Environment variable overrides available for registry, namespace, tag, platform, and compression level
- Temporary build directories cleaned up automatically unless `--keep-workdir` flag used

https://claude.ai/code/session_016QW2ZA7XDBP74WzkkuieW8