### PR TITLE
Allow typing during streaming and resume active tasks on topic re-entry

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -318,8 +318,8 @@
               ref="textareaRef"
               v-model="inputText"
               class="v2-textarea"
-              :placeholder="isStreaming ? '正在回复中…' : '输入数据问题…'"
-              :disabled="isStreaming || !availableModels.length"
+              :placeholder="isStreaming ? '可继续输入，回复结束后发送…' : '输入数据问题…'"
+              :disabled="!availableModels.length"
               rows="1"
               @keydown.enter="onEnterKey"
               @input="autoResize"
@@ -497,6 +497,7 @@ const {
   availableModels, canSend, isBusy: isStreaming, activeTaskId,
   thinkingExpanded, toggleThinking,
   send: engineSend, cancel: engineCancel, detach,
+  resumeActiveTopicTask,
   loadConfig,
 } = chat
 const { handleCopyMessage, toggleMessageFeedback } = useChatMessageActions({
@@ -841,6 +842,12 @@ async function selectTopic(topicId, options = {}) {
       : await topicApi.getTopicMessages(normalizedTopicId, { page: 1, page_size: 500, order: 'asc' })
     const list = Array.isArray(data?.items) ? data.items : (Array.isArray(data) ? data : [])
     messages.value = list.map(hydrateMessageFromApi)
+    // Re-attach to a still-running task so re-entering a live conversation keeps
+    // streaming and exposes the stop button. Widget mode is a read-only audit
+    // view of other users' sessions, so it never resumes a live stream.
+    if (!isWidgetMode.value) {
+      resumeActiveTopicTask(normalizedTopicId)
+    }
     const messageId = normalizeQueryValue(options.messageId)
     if (messageId) {
       focusMessage(messageId)

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -318,7 +318,7 @@
               ref="textareaRef"
               v-model="inputText"
               class="v2-textarea"
-              :placeholder="isStreaming ? '可继续输入，回复结束后发送…' : '输入数据问题…'"
+              placeholder="输入数据问题…"
               :disabled="!availableModels.length"
               rows="1"
               @keydown.enter="onEnterKey"

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -762,6 +762,14 @@ async function loadAgents() {
   }
 }
 
+// The session list is always scoped to one assistant. A deep-link agent_id in
+// the route takes priority; otherwise fall back to the live selector value
+// (defaulted in loadAgents) so a fresh entry never lists every assistant's
+// sessions before the route has been seeded.
+function currentAgentFilterId() {
+  return normalizeQueryValue(route.query.agent_id) || String(agentSelectValue.value || '').trim()
+}
+
 async function loadTopics() {
   if (sourceMode.value === 'widget') {
     await loadWidgetTopics()
@@ -769,7 +777,8 @@ async function loadTopics() {
   }
   try {
     const params = { page: 1, page_size: 50 }
-    if (route.query.agent_id) params.agent_id = route.query.agent_id
+    const agentId = currentAgentFilterId()
+    if (agentId) params.agent_id = agentId
     const data = await topicApi.listTopics(params)
     topics.value = Array.isArray(data?.list) ? data.list : (Array.isArray(data) ? data : [])
     const requestedTopicId = routeTopicId()
@@ -790,7 +799,8 @@ async function loadWidgetTopics() {
     const params = { page: 1, page_size: 50 }
     // Assistant filter mirrors portal mode so the same agent selector narrows
     // both sources; the admin widget endpoint accepts agent_id server-side.
-    if (route.query.agent_id) params.agent_id = route.query.agent_id
+    const agentId = currentAgentFilterId()
+    if (agentId) params.agent_id = agentId
     // User filter is applied server-side so it stays accurate across pages.
     if (filterUser.value.startsWith('ext:')) params.external_user_id = filterUser.value.slice(4)
     else if (filterUser.value.startsWith('vis:')) params.visitor_id = filterUser.value.slice(4)

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -489,6 +489,48 @@ describe('NL2SqlChatV2 URL location', () => {
     resolveStream()
   })
 
+  it('resumes the live stream and shows the stop button when re-entering a running topic', async () => {
+    let resolveStream
+    apiMocks.topicApi.listTopics.mockResolvedValue({
+      list: [
+        { ...makeTopic('topic-run', 'Running topic'), current_task_id: 'task-run', current_task_status: 'running' }
+      ]
+    })
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
+      topic_id: topicId,
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 1,
+      items: [
+        { message_id: 'u-run', topic_id: topicId, sender_type: 'user', content: 'running question', created_at: '2026-05-30T02:00:00Z' }
+      ]
+    }))
+    apiMocks.taskApi.streamSdkEvents.mockImplementation((_taskId, opts) => {
+      opts.onRecord({ record_type: 'stream', data: { type: 'message_start', usage: {} } })
+      opts.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 0, content_block: { type: 'text' } } })
+      opts.onRecord({ record_type: 'stream', data: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'resumed stream' } } })
+      return new Promise((resolve) => { resolveStream = resolve })
+    })
+    routeState.query = { tab: 'chat-v2', topic_id: 'topic-run' }
+
+    const wrapper = mountChat()
+    await flushPromises()
+    await nextTick()
+
+    // The engine re-attaches to the still-running backend task from seq 0.
+    expect(apiMocks.taskApi.streamSdkEvents).toHaveBeenCalledWith('task-run', expect.objectContaining({ afterId: 0 }))
+    expect(wrapper.text()).toContain('resumed stream')
+    // An active task turns the send button into the stop/cancel control.
+    const button = wrapper.get('.v2-send-btn')
+    expect(button.classes()).toContain('v2-cancel-btn')
+    expect(button.attributes('disabled')).toBeUndefined()
+    // The composer stays editable mid-run so the next question can be typed.
+    expect(wrapper.find('textarea').attributes('disabled')).toBeUndefined()
+
+    resolveStream()
+  })
+
   it('forwards the selected assistant to the widget topic query', async () => {
     routeState.query = { tab: 'chat-v2', agent_id: 'agent_sales' }
     const wrapper = mountChat()

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -201,8 +201,7 @@
               v-model="inputText"
               class="query-textarea"
               rows="1"
-              :disabled="isBusy"
-              placeholder="输入数据问题…"
+              :placeholder="isBusy ? '可继续输入，回复结束后发送…' : '输入数据问题…'"
               @keydown.enter="onEnterKey"
               @input="autoResizeTextarea"
             />

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -201,7 +201,7 @@
               v-model="inputText"
               class="query-textarea"
               rows="1"
-              :placeholder="isBusy ? '可继续输入，回复结束后发送…' : '输入数据问题…'"
+              placeholder="输入数据问题…"
               @keydown.enter="onEnterKey"
               @input="autoResizeTextarea"
             />


### PR DESCRIPTION
## Summary
This PR improves the chat UX by allowing users to compose their next question while the assistant is still responding, and by automatically resuming live streams when re-entering a topic with an active running task.

## Key Changes
- **Enable textarea during streaming**: Removed the `disabled` attribute from the textarea when `isStreaming` is true, allowing users to type their next question while waiting for the current response. Also removed the dynamic placeholder text that indicated streaming state.
- **Resume active topic tasks**: Added `resumeActiveTopicTask()` call when selecting a topic to re-attach to still-running backend tasks, preserving the live stream and showing the stop button for active conversations.
- **Refactor agent filter logic**: Extracted `currentAgentFilterId()` helper function to consistently apply agent filtering across both portal and widget topic loading, prioritizing route query parameters over selector values.
- **Widget mode read-only behavior**: Ensured widget mode (audit view) never resumes live streams, maintaining its read-only nature.
- **Remove widget textarea disable**: Removed the `isBusy` disable condition from the widget chat textarea for consistency.

## Implementation Details
- The textarea remains editable during streaming to support the improved UX of composing follow-up questions.
- Task resumption only occurs in non-widget mode to preserve the audit-only nature of widget sessions.
- The `afterId: 0` parameter ensures the engine re-attaches from the beginning of the task sequence when resuming.

https://claude.ai/code/session_01Uj25tp9o3AWzoxj5w6vfj4