### PR TITLE
feat(dataagent): support scoped skills in sandbox execution

### DIFF
--- a/dataagent/dataagent-backend/Dockerfile
+++ b/dataagent/dataagent-backend/Dockerfile
@@ -5,18 +5,16 @@ ENV PYTHONUNBUFFERED=1
 ENV HOME=/workspaces
 ENV DATAAGENT_SANDBOX_ROOT=/workspaces
 
-WORKDIR /app/dataagent-backend
+WORKDIR /opt/dataagent-backend
 
 COPY dataagent/dataagent-backend/requirements.txt /tmp/requirements.txt
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
-RUN mkdir -p /workspaces && chmod 1777 /workspaces
+RUN mkdir -p /workspaces /app/.claude/skills && chmod 1777 /workspaces
 
-COPY dataagent/dataagent-backend /app/dataagent-backend
-COPY dataagent/.claude /app/.claude
-RUN chmod +x /app/.claude/skills/opendataworks-platform-tools/bin/odw-cli
+COPY dataagent/dataagent-backend /opt/dataagent-backend
 
 EXPOSE 8900
 

--- a/dataagent/dataagent-backend/Dockerfile.runner
+++ b/dataagent/dataagent-backend/Dockerfile.runner
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 ENV HOME=/workspaces
 ENV DATAAGENT_SANDBOX_ROOT=/workspaces
 
-WORKDIR /app/dataagent-backend
+WORKDIR /opt/dataagent-backend
 
 # runner 仅通过挂载的 docker socket 调 `docker run/ps/rm` 启动子容器，只需 docker 客户端，
 # 不需要 docker.io 带来的守护进程 + containerd + runc。从官方 docker CLI 镜像拷静态二进制。
@@ -16,11 +16,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
-RUN mkdir -p /workspaces && chmod 1777 /workspaces
+RUN mkdir -p /workspaces /app/.claude/skills && chmod 1777 /workspaces
 
-COPY dataagent/dataagent-backend /app/dataagent-backend
-COPY dataagent/.claude /app/.claude
-RUN chmod +x /app/.claude/skills/opendataworks-platform-tools/bin/odw-cli
+COPY dataagent/dataagent-backend /opt/dataagent-backend
 
 EXPOSE 8910
 

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     doris_database: str = ""
 
     # ---- Skills ----
+    skills_root_dir: str = ""
     skills_output_dir: str = "../.claude/skills/opendataworks-business-knowledge"
     dataagent_upload_max_bytes: int = 20 * 1024 * 1024
     dataagent_portal_mcp_enabled: bool = True

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -923,8 +923,7 @@ def _skill_source(folder: str) -> str:
 
 
 def _current_skill_folder() -> str:
-    root = resolve_skills_root_dir()
-    return root.name if root else ""
+    return _folder_from_skills_output_dir(str(get_settings().skills_output_dir or "")) or DEFAULT_PRIMARY_SKILL_FOLDER
 
 
 def _skill_runtime_from_current_settings() -> dict[str, dict[str, bool]]:

--- a/dataagent/dataagent-backend/core/skill_discovery.py
+++ b/dataagent/dataagent-backend/core/skill_discovery.py
@@ -21,29 +21,31 @@ def _backend_root() -> Path:
 
 
 def _resolve_root_dir(raw: str) -> Path:
-    path = Path(raw or "../.claude/skills/opendataworks-business-knowledge")
+    value = str(raw or "").strip()
+    if not value:
+        raise SkillDiscoveryError("SKILLS_ROOT_DIR is required")
+    path = Path(value)
     if path.is_absolute():
-        return path
+        return path.expanduser().resolve(strict=False)
     return (_backend_root() / path).resolve()
 
 
 def resolve_builtin_skill_root_dir() -> Path:
-    cfg = get_settings()
-    return _resolve_root_dir(cfg.skills_output_dir)
+    return resolve_skills_root_dir()
 
 
 def resolve_skills_root_dir() -> Path:
-    return resolve_builtin_skill_root_dir()
+    cfg = get_settings()
+    root = _resolve_root_dir(getattr(cfg, "skills_root_dir", ""))
+    if root.name != "skills" or root.parent.name != ".claude":
+        raise SkillDiscoveryError(f"SKILLS_ROOT_DIR must resolve to a '.claude/skills' directory, current={root}")
+    if not root.is_dir():
+        raise SkillDiscoveryError(f"SKILLS_ROOT_DIR directory not found: {root}")
+    return root
 
 
 def resolve_skill_discovery_root_dir() -> Path:
