### PR TITLE
Fix composer width stability and landing state alignment

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1628,7 +1628,12 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  /* Hold a stable max width so the message does not resize when the thinking
+     panel or a tool call is expanded/collapsed. width:100% is capped by
+     max-width:88%, and the column's children stretch to fill it. */
+  width: 100%;
   max-width: 88%;
+  min-width: 0;
 }
 
 .v2-msg-footer {
@@ -1871,8 +1876,10 @@ onBeforeUnmount(() => {
   transition: max-width 0.3s ease;
 }
 
+/* Keep the landing composer at the same width as the in-conversation composer
+   so the input box does not jump wider after the first message is sent. */
 .v2-composer-bar.is-landing .v2-composer-wrap {
-  max-width: 860px;
+  max-width: 1280px;
 }
 
 .v2-composer {


### PR DESCRIPTION
## Summary
Improved layout stability of the chat message container and aligned the landing composer width with the in-conversation composer to prevent visual jumping when the first message is sent.

## Key Changes
- **Message container stability**: Added `width: 100%` and `min-width: 0` to `.v2-msg-wrap` to maintain a stable max-width constraint. This prevents the message container from resizing when the thinking panel or tool calls are expanded/collapsed.
- **Landing composer alignment**: Changed `.v2-composer-bar.is-landing .v2-composer-wrap` max-width from `860px` to `1280px` to match the in-conversation composer width, eliminating layout shift after the first message is sent.
- **Documentation**: Added clarifying comments explaining the purpose of the width constraints.

## Implementation Details
The message container now uses a three-part width strategy:
- `width: 100%` allows it to be responsive
- `max-width: 88%` caps the maximum width
- `min-width: 0` ensures flex children can shrink below their content size, preventing overflow

This approach maintains visual stability while preserving responsive behavior.

https://claude.ai/code/session_01GSCh7QvQi8VGd6FVKgqgvD