### PR TITLE
沙箱运行时隔离加固与文件访问边界三层职责划分

### DIFF
--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -93,6 +93,13 @@ class Settings(BaseSettings):
     dataagent_sandbox_backend: str = "docker"
     dataagent_sandbox_network: str = ""
     dataagent_sandbox_host_skills_dir: str = ""
+    # Runtime isolation hardening for the child task container. The workspace
+    # bind-mount is always the only writable host path; these tighten the rest.
+    # read_only_rootfs locks the container root filesystem read-only so the
+    # agent's Bash/Python cannot persist anything outside the bind-mounted
+    # workspace; a writable tmpfs is mounted at /tmp for transient scratch.
+    dataagent_sandbox_read_only_rootfs: bool = False
+    dataagent_sandbox_tmpfs_size: str = "512m"
 
     # ---- 运行策略 ----
     max_few_shot_examples: int = 5

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -395,6 +395,18 @@ def _build_container_command(params: TaskExecutionInput) -> tuple[str, str, list
         "--mount",
         f"type=bind,source={topic_workspace},target={CHILD_APP_ROOT}",
     ]
+    # Runtime isolation hardening. The workspace bind-mount (and read-only skill
+    # mounts) are the only host paths the child can touch; block privilege
+    # escalation, and optionally lock the rest of the container filesystem
+    # read-only so the agent's Bash/Python cannot persist anything outside the
+    # bind-mounted workspace (true runtime write isolation, independent of the
+    # static PreToolUse boundary hook). A writable tmpfs at /tmp covers transient
+    # scratch; HOME/PWD already point at the writable workspace mount.
+    command.extend(["--security-opt", "no-new-privileges"])
+    if bool(getattr(cfg, "dataagent_sandbox_read_only_rootfs", False)):
+        tmpfs_size = str(getattr(cfg, "dataagent_sandbox_tmpfs_size", "") or "512m").strip()
+        command.append("--read-only")
+        command.extend(["--tmpfs", f"/tmp:rw,nosuid,nodev,size={tmpfs_size}"])
     network = str(getattr(cfg, "dataagent_sandbox_network", "") or "").strip()
     if network:
         command.extend(["--network", network])

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -139,6 +139,11 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
     assert not any("/var/run/docker.sock" in arg for arg in command)
     assert not any("target=/skills" in arg for arg in command)
     assert not any("target=/workspace" in arg for arg in command)
+    # Privilege-escalation guard is always applied; read-only rootfs stays opt-in.
+    assert "--security-opt" in command
+    assert "no-new-privileges" in command
+    assert "--read-only" not in command
+    assert not any(arg == "--tmpfs" for arg in command)
 
     env_values = [command[index + 1] for index, item in enumerate(command) if item == "--env"]
     assert "HOME=/app" in env_values
@@ -149,6 +154,45 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
     assert "SKILLS_ROOT_DIR=/app/.claude/skills" in env_values
     assert not any(value.startswith("DATAAGENT_SKILL_LINK_ROOT=") for value in env_values)
     assert not any(value.startswith("DATAAGENT_TASK_PAYLOAD_B64=") for value in env_values)
+
+
+def test_sandbox_runner_read_only_rootfs_opt_in(monkeypatch, tmp_path: Path):
+    settings = get_settings()
+    originals = {
+        "dataagent_sandbox_backend": settings.dataagent_sandbox_backend,
+        "dataagent_sandbox_image": settings.dataagent_sandbox_image,
+        "dataagent_sandbox_host_root": settings.dataagent_sandbox_host_root,
+        "dataagent_sandbox_root": settings.dataagent_sandbox_root,
+        "dataagent_sandbox_host_skills_dir": settings.dataagent_sandbox_host_skills_dir,
+        "dataagent_sandbox_read_only_rootfs": settings.dataagent_sandbox_read_only_rootfs,
+        "dataagent_sandbox_tmpfs_size": settings.dataagent_sandbox_tmpfs_size,
+    }
+    update_settings(
+        {
+            "dataagent_sandbox_backend": "docker",
+            "dataagent_sandbox_image": "opendataworks-dataagent-runner:test",
+            "dataagent_sandbox_host_root": str(tmp_path / "topics"),
+            "dataagent_sandbox_root": str(tmp_path / "container-topics"),
+            "dataagent_sandbox_host_skills_dir": "",
+            "dataagent_sandbox_read_only_rootfs": True,
+            "dataagent_sandbox_tmpfs_size": "256m",
+        }
+    )
+    try:
+        _, _, command = sandbox_runner_main._build_container_command(
+            TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot([])))
+        )
+    finally:
+        update_settings(originals)
+
+    assert "--read-only" in command
+    assert "--tmpfs" in command
+    assert "/tmp:rw,nosuid,nodev,size=256m" in command
+    # The workspace bind-mount remains read-write so the agent can still produce files.
+    assert any(
+        arg.startswith("type=bind,") and "target=/app" in arg and "readonly" not in arg
+        for arg in command
+    )
 
 
 def test_sandbox_runner_startup_cleanup_removes_labeled_stale_containers(monkeypatch):

--- a/docs/design/2026-06-04-dataagent-conversation-files-design.md
+++ b/docs/design/2026-06-04-dataagent-conversation-files-design.md
@@ -120,6 +120,52 @@ No change to the boundary hook or skill contract.
 - Endpoints sit under `/api/v1/nl2sql/*`, inheriting the existing portal proxy
   auth; topic ownership is enforced the same way as existing topic routes.
 
