### PR TITLE
feat(dataagent): conversation file upload + right-side artifact panel

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import mimetypes
 from typing import Any, AsyncIterator
 
 import anyio
-from fastapi import APIRouter, HTTPException, Query, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, build_agent_snapshot, get_agent_profile
@@ -14,6 +15,7 @@ from core.magic_events import TERMINAL_TASK_STATUSES, encode_sse
 from core.skill_admin_service import current_settings_payload, resolved_chat_settings_payload
 from core.task_coordinator import get_task_coordinator
 from core.task_submission_service import compute_next_run_at, current_utc_naive, submit_message_task
+from core.topic_files import TopicFileError, list_files, safe_workspace_file, save_upload
 from core.topic_task_store import get_topic_task_store
 from models.schemas import (
     CancelTaskResponse,
@@ -47,6 +49,8 @@ from models.schemas import (
     UpdateTopicRequest,
     WidgetEventBatchRequest,
     WidgetEventIngestResponse,
+    WorkspaceFile,
+    WorkspaceFileListResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -296,6 +300,62 @@ async def api_list_topic_messages(
     _require_topic(topic_id, context)
     payload = _get_store().list_topic_messages_page(topic_id=topic_id, page=page, page_size=page_size, order=order, context=context)
     return TopicMessagePageResponse.model_validate(payload)
+
+
+# Content types safe to render inline in the browser; anything else (notably
+# text/html) is served as an attachment so direct navigation cannot execute it.
+_INLINE_SAFE_CONTENT_TYPES = {
+    "application/json",
+    "application/pdf",
+    "text/csv",
+    "text/plain",
+}
+
+
+@topic_router.post("/{topic_id}/files", response_model=WorkspaceFile)
+async def api_upload_topic_file(topic_id: str, request: Request, file: UploadFile = File(...)):
+    _require_topic(topic_id, _request_context(request))
+    data = await file.read()
+    cap = int(get_settings().dataagent_upload_max_bytes or 0)
+    if cap and len(data) > cap:
+        raise HTTPException(status_code=413, detail=f"file exceeds the {cap} byte upload limit")
+    try:
+        meta = save_upload(topic_id, file.filename or "file", data)
+    except TopicFileError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return WorkspaceFile.model_validate(meta)
+
+
+@topic_router.get("/{topic_id}/files", response_model=WorkspaceFileListResponse)
+async def api_list_topic_files(topic_id: str, request: Request):
+    _require_topic(topic_id, _request_context(request))
+    return WorkspaceFileListResponse(files=[WorkspaceFile.model_validate(item) for item in list_files(topic_id)])
+
+
+@topic_router.get("/{topic_id}/files/{rel_path:path}")
+async def api_download_topic_file(
+    topic_id: str,
+    rel_path: str,
+    request: Request,
+    download: int = Query(default=0),
+):
+    _require_topic(topic_id, _request_context(request))
+    try:
+        path = safe_workspace_file(topic_id, rel_path)
+    except TopicFileError:
+        raise HTTPException(status_code=404, detail="file not found")
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    force_inline = not download and content_type in _INLINE_SAFE_CONTENT_TYPES
+    disposition = "inline" if force_inline else "attachment"
+    return FileResponse(
+        path,
+        media_type=content_type,
+        filename=path.name,
+        content_disposition_type=disposition,
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
 
 
 @topic_router.put("/{topic_id}/messages/{message_id}/feedback", response_model=TopicMessage)

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -77,6 +77,7 @@ class Settings(BaseSettings):
 
     # ---- Skills ----
     skills_output_dir: str = "../.claude/skills/opendataworks-business-knowledge"
+    dataagent_upload_max_bytes: int = 20 * 1024 * 1024
     dataagent_portal_mcp_enabled: bool = True
     dataagent_portal_mcp_base_url: str = ""
     dataagent_portal_mcp_token: str = ""

--- a/dataagent/dataagent-backend/core/topic_files.py
+++ b/dataagent/dataagent-backend/core/topic_files.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""
+Per-topic conversation file helpers.
+
+Uploaded inputs and agent-generated outputs live in the topic workspace
+(`/workspaces/<topic_id>/`). The reserved `.claude/` subtree (skills + SDK
+sessions) is never listed or served. All path resolution is confined to the
+workspace root to prevent traversal/symlink escape.
+"""
+
+import mimetypes
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from core.topic_workspace import resolve_topic_workspace
+
+RESERVED_DIRNAME = ".claude"
+UPLOADS_DIRNAME = "uploads"
+_BLOCKED_UPLOAD_SUFFIXES = {
+    ".exe", ".com", ".msi", ".bat", ".cmd", ".scr", ".dll", ".so", ".dylib", ".sh",
+}
+
+
+class TopicFileError(ValueError):
+    """Raised for invalid file names, blocked types, or traversal attempts."""
+
+
+def _workspace_root(topic_id: str) -> Path:
+    return resolve_topic_workspace(topic_id).resolve()
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _safe_filename(filename: str) -> str:
+    base = os.path.basename(str(filename or "").strip().replace("\\", "/"))
+    base = re.sub(r"[^A-Za-z0-9_.\-]+", "_", base).strip("._-")
+    return base or "file"
+
+
+def _file_meta(root: Path, path: Path) -> dict:
+    rel = path.relative_to(root).as_posix()
+    stat = path.stat()
+    return {
+        "name": path.name,
+        "rel_path": rel,
+        "size": int(stat.st_size),
+        "modified_at": _iso(stat.st_mtime),
+        "content_type": mimetypes.guess_type(path.name)[0] or "application/octet-stream",
+        "kind": "input" if rel.startswith(f"{UPLOADS_DIRNAME}/") else "output",
+    }
+
+
+def safe_workspace_file(topic_id: str, rel_path: str) -> Path:
+    """Resolve a workspace-relative path, confined to the workspace and outside
+    `.claude/`. Raises TopicFileError on traversal/symlink escape."""
+    root = _workspace_root(topic_id)
+    raw = str(rel_path or "").strip().lstrip("/")
+    if not raw:
+        raise TopicFileError("empty path")
+    parts = [seg for seg in raw.replace("\\", "/").split("/") if seg]
+    if any(seg == ".." for seg in parts):
+        raise TopicFileError("parent traversal is not allowed")
+    candidate = (root / Path(*parts)).resolve()
+    if candidate != root and root not in candidate.parents:
+        raise TopicFileError("path escapes the conversation workspace")
+    rel = candidate.relative_to(root)
+    if rel.parts and rel.parts[0] == RESERVED_DIRNAME:
+        raise TopicFileError("the .claude directory is not accessible")
+    return candidate
+
+
+def save_upload(topic_id: str, filename: str, data: bytes) -> dict:
+    """Write an uploaded file into `<workspace>/uploads/`, de-duping names."""
+    safe_name = _safe_filename(filename)
+    if Path(safe_name).suffix.lower() in _BLOCKED_UPLOAD_SUFFIXES:
+        raise TopicFileError(f"file type not allowed: {Path(safe_name).suffix}")
+    root = _workspace_root(topic_id)
+    uploads = root / UPLOADS_DIRNAME
+    uploads.mkdir(parents=True, exist_ok=True)
+
+    target = uploads / safe_name
+    if target.exists():
+        stem, suffix = Path(safe_name).stem, Path(safe_name).suffix
+        counter = 1
+        while target.exists():
+            target = uploads / f"{stem}-{counter}{suffix}"
+            counter += 1
+    target.write_bytes(data)
+    return _file_meta(root, target)
+
+
+def list_files(topic_id: str) -> list[dict]:
+    """List workspace files (excluding `.claude/` and symlinks), newest first."""
+    root = _workspace_root(topic_id)
+    if not root.is_dir():
+        return []
+    items: list[dict] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        if Path(dirpath) == root and RESERVED_DIRNAME in dirnames:
+            dirnames.remove(RESERVED_DIRNAME)
+        for name in filenames:
+            path = Path(dirpath) / name
+            if path.is_symlink() or not path.is_file():
+                continue
+            items.append(_file_meta(root, path))
+    items.sort(key=lambda item: item["modified_at"], reverse=True)
+    return items

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -472,6 +472,19 @@ class TopicMessage(BaseModel):
     updated_at: str = ""
 
 
+class WorkspaceFile(BaseModel):
+    name: str
+    rel_path: str
+    size: int = 0
+    modified_at: str = ""
+    content_type: str = "application/octet-stream"
+    kind: str = "output"
+
+
+class WorkspaceFileListResponse(BaseModel):
+    files: List[WorkspaceFile] = Field(default_factory=list)
+
+
 class TopicSummary(BaseModel):
     topic_id: str
     title: str

--- a/dataagent/dataagent-backend/tests/test_topic_files.py
+++ b/dataagent/dataagent-backend/tests/test_topic_files.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from config import get_settings, update_settings
+from core.topic_files import TopicFileError, list_files, safe_workspace_file, save_upload
+
+
+@pytest.fixture(autouse=True)
+def sandbox_root(tmp_path: Path):
+    original = get_settings().dataagent_sandbox_root
+    update_settings({"dataagent_sandbox_root": str(tmp_path / "workspaces")})
+    try:
+        yield tmp_path / "workspaces"
+    finally:
+        update_settings({"dataagent_sandbox_root": original})
+
+
+def test_save_upload_writes_into_uploads_dir(sandbox_root: Path):
+    meta = save_upload("topic_1", "a b!.csv", b"col\n1\n")
+
+    assert meta["rel_path"] == "uploads/a_b_.csv"
+    assert meta["kind"] == "input"
+    assert meta["size"] == 6
+    assert (sandbox_root / "topic_1" / "uploads" / "a_b_.csv").read_bytes() == b"col\n1\n"
+
+
+def test_save_upload_dedupes_colliding_names(sandbox_root: Path):
+    first = save_upload("topic_1", "data.csv", b"a")
+    second = save_upload("topic_1", "data.csv", b"b")
+
+    assert first["rel_path"] == "uploads/data.csv"
+    assert second["rel_path"] == "uploads/data-1.csv"
+
+
+def test_save_upload_rejects_blocked_extensions(sandbox_root: Path):
+    with pytest.raises(TopicFileError):
+        save_upload("topic_1", "evil.sh", b"#!/bin/sh\n")
+
+
+def test_list_files_excludes_claude_and_tags_kind(sandbox_root: Path):
+    root = sandbox_root / "topic_1"
+    (root / ".claude" / "skills" / "x").mkdir(parents=True)
+    (root / ".claude" / "skills" / "x" / "SKILL.md").write_text("# x\n", encoding="utf-8")
+    (root / "report.html").write_text("<h1>ok</h1>", encoding="utf-8")
+    save_upload("topic_1", "data.csv", b"a,b\n")
+
+    files = list_files("topic_1")
+    rels = {item["rel_path"]: item["kind"] for item in files}
+
+    assert rels == {"report.html": "output", "uploads/data.csv": "input"}
+    assert not any(item["rel_path"].startswith(".claude") for item in files)
+
+
+def test_list_files_skips_symlinks(sandbox_root: Path, tmp_path: Path):
+    root = sandbox_root / "topic_1"
+    root.mkdir(parents=True)
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "link.txt").symlink_to(outside)
+    (root / "real.txt").write_text("real", encoding="utf-8")
+
+    rels = {item["rel_path"] for item in list_files("topic_1")}
+    assert rels == {"real.txt"}
+
+
+def test_safe_workspace_file_resolves_inside_workspace(sandbox_root: Path):
+    root = sandbox_root / "topic_1"
+    (root / "outputs").mkdir(parents=True)
+    target = root / "outputs" / "r.html"
+    target.write_text("<p>ok</p>", encoding="utf-8")
+
+    resolved = safe_workspace_file("topic_1", "outputs/r.html")
+    assert resolved == target.resolve()
+
+
+@pytest.mark.parametrize("bad", ["../escape.txt", "a/../../escape", ".claude/skills/x"])
+def test_safe_workspace_file_rejects_traversal_and_reserved(sandbox_root: Path, bad: str):
+    (sandbox_root / "topic_1").mkdir(parents=True)
+    with pytest.raises(TopicFileError):
+        safe_workspace_file("topic_1", bad)
+
+
+def test_safe_workspace_file_confines_absolute_looking_paths(sandbox_root: Path):
+    root = (sandbox_root / "topic_1")
+    root.mkdir(parents=True)
+    # A leading slash is stripped and confined under the workspace, not the host root.
+    resolved = safe_workspace_file("topic_1", "/etc/passwd")
+    assert resolved == (root / "etc" / "passwd").resolve()
+
+
+def test_safe_workspace_file_rejects_symlink_escape(sandbox_root: Path, tmp_path: Path):
+    root = sandbox_root / "topic_1"
+    root.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("x", encoding="utf-8")
+    (root / "link.txt").symlink_to(outside)
+
+    with pytest.raises(TopicFileError):
+        safe_workspace_file("topic_1", "link.txt")

--- a/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -80,6 +80,27 @@ describe('createNl2SqlApiClient', () => {
     ])
   })
 
+  it('builds workspace file urls and routes uploads/listing to the runtime client', () => {
+    const client = createNl2SqlApiClient({ baseURL: 'https://odw.example.com' })
+
+    expect(client.topicApi.fileUrl('t1', 'uploads/a b.csv', { download: true })).toBe(
+      'https://odw.example.com/api/v1/nl2sql/topics/t1/files/uploads/a%20b.csv?download=1'
+    )
+    expect(client.topicApi.fileUrl('t1', 'report.html')).toBe(
+      'https://odw.example.com/api/v1/nl2sql/topics/t1/files/report.html'
+    )
+
+    client.topicApi.listFiles('t1')
+    expect(clients[0].get).toHaveBeenCalledWith('/topics/t1/files')
+
+    client.topicApi.uploadFile('t1', new Blob(['x']))
+    expect(clients[0].post).toHaveBeenCalledWith(
+      '/topics/t1/files',
+      expect.any(FormData),
+      expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } })
+    )
+  })
+
   it('exposes safe runtime config through the unified runtime API', () => {
     const client = createNl2SqlApiClient()
 

--- a/dataagent/dataagent-frontend/src/api/nl2sql.js
+++ b/dataagent/dataagent-frontend/src/api/nl2sql.js
@@ -149,6 +149,35 @@ export function createNl2SqlApiClient(options = {}) {
     },
     generateFollowupSuggestions(topicId, messageId) {
       return runtimeRequest.post(`/topics/${topicId}/messages/${messageId}/followup-suggestions`, {})
+    },
+    uploadFile(topicId, file, { onUploadProgress } = {}) {
+      const form = new FormData()
+      form.append('file', file)
+      return runtimeRequest.post(`/topics/${topicId}/files`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+        onUploadProgress
+      })
+    },
+    listFiles(topicId) {
+      return runtimeRequest.get(`/topics/${topicId}/files`)
+    },
+    fileUrl(topicId, relPath, { download = false } = {}) {
+      const encoded = String(relPath || '')
+        .split('/')
+        .map((seg) => encodeURIComponent(seg))
+        .join('/')
+      const query = download ? '?download=1' : ''
+      return buildUrl(baseURL, `${RUNTIME_PREFIX}/topics/${topicId}/files/${encoded}${query}`)
+    },
+    async fetchFileText(topicId, relPath) {
+      const response = await fetch(this.fileUrl(topicId, relPath), {
+        credentials: 'include',
+        headers: { ...defaultHeaders }
+      })
+      if (!response.ok) {
+        throw new Error(await extractHttpError(response))
+      }
+      return response.text()
     }
   }
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="v2-workbench">
+  <div class="v2-workbench" :class="{ 'artifacts-open': artifactsPanelOpen && !isWidgetMode }">
     <!-- Sidebar: topic list + agent selector -->
     <aside class="v2-sidebar">
       <div class="v2-sidebar-head">
@@ -137,6 +137,17 @@
     <main class="v2-main">
       <div v-if="messages.length" class="v2-main-top-bar">
         <h4 class="v2-topic-title">{{ activeTopic?.title }}</h4>
+        <button
+          v-if="!isWidgetMode"
+          type="button"
+          class="v2-artifacts-toggle"
+          :class="{ active: artifactsPanelOpen }"
+          title="会话文件 / 产物"
+          @click="toggleArtifactsPanel"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M4 5h6l2 2h8v11a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5z" /></svg>
+          <span>文件</span>
+        </button>
       </div>
 
       <el-scrollbar v-show="messages.length" ref="messagesScrollbarRef" class="v2-messages" @scroll="handleScroll">
@@ -269,8 +280,40 @@
             <div class="v2-landing-greeting">您好，我是{{ currentAgentName }}。</div>
           </template>
 
+          <!-- Attachment chips -->
+          <div v-if="pendingAttachments.length" class="v2-attach-chips">
+            <span
+              v-for="(att, i) in pendingAttachments"
+              :key="i"
+              class="v2-attach-chip"
+              :class="{ 'is-error': att.error, 'is-uploading': att.uploading }"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><path d="M21 12.5 12.5 21a4 4 0 0 1-5.66-5.66l8.49-8.49a2.5 2.5 0 0 1 3.54 3.54l-8.49 8.49a1 1 0 0 1-1.41-1.41l7.78-7.78" /></svg>
+              <span class="v2-attach-name">{{ att.name }}</span>
+              <span v-if="att.uploading" class="v2-attach-state">上传中…</span>
+              <span v-else-if="att.error" class="v2-attach-state">失败</span>
+              <button type="button" class="v2-attach-remove" title="移除" @click="removeAttachment(att)">×</button>
+            </span>
+          </div>
+
           <!-- Input bar -->
           <div class="v2-composer" :class="{ 'is-focused': inputText }">
+            <input
+              ref="fileInputRef"
+              type="file"
+              multiple
+              class="v2-file-input"
+              @change="handleFilesSelected"
+            />
+            <button
+              type="button"
+              class="v2-attach-btn"
+              :disabled="isStreaming"
+              title="上传文件"
+              @click="triggerFilePicker"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 12.5 12.5 21a4 4 0 0 1-5.66-5.66l8.49-8.49a2.5 2.5 0 0 1 3.54 3.54l-8.49 8.49a1 1 0 0 1-1.41-1.41l7.78-7.78" /></svg>
+            </button>
             <textarea
               ref="textareaRef"
               v-model="inputText"
@@ -285,7 +328,7 @@
               type="button"
               class="v2-send-btn"
               :class="{ 'v2-cancel-btn': activeTaskId }"
-              :disabled="activeTaskId ? false : !canSend"
+              :disabled="activeTaskId ? false : !canSendV2"
               @click="activeTaskId ? handleCancel() : handleSend()"
             >
               <svg v-if="activeTaskId" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><rect x="8" y="8" width="8" height="8" rx="1.5" /></svg>
@@ -336,6 +379,75 @@
         </div>
       </div>
     </main>
+
+    <!-- Right-side conversation artifact panel -->
+    <aside v-if="artifactsPanelOpen && !isWidgetMode" class="v2-artifacts-panel">
+      <div class="v2-artifacts-head">
+        <span class="v2-artifacts-title">会话文件</span>
+        <span class="v2-artifacts-actions">
+          <button type="button" title="刷新" @click="refreshArtifacts">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M21 12a9 9 0 1 1-2.64-6.36M21 4v5h-5" /></svg>
+          </button>
+          <button type="button" title="收起" @click="toggleArtifactsPanel">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" /></svg>
+          </button>
+        </span>
+      </div>
+
+      <div v-if="previewArtifact" class="v2-artifact-preview">
+        <div class="v2-artifact-preview-head">
+          <button type="button" class="v2-artifact-back" @click="closeArtifactPreview">← 返回</button>
+          <span class="v2-artifact-preview-name" :title="previewArtifact.name">{{ previewArtifact.name }}</span>
+          <a class="v2-artifact-dl-link" :href="artifactDownloadUrl(previewArtifact)" download>下载</a>
+        </div>
+        <div class="v2-artifact-preview-body">
+          <div v-if="previewError" class="v2-artifact-empty">{{ previewError }}</div>
+          <iframe
+            v-else-if="isHtmlArtifact(previewArtifact)"
+            class="v2-artifact-frame"
+            sandbox=""
+            referrerpolicy="no-referrer"
+            :srcdoc="previewText"
+          ></iframe>
+          <img
+            v-else-if="isImageArtifact(previewArtifact)"
+            class="v2-artifact-img"
+            :src="artifactInlineUrl(previewArtifact)"
+            :alt="previewArtifact.name"
+          />
+          <pre v-else-if="isTextArtifact(previewArtifact)" class="v2-artifact-text">{{ previewText }}</pre>
+          <div v-else class="v2-artifact-empty">该文件不支持预览，请下载查看。</div>
+        </div>
+      </div>
+
+      <el-scrollbar v-else class="v2-artifacts-scroll">
+        <div v-if="artifactsLoading" class="v2-artifacts-empty">加载中…</div>
+        <div v-else-if="!artifacts.length" class="v2-artifacts-empty">暂无文件</div>
+        <button
+          v-for="file in artifacts"
+          v-else
+          :key="file.rel_path"
+          type="button"
+          class="v2-artifact-item"
+          @click="openArtifact(file)"
+        >
+          <span class="v2-artifact-name" :title="file.name">{{ file.name }}</span>
+          <span class="v2-artifact-meta">
+            <span class="v2-artifact-tag" :class="file.kind">{{ file.kind === 'input' ? '上传' : '生成' }}</span>
+            <span class="v2-artifact-size">{{ formatBytes(file.size) }}</span>
+          </span>
+          <a
+            class="v2-artifact-row-dl"
+            :href="artifactDownloadUrl(file)"
+            download
+            title="下载"
+            @click.stop
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" /></svg>
+          </a>
+        </button>
+      </el-scrollbar>
+    </aside>
   </div>
 </template>
 
@@ -858,8 +970,12 @@ function handleModelCommand(command) {
 // through the engine options at setup.
 async function handleSend() {
   if (isWidgetMode.value) return
-  if (!inputText.value.trim() || isStreaming.value) return
-  await engineSend()
+  if (isStreaming.value || isUploading.value) return
+  const ready = pendingAttachments.value.filter((a) => a.rel_path && !a.uploading)
+  if (!inputText.value.trim() && !ready.length) return
+  const attachments = ready.map((a) => ({ name: a.name, rel_path: a.rel_path }))
+  pendingAttachments.value = []
+  await engineSend({ attachments })
 }
 
 // Enter 发送，Shift + Enter 换行;输入法组合输入期间的回车用于确认候选词,不发送。
@@ -873,6 +989,138 @@ function onEnterKey(event) {
 function handleCancel() {
   void engineCancel()
 }
+
+// ── Conversation files: composer upload + right-side artifact panel ──────────
+const fileInputRef = ref(null)
+const pendingAttachments = ref([])       // [{ name, rel_path, size, uploading, error }]
+const isUploading = computed(() => pendingAttachments.value.some((a) => a.uploading))
+const canSendV2 = computed(
+  () => !isUploading.value && (canSend.value || pendingAttachments.value.some((a) => a.rel_path && !a.uploading)),
+)
+
+const ARTIFACTS_PREF_KEY = 'nl2sql.artifactsPanelOpen'
+const artifactsPanelOpen = ref(readArtifactsPref())
+const artifacts = ref([])
+const artifactsLoading = ref(false)
+const previewArtifact = ref(null)
+const previewText = ref('')
+const previewError = ref('')
+
+function readArtifactsPref() {
+  try { return localStorage.getItem(ARTIFACTS_PREF_KEY) === '1' } catch (_e) { return false }
+}
+
+function triggerFilePicker() {
+  if (isStreaming.value) return
+  fileInputRef.value?.click()
+}
+
+async function handleFilesSelected(event) {
+  const files = Array.from(event?.target?.files || [])
+  if (event?.target) event.target.value = ''
+  if (!files.length) return
+  let topicId = activeTopicId.value
+  if (!topicId) {
+    try {
+      topicId = await chat.ensureTopic('新话题')
+      if (!isWidgetMode.value) replaceRouteTopic(topicId)
+    } catch (error) {
+      ElMessage.error('创建话题失败: ' + (error?.message || error))
+      return
+    }
+  }
+  for (const file of files) {
+    const entry = reactive({ name: file.name, rel_path: '', size: file.size, uploading: true, error: '' })
+    pendingAttachments.value.push(entry)
+    try {
+      const meta = await topicApi.uploadFile(topicId, file)
+      entry.name = meta.name
+      entry.rel_path = meta.rel_path
+      entry.size = meta.size
+      entry.uploading = false
+    } catch (error) {
+      entry.uploading = false
+      entry.error = String(error?.message || '上传失败')
+      ElMessage.error(`上传 ${file.name} 失败: ${entry.error}`)
+    }
+  }
+}
+
+function removeAttachment(entry) {
+  pendingAttachments.value = pendingAttachments.value.filter((a) => a !== entry)
+}
+
+function toggleArtifactsPanel() {
+  artifactsPanelOpen.value = !artifactsPanelOpen.value
+  try { localStorage.setItem(ARTIFACTS_PREF_KEY, artifactsPanelOpen.value ? '1' : '0') } catch (_e) { /* ignore */ }
+  if (artifactsPanelOpen.value) refreshArtifacts()
+}
+
+async function refreshArtifacts() {
+  const topicId = activeTopicId.value
+  if (!topicId) { artifacts.value = []; return }
+  artifactsLoading.value = true
+  try {
+    const res = await topicApi.listFiles(topicId)
+    artifacts.value = Array.isArray(res?.files) ? res.files : []
+  } catch (_error) {
+    // keep the previous list; listing is best-effort
+  } finally {
+    artifactsLoading.value = false
+  }
+}
+
+function artifactDownloadUrl(file) {
+  return topicApi.fileUrl(activeTopicId.value, file.rel_path, { download: true })
+}
+function artifactInlineUrl(file) {
+  return topicApi.fileUrl(activeTopicId.value, file.rel_path)
+}
+function isHtmlArtifact(file) {
+  return /text\/html/.test(file?.content_type || '') || /\.html?$/i.test(file?.name || '')
+}
+function isImageArtifact(file) {
+  return /^image\//.test(file?.content_type || '') || /\.(png|jpe?g|gif|svg|webp)$/i.test(file?.name || '')
+}
+function isTextArtifact(file) {
+  return /^text\/|application\/json|csv/.test(file?.content_type || '') || /\.(txt|csv|json|md|log|yaml|yml)$/i.test(file?.name || '')
+}
+
+async function openArtifact(file) {
+  previewArtifact.value = file
+  previewText.value = ''
+  previewError.value = ''
+  if (isHtmlArtifact(file) || isTextArtifact(file)) {
+    try {
+      previewText.value = await topicApi.fetchFileText(activeTopicId.value, file.rel_path)
+    } catch (error) {
+      previewError.value = String(error?.message || '加载失败')
+    }
+  }
+}
+function closeArtifactPreview() {
+  previewArtifact.value = null
+  previewText.value = ''
+  previewError.value = ''
+}
+
+function formatBytes(size) {
+  const n = Number(size) || 0
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// Refresh artifacts when a run finishes (new files may have been generated) and
+// reset the panel when switching conversations.
+watch(isStreaming, (now, prev) => {
+  if (prev && !now && artifactsPanelOpen.value) refreshArtifacts()
+})
+watch(activeTopicId, () => {
+  closeArtifactPreview()
+  if (artifactsPanelOpen.value) refreshArtifacts()
+  else artifacts.value = []
+})
 
 // Keep the view pinned to the latest content as the engine streams (the engine
 // triggers messages reactively); reloads / focus still force-scroll explicitly.
@@ -943,7 +1191,108 @@ onBeforeUnmount(() => {
 
 @media (min-width: 1280px) {
   .v2-workbench { grid-template-columns: 300px 1fr; }
+  .v2-workbench.artifacts-open { grid-template-columns: 300px 1fr 360px; }
 }
+
+.v2-workbench.artifacts-open { grid-template-columns: 260px 1fr 340px; }
+
+/* ── Conversation artifacts panel ────────────────────────────────────────── */
+.v2-artifacts-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-left: 1px solid #E5EAF1;
+  background: #FBFCFD;
+}
+.v2-artifacts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid #EDF0F4;
+}
+.v2-artifacts-title { font-size: 13px; font-weight: 600; color: #1F2937; }
+.v2-artifacts-actions { display: flex; gap: 4px; }
+.v2-artifacts-actions button {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; border: none; border-radius: 7px;
+  background: transparent; color: #6B7280; cursor: pointer;
+}
+.v2-artifacts-actions button:hover { background: #EEF1F5; color: #111827; }
+.v2-artifacts-scroll { flex: 1; min-height: 0; }
+.v2-artifacts-empty { padding: 24px 14px; color: #9AA4B2; font-size: 13px; text-align: center; }
+.v2-artifact-item {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 10px 14px; border: none; border-bottom: 1px solid #F1F3F6;
+  background: transparent; cursor: pointer; text-align: left;
+}
+.v2-artifact-item:hover { background: #F2F5F9; }
+.v2-artifact-name {
+  flex: 1; min-width: 0; font-size: 13px; color: #1F2937;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.v2-artifact-meta { display: flex; align-items: center; gap: 6px; }
+.v2-artifact-tag {
+  font-size: 11px; padding: 1px 6px; border-radius: 6px;
+  background: #EEF2FF; color: #4F46E5;
+}
+.v2-artifact-tag.input { background: #ECFDF3; color: #047857; }
+.v2-artifact-size { font-size: 11px; color: #9AA4B2; }
+.v2-artifact-row-dl {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 6px; color: #6B7280;
+}
+.v2-artifact-row-dl:hover { background: #E6EAF0; color: #111827; }
+.v2-artifact-preview { display: flex; flex-direction: column; min-height: 0; flex: 1; }
+.v2-artifact-preview-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px; border-bottom: 1px solid #EDF0F4;
+}
+.v2-artifact-back { border: none; background: transparent; color: #4F46E5; cursor: pointer; font-size: 13px; }
+.v2-artifact-preview-name {
+  flex: 1; min-width: 0; font-size: 13px; color: #1F2937;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.v2-artifact-dl-link { font-size: 13px; color: #4F46E5; text-decoration: none; }
+.v2-artifact-preview-body { flex: 1; min-height: 0; overflow: auto; background: #fff; }
+.v2-artifact-frame { width: 100%; height: 100%; border: none; background: #fff; }
+.v2-artifact-img { max-width: 100%; display: block; margin: 0 auto; }
+.v2-artifact-text {
+  margin: 0; padding: 12px 14px; font-size: 12px; line-height: 1.6;
+  white-space: pre-wrap; word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+/* ── Composer attachments ────────────────────────────────────────────────── */
+.v2-attach-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.v2-attach-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  max-width: 220px; padding: 4px 8px; border-radius: 8px;
+  background: #EEF2F7; color: #374151; font-size: 12px;
+}
+.v2-attach-chip.is-uploading { opacity: 0.75; }
+.v2-attach-chip.is-error { background: #FEF2F2; color: #B91C1C; }
+.v2-attach-name { max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-attach-state { font-size: 11px; color: #6B7280; }
+.v2-attach-remove { border: none; background: transparent; color: #6B7280; cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; }
+.v2-attach-remove:hover { color: #111827; }
+.v2-file-input { display: none; }
+.v2-attach-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; flex: none; border: none; border-radius: 8px;
+  background: transparent; color: #6B7280; cursor: pointer;
+}
+.v2-attach-btn:hover:not(:disabled) { background: #EEF1F5; color: #111827; }
+.v2-attach-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Artifacts toggle (top bar) ──────────────────────────────────────────── */
+.v2-artifacts-toggle {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 10px; border: 1px solid #E5EAF1; border-radius: 8px;
+  background: #fff; color: #4B5563; font-size: 12px; cursor: pointer;
+}
+.v2-artifacts-toggle:hover { background: #F4F6F9; }
+.v2-artifacts-toggle.active { border-color: #C7D2FE; background: #EEF2FF; color: #4338CA; }
 
 /* ── Sidebar ─────────────────────────────────────────────────────────────── */
 .v2-sidebar {
@@ -1151,11 +1500,13 @@ onBeforeUnmount(() => {
 .v2-main-top-bar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 10px;
   padding: 14px 24px 12px;
   border-bottom: 1px solid #eef1f5;
   flex-shrink: 0;
 }
+.v2-main-top-bar .v2-topic-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .v2-topic-title {
   flex: 1;

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
@@ -62,6 +62,41 @@ describe('useNl2SqlChat engine', () => {
     expect(chat.topicId.value).toBe('topic-new')
   })
 
+  it('send: appends an attachment note to the delivered content', async () => {
+    const api = makeApi()
+    api.taskApi.streamSdkEvents.mockImplementation(async (_taskId, opts) => {
+      opts.onRecord({ record_type: 'done', data: {} })
+    })
+    const chat = await ready(api)
+
+    chat.inputText.value = '分析这个文件'
+    await chat.send({ attachments: [{ name: 'sales.csv', rel_path: 'uploads/sales.csv' }] })
+    await flushPromises()
+
+    const delivered = api.taskApi.deliverMessage.mock.calls[0][0]
+    expect(delivered.content).toContain('分析这个文件')
+    expect(delivered.content).toContain('uploads/sales.csv')
+    const userMsg = chat.messages.value.find((m) => m.role === 'user')
+    expect(userMsg.content).toContain('📎')
+    expect(userMsg.content).toContain('sales.csv')
+  })
+
+  it('send: works with only attachments and no text', async () => {
+    const api = makeApi()
+    api.taskApi.streamSdkEvents.mockImplementation(async (_taskId, opts) => {
+      opts.onRecord({ record_type: 'done', data: {} })
+    })
+    const chat = await ready(api)
+
+    chat.inputText.value = ''
+    await chat.send({ attachments: [{ name: 'a.csv', rel_path: 'uploads/a.csv' }] })
+    await flushPromises()
+
+    expect(api.taskApi.deliverMessage).toHaveBeenCalledTimes(1)
+    const delivered = api.taskApi.deliverMessage.mock.calls[0][0]
+    expect(delivered.content).toContain('uploads/a.csv')
+  })
+
   it('newConversation while streaming detaches without cancelling the backend task', async () => {
     const api = makeApi()
     let resolveStream

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -341,14 +341,22 @@ export function useNl2SqlChat(options) {
 
   // Real backend send. Demo/mock flows live in the component and drive the
   // exposed message/state primitives directly.
-  const send = async () => {
+  const send = async ({ attachments = [] } = {}) => {
     const text = inputText.value.trim()
-    if (!text || isBusy.value) return
+    const ready = (attachments || []).filter((a) => a && a.rel_path)
+    if ((!text && !ready.length) || isBusy.value) return
     const runId = ++runToken
     isSubmitting.value = true
     inputText.value = ''
     errorText.value = ''
-    appendUserMessage(text)
+    const effectiveText = text || '请分析我上传的文件。'
+    const note = ready.length
+      ? `\n\n[附件] 用户上传了以下文件（位于当前工作区，可直接读取）：\n${ready.map((a) => `- ${a.rel_path}`).join('\n')}`
+      : ''
+    const displayText = ready.length
+      ? `${effectiveText}\n\n📎 ${ready.map((a) => a.name).join('、')}`
+      : effectiveText
+    appendUserMessage(displayText)
     const assistant = appendAssistantMessage('')
 
     // Create the controller before the network round-trip so a mid-request
@@ -356,11 +364,11 @@ export function useNl2SqlChat(options) {
     const controller = new AbortController()
     abortController.value = controller
     try {
-      const currentTopicId = await ensureTopic(truncate(text, topicTitleLength))
+      const currentTopicId = await ensureTopic(truncate(effectiveText, topicTitleLength))
       onTopicEnsured(currentTopicId)
       const response = await api.taskApi.deliverMessage({
         topic_id: currentTopicId,
-        content: text,
+        content: effectiveText + note,
         provider_id: selectedProvider.value || undefined,
         model: selectedModel.value || undefined,
         agent_id: getAgentId() || undefined,

--- a/docs/design/2026-06-04-dataagent-conversation-files-design.md
+++ b/docs/design/2026-06-04-dataagent-conversation-files-design.md
@@ -1,0 +1,137 @@
+# DataAgent Conversation Files Design
+
+## Current State
+
+Each conversation (topic) already owns an isolated workspace dir at
+`/workspaces/<topic_id>/` (`core/topic_workspace.py`). The agent runs with
+`cwd`/`HOME`/`PWD` = that dir, and a `PreToolUse` boundary hook
+(`core/agent_runtime.py`) restricts file tools to the workspace + enabled skill
+roots. In sandbox-runner mode the same host dir is bind-mounted into the child
+container as `/workspace`, so files written by either execution mode are visible
+to the other and to the backend (shared `/workspaces` mount).
+
+The chat frontend is `dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue`
+(2-column workbench: `260px` topic sidebar + `1fr` main = messages + composer),
+driven by `useNl2SqlChat.js` and the `/api/v1/nl2sql/*` client in `api/nl2sql.js`.
+There is no file upload in the composer and no artifact surface today. The backend
+(`api/routes.py`) has no workspace file upload/list/download endpoints; the only
+multipart endpoint is admin skill ZIP import.
+
+## Problem
+
+Users want to (1) attach files in the input box for the agent to analyze, and
+(2) see/download files the conversation produced (HTML reports, exports, charts)
+from a collapsible right-side artifact panel.
+
+## Scope
+
+In scope (phase 1):
+
+- Backend: per-topic file upload, list, and download endpoints over the topic
+  workspace.
+- Frontend `NL2SqlChatV2.vue` only: composer upload control; collapsible
+  right-side artifact panel with preview + download.
+
+Out of scope (later phases):
+
+- The embedded `WidgetChat.vue` / portal widget surface.
+- Image/most binary inline preview beyond basic types.
+- Versioning, multi-file ZIP download, server-side virus scanning.
+
+## Solution
+
+### Workspace layout
+
+```text
+/workspaces/<topic_id>/
+  .claude/            # reserved (skills, SDK sessions) — never listed/served
+  uploads/            # user-attached inputs
+  <agent-generated files...>   # HTML/CSV/PNG/... wherever the agent writes
+```
+
+Artifacts = every file under the workspace **except `.claude/`**. Uploaded files
+(under `uploads/`) are included too, tagged `input` vs `output` by whether they
+sit under `uploads/`.
+
+### Backend API (`/api/v1/nl2sql/topics/{topic_id}/files`)
+
+- `POST .../files` (multipart `file`) — sanitize the filename, ensure the topic
+  workspace + `uploads/` exist, write to `uploads/<safe_name>` (de-dupe on
+  collision), return `{name, rel_path, size, modified_at, kind: "input"}`.
+- `GET .../files` — walk the workspace, skipping `.claude/`, return a list of
+  `{name, rel_path, size, modified_at, content_type, kind}` sorted by mtime desc.
+- `GET .../files/{rel_path}` — stream the file via `FileResponse`. Hard
+  path-traversal guard: resolve under the workspace, reject `..`, symlink escape,
+  and any path under `.claude/`. `?download=1` forces attachment disposition;
+  otherwise inline with a sniffed content-type.
+
+All three reuse `resolve_topic_workspace(topic_id)` for the root and a shared
+`_safe_workspace_file(topic_id, rel_path)` resolver for the traversal guard. A
+configurable upload size cap (`DATAAGENT_UPLOAD_MAX_BYTES`, default 20 MiB) and an
+allowed-extension denylist for executables.
+
+### How the agent sees uploads
+
+The backend uploads files **before** the task runs (frontend uploads on select,
+after `ensureTopic`). When the user sends, the message content gets an appended
+attachment note listing the workspace-relative paths, e.g.
+
+```text
+[附件] 用户上传了以下文件（位于当前工作区，可直接读取）：
+- uploads/sales_q3.csv
+```
+
+Because the agent cwd is the workspace and the boundary hook already allows
+workspace paths, `Read uploads/sales_q3.csv` just works in both execution modes.
+No change to the boundary hook or skill contract.
+
+### Frontend `NL2SqlChatV2.vue`
+
+- Composer: a paperclip button + hidden `<input type=file multiple>`; on select,
+  upload each file (`topicApi.uploadFile`) and show removable chips above the
+  textarea with progress. Track uploaded `rel_path`s; on send, pass them so
+  `useNl2SqlChat.send()` appends the attachment note to the content.
+- Layout: add a third grid column. `.v2-workbench` becomes
+  `260px 1fr [auto]`; when the panel is open, `grid-template-columns:
+  260px 1fr 340px`. A toggle button in the main top bar opens/collapses it; state
+  persists per session in `localStorage`.
+- Artifact panel (`<aside class="v2-artifacts-panel">`): lists
+  `topicApi.listFiles(topic_id)`, refreshed when a task reaches a terminal state
+  and on manual refresh. Each row: icon by kind, name, size, `input`/`output`
+  tag, download button. Clicking a row opens a preview:
+  - HTML → **sandboxed `<iframe sandbox srcdoc=...>`** (no `allow-same-origin`,
+    no `allow-scripts` unless we later opt in) fetched via the download endpoint
+    as text; plus a download button.
+  - image → `<img>` from the inline URL.
+  - text/csv/json/md → `<pre>`/lightweight render.
+  - other → download-only.
+- Reset/refetch on conversation switch and new conversation.
+
+### Security
+
+- Path traversal: every file path resolved and confirmed under the workspace
+  root, `.claude/` always excluded, symlinks not followed out of the workspace.
+- HTML artifacts rendered only inside a sandboxed iframe so agent/result-derived
+  HTML cannot touch the portal session or call APIs as the user (XSS containment).
+- Upload size cap + executable-extension denylist; filenames sanitized.
+- Endpoints sit under `/api/v1/nl2sql/*`, inheriting the existing portal proxy
+  auth; topic ownership is enforced the same way as existing topic routes.
+
+## Tradeoffs
+
+Pros: reuses the per-topic workspace and existing boundary model; no agent/skill
+contract change; works in both in-process and sandbox execution via the shared
+mount.
+
+Cons: listing "all non-`.claude` files" can surface incidental scratch files the
+agent wrote; acceptable for phase 1 and avoids an output-dir contract. Sandboxed
+iframe without `allow-scripts` means HTML reports with JS (e.g. ECharts) render
+statically unless we later opt into a stricter scripted-sandbox review.
+
+## Affected Stacks
+
+- DataAgent backend: `api/routes.py` (new topic file router), a new
+  `core/topic_files.py` helper, `config.py` (size cap), `models/schemas.py`
+  (file metadata model).
+- Frontend: `NL2SqlChatV2.vue`, `useNl2SqlChat.js`, `api/nl2sql.js`.
+- Tests: backend file endpoint/traversal tests; frontend composer + panel specs.

--- a/docs/plans/2026-06-04-dataagent-conversation-files-plan.md
+++ b/docs/plans/2026-06-04-dataagent-conversation-files-plan.md
@@ -1,0 +1,73 @@
+# DataAgent Conversation Files Plan
+
+## Goal
+
+Add per-conversation file upload (for agent analysis) and a collapsible
+right-side artifact panel (preview + download of workspace files) to the
+standalone chat `NL2SqlChatV2.vue`, built on the existing per-topic workspace.
+
+## Phasing
+
+### Phase A — Backend topic file endpoints
+
+1. `core/topic_files.py`:
+   - `safe_workspace_file(topic_id, rel_path) -> Path` (resolve under workspace,
+     reject `..`/symlink escape/`.claude/`).
+   - `save_upload(topic_id, filename, data) -> dict` (sanitize name, ensure
+     `uploads/`, de-dupe, enforce size cap + extension denylist).
+   - `list_files(topic_id) -> list[dict]` (walk, skip `.claude/`, tag
+     input/output, sort by mtime desc).
+2. `models/schemas.py`: `WorkspaceFile` metadata model + list response.
+3. `config.py`: `dataagent_upload_max_bytes` (default 20 MiB).
+4. `api/routes.py`: topic-scoped file router — `POST/GET .../files`,
+   `GET .../files/{rel_path}` (FileResponse, `?download=1`).
+5. Tests `tests/test_topic_files.py`: upload roundtrip, list excludes `.claude/`,
+   traversal/`..`/symlink/`.claude` rejection, size-cap rejection, download
+   content-type + attachment disposition.
+
+### Phase B — Frontend upload in composer
+
+6. `api/nl2sql.js` `topicApi`: `uploadFile(topicId, file, {onProgress})`,
+   `listFiles(topicId)`, `fileUrl(topicId, relPath, {download})`,
+   `fetchFileText(topicId, relPath)`.
+7. `NL2SqlChatV2.vue` composer: paperclip button + hidden input + file chips
+   (progress, remove). Upload on select (after `ensureTopic`); keep uploaded
+   `rel_path`s.
+8. `useNl2SqlChat.js` `send()`: accept attached file refs, append the `[附件]`
+   note to content; clear refs after send.
+9. Spec: composer uploads a file and includes the attachment note on send.
+
+### Phase C — Artifact panel
+
+10. `NL2SqlChatV2.vue`: third grid column + top-bar toggle (persist open state in
+    `localStorage`); `<aside class="v2-artifacts-panel">` listing
+    `listFiles(topic_id)`, refreshed on terminal task status + manual refresh +
+    conversation switch.
+11. Preview: HTML in **sandboxed `<iframe sandbox srcdoc>`** (fetched text),
+    image `<img>`, text/csv/json/md `<pre>`, else download-only. Download button
+    per row + in preview.
+12. Spec: panel lists files (excludes `.claude`), toggles, renders an HTML
+    artifact inside a sandboxed iframe, triggers download.
+
+## Verification
+
+- Backend: `pytest tests/test_topic_files.py` plus existing topic/route tests.
+- Frontend: `nvm use` then `vitest run` for the new/updated specs.
+- Local e2e smoke (when Docker available): start MySQL/Redis/backend/frontend,
+  create a topic, upload a CSV, ask the agent to read it, have it write an HTML
+  report, confirm the panel lists + previews + downloads it; confirm a second
+  topic cannot see the first topic's files; confirm `.claude/` is never served.
+  Note explicitly if the e2e smoke is not run.
+
+## Backout
+
+- Remove the file router + `core/topic_files.py` + schema/config additions
+  (backend), and the composer upload + artifact panel (frontend). No schema or
+  DB migration is involved; workspaces are unaffected.
+
+## Notes / open items
+
+- Sandboxed iframe renders HTML without scripts by default; revisit a stricter
+  scripted-sandbox review if interactive (JS/ECharts) reports are needed.
+- Phase 2 (separate change): bring upload + artifacts to the embedded
+  `WidgetChat.vue` with a drawer layout.


### PR DESCRIPTION
## Summary

Builds on the per-topic workspace isolation (merged in #308) to add two conversation-scoped file capabilities to the standalone chat `NL2SqlChatV2.vue`:

1. **Composer file upload** — attach files for the agent to analyze.
2. **Collapsible right-side artifact panel** — preview/download files the conversation produced (HTML, CSV, images, …).

Files live in the topic workspace (`/workspaces/<topic_id>/`), so they are visible to both in-process and sandbox-runner execution via the shared mount, with no agent/skill contract change.

## Backend

- `core/topic_files.py`: confines every path to the workspace, excludes `.claude/`, skips symlinks, de-dupes uploads, blocks executable extensions, enforces an upload size cap (`dataagent_upload_max_bytes`, default 20 MiB).
- New endpoints under `/api/v1/nl2sql/topics/{topic_id}/files`:
  - `POST` — upload to `uploads/`
  - `GET` — list workspace files (all except `.claude/`), tagged `input`/`output`
  - `GET /{rel_path}` — download via `FileResponse` (`?download=1`)
- HTML is always served as `attachment` (never inline) + `X-Content-Type-Options: nosniff` to contain XSS on direct navigation.
- `models/schemas.py`: `WorkspaceFile` / `WorkspaceFileListResponse`.

## Frontend (`NL2SqlChatV2.vue`)

- Paperclip upload control: uploads to the workspace (ensuring a topic first), shows removable chips with progress; on send, the message content gets an attachment note so the agent reads the files (`Read uploads/x.csv` works since cwd is the workspace).
- Right-side artifact panel: top-bar toggle (state persisted in `localStorage`, 3-column grid), lists workspace files with input/output tags, size, and download. Preview: **HTML in a sandboxed `<iframe srcdoc>`** (no scripts/same-origin), images inline, text/csv/json as text, others download-only. Refreshes when a run finishes; resets on conversation switch.
- API client gains `uploadFile` / `listFiles` / `fileUrl` / `fetchFileText`; engine `send()` accepts attachments.

## Tests

- Backend: `tests/test_topic_files.py` (11) — upload roundtrip, listing excludes `.claude/`, traversal/`..`/symlink/`.claude` rejection, absolute-path confinement, blocked extensions.
- Frontend: engine attachment-note specs + API client `fileUrl`/upload specs (13 passing in the touched files).

## Not done / follow-ups

- Live `docker compose up` end-to-end smoke (upload CSV → agent reads → generates HTML → panel previews/downloads) was **not run** — no Docker in the change environment.
- The embedded `WidgetChat.vue` surface and demo-mode mocks are intentionally out of scope (phase 2).
- Sandboxed iframe renders HTML without scripts; interactive (JS/ECharts) reports render statically until a stricter scripted-sandbox review.

Design/plan: `docs/design|plans/2026-06-04-dataagent-conversation-files-*`.

https://claude.ai/code/session_01DHjgz4f51kkiqULRgGrpMU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHjgz4f51kkiqULRgGrpMU)_