### PR TITLE
feat(dataagent): support configured stream limit, async record emission, and skill folder validation

### DIFF
--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -1171,6 +1171,22 @@ def _skill_name_from_front_matter(skill_md: Path) -> str:
     raise ValueError("根目录 SKILL.md 必须包含 front matter name")
 
 
+def _optional_skill_name_from_front_matter(skill_md: Path) -> str:
+    try:
+        lines = skill_md.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ValueError("SKILL.md must be UTF-8 encoded") from exc
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        key, separator, value = line.partition(":")
+        if separator and key.strip() == "name":
+            return value.strip().strip("'\"")
+    return ""
+
+
 def _resolve_imported_skill_root(extract_root: Path) -> tuple[Path, str]:
     root_skill_md = extract_root / "SKILL.md"
     if root_skill_md.is_file():
@@ -1183,6 +1199,9 @@ def _resolve_imported_skill_root(extract_root: Path) -> tuple[Path, str]:
     ]
     if len(candidates) == 1:
         candidate = candidates[0]
+        declared_name = _optional_skill_name_from_front_matter(candidate / "SKILL.md")
+        if declared_name and declared_name != candidate.name:
+            raise ValueError("SKILL.md name must match skill folder")
         return candidate, _validate_skill_folder_name(candidate.name)
     if len(candidates) > 1:
         raise ValueError("ZIP 包只能包含一个 Skill")

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -987,6 +987,7 @@ async def _execute_task_stream_local(
         setting_sources=setting_sources,
         max_turns=max_turns,
         allowed_tools=allowed_tools,
+        skills=list(enabled_folders),
         mcp_servers=mcp_servers,
         include_partial_messages=supports_partial_messages,
         max_buffer_size=max(1024 * 1024, int(cfg.agent_max_buffer_size_bytes)),

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -436,16 +436,24 @@ async def _execute_task_stream_container(
     is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
 ) -> TaskExecutionResult:
     backend, container_name, command = _build_container_command(params)
+    stream_limit = max(1024 * 1024, int(getattr(get_settings(), "agent_max_buffer_size_bytes", 0) or 0))
     process = await asyncio.create_subprocess_exec(
         *command,
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        limit=stream_limit,
     )
     stderr_task: asyncio.Task[Any] | None = None
     cancel_task: asyncio.Task[Any] | None = None
     result: TaskExecutionResult | None = None
     returncode: int | None = None
+
+    async def _emit(record: dict[str, Any]) -> None:
+        emitted = emit(record)
+        if inspect.isawaitable(emitted):
+            await emitted
+
     try:
         await _send_payload_to_child(process, params)
         async with RUNNING_CONTAINERS_LOCK:
@@ -467,7 +475,7 @@ async def _execute_task_stream_container(
             if message_type == "record":
                 record = message.get("record") or {}
                 if isinstance(record, dict):
-                    await emit(record)
+                    await _emit(record)
                 continue
             if message_type == "result":
                 result_payload = message.get("result") or {}

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -198,6 +198,72 @@ def test_sandbox_runner_startup_cleanup_removes_labeled_stale_containers(monkeyp
     assert calls[1] == ("docker", "rm", "-f", "container-a", "container-b")
 
 
+def test_sandbox_runner_container_process_uses_configured_stream_limit(monkeypatch):
+    settings = get_settings()
+    originals = {
+        "agent_max_buffer_size_bytes": settings.agent_max_buffer_size_bytes,
+    }
+    emitted: list[dict] = []
+    sandbox_runner_main.CANCELLED_TASK_IDS.discard("task-1")
+
+    update_settings({"agent_max_buffer_size_bytes": 4 * 1024 * 1024})
+    child_code = """
+import json
+import sys
+
+sys.stdin.read()
+large_payload = "x" * (96 * 1024)
+print(json.dumps({
+    "type": "record",
+    "record": {
+        "record_type": "event",
+        "event_type": "DEBUG",
+        "data": {"payload": large_payload},
+    },
+}), flush=True)
+print(json.dumps({
+    "type": "result",
+    "result": {
+        "task_status": "finished",
+        "content": "large-line-ok",
+        "provider_id": "openrouter",
+        "model": "anthropic/claude-sonnet-4.5",
+    },
+}), flush=True)
+"""
+    monkeypatch.setattr(
+        sandbox_runner_main,
+        "_build_container_command",
+        lambda params: ("docker", "container-1", [sys.executable, "-c", child_code]),
+    )
+    kill_calls: list[tuple[str, str]] = []
+
+    async def fake_kill_container(backend: str, container_name: str) -> None:
+        kill_calls.append((backend, container_name))
+
+    monkeypatch.setattr(sandbox_runner_main, "_kill_container", fake_kill_container)
+
+    async def emit(record: dict) -> None:
+        emitted.append(record)
+
+    try:
+        result = asyncio.run(
+            sandbox_runner_main._execute_task_stream_container(
+                TaskExecutionInput(**_payload()),
+                emit=emit,
+                is_cancel_requested=lambda: False,
+            )
+        )
+    finally:
+        sandbox_runner_main.CANCELLED_TASK_IDS.discard("task-1")
+        update_settings(originals)
+
+    assert result.task_status == "finished"
+    assert result.content == "large-line-ok"
+    assert emitted[0]["data"]["payload"] == "x" * (96 * 1024)
+    assert kill_calls == []
+
+
 def test_resolve_host_skills_dir_uses_explicit_setting_only(monkeypatch):
     settings = get_settings()
     original = settings.dataagent_sandbox_host_skills_dir

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -730,6 +730,21 @@ def test_import_skill_from_folder_zip(monkeypatch, tmp_path):
     assert "marketing-insights/scripts/run.py" in store.documents
 
 
+def test_import_skill_rejects_folder_zip_when_front_matter_name_differs(monkeypatch, tmp_path):
+    configure_skill_filesystem(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="SKILL.md name must match skill folder"):
+        skill_admin_service.import_skill_from_zip(
+            "marketing-insights.zip",
+            make_zip(
+                {
+                    "marketing-insights/SKILL.md": "---\nname: crm-insights\n---\n# CRM\n",
+                    "marketing-insights/reference/guide.md": "# Guide\n",
+                }
+            ),
+        )
+
+
 def test_import_skill_rejects_unsafe_zip_path(monkeypatch, tmp_path):
     configure_skill_filesystem(monkeypatch, tmp_path)
 

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -225,6 +225,7 @@ def test_execute_task_stream_converts_claude_events_to_magic_records(monkeypatch
     assert ClaudeAgentOptions.last_kwargs["include_partial_messages"] is True
     assert ClaudeAgentOptions.last_kwargs["cwd"] == str(tmp_path)
     assert ClaudeAgentOptions.last_kwargs["cli_path"] == "/tmp/claude-cli"
+    assert ClaudeAgentOptions.last_kwargs["skills"] == ["opendataworks-business-knowledge", "marketing-insights"]
     assert runtime["folders"] == ["opendataworks-business-knowledge", "marketing-insights"]
     assert ClaudeAgentOptions.last_kwargs["env"]["DISABLE_PROMPT_CACHING"] == ""
 
@@ -347,6 +348,7 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     assert captured["folders"] == []
     assert captured["kwargs"]["allow_empty"] is True
     assert ClaudeAgentOptions.last_kwargs["cwd"] == str(topic_workspace)
+    assert ClaudeAgentOptions.last_kwargs["skills"] == []
     assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read"]
     assert ClaudeAgentOptions.last_kwargs["mcp_servers"] == {}
     assert ClaudeAgentOptions.last_kwargs["max_turns"] == 7


### PR DESCRIPTION
This PR introduces several improvements to the DataAgent backend:

1. **Skill ZIP Validation:** Adds verification when importing skills from ZIP files to ensure that the skill name declared in the `SKILL.md` front-matter matches the folder name exactly.
2. **Local Task Execution:** Correctly passes the list of enabled skills to Claude SDK options during execution.
3. **Sandbox Runner Stream Limit:** Respects the configured `agent_max_buffer_size_bytes` setting for the subprocess stream limit when executing container tasks.
4. **Async Event Emitter:** Supports handling asynchronous return values from the `emit` callback in the sandbox runner without blocking.