+### File-access boundary layering (do not collapse into one)
+
+File access is protected by three independent layers with distinct jobs. They are
+complementary, not redundant — removing any one widens the attack surface that the
+others were never designed to cover.
+
+1. **PreToolUse boundary hook** (`core/agent_runtime.py`,
+   `_build_workspace_boundary_hooks`, attached in `_execute_task_stream_local`).
+   - Job: block tools from touching paths *outside* the workspace + enabled skill
+     roots (cross-topic workspaces, backend source, `.env`, DB credentials).
+   - Scope: runs in **every** execution mode — in-process, the runner's local
+     fallback, and inside the container child (the child also runs
+     `_execute_task_stream_local`).
+   - Limit: it is a **static** check of tool inputs. It validates `Write`/`Edit`
+     path args and scans `Bash` tokens, but cannot police where a *program*
+     (Python, etc.) writes at runtime. It is an escape guard, not a
+     runtime write-location enforcer.
+   - **Why it cannot be deleted:** by default `DATAAGENT_SANDBOX_MODE` is empty, so
+     `execute_task_stream` runs `_execute_task_stream_local` directly in the
+     backend process with **no container**. In that default deployment the hook is
+     the *only* filesystem boundary. Deleting it would let the agent read/write
+     anything the backend process can.
+
+2. **Sandbox container isolation** (`sandbox_runner_main.py`, opt-in via
+   `DATAAGENT_SANDBOX_MODE` + image).
+   - Job: OS-level confinement of *runtime* writes. The topic workspace bind-mount
+     is the only writable host path; skills are mounted read-only;
+     `--security-opt no-new-privileges` always applied; optional
+     `DATAAGENT_SANDBOX_READ_ONLY_ROOTFS` locks the container rootfs read-only with
+     a writable `/tmp` tmpfs so Bash/Python cannot persist anything outside the
+     workspace mount.
+   - Limit: only active on the container execution path; opt-in. Does not cover the
+     default in-process mode — hence layer 1 stays.
+
+3. **Backend download curation** (`core/topic_files.py`).
+   - Job: regardless of where the agent writes inside the workspace, only
+     `uploads/` (inputs) and `output/` (deliverables) are listed and downloadable;
+     scratch files and `.claude/` are never served.
+   - This is independent of layers 1–2: it holds even if the agent scatters scratch
+     files all over the workspace.
+
+Rule of thumb: layer 1 owns "can it touch outside the workspace", layer 2 owns
+"can a running program persist outside the workspace", layer 3 owns "what is
+exposed for download". Do not try to make the hook enforce write *locations*
+(layer 2's job) or download scoping (layer 3's job).
+
 ## Tradeoffs
 
 Pros: reuses the per-topic workspace and existing boundary model; no agent/skill


### PR DESCRIPTION
## 背景

承接已合并的 #315（会话文件下载面板只暴露 `output/` 与 `uploads/`）。在讨论中发现 `PreToolUse` 边界 hook 是静态命令扫描，能拦 Bash 里出现的越界路径，但无法约束 Python/程序在运行时实际写到哪里。真正的运行时写入隔离应由沙箱容器在 OS 层提供。本 PR 包含这两个后续提交。

## 改动

### 1. 沙箱运行时隔离加固（`sandbox_runner_main.py`、`config.py`）

子任务容器已把会话工作区 bind-mount 为唯一可写宿主路径、技能目录只读挂载。在此基础上：

- 始终追加 `--security-opt no-new-privileges`，阻止子进程提权（低风险，标准加固）。
- 新增可选 `DATAAGENT_SANDBOX_READ_ONLY_ROOTFS`：开启后容器根文件系统只读 + `/tmp` 挂可写 tmpfs，使 agent 的 Bash/Python 无法在工作区 bind-mount 之外持久化任何文件。
- tmpfs 大小可配 `DATAAGENT_SANDBOX_TMPFS_SIZE`（默认 `512m`）。
- 只读根文件系统**默认关闭**，因为可能影响 SDK runtime 写入行为，需先在能起容器的环境跑真实冒烟后再于部署里开启。

### 2. 设计文档补充「文件访问安全边界三层职责划分」

明确三层互补、不可合并：

| 层 | 职责 | 覆盖范围 |
|---|---|---|
| PreToolUse hook | 拦工作区外访问 | **所有执行模式**；默认无容器模式下是唯一边界，**不可删除** |
| 沙箱容器隔离 | OS 层运行时写入隔离 | 仅容器路径、可选 |
| 后端下载筛选 | 只暴露 `output/`、`uploads/` | 独立于前两层 |

口诀：hook 管「能不能碰工作区外」，沙箱管「运行的程序能不能写到工作区外」，下载筛选管「对外暴露什么」。避免后续误删 hook 或让其承担运行时写入位置约束。

## 验证

- 已跑通：`tests/test_topic_files.py` + `tests/test_sandbox_runner_main.py` 共 28 个单测全过（含新增命令构造断言：始终带 `no-new-privileges`、只读根文件系统按开关生效）。
- **未跑**：真实 docker/podman 容器全链路冒烟（环境无容器运行时）。`DATAAGENT_SANDBOX_READ_ONLY_ROOTFS` 设为 true 前需在能起容器的环境冒烟确认 `claude-agent-sdk` session 写入、Python 临时文件等不受影响。

https://claude.ai/code/session_01SMshGemqbP8rEeyDg1j9GA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMshGemqbP8rEeyDg1j9GA)_