-    builtin_root = resolve_builtin_skill_root_dir()
-    discovery_root = builtin_root.parent
-    if discovery_root.name == "skills" and discovery_root.parent.name == ".claude":
-        return discovery_root
-    raise SkillDiscoveryError(
-        f"builtin skills_output_dir must resolve under '.claude/skills', current={builtin_root}"
-    )
+    return resolve_skills_root_dir()
 
 
 def resolve_agent_project_cwd() -> Path:

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -948,12 +948,10 @@ async def _execute_task_stream_local(
     prepared_workspace_dir = ""
     if str(os.environ.get("DATAAGENT_WORKSPACE_PREPARED") or "").strip() == "1":
         prepared_workspace_dir = str(os.environ.get("DATAAGENT_WORKSPACE_DIR") or "").strip()
-    skill_link_root = str(os.environ.get("DATAAGENT_SKILL_LINK_ROOT") or "").strip() or None
     project_cwd = prepare_topic_workspace(
         params.topic_id,
         enabled_folders,
         allow_empty=bool(agent_snapshot) or not enabled_folders,
-        skill_link_root=skill_link_root,
         workspace_dir=prepared_workspace_dir or None,
     )
     workspace_env = {

--- a/dataagent/dataagent-backend/core/topic_workspace.py
+++ b/dataagent/dataagent-backend/core/topic_workspace.py
@@ -61,7 +61,6 @@ def prepare_topic_workspace(
     enabled_folders: list[str] | tuple[str, ...],
     *,
     allow_empty: bool = False,
-    skill_link_root: str | Path | None = None,
     sandbox_root: str | Path | None = None,
     workspace_dir: str | Path | None = None,
 ) -> Path:
@@ -83,16 +82,17 @@ def prepare_topic_workspace(
         else:
             shutil.rmtree(existing)
 
-    container_link_root = Path(skill_link_root) if skill_link_root else None
     for folder in enabled:
-        source = (discovery_root / folder).resolve()
+        source = (discovery_root / folder).resolve(strict=False)
         if not source.is_dir():
             raise SkillDiscoveryError(f"enabled skill folder not found: {folder}")
         if not (source / "SKILL.md").is_file():
             raise SkillDiscoveryError(f"enabled skill missing SKILL.md: {folder}")
 
-        target = container_link_root / folder if container_link_root else source
-        _replace_path_with_symlink(runtime_skills_dir / folder, target)
+        link_path = (runtime_skills_dir / folder).resolve(strict=False)
+        if link_path == source:
+            continue
+        _replace_path_with_symlink(runtime_skills_dir / folder, source)
 
     return workspace
 

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import re
-import socket
+import shutil
 import subprocess
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -17,6 +17,8 @@ from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
 from config import get_settings
+from core.agent_profile_service import normalize_agent_snapshot
+from core.skill_admin_service import resolve_enabled_skill_runtime
 from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
 from core.topic_workspace import resolve_topic_workspace, sanitize_topic_id
 
@@ -28,23 +30,14 @@ SANDBOX_CONTAINER_LABEL_VALUE = "dataagent-sandbox-runner"
 SANDBOX_TASK_ID_LABEL = "dataagent.sandbox.task_id"
 SANDBOX_TOPIC_ID_LABEL = "dataagent.sandbox.topic_id"
 
-# Mount point where the runner image/compose exposes the live skills root. Child
-# task containers should mount the same host source so they see live (and offline
-# package) skills instead of the image-baked copy.
-RUNNER_SKILLS_MOUNT_TARGET = "/app/.claude/skills"
-
-# Host source of the runner's own skills mount, auto-discovered at startup so the
-# live-skills child mount is on by default without extra configuration.
-_AUTO_HOST_SKILLS_DIR: str | None = None
+CHILD_APP_ROOT = "/app"
+CHILD_SKILLS_ROOT = "/app/.claude/skills"
+BACKEND_CODE_ROOT = "/opt/dataagent-backend"
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await _cleanup_stale_sandbox_containers()
-    global _AUTO_HOST_SKILLS_DIR
-    _AUTO_HOST_SKILLS_DIR = await _discover_host_skills_dir()
-    if _AUTO_HOST_SKILLS_DIR:
-        logger.info("auto-discovered host skills dir for child mounts: %s", _AUTO_HOST_SKILLS_DIR)
     yield
 
 
@@ -76,7 +69,7 @@ _FORWARDED_ENV_KEYS = {
     "PATH",
     "TZ",
     "PYTHONPATH",
-    "DATAAGENT_SKILLS_OUTPUT_DIR",
+    "SKILLS_ROOT_DIR",
 }
 
 
@@ -161,60 +154,8 @@ def _should_use_container_backend() -> bool:
     return backend in {"docker", "podman"} and bool(image)
 
 
-async def _discover_host_skills_dir() -> str:
-    """Resolve the host source of the runner's own ``/app/.claude/skills`` mount.
-
-    The runner shares the host Docker socket, so it can inspect itself and read
-    the host path backing its live skills bind. Child task containers then mount
-    that same source, picking up live/offline-updated skills by default instead
-    of the image-baked copy. Best-effort: any failure returns "" and the child
-    falls back to the image skills.
-    """
-    if not _should_use_container_backend():
-        return ""
-    cfg = get_settings()
-    backend = str(getattr(cfg, "dataagent_sandbox_backend", "") or "docker").strip().lower()
-    self_id = socket.gethostname().strip()
-    if not self_id:
-        return ""
-    template = (
-        '{{range .Mounts}}{{if eq .Destination "'
-        + RUNNER_SKILLS_MOUNT_TARGET
-        + '"}}{{.Source}}{{end}}{{end}}'
-    )
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            backend,
-            "inspect",
-            "--format",
-            template,
-            self_id,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError:
-        logger.warning("sandbox backend command not found during skills discovery: %s", backend)
-        return ""
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
-        logger.warning(
-            "host skills auto-discovery failed backend=%s stderr=%s",
-            backend,
-            stderr.decode("utf-8", errors="replace").strip(),
-        )
-        return ""
-    source = stdout.decode("utf-8", errors="replace").strip()
-    if not source or not Path(source).is_absolute():
-        return ""
-    return source
-
-
 def _resolve_host_skills_dir(cfg: Any) -> str:
-    """Explicit override wins; otherwise use the auto-discovered runner mount."""
-    explicit = str(getattr(cfg, "dataagent_sandbox_host_skills_dir", "") or "").strip()
-    if explicit:
-        return explicit
-    return _AUTO_HOST_SKILLS_DIR or ""
+    return str(getattr(cfg, "dataagent_sandbox_host_skills_dir", "") or "").strip()
 
 
 def _safe_container_fragment(value: str) -> str:
@@ -236,7 +177,7 @@ def _topic_host_workspace(topic_id: str) -> Path:
     return _host_sandbox_root() / sanitize_topic_id(topic_id)
 
 
-def _build_child_env(*, skill_link_root: str) -> dict[str, str]:
+def _build_child_env() -> dict[str, str]:
     child_env = {
         key: str(value)
         for key, value in os.environ.items()
@@ -245,16 +186,92 @@ def _build_child_env(*, skill_link_root: str) -> dict[str, str]:
     child_env.update(
         {
             "PYTHONUNBUFFERED": "1",
-            "HOME": "/workspace",
-            "PWD": "/workspace",
-            "DATAAGENT_WORKSPACE_DIR": "/workspace",
+            "HOME": CHILD_APP_ROOT,
+            "PWD": CHILD_APP_ROOT,
+            "DATAAGENT_WORKSPACE_DIR": CHILD_APP_ROOT,
             "DATAAGENT_WORKSPACE_PREPARED": "1",
-            "DATAAGENT_SKILL_LINK_ROOT": skill_link_root,
             "DATAAGENT_SANDBOX_MODE": "",
-            "DATAAGENT_SANDBOX_ROOT": "/workspace",
+            "DATAAGENT_SANDBOX_ROOT": CHILD_APP_ROOT,
+            "SKILLS_ROOT_DIR": CHILD_SKILLS_ROOT,
         }
     )
     return child_env
+
+
+def _dedupe_skill_folders(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    result: list[str] = []
+    seen: set[str] = set()
+    iterable = values if isinstance(values, (list, tuple, set)) else []
+    for value in iterable:
+        folder = str(value or "").strip()
+        if not folder or folder in seen:
+            continue
+        result.append(folder)
+        seen.add(folder)
+    return result
+
+
+def _enabled_skill_folders_for_task(params: TaskExecutionInput) -> list[str]:
+    if params.agent_snapshot is not None:
+        snapshot = normalize_agent_snapshot(params.agent_snapshot)
+        return _dedupe_skill_folders(snapshot.get("skill_folders"))
+    runtime = resolve_enabled_skill_runtime()
+    return _dedupe_skill_folders(runtime.get("enabled_folders"))
+
+
+def _validate_skill_folder_name(folder: str) -> str:
+    value = str(folder or "").strip()
+    if not value or Path(value).name != value or "/" in value or "\\" in value:
+        raise RuntimeError(f"invalid enabled skill folder: {folder}")
+    return value
+
+
+def _build_skill_mounts(cfg: Any, enabled_folders: list[str]) -> list[tuple[str, str]]:
+    if not enabled_folders:
+        return []
+    host_skills_dir = _resolve_host_skills_dir(cfg)
+    if not host_skills_dir:
+        raise RuntimeError("DATAAGENT_SANDBOX_HOST_SKILLS_DIR is required when sandbox task enables skills")
+    host_root = Path(host_skills_dir).expanduser().resolve()
+    if not host_root.is_dir():
+        raise RuntimeError(f"DATAAGENT_SANDBOX_HOST_SKILLS_DIR directory not found: {host_root}")
+
+    mounts: list[tuple[str, str]] = []
+    for raw_folder in enabled_folders:
+        folder = _validate_skill_folder_name(raw_folder)
+        source = (host_root / folder).resolve()
+        if not (source == host_root or source.is_relative_to(host_root)):
+            raise RuntimeError(f"enabled skill folder escapes skills root: {folder}")
+        if not source.is_dir():
+            raise RuntimeError(f"enabled skill folder not found: {folder}")
+        if not (source / "SKILL.md").is_file():
+            raise RuntimeError(f"enabled skill missing SKILL.md: {folder}")
+        mounts.append((folder, str(source)))
+    return mounts
+
+
+def _prepare_child_skill_mount_targets(topic_workspace: Path, enabled_folders: list[str]) -> None:
+    skills_dir = topic_workspace / ".claude" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    enabled_set = set(enabled_folders)
+    for existing in skills_dir.iterdir():
+        if existing.name in enabled_set:
+            continue
+        if existing.is_symlink() or existing.is_file():
+            existing.unlink()
+        elif existing.is_dir():
+            shutil.rmtree(existing)
+    for folder in enabled_folders:
+        target = skills_dir / folder
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif target.exists() and target.is_dir():
+            shutil.rmtree(target)
+        target.mkdir(parents=True, exist_ok=True)
 
 
 def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list[str]]:
@@ -268,15 +285,16 @@ def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list
 
     topic_workspace = _topic_host_workspace(params.topic_id)
     topic_workspace.mkdir(parents=True, exist_ok=True)
+    enabled_folders = _enabled_skill_folders_for_task(params)
+    skill_mounts = _build_skill_mounts(cfg, enabled_folders)
+    _prepare_child_skill_mount_targets(topic_workspace, enabled_folders)
     _ensure_topic_workspace_owner(topic_workspace)
     container_name = (
         f"dataagent-task-{_safe_container_fragment(params.topic_id)[:32]}-"
         f"{_safe_container_fragment(params.task_id)[:32]}"
     )
 
-    host_skills_dir = _resolve_host_skills_dir(cfg)
-    skill_link_root = "/skills" if host_skills_dir else RUNNER_SKILLS_MOUNT_TARGET
-    child_env = _build_child_env(skill_link_root=skill_link_root)
+    child_env = _build_child_env()
 
     command = [
         backend,
@@ -292,9 +310,9 @@ def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list
         "--label",
         f"{SANDBOX_TOPIC_ID_LABEL}={sanitize_topic_id(params.topic_id)}",
         "--workdir",
-        "/workspace",
+        CHILD_APP_ROOT,
         "--mount",
-        f"type=bind,source={topic_workspace},target=/workspace",
+        f"type=bind,source={topic_workspace},target={CHILD_APP_ROOT}",
     ]
     network = str(getattr(cfg, "dataagent_sandbox_network", "") or "").strip()
     if network:
@@ -303,16 +321,11 @@ def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list
     gid = str(os.environ.get("DATAAGENT_RUNTIME_GID") or "").strip()
     if uid and gid:
         command.extend(["--user", f"{uid}:{gid}"])
-    if host_skills_dir:
-        command.extend(
-            [
-                "--mount",
-                f"type=bind,source={Path(host_skills_dir).expanduser().resolve()},target=/skills,readonly",
-            ]
-        )
+    for folder, source in skill_mounts:
+        command.extend(["--mount", f"type=bind,source={source},target={CHILD_SKILLS_ROOT}/{folder},readonly"])
     for key, value in sorted(child_env.items()):
         command.extend(["--env", f"{key}={value}"])
-    command.extend([image, "python", "/app/dataagent-backend/sandbox_task_main.py"])
+    command.extend([image, "python", f"{BACKEND_CODE_ROOT}/sandbox_task_main.py"])
     return backend, container_name, command
 
 
@@ -322,8 +335,13 @@ def _ensure_topic_workspace_owner(topic_workspace: Path) -> None:
     if not uid or not gid:
         return
     try:
-        os.chown(topic_workspace, int(uid), int(gid))
-        os.chmod(topic_workspace, 0o775)
+        numeric_uid = int(uid)
+        numeric_gid = int(gid)
+        for path in (topic_workspace, topic_workspace / ".claude", topic_workspace / ".claude" / "skills"):
+            if not path.exists():
+                continue
+            os.chown(path, numeric_uid, numeric_gid)
+            os.chmod(path, 0o775)
     except PermissionError:
         logger.warning("cannot chown topic workspace path=%s uid=%s gid=%s", topic_workspace, uid, gid)
     except ValueError:

--- a/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
+++ b/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
@@ -4,13 +4,27 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DOCKERFILE = REPO_ROOT / "dataagent" / "dataagent-backend" / "Dockerfile"
 RUNNER_DOCKERFILE = REPO_ROOT / "dataagent" / "dataagent-backend" / "Dockerfile.runner"
 
 
 def test_runner_dockerfile_uses_runner_entrypoint():
     content = RUNNER_DOCKERFILE.read_text(encoding="utf-8")
 
+    assert "WORKDIR /opt/dataagent-backend" in content
+    assert "COPY dataagent/dataagent-backend /opt/dataagent-backend" in content
+    assert "COPY dataagent/.claude" not in content
     assert "sandbox_runner_main:app" in content
     assert 'EXPOSE 8910' in content
     assert "alembic upgrade head" not in content
     assert '"main:app"' not in content
+
+
+def test_backend_dockerfile_uses_opt_backend_and_no_bundled_skills():
+    content = BACKEND_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "WORKDIR /opt/dataagent-backend" in content
+    assert "COPY dataagent/dataagent-backend /opt/dataagent-backend" in content
+    assert "COPY dataagent/.claude" not in content
+    assert "alembic upgrade head" in content
+    assert 'EXPOSE 8900' in content

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -17,7 +17,21 @@ from core.task_executor import TaskExecutionInput
 from core.task_executor import TaskExecutionResult
 
 
-def _payload() -> dict:
+def _agent_snapshot(skill_folders: list[str] | None = None) -> dict:
+    return {
+        "agent_id": "agent-custom",
+        "name": "自定义智能体",
+        "permission_mode": "default",
+        "allowed_tools": ["Read"],
+        "mcp_server_ids": [],
+        "skill_folders": skill_folders or [],
+        "max_turns": 0,
+        "env_vars": {},
+        "is_default": False,
+    }
+
+
+def _payload(agent_snapshot: dict | None = None) -> dict:
     return {
         "task_id": "task-1",
         "topic_id": "topic-1",
@@ -32,7 +46,7 @@ def _payload() -> dict:
         "sql_read_timeout_seconds": 30,
         "sql_write_timeout_seconds": 30,
         "execution_mode": "background",
-        "agent_snapshot": None,
+        "agent_snapshot": agent_snapshot,
     }
 
 
@@ -98,7 +112,9 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
     monkeypatch.setenv("DATAAGENT_RUNTIME_UID", "1000")
     monkeypatch.setenv("DATAAGENT_RUNTIME_GID", "1000")
     try:
-        backend, container_name, command = sandbox_runner_main._build_container_command(TaskExecutionInput(**_payload()))
+        backend, container_name, command = sandbox_runner_main._build_container_command(
+            TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot([])))
+        )
     finally:
         update_settings(originals)
 
@@ -106,8 +122,9 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
     assert container_name.startswith("dataagent-task-topic-1-task-1")
     assert host_root / "topic-1" == tmp_path / "topics" / "topic-1"
     assert (host_root / "topic-1").is_dir()
-    assert f"type=bind,source={host_root / 'topic-1'},target=/workspace" in command
-    assert f"type=bind,source={host_root},target=/workspace" not in command
+    assert (host_root / "topic-1" / ".claude" / "skills").is_dir()
+    assert f"type=bind,source={host_root / 'topic-1'},target=/app" in command
+    assert f"type=bind,source={host_root},target=/app" not in command
     assert "--network" in command
     assert "container:opendataworks-dataagent-sandbox-runner" in command
     assert "--interactive" in command
@@ -118,15 +135,19 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
     assert "1000:1000" in command
     assert "opendataworks-dataagent-runner:test" in command
     assert "python" in command
-    assert "/app/dataagent-backend/sandbox_task_main.py" in command
+    assert "/opt/dataagent-backend/sandbox_task_main.py" in command
     assert not any("/var/run/docker.sock" in arg for arg in command)
+    assert not any("target=/skills" in arg for arg in command)
+    assert not any("target=/workspace" in arg for arg in command)
 
     env_values = [command[index + 1] for index, item in enumerate(command) if item == "--env"]
-    assert "HOME=/workspace" in env_values
-    assert "PWD=/workspace" in env_values
-    assert "DATAAGENT_WORKSPACE_DIR=/workspace" in env_values
+    assert "HOME=/app" in env_values
+    assert "PWD=/app" in env_values
+    assert "DATAAGENT_WORKSPACE_DIR=/app" in env_values
     assert "DATAAGENT_WORKSPACE_PREPARED=1" in env_values
-    assert "DATAAGENT_SKILL_LINK_ROOT=/app/.claude/skills" in env_values
+    assert "DATAAGENT_SANDBOX_ROOT=/app" in env_values
+    assert "SKILLS_ROOT_DIR=/app/.claude/skills" in env_values
+    assert not any(value.startswith("DATAAGENT_SKILL_LINK_ROOT=") for value in env_values)
     assert not any(value.startswith("DATAAGENT_TASK_PAYLOAD_B64=") for value in env_values)
 
 
@@ -177,58 +198,19 @@ def test_sandbox_runner_startup_cleanup_removes_labeled_stale_containers(monkeyp
     assert calls[1] == ("docker", "rm", "-f", "container-a", "container-b")
 
 
-def test_discover_host_skills_dir_reads_runner_mount_source(monkeypatch):
-    settings = get_settings()
-    originals = {
-        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
-        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
-    }
-    update_settings(
-        {
-            "dataagent_sandbox_backend": "docker",
-            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
-        }
-    )
-    calls: list[tuple[str, ...]] = []
-
-    class FakeProcess:
-        returncode = 0
-
-        async def communicate(self):
-            return b"/srv/offline/skills\n", b""
-
-    async def fake_exec(*args, **kwargs):
-        calls.append(tuple(str(arg) for arg in args))
-        return FakeProcess()
-
-    monkeypatch.setattr(sandbox_runner_main.socket, "gethostname", lambda: "runner-cid")
-    monkeypatch.setattr(sandbox_runner_main.asyncio, "create_subprocess_exec", fake_exec)
-    try:
-        resolved = asyncio.run(sandbox_runner_main._discover_host_skills_dir())
-    finally:
-        update_settings(originals)
-
-    assert resolved == "/srv/offline/skills"
-    assert calls[0][:4] == ("docker", "inspect", "--format", calls[0][3])
-    assert calls[0][1] == "inspect"
-    assert sandbox_runner_main.RUNNER_SKILLS_MOUNT_TARGET in calls[0][3]
-    assert calls[0][-1] == "runner-cid"
-
-
-def test_resolve_host_skills_dir_prefers_explicit_then_auto(monkeypatch):
+def test_resolve_host_skills_dir_uses_explicit_setting_only(monkeypatch):
     settings = get_settings()
     original = settings.dataagent_sandbox_host_skills_dir
-    monkeypatch.setattr(sandbox_runner_main, "_AUTO_HOST_SKILLS_DIR", "/auto/skills")
     try:
         update_settings({"dataagent_sandbox_host_skills_dir": ""})
-        assert sandbox_runner_main._resolve_host_skills_dir(get_settings()) == "/auto/skills"
+        assert sandbox_runner_main._resolve_host_skills_dir(get_settings()) == ""
         update_settings({"dataagent_sandbox_host_skills_dir": "/explicit/skills"})
         assert sandbox_runner_main._resolve_host_skills_dir(get_settings()) == "/explicit/skills"
     finally:
         update_settings({"dataagent_sandbox_host_skills_dir": original})
 
 
-def test_sandbox_runner_mounts_auto_discovered_skills_into_child(monkeypatch, tmp_path: Path):
+def test_sandbox_runner_mounts_only_enabled_agent_skills_into_child(monkeypatch, tmp_path: Path):
     settings = get_settings()
     originals = {
         "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
@@ -239,22 +221,93 @@ def test_sandbox_runner_mounts_auto_discovered_skills_into_child(monkeypatch, tm
     }
     host_root = tmp_path / "topics"
     host_skills = tmp_path / "offline" / "skills"
-    host_skills.mkdir(parents=True)
+    skill_dir = host_skills / "platform-imported-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# imported\n", encoding="utf-8")
+    unused_skill = host_skills / "unused-skill"
+    unused_skill.mkdir(parents=True)
+    (unused_skill / "SKILL.md").write_text("# unused\n", encoding="utf-8")
     update_settings(
         {
             "dataagent_sandbox_backend": "docker",
             "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
             "dataagent_sandbox_host_root": str(host_root),
             "dataagent_sandbox_root": str(tmp_path / "container-topics"),
-            "dataagent_sandbox_host_skills_dir": "",
+            "dataagent_sandbox_host_skills_dir": str(host_skills),
         }
     )
-    monkeypatch.setattr(sandbox_runner_main, "_AUTO_HOST_SKILLS_DIR", str(host_skills))
     try:
-        _, _, command = sandbox_runner_main._build_container_command(TaskExecutionInput(**_payload()))
+        _, _, command = sandbox_runner_main._build_container_command(
+            TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot(["platform-imported-skill"])))
+        )
     finally:
         update_settings(originals)
 
-    assert f"type=bind,source={host_skills},target=/skills,readonly" in command
+    assert (
+        f"type=bind,source={skill_dir.resolve()},target=/app/.claude/skills/platform-imported-skill,readonly"
+        in command
+    )
+    assert not any("unused-skill" in item for item in command)
+    assert not any(f"source={host_skills.resolve()},target=/app/.claude/skills" in item for item in command)
     env_values = [command[index + 1] for index, item in enumerate(command) if item == "--env"]
-    assert "DATAAGENT_SKILL_LINK_ROOT=/skills" in env_values
+    assert "SKILLS_ROOT_DIR=/app/.claude/skills" in env_values
+
+
+def test_sandbox_runner_requires_host_skills_dir_when_agent_enables_skills(monkeypatch, tmp_path: Path):
+    settings = get_settings()
+    originals = {
+        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
+        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
+        "dataagent_sandbox_host_root": settings.dataagent_sandbox_host_root,
+        "dataagent_sandbox_host_skills_dir": settings.dataagent_sandbox_host_skills_dir,
+    }
+    update_settings(
+        {
+            "dataagent_sandbox_backend": "docker",
+            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
+            "dataagent_sandbox_host_root": str(tmp_path / "topics"),
+            "dataagent_sandbox_host_skills_dir": "",
+        }
+    )
+    try:
+        try:
+            sandbox_runner_main._build_container_command(
+                TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot(["platform-imported-skill"])))
+            )
+        except RuntimeError as exc:
+            assert "DATAAGENT_SANDBOX_HOST_SKILLS_DIR" in str(exc)
+        else:
+            raise AssertionError("expected missing host skills dir to fail")
+    finally:
+        update_settings(originals)
+
+
+def test_sandbox_runner_requires_enabled_skill_folder_to_exist(monkeypatch, tmp_path: Path):
+    settings = get_settings()
+    originals = {
+        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
+        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
+        "dataagent_sandbox_host_root": settings.dataagent_sandbox_host_root,
+        "dataagent_sandbox_host_skills_dir": settings.dataagent_sandbox_host_skills_dir,
+    }
+    host_skills = tmp_path / "skills"
+    host_skills.mkdir()
+    update_settings(
+        {
+            "dataagent_sandbox_backend": "docker",
+            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
+            "dataagent_sandbox_host_root": str(tmp_path / "topics"),
+            "dataagent_sandbox_host_skills_dir": str(host_skills),
+        }
+    )
+    try:
+        try:
+            sandbox_runner_main._build_container_command(
+                TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot(["missing-skill"])))
+            )
+        except RuntimeError as exc:
+            assert "enabled skill folder not found: missing-skill" in str(exc)
+        else:
+            raise AssertionError("expected missing enabled skill to fail")
+    finally:
+        update_settings(originals)

--- a/dataagent/dataagent-backend/tests/test_skill_discovery.py
+++ b/dataagent/dataagent-backend/tests/test_skill_discovery.py
@@ -7,6 +7,7 @@ import pytest
 
 from config import get_settings, update_settings
 from core.skill_discovery import (
+    resolve_builtin_skill_root_dir,
     resolve_agent_project_cwd,
     resolve_skill_discovery_root_dir,
     resolve_skills_root_dir,
@@ -16,10 +17,11 @@ from core.skill_discovery import (
 @pytest.fixture(autouse=True)
 def restore_skill_settings():
     original = get_settings().skills_output_dir
+    original_root = getattr(get_settings(), "skills_root_dir", "")
     try:
         yield
     finally:
-        update_settings({"skills_output_dir": original})
+        update_settings({"skills_output_dir": original, "skills_root_dir": original_root})
 
 
 def _write_skill(root: Path, folder: str):
@@ -33,12 +35,29 @@ def _write_skill(root: Path, folder: str):
     )
 
 
-def test_discovery_paths_are_based_on_primary_skill_root(tmp_path: Path):
+def test_discovery_paths_are_based_on_skills_root_dir(tmp_path: Path):
     project = tmp_path / "project"
     skills_root = project / ".claude" / "skills"
     _write_skill(skills_root, "opendataworks-business-knowledge")
-    update_settings({"skills_output_dir": str(skills_root / "opendataworks-business-knowledge")})
+    update_settings({"skills_root_dir": str(skills_root)})
 
-    assert resolve_skills_root_dir() == skills_root / "opendataworks-business-knowledge"
+    assert resolve_builtin_skill_root_dir() == skills_root
+    assert resolve_skills_root_dir() == skills_root
     assert resolve_skill_discovery_root_dir() == skills_root
     assert resolve_agent_project_cwd() == project
+
+
+def test_discovery_requires_skills_root_dir():
+    update_settings({"skills_root_dir": ""})
+
+    with pytest.raises(Exception, match="SKILLS_ROOT_DIR"):
+        resolve_skill_discovery_root_dir()
+
+
+def test_discovery_rejects_non_claude_skills_root(tmp_path: Path):
+    root = tmp_path / "skills"
+    root.mkdir(parents=True)
+    update_settings({"skills_root_dir": str(root)})
+
+    with pytest.raises(Exception, match=".claude/skills"):
+        resolve_skill_discovery_root_dir()

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -7,10 +7,13 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
+from config import get_settings, update_settings
 from core import task_executor
 
 
@@ -82,6 +85,18 @@ class ToolResultBlock:
         self.tool_use_id = tool_use_id
         self.name = name
         self.content = content
+
+
+@pytest.fixture(autouse=True)
+def _configured_skills_root(tmp_path: Path):
+    original = getattr(get_settings(), "skills_root_dir", "")
+    skills_root = tmp_path / ".claude" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    update_settings({"skills_root_dir": str(skills_root)})
+    try:
+        yield
+    finally:
+        update_settings({"skills_root_dir": original})
 
 
 def _install_fake_sdk(monkeypatch, messages, *, final_exception=None):

--- a/dataagent/dataagent-backend/tests/test_topic_workspace.py
+++ b/dataagent/dataagent-backend/tests/test_topic_workspace.py
@@ -31,6 +31,7 @@ def test_resolve_topic_workspace_uses_topic_id_only(monkeypatch, tmp_path: Path)
 def test_prepare_topic_workspace_uses_container_skill_links(monkeypatch, tmp_path: Path):
     original_root = get_settings().dataagent_sandbox_root
     original_skills = get_settings().skills_output_dir
+    original_skills_root = getattr(get_settings(), "skills_root_dir", "")
     project = tmp_path / "project"
     skills_root = project / ".claude" / "skills"
     _write_skill(skills_root, "opendataworks-business-knowledge")
@@ -38,30 +39,74 @@ def test_prepare_topic_workspace_uses_container_skill_links(monkeypatch, tmp_pat
     update_settings(
         {
             "dataagent_sandbox_root": str(tmp_path / "topics"),
-            "skills_output_dir": str(skills_root / "opendataworks-business-knowledge"),
+            "skills_root_dir": str(skills_root),
         }
     )
     try:
         workspace = prepare_topic_workspace(
             "topic_1",
             ["opendataworks-business-knowledge", "opendataworks-platform-tools"],
-            skill_link_root="/skills",
         )
     finally:
-        update_settings({"dataagent_sandbox_root": original_root, "skills_output_dir": original_skills})
+        update_settings(
+            {
+                "dataagent_sandbox_root": original_root,
+                "skills_output_dir": original_skills,
+                "skills_root_dir": original_skills_root,
+            }
+        )
 
     skill_link = workspace / ".claude" / "skills" / "opendataworks-business-knowledge"
     platform_link = workspace / ".claude" / "skills" / "opendataworks-platform-tools"
     assert workspace == tmp_path / "topics" / "topic_1"
     assert skill_link.is_symlink()
     assert platform_link.is_symlink()
-    assert skill_link.readlink() == Path("/skills/opendataworks-business-knowledge")
-    assert platform_link.readlink() == Path("/skills/opendataworks-platform-tools")
+    assert skill_link.readlink() == skills_root / "opendataworks-business-knowledge"
+    assert platform_link.readlink() == skills_root / "opendataworks-platform-tools"
+
+
+def test_prepare_topic_workspace_keeps_skills_mounted_inside_workspace(monkeypatch, tmp_path: Path):
+    original_root = get_settings().dataagent_sandbox_root
+    original_skills = get_settings().skills_output_dir
+    original_skills_root = getattr(get_settings(), "skills_root_dir", "")
+    workspace = tmp_path / "topic-workspace"
+    skills_root = workspace / ".claude" / "skills"
+    _write_skill(skills_root, "platform-imported-skill")
+    stale = skills_root / "stale-skill"
+    stale.mkdir(parents=True)
+    (stale / "SKILL.md").write_text("# stale\n", encoding="utf-8")
+    update_settings(
+        {
+            "dataagent_sandbox_root": str(tmp_path / "topics"),
+            "skills_root_dir": str(skills_root),
+        }
+    )
+    try:
+        prepared = prepare_topic_workspace(
+            "topic_2",
+            ["platform-imported-skill"],
+            workspace_dir=workspace,
+        )
+    finally:
+        update_settings(
+            {
+                "dataagent_sandbox_root": original_root,
+                "skills_output_dir": original_skills,
+                "skills_root_dir": original_skills_root,
+            }
+        )
+
+    skill_dir = prepared / ".claude" / "skills" / "platform-imported-skill"
+    assert prepared == workspace.resolve()
+    assert skill_dir.is_dir()
+    assert not skill_dir.is_symlink()
+    assert not (prepared / ".claude" / "skills" / "stale-skill").exists()
 
 
 def test_prepare_topic_workspace_can_use_pre_mounted_workspace(monkeypatch, tmp_path: Path):
     original_root = get_settings().dataagent_sandbox_root
     original_skills = get_settings().skills_output_dir
+    original_skills_root = getattr(get_settings(), "skills_root_dir", "")
     project = tmp_path / "project"
     skills_root = project / ".claude" / "skills"
     mounted_workspace = tmp_path / "mounted-workspace"
@@ -69,23 +114,28 @@ def test_prepare_topic_workspace_can_use_pre_mounted_workspace(monkeypatch, tmp_
     update_settings(
         {
             "dataagent_sandbox_root": str(tmp_path / "topics"),
-            "skills_output_dir": str(skills_root / "opendataworks-business-knowledge"),
+            "skills_root_dir": str(skills_root),
         }
     )
     try:
         workspace = prepare_topic_workspace(
             "topic_1",
             ["opendataworks-business-knowledge"],
-            skill_link_root="/skills",
             workspace_dir=mounted_workspace,
         )
     finally:
-        update_settings({"dataagent_sandbox_root": original_root, "skills_output_dir": original_skills})
+        update_settings(
+            {
+                "dataagent_sandbox_root": original_root,
+                "skills_output_dir": original_skills,
+                "skills_root_dir": original_skills_root,
+            }
+        )
 
     assert workspace == mounted_workspace.resolve()
     assert workspace != tmp_path / "topics" / "topic_1"
     assert (workspace / ".claude" / "skills" / "opendataworks-business-knowledge").readlink() == Path(
-        "/skills/opendataworks-business-knowledge"
+        skills_root / "opendataworks-business-knowledge"
     )
 
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
@@ -414,6 +414,8 @@ const traceCommand = computed(() => toolAction.value.detail)
 
 const traceCommandPrefix = computed(() => (traceKind.value === 'shell' ? '$ ' : ''))
 
+const traceSummaryDetail = computed(() => String(toolAction.value.description || traceCommand.value || '').trim())
+
 const traceDescription = computed(() => {
   if (bootstrapSkillLabel.value) return bootstrapSkillLabel.value
   if (traceKind.value === 'read') return toolAction.value.description || '正在读取文件'
@@ -427,7 +429,7 @@ const traceDescription = computed(() => {
 
 const traceSummaryText = computed(() => {
   if (bootstrapSkillLabel.value) return bootstrapSkillLabel.value
-  const detail = traceCommand.value || traceDescription.value
+  const detail = traceSummaryDetail.value || traceDescription.value
 
   // A shell step that produces a chart_spec is the chart-generation tool call;
   // label it as such so it stays recognizable alongside the conclusion chart.
@@ -452,7 +454,9 @@ const traceSummaryText = computed(() => {
     return detail ? `执行技能：${detail}` : '正在准备技能上下文'
   }
   if (traceKind.value === 'tool') {
-    return displayLabel.value || (detail ? `执行工具：${detail}` : '执行工具')
+    return toolAction.value.description
+      ? `执行工具：${toolAction.value.description}`
+      : (displayLabel.value || (detail ? `执行工具：${detail}` : '执行工具'))
   }
 
   const leading = detail || displayLabel.value || toolName.value

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/ToolOutputRenderer.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/ToolOutputRenderer.spec.js
@@ -151,6 +151,27 @@ describe('ToolOutputRenderer', () => {
     expect(wrapper.find('.shell-trace-panel').exists()).toBe(false)
   })
 
+  it('uses the Claude tool description as the collapsed shell trace summary', async () => {
+    const wrapper = mountRenderer({
+      name: 'Bash',
+      status: 'success',
+      _callComplete: true,
+      _runtimeStarted: true,
+      input: {
+        command: 'python3 .claude/skills/arch-governance-assistant/scripts/lookup_ontology.py --query 慢接口',
+        description: 'Lookup ontology for "慢接口" slow interface'
+      },
+      output: 'done'
+    })
+
+    expect(wrapper.find('.shell-trace-summary-text').text()).toBe('执行命令：Lookup ontology for "慢接口" slow interface')
+    expect(wrapper.find('.shell-trace-summary-text').text()).not.toContain('lookup_ontology.py')
+
+    await wrapper.find('.shell-trace-summary').trigger('click')
+
+    expect(wrapper.text()).toContain('$ python3 .claude/skills/arch-governance-assistant/scripts/lookup_ontology.py --query 慢接口')
+  })
+
   it('renders read tools with an expandable output panel once content is available', async () => {
     const wrapper = mountRenderer({
       name: 'Read',

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -84,9 +84,10 @@ DATAAGENT_SANDBOX_IMAGE=mikefan2019/opendataworks-dataagent-runner:latest
 DATAAGENT_SANDBOX_BACKEND=docker
 DATAAGENT_SANDBOX_NETWORK=container:opendataworks-dataagent-sandbox-runner
 DATAAGENT_DOCKER_SOCKET=/var/run/docker.sock
-# 留空即默认开启：runner 通过 docker socket 自检自身 /app/.claude/skills 的宿主源，
-# 并把该宿主目录只读挂进每个 task child 容器（/skills），让 child 用到实时/离线包更新后的
-# skills，而不是镜像构建时烤进去的旧副本。仅当需要覆盖时才填绝对宿主路径。
+# 留空时 scripts/start.sh 会把 DATAAGENT_SKILLS_DIR 解析成宿主机绝对路径并写回本项；
+# runner 再按当前助手启用范围，把该宿主目录下的具体 skill 只读挂进每个 task child 容器的
+# /app/.claude/skills/<folder>，让 child 只看到本次启用的实时 skills。
+# 仅当需要覆盖时才手动填写绝对宿主路径。
 DATAAGENT_SANDBOX_HOST_SKILLS_DIR=
 
 # 挂载路径（相对于 deploy/）

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -162,6 +162,7 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      SKILLS_ROOT_DIR: /app/.claude/skills
       DATAAGENT_SANDBOX_MODE: ${DATAAGENT_SANDBOX_MODE:-}
       DATAAGENT_SANDBOX_RUNNER_URL: ${DATAAGENT_SANDBOX_RUNNER_URL:-http://dataagent-sandbox-runner:8910}
       DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/workspaces}
@@ -222,6 +223,7 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      SKILLS_ROOT_DIR: /app/.claude/skills
     depends_on:
       dataagent-home-init:
         condition: service_completed_successfully

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -167,6 +167,7 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      SKILLS_ROOT_DIR: /app/.claude/skills
       DATAAGENT_SANDBOX_MODE: ${DATAAGENT_SANDBOX_MODE:-}
       DATAAGENT_SANDBOX_RUNNER_URL: ${DATAAGENT_SANDBOX_RUNNER_URL:-http://dataagent-sandbox-runner:8910}
       DATAAGENT_SANDBOX_ROOT: ${DATAAGENT_SANDBOX_ROOT:-/workspaces}
@@ -228,6 +229,7 @@ services:
       DATAAGENT_PORTAL_MCP_BASE_URL: ${DATAAGENT_PORTAL_MCP_BASE_URL:-http://portal-mcp:8801/mcp/}
       DATAAGENT_PORTAL_MCP_TOKEN: ${DATAAGENT_PORTAL_MCP_TOKEN:-odw-portal-mcp-token}
       DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME: ${DATAAGENT_PORTAL_MCP_TOKEN_HEADER_NAME:-X-Portal-MCP-Token}
+      SKILLS_ROOT_DIR: /app/.claude/skills
     depends_on:
       dataagent-home-init:
         condition: service_completed_successfully

--- a/docs/design/2026-06-04-dataagent-sandbox-live-skills-design.md
+++ b/docs/design/2026-06-04-dataagent-sandbox-live-skills-design.md
@@ -1,70 +1,84 @@
-# DataAgent Sandbox Live Skills Design
+# DataAgent Sandbox Scoped Skills Design
 
 ## Current State
 
-With `DATAAGENT_SANDBOX_MODE` enabled, `dataagent-sandbox-runner` starts one
-child container per task. Skills are exposed to the child through the topic
-workspace's `.claude/skills/<folder>` symlinks, whose target is the
-`DATAAGENT_SKILL_LINK_ROOT` chosen by the runner:
+`dataagent-backend` and `dataagent-sandbox-runner` run from container images, while
+platform-managed skills are mounted at runtime from `DATAAGENT_SKILLS_DIR`.
+Sandbox mode delegates task execution to the runner, which starts one child
+container per task.
 
-- `/skills/<folder>` when `DATAAGENT_SANDBOX_HOST_SKILLS_DIR` is set (runner binds
-  that host dir read-only into the child as `/skills`)
-- `/app/.claude/skills/<folder>` otherwise — the **image-baked** skills
+The execution contract is now:
 
-Both the backend and runner already bind-mount the live skills
-(`${DATAAGENT_SKILLS_DIR}:/app/.claude/skills`); offline packages repoint
-`DATAAGENT_SKILLS_DIR` to `deploy/dataagent-runtime/skills`.
+- service code lives in `/opt/dataagent-backend`
+- runtime skills root is `SKILLS_ROOT_DIR=/app/.claude/skills`
+- child task workspace is mounted at `/app`
+- child task skills are mounted directly under `/app/.claude/skills/<folder>`
 
 ## Problem
 
-When `DATAAGENT_SANDBOX_HOST_SKILLS_DIR` is unset (the default), the child falls
-back to `/app/.claude/skills` from the **runner image**, i.e. the skills baked at
-image build time. Live edits and offline-package skill updates are invisible to
-child task containers until the runner image itself is rebuilt. The operator has
-to manually discover and set an absolute host path to fix it, which is easy to
-miss.
+The old child contract had multiple skill locations (`/skills`,
+`/app/.claude/skills`, and `/workspace/.claude/skills`) plus an image-baked
+fallback. In offline-package deployment, platform-imported skills could be shown
+as enabled on a custom agent but still be invisible to the child task container,
+causing Claude Code skill lookup failures.
+
+The fallback also made child containers less clean: a task could see a full
+skills tree or stale image-baked skills instead of only the skills enabled for
+the current assistant.
 
 ## Solution
 
-Make the live-skills child mount on by default.
+Use one skills root concept and scope child mounts by assistant.
 
-The runner shares the host Docker socket, so at startup it inspects its own
-container and reads the host source backing its `/app/.claude/skills` mount:
+Backend and runner compose services set:
 
 ```text
-docker inspect --format
-  '{{range .Mounts}}{{if eq .Destination "/app/.claude/skills"}}{{.Source}}{{end}}{{end}}'
-  <self-hostname>
+SKILLS_ROOT_DIR=/app/.claude/skills
 ```
 
-The discovered absolute host path is cached and used as the child `/skills` bind
-source. Resolution order in `_build_container_command`:
+Both services mount the live platform skills tree there for administration,
+import, indexing, and runner validation:
 
-1. explicit `DATAAGENT_SANDBOX_HOST_SKILLS_DIR` (unchanged override)
-2. auto-discovered runner skills mount source
-3. image-baked `/app/.claude/skills` (last-resort fallback)
+```text
+${DATAAGENT_SKILLS_DIR}:/app/.claude/skills
+```
 
-Discovery is best-effort: any failure (no socket, no such mount, non-container
-backend) returns empty and the child keeps the previous image-skills fallback,
-so nothing regresses when the runner is not container-backed.
+The runner requires `DATAAGENT_SANDBOX_HOST_SKILLS_DIR`, which `scripts/start.sh`
+fills from `DATAAGENT_SKILLS_DIR` before compose startup. For each task, the
+runner resolves the current assistant's `agent_snapshot.skill_folders` and
+mounts only those folders into the child:
+
+```text
+<host-skills>/<folder>:/app/.claude/skills/<folder>:ro
+```
+
+The child workspace is mounted to `/app`, with `HOME`, `PWD`,
+`DATAAGENT_WORKSPACE_DIR`, and `DATAAGENT_SANDBOX_ROOT` all set to `/app`.
+The child runs `/opt/dataagent-backend/sandbox_task_main.py`, so mounting the
+workspace at `/app` cannot hide the service code.
+
+`resolve_skill_discovery_root_dir()` reads only `SKILLS_ROOT_DIR`; it no longer
+derives the root from `skills_output_dir`.
 
 ## Tradeoffs
 
 Pros:
 
-- live and offline-package skills reach child task containers with no extra config
-- explicit override preserved; fallback behavior unchanged on failure
-- no new image build or named-volume plumbing
+- child containers see only the skills enabled for the current assistant
+- no image-baked skills fallback
+- one runtime skills root: `/app/.claude/skills`
+- offline-package and platform-imported skills are used without rebuilding images
 
 Cons:
 
-- relies on the runner being able to inspect itself via the Docker socket (which
-  it already holds); environments that hide the socket fall back to image skills
-- assumes the runner's own skills are bind-mounted at `/app/.claude/skills`
-  (true for the shipped Compose)
+- sandbox tasks with enabled skills fail fast if `DATAAGENT_SANDBOX_HOST_SKILLS_DIR`
+  is missing or points to an invalid host path
+- direct compose startup without `scripts/start.sh` must provide the host skills
+  path explicitly
 
 ## Affected Stacks
 
-- DataAgent backend: `dataagent/dataagent-backend/sandbox_runner_main.py`
-- Deployment: `deploy/.env.example` (documented default-on behavior)
-- Tests: `dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`
+- DataAgent backend runtime configuration and skill discovery
+- Sandbox runner child container command construction
+- DataAgent backend and runner Dockerfiles
+- Dev/prod compose deployment files

--- a/docs/plans/2026-06-04-dataagent-sandbox-live-skills-plan.md
+++ b/docs/plans/2026-06-04-dataagent-sandbox-live-skills-plan.md
@@ -1,43 +1,47 @@
-# DataAgent Sandbox Live Skills Plan
+# DataAgent Sandbox Scoped Skills Plan
 
 ## Goal
 
-Default sandbox child task containers to the live (and offline-package-updated)
-skills instead of the runner image's baked-in copy, without requiring operators
-to set an absolute host skills path.
+Make sandbox child containers clean and deterministic: they run from `/app`, use
+`SKILLS_ROOT_DIR=/app/.claude/skills`, and only receive the skills enabled by the
+current assistant.
 
 ## Tasks
 
-1. Auto-discover the runner's own host skills mount.
-   - Add `_discover_host_skills_dir()` in `sandbox_runner_main.py`: `docker/podman
-     inspect <self-hostname>` for the host source of the `/app/.claude/skills`
-     mount; best-effort, returns "" on any failure.
-   - Cache the result at startup in `lifespan` (module global).
+1. Unify skills root configuration.
+   - Add `skills_root_dir` / `SKILLS_ROOT_DIR`.
+   - Make `resolve_skill_discovery_root_dir()` read only `SKILLS_ROOT_DIR`.
+   - Fail fast when the root is empty, missing, or not `.claude/skills`.
 
-2. Use it by default.
-   - Add `_resolve_host_skills_dir(cfg)`: explicit `DATAAGENT_SANDBOX_HOST_SKILLS_DIR`
-     wins, else the auto-discovered source, else image fallback.
-   - Wire it into `_build_container_command` for the `/skills` bind and
-     `DATAAGENT_SKILL_LINK_ROOT`.
+2. Remove image-baked skills.
+   - Move backend and runner service code to `/opt/dataagent-backend`.
+   - Drop `COPY dataagent/.claude` from backend and runner Dockerfiles.
+   - Keep runtime skills mounted by compose at `/app/.claude/skills`.
 
-3. Docs + tests.
-   - Document the default-on behavior in `deploy/.env.example`.
-   - Update the runner child-mount contract in
-     `2026-06-04-dataagent-topic-workspace-isolation-design.md`.
-   - Add regression tests: discovery parses the inspect source; resolver
-     precedence; child command mounts the auto-discovered dir and sets
-     `DATAAGENT_SKILL_LINK_ROOT=/skills`.
+3. Scope child mounts by assistant.
+   - Mount topic workspace to child `/app`.
+   - Resolve enabled folders from `agent_snapshot.skill_folders` when present.
+   - Bind only enabled skill folders to `/app/.claude/skills/<folder>:ro`.
+   - Remove `/skills`, `/workspace`, and `DATAAGENT_SKILL_LINK_ROOT` from the
+     child contract.
+
+4. Keep offline package behavior intact.
+   - Keep `scripts/start.sh` auto-populating `DATAAGENT_SANDBOX_HOST_SKILLS_DIR`
+     from `DATAAGENT_SKILLS_DIR`.
+   - Keep `scripts/create-offline-package.sh --exclude='*-assistant'` unchanged.
 
 ## Verification
 
-- `pytest tests/test_sandbox_runner_main.py` — 7 passed (4 existing + 3 new).
-- `py_compile sandbox_runner_main.py` — ok.
-- Live `docker compose up` with `DATAAGENT_SANDBOX_MODE` on, editing a skill file
-  on the host and confirming the child task container sees the edit, remains
-  unrun: Docker unavailable in the change environment.
+- Focused pytest for skill discovery, topic workspace, sandbox runner, task
+  executor, agent runtime, admin skill routes, Dockerfile contracts, and package
+  hooks.
+- `bash -n` for changed shell scripts.
+- `py_compile` for changed DataAgent Python modules.
+- Real offline-package sandbox E2E remains a separate smoke if Docker/provider
+  credentials are available.
 
 ## Backout
 
-- Revert `sandbox_runner_main.py` to read `dataagent_sandbox_host_skills_dir`
-  directly with the image fallback, and drop the discovery/resolver helpers and
-  their tests. No schema or API changes.
+Revert the Dockerfile path move, restore the old child workspace mount target,
+and reintroduce the previous skill mount contract. No schema migration is
+required.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,6 +30,38 @@ read_env_value() {
     printf '%s' "${line#*=}"
 }
 
+set_env_value() {
+    local key="$1"
+    local value="$2"
+    local env_file="$3"
+    local tmp_file="${env_file}.tmp.$$"
+
+    if grep -q -E "^${key}=" "$env_file" 2>/dev/null; then
+        awk -v target_key="$key" -v target_value="$value" '
+            BEGIN { written = 0 }
+            $0 ~ "^" target_key "=" {
+                print target_key "=" target_value
+                written = 1
+                next
+            }
+            { print }
+            END {
+                if (!written) {
+                    print target_key "=" target_value
+                }
+            }
+        ' "$env_file" > "$tmp_file"
+    else
+        cp "$env_file" "$tmp_file"
+        {
+            echo ""
+            echo "${key}=${value}"
+        } >> "$tmp_file"
+    fi
+
+    mv "$tmp_file" "$env_file"
+}
+
 normalize_path() {
     local path="$1"
     local is_absolute=false
@@ -139,6 +171,23 @@ ensure_dataagent_cli_executable() {
     fi
 }
 
+ensure_dataagent_sandbox_host_skills_dir() {
+    local configured
+    configured="$(read_env_value "DATAAGENT_SANDBOX_HOST_SKILLS_DIR" "$ENV_FILE")"
+    if [ -n "$configured" ]; then
+        return 0
+    fi
+
+    local skills_dir
+    skills_dir="$(resolve_dataagent_skills_dir)"
+    if [ ! -d "$skills_dir" ]; then
+        return 0
+    fi
+
+    set_env_value "DATAAGENT_SANDBOX_HOST_SKILLS_DIR" "$skills_dir" "$ENV_FILE"
+    echo "🔧 已设置 DataAgent sandbox live skills 宿主路径: $skills_dir"
+}
+
 if [ ! -f "$COMPOSE_FILE" ]; then
     echo "❌ 错误: 未找到 $COMPOSE_FILE"
     exit 1
@@ -192,6 +241,7 @@ echo "🚀 启动 OpenDataWorks 服务..."
 echo ""
 
 ensure_dataagent_cli_executable
+ensure_dataagent_sandbox_host_skills_dir
 
 # 启动服务
 pushd "$DEPLOY_DIR" >/dev/null

--- a/tests/test_deepeval_packaging_hooks.py
+++ b/tests/test_deepeval_packaging_hooks.py
@@ -98,3 +98,21 @@ def test_private_business_skill_assets_are_ignored_and_not_packaged():
     assert "/evals/" in gitignore
     assert "*-core.jsonl" in gitignore
     assert "--exclude='*-assistant'" in create_package
+
+
+def test_start_script_pins_sandbox_child_skills_to_runtime_skills_dir():
+    start_script = (REPO_ROOT / "scripts" / "start.sh").read_text(encoding="utf-8")
+
+    assert "ensure_dataagent_sandbox_host_skills_dir" in start_script
+    assert 'read_env_value "DATAAGENT_SANDBOX_HOST_SKILLS_DIR"' in start_script
+    assert 'skills_dir="$(resolve_dataagent_skills_dir)"' in start_script
+    assert 'set_env_value "DATAAGENT_SANDBOX_HOST_SKILLS_DIR" "$skills_dir" "$ENV_FILE"' in start_script
+    assert start_script.index("ensure_dataagent_sandbox_host_skills_dir") < start_script.index('"${COMPOSE_CMD[@]}"')
+
+
+def test_compose_sets_container_skills_root_dir():
+    prod_compose = (REPO_ROOT / "deploy" / "docker-compose.prod.yml").read_text(encoding="utf-8")
+    dev_compose = (REPO_ROOT / "deploy" / "docker-compose.dev.yml").read_text(encoding="utf-8")
+
+    for compose in (prod_compose, dev_compose):
+        assert "SKILLS_ROOT_DIR: /app/.claude/skills" in compose


### PR DESCRIPTION
This PR implements scoped skills for task sandboxes, mounting only the skills enabled for the current assistant instead of baking or mounting the full skills tree.