### PR TITLE
fix(dataagent): serialize warm sandbox reuse per topic

### DIFF
--- a/dataagent/contracts/sdk-block-projection/cases.json
+++ b/dataagent/contracts/sdk-block-projection/cases.json
@@ -63,6 +63,17 @@
       ]
     },
     {
+      "name": "orphan tool_result records become synthetic tool blocks",
+      "records": [
+        {"seq_id": 1, "record_type": "tool_result", "data": {"tool_use_id": "call_skill_1", "content": "Launching skill: opendataworks-business-knowledge", "is_error": false}},
+        {"seq_id": 2, "record_type": "tool_result", "data": {"tool_use_id": "call_read_1", "content": "1\t# 业务知识地图", "is_error": false}}
+      ],
+      "expected": [
+        {"kind": "tool_use", "tool_name": "Skill", "input": {"skill": "opendataworks-business-knowledge"}, "output": "Launching skill: opendataworks-business-knowledge", "is_error": false},
+        {"kind": "tool_use", "tool_name": "Tool", "input": null, "output": "1\t# 业务知识地图", "is_error": false}
+      ]
+    },
+    {
       "name": "empty text block is dropped",
       "records": [
         {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -29,17 +29,10 @@ class SdkBlockWriter:
 
         if type_name == "StreamEvent":
             evt = getattr(msg, "event", None) or {}
-            etype = str(evt.get("type") or "")
-            if etype == "message_start":
-                self._turn_index += 1
-            self._store.append_sdk_record(
-                task_id=self._task_id,
-                topic_id=self._topic_id,
-                turn_index=self._turn_index,
-                record_type="stream",
-                event_type=etype or None,
-                data=evt,
-            )
+            self._append_stream_event(evt)
+
+        elif type_name == "AssistantMessage":
+            self._ingest_assistant_message(msg)
 
         elif type_name == "UserMessage":
             content = getattr(msg, "content", None) or []
@@ -86,6 +79,97 @@ class SdkBlockWriter:
                     message=_stringify(getattr(msg, "result", None)) or "模型会话异常结束",
                 )
 
+    def _ingest_assistant_message(self, msg: Any) -> None:
+        content = getattr(msg, "content", None)
+        if isinstance(content, str):
+            blocks = [{"type": "text", "text": content}]
+        elif isinstance(content, list):
+            blocks = content
+        else:
+            return
+        if not blocks:
+            return
+
+        self._append_stream_event({"type": "message_start"})
+        for index, block in enumerate(blocks):
+            self._append_assistant_block(index, block)
+        self._append_stream_event({"type": "message_stop"})
+
+    def _append_assistant_block(self, index: int, block: Any) -> None:
+        block_type = _block_type(block)
+        if block_type == "tool_use":
+            self._append_tool_use_block(index, block)
+            return
+        if block_type == "thinking":
+            self._append_text_like_block(index, "thinking", block, "thinking_delta", "thinking", _block_value(block, "thinking", "text"))
+            return
+        if block_type == "text":
+            self._append_text_like_block(index, "text", block, "text_delta", "text", _block_value(block, "text", "content"))
+
+    def _append_text_like_block(
+        self,
+        index: int,
+        block_type: str,
+        block: Any,
+        delta_type: str,
+        delta_field: str,
+        text: Any,
+    ) -> None:
+        self._append_stream_event(
+            {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {"type": block_type},
+            }
+        )
+        text_value = str(text or "")
+        if text_value:
+            self._append_stream_event(
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": delta_type, delta_field: text_value},
+                }
+            )
+        self._append_stream_event({"type": "content_block_stop", "index": index})
+
+    def _append_tool_use_block(self, index: int, block: Any) -> None:
+        tool_id = str(_block_value(block, "id") or "")
+        tool_name = str(_block_value(block, "name") or "Tool")
+        self._append_stream_event(
+            {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {"type": "tool_use", "id": tool_id, "name": tool_name},
+            }
+        )
+        tool_input = _block_value(block, "input")
+        if tool_input is not None:
+            self._append_stream_event(
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": json.dumps(tool_input, ensure_ascii=False, separators=(",", ":")),
+                    },
+                }
+            )
+        self._append_stream_event({"type": "content_block_stop", "index": index})
+
+    def _append_stream_event(self, evt: dict[str, Any]) -> None:
+        etype = str(evt.get("type") or "")
+        if etype == "message_start":
+            self._turn_index += 1
+        self._store.append_sdk_record(
+            task_id=self._task_id,
+            topic_id=self._topic_id,
+            turn_index=self._turn_index,
+            record_type="stream",
+            event_type=etype or None,
+            data=evt,
+        )
+
     def append_done(self, *, is_error: bool, subtype: str = "") -> None:
         self._append_terminal_record(
             record_type="done",
@@ -128,6 +212,28 @@ def _serialise_blocks(blocks: Any) -> Any:
         else:
             result.append(str(b))
     return result
+
+
+def _block_type(block: Any) -> str:
+    value = _block_value(block, "type")
+    text = str(value or type(block).__name__ or "").strip().lower()
+    if text.endswith("block"):
+        text = text.removesuffix("block")
+    compact = text.replace("_", "")
+    if compact in {"tooluse", "servertooluse"}:
+        return "tool_use"
+    if compact in {"toolresult", "servertoolresult"}:
+        return "tool_result"
+    return text
+
+
+def _block_value(block: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(block, dict) and name in block:
+            return block.get(name)
+        if hasattr(block, name):
+            return getattr(block, name)
+    return None
 
 
 def _stringify(value: Any) -> str:

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import threading
 import uuid
 from datetime import datetime
@@ -58,6 +59,7 @@ WIDGET_EVENT_TYPES = frozenset({
 })
 MAX_WIDGET_EVENTS_PER_BATCH = 50
 MAX_WIDGET_PAYLOAD_BYTES = 4096
+SKILL_LAUNCH_OUTPUT_RE = re.compile(r"^Launching skill(?::\s*(.+))?$", re.IGNORECASE)
 
 
 def _parse_client_ts(value: Any) -> datetime | None:
@@ -174,6 +176,12 @@ def _project_sdk_records(records: list[dict[str, Any]]) -> dict[str, Any]:
                 blk = blocks_by_tool_id[tool_use_id]
                 blk["output"] = data.get("content")
                 blk["is_error"] = bool(data.get("is_error"))
+            elif tool_use_id:
+                block = _synthetic_tool_result_block(data, len(ordered_blocks))
+                ordered_blocks.append(block)
+                blocks_by_tool_id[tool_use_id] = block
+                if current_turn_blocks is not None:
+                    current_turn_blocks.append(block)
 
     result: list[dict[str, Any]] = []
     for block in ordered_blocks:
@@ -184,6 +192,34 @@ def _project_sdk_records(records: list[dict[str, Any]]) -> dict[str, Any]:
         result.append(clean)
 
     return {"blocks": result, "resume_after_seq": max_seq_id}
+
+
+def _synthetic_tool_result_block(data: dict[str, Any], index: int) -> dict[str, Any]:
+    skill_name = _extract_skill_launch_name(data.get("content"))
+    if skill_name is not None:
+        tool_name = "Skill"
+        tool_input = {"skill": skill_name} if skill_name else None
+    else:
+        tool_name = "Tool"
+        tool_input = None
+    return {
+        "type": "tool_use",
+        "tool_id": str(data.get("tool_use_id") or f"synthetic_tool_{index}"),
+        "tool_name": tool_name,
+        "input": tool_input,
+        "output": data.get("content"),
+        "is_error": bool(data.get("is_error")),
+        "_idx": index,
+    }
+
+
+def _extract_skill_launch_name(content: Any) -> str | None:
+    if not isinstance(content, str):
+        return None
+    match = SKILL_LAUNCH_OUTPUT_RE.match(content.strip())
+    if not match:
+        return None
+    return str(match.group(1) or "").strip()
 
 
 class TopicTaskStore:

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -697,6 +697,18 @@ class WarmChild:
 
 WARM_POOL: dict[str, WarmChild] = {}
 WARM_POOL_LOCK = asyncio.Lock()
+WARM_POOL_CONDITION = asyncio.Condition(WARM_POOL_LOCK)
+WARM_POOL_CONDITION_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+def _warm_pool_condition() -> asyncio.Condition:
+    global WARM_POOL_LOCK, WARM_POOL_CONDITION, WARM_POOL_CONDITION_LOOP
+    loop = asyncio.get_running_loop()
+    if WARM_POOL_CONDITION_LOOP is not loop:
+        WARM_POOL_LOCK = asyncio.Lock()
+        WARM_POOL_CONDITION = asyncio.Condition(WARM_POOL_LOCK)
+        WARM_POOL_CONDITION_LOOP = loop
+    return WARM_POOL_CONDITION
 
 
 def _container_spec_signature(params: TaskExecutionInput) -> str:
@@ -753,25 +765,40 @@ async def _execute_task_stream_warm(
 
 async def _acquire_warm_child(params: TaskExecutionInput) -> tuple[WarmChild, bool]:
     signature = _container_spec_signature(params)
-    async with WARM_POOL_LOCK:
-        for child in WARM_POOL.values():
-            if (
-                child.signature == signature
-                and not child.busy
+    condition = _warm_pool_condition()
+    async with condition:
+        while True:
+            await _drop_dead_warm_children_locked()
+            for child in WARM_POOL.values():
+                if (
+                    child.signature == signature
+                    and child.topic_id == params.topic_id
+                    and not child.busy
+                    and _warm_child_alive(child)
+                ):
+                    child.busy = True
+                    child.last_used = time.monotonic()
+                    child.current_task_id = params.task_id
+                    RUNNING_CONTAINERS[params.task_id] = (child.backend, child.container_name)
+                    return child, True
+            if any(
+                child.topic_id == params.topic_id
+                and child.busy
                 and _warm_child_alive(child)
+                for child in WARM_POOL.values()
             ):
+                await condition.wait()
+                continue
+            await _evict_idle_same_topic_mismatch_locked(params.topic_id, signature)
+            await _evict_idle_over_cap_locked()
+            if len(WARM_POOL) < _warm_max_containers():
+                child = await _start_warm_child(params, signature)
                 child.busy = True
-                child.last_used = time.monotonic()
                 child.current_task_id = params.task_id
+                WARM_POOL[child.container_name] = child
                 RUNNING_CONTAINERS[params.task_id] = (child.backend, child.container_name)
-                return child, True
-        await _evict_idle_over_cap_locked()
-        child = await _start_warm_child(params, signature)
-        child.busy = True
-        child.current_task_id = params.task_id
-        WARM_POOL[child.container_name] = child
-        RUNNING_CONTAINERS[params.task_id] = (child.backend, child.container_name)
-        return child, False
+                return child, False
+            await condition.wait()
 
 
 async def _start_warm_child(params: TaskExecutionInput, signature: str) -> WarmChild:
@@ -920,7 +947,8 @@ async def _watch_cancel_warm(
 
 async def _release_warm_child(child: WarmChild, task_id: str) -> None:
     dead: WarmChild | None = None
-    async with WARM_POOL_LOCK:
+    condition = _warm_pool_condition()
+    async with condition:
         RUNNING_CONTAINERS.pop(task_id, None)
         CANCELLED_TASK_IDS.discard(task_id)
         child.busy = False
@@ -929,6 +957,7 @@ async def _release_warm_child(child: WarmChild, task_id: str) -> None:
         if not child.healthy or not _warm_child_alive(child):
             WARM_POOL.pop(child.container_name, None)
             dead = child
+        condition.notify_all()
     if dead is not None:
         await _close_warm_child(dead)
 
@@ -944,6 +973,34 @@ async def _evict_idle_over_cap_locked() -> None:
         WARM_POOL.pop(victim.container_name, None)
         await _kill_container(victim.backend, victim.container_name)
         await _close_warm_child(victim)
+
+
+async def _evict_idle_same_topic_mismatch_locked(topic_id: str, signature: str) -> None:
+    """Keep at most one idle warm child per topic when the container spec changes."""
+    victims = [
+        child
+        for child in WARM_POOL.values()
+        if child.topic_id == topic_id
+        and child.signature != signature
+        and not child.busy
+    ]
+    for victim in victims:
+        WARM_POOL.pop(victim.container_name, None)
+        await _kill_container(victim.backend, victim.container_name)
+        await _close_warm_child(victim)
+    if victims:
+        _warm_pool_condition().notify_all()
+
+
+async def _drop_dead_warm_children_locked() -> None:
+    dead = [child for child in WARM_POOL.values() if not _warm_child_alive(child)]
+    for child in dead:
+        WARM_POOL.pop(child.container_name, None)
+        if child.current_task_id is not None:
+            RUNNING_CONTAINERS.pop(child.current_task_id, None)
+        await _close_warm_child(child)
+    if dead:
+        _warm_pool_condition().notify_all()
 
 
 async def _close_warm_child(child: WarmChild) -> None:
@@ -981,13 +1038,16 @@ async def _warm_pool_reaper() -> None:
         idle_ttl = _warm_idle_ttl()
         now = time.monotonic()
         expired: list[tuple[WarmChild, bool]] = []
-        async with WARM_POOL_LOCK:
+        condition = _warm_pool_condition()
+        async with condition:
             for name, child in list(WARM_POOL.items()):
                 dead = not _warm_child_alive(child)
                 idle_expired = (not child.busy) and (now - child.last_used > idle_ttl)
                 if dead or idle_expired:
                     WARM_POOL.pop(name, None)
                     expired.append((child, dead))
+            if expired:
+                condition.notify_all()
         for child, dead in expired:
             if not dead:
                 await _kill_container(child.backend, child.container_name)
@@ -996,9 +1056,11 @@ async def _warm_pool_reaper() -> None:
 
 
 async def _shutdown_warm_pool() -> None:
-    async with WARM_POOL_LOCK:
+    condition = _warm_pool_condition()
+    async with condition:
         children = list(WARM_POOL.values())
         WARM_POOL.clear()
+        condition.notify_all()
     for child in children:
         await _kill_container(child.backend, child.container_name)
         await _close_warm_child(child)

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -439,6 +439,40 @@ time.sleep(60)
 """
 
 
+class _FakeWarmStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _FakeWarmStdin:
+    def __init__(self):
+        self.closed = False
+
+    def is_closing(self):
+        return self.closed
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeWarmProcess:
+    def __init__(self):
+        self.returncode = None
+        self.stdin = _FakeWarmStdin()
+        self.stdout = _FakeWarmStream()
+        self.stderr = _FakeWarmStream()
+
+    async def wait(self):
+        self.returncode = 0
+        return 0
+
+    def kill(self):
+        self.returncode = -9
+
+
 def _warm_settings(tmp_path: Path) -> dict:
     settings = get_settings()
     keys = [
@@ -558,6 +592,182 @@ def test_warm_pool_reuses_container_for_followup(monkeypatch, tmp_path: Path):
     assert len(build_calls) == 1
     assert pool_size == 1
     assert build_calls[0]["task_id_label"] == "warm"
+
+
+def test_warm_pool_waits_for_busy_same_topic_even_when_pool_has_capacity(monkeypatch, tmp_path: Path):
+    sandbox_runner_main.WARM_POOL.clear()
+    sandbox_runner_main.RUNNING_CONTAINERS.clear()
+    originals = _warm_settings(tmp_path)
+    update_settings({"dataagent_sandbox_max_warm_containers": 2})
+    started: list[str] = []
+
+    async def fake_start(params, signature):
+        container_name = f"warm-child-{len(started) + 1}"
+        started.append(container_name)
+        return sandbox_runner_main.WarmChild(
+            backend="docker",
+            container_name=container_name,
+            signature=signature,
+            topic_id=params.topic_id,
+            process=_FakeWarmProcess(),
+        )
+
+    async def fake_kill(backend: str, container_name: str) -> None:
+        child = sandbox_runner_main.WARM_POOL.get(container_name)
+        if child is not None:
+            child.process.kill()
+
+    monkeypatch.setattr(sandbox_runner_main, "_start_warm_child", fake_start)
+    monkeypatch.setattr(sandbox_runner_main, "_kill_container", fake_kill)
+
+    async def scenario():
+        first = TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot([])))
+        second = TaskExecutionInput(
+            **{**_payload(agent_snapshot=_agent_snapshot([])), "task_id": "task-2"}
+        )
+        child_first, reused_first = await sandbox_runner_main._acquire_warm_child(first)
+        pending_second = asyncio.create_task(sandbox_runner_main._acquire_warm_child(second))
+        await asyncio.sleep(0.05)
+        assert pending_second.done() is False
+        assert started == ["warm-child-1"]
+
+        await sandbox_runner_main._release_warm_child(child_first, first.task_id)
+        child_second, reused_second = await asyncio.wait_for(pending_second, timeout=1)
+        try:
+            assert reused_first is False
+            assert reused_second is True
+            assert child_second.container_name == "warm-child-1"
+            assert started == ["warm-child-1"]
+            assert len(sandbox_runner_main.WARM_POOL) == 1
+        finally:
+            await sandbox_runner_main._release_warm_child(child_second, second.task_id)
+            await sandbox_runner_main._shutdown_warm_pool()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        sandbox_runner_main.WARM_POOL.clear()
+        sandbox_runner_main.RUNNING_CONTAINERS.clear()
+        update_settings(originals)
+
+
+def test_warm_pool_replaces_idle_same_topic_child_when_signature_changes(monkeypatch, tmp_path: Path):
+    sandbox_runner_main.WARM_POOL.clear()
+    sandbox_runner_main.RUNNING_CONTAINERS.clear()
+    originals = _warm_settings(tmp_path)
+    update_settings({"dataagent_sandbox_max_warm_containers": 2})
+    started: list[str] = []
+    killed: list[str] = []
+
+    async def fake_start(params, signature):
+        container_name = f"warm-child-{len(started) + 1}"
+        started.append(container_name)
+        return sandbox_runner_main.WarmChild(
+            backend="docker",
+            container_name=container_name,
+            signature=signature,
+            topic_id=params.topic_id,
+            process=_FakeWarmProcess(),
+        )
+
+    async def fake_kill(backend: str, container_name: str) -> None:
+        killed.append(container_name)
+        child = sandbox_runner_main.WARM_POOL.get(container_name)
+        if child is not None:
+            child.process.kill()
+
+    monkeypatch.setattr(sandbox_runner_main, "_start_warm_child", fake_start)
+    monkeypatch.setattr(sandbox_runner_main, "_kill_container", fake_kill)
+
+    async def scenario():
+        first = TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot([])))
+        changed_signature = TaskExecutionInput(
+            **{
+                **_payload(agent_snapshot=_agent_snapshot(["new-skill"])),
+                "task_id": "task-2",
+            }
+        )
+        child_first, reused_first = await sandbox_runner_main._acquire_warm_child(first)
+        await sandbox_runner_main._release_warm_child(child_first, first.task_id)
+        child_second, reused_second = await sandbox_runner_main._acquire_warm_child(changed_signature)
+        try:
+            assert reused_first is False
+            assert reused_second is False
+            assert child_second.container_name == "warm-child-2"
+            assert started == ["warm-child-1", "warm-child-2"]
+            assert killed == ["warm-child-1"]
+            assert list(sandbox_runner_main.WARM_POOL) == ["warm-child-2"]
+        finally:
+            await sandbox_runner_main._release_warm_child(child_second, changed_signature.task_id)
+            await sandbox_runner_main._shutdown_warm_pool()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        sandbox_runner_main.WARM_POOL.clear()
+        sandbox_runner_main.RUNNING_CONTAINERS.clear()
+        update_settings(originals)
+
+
+def test_warm_pool_waits_at_cap_until_busy_child_releases(monkeypatch, tmp_path: Path):
+    sandbox_runner_main.WARM_POOL.clear()
+    sandbox_runner_main.RUNNING_CONTAINERS.clear()
+    originals = _warm_settings(tmp_path)
+    update_settings({"dataagent_sandbox_max_warm_containers": 1})
+    started: list[str] = []
+
+    async def fake_start(params, signature):
+        container_name = f"warm-child-{len(started) + 1}"
+        started.append(container_name)
+        return sandbox_runner_main.WarmChild(
+            backend="docker",
+            container_name=container_name,
+            signature=signature,
+            topic_id=params.topic_id,
+            process=_FakeWarmProcess(),
+        )
+
+    async def fake_kill(backend: str, container_name: str) -> None:
+        child = sandbox_runner_main.WARM_POOL.get(container_name)
+        if child is not None:
+            child.process.kill()
+
+    monkeypatch.setattr(sandbox_runner_main, "_start_warm_child", fake_start)
+    monkeypatch.setattr(sandbox_runner_main, "_kill_container", fake_kill)
+
+    async def scenario():
+        first = TaskExecutionInput(**_payload(agent_snapshot=_agent_snapshot([])))
+        second = TaskExecutionInput(
+            **{
+                **_payload(agent_snapshot=_agent_snapshot([])),
+                "task_id": "task-2",
+                "topic_id": "topic-2",
+            }
+        )
+        child_first, reused_first = await sandbox_runner_main._acquire_warm_child(first)
+        pending_second = asyncio.create_task(sandbox_runner_main._acquire_warm_child(second))
+        await asyncio.sleep(0.05)
+        assert pending_second.done() is False
+        assert started == ["warm-child-1"]
+
+        await sandbox_runner_main._release_warm_child(child_first, first.task_id)
+        child_second, reused_second = await asyncio.wait_for(pending_second, timeout=1)
+        try:
+            assert reused_first is False
+            assert reused_second is False
+            assert child_second.container_name == "warm-child-2"
+            assert started == ["warm-child-1", "warm-child-2"]
+            assert len(sandbox_runner_main.WARM_POOL) == 1
+        finally:
+            await sandbox_runner_main._release_warm_child(child_second, second.task_id)
+            await sandbox_runner_main._shutdown_warm_pool()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        sandbox_runner_main.WARM_POOL.clear()
+        sandbox_runner_main.RUNNING_CONTAINERS.clear()
+        update_settings(originals)
 
 
 def test_warm_pool_cancel_kills_child_and_returns_suspended(monkeypatch, tmp_path: Path):

--- a/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from core.sdk_block_writer import SdkBlockWriter
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def append_sdk_record(self, **kwargs) -> None:
+        self.records.append(kwargs)
+
+
+class AssistantMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class UserMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class TextBlock:
+    type = "text"
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+class ToolUseBlock:
+    type = "tool_use"
+
+    def __init__(self, *, id: str, name: str, input):
+        self.id = id
+        self.name = name
+        self.input = input
+
+
+class ToolResultBlock:
+    type = "tool_result"
+
+    def __init__(self, *, tool_use_id: str, content, is_error: bool = False):
+        self.tool_use_id = tool_use_id
+        self.content = content
+        self.is_error = is_error
+
+
+def test_assistant_message_tool_use_is_recorded_as_stream_events() -> None:
+    store = FakeStore()
+    writer = SdkBlockWriter(store, task_id="task-1", topic_id="topic-1")
+
+    writer.ingest(
+        AssistantMessage(
+            [
+                TextBlock("我先查看业务知识。"),
+                ToolUseBlock(
+                    id="call_skill_1",
+                    name="Skill",
+                    input={"skill": "opendataworks-business-knowledge"},
+                ),
+            ]
+        )
+    )
+    writer.ingest(
+        UserMessage(
+            [
+                ToolResultBlock(
+                    tool_use_id="call_skill_1",
+                    content="Launching skill: opendataworks-business-knowledge",
+                )
+            ]
+        )
+    )
+
+    event_types = [record["event_type"] for record in store.records if record["record_type"] == "stream"]
+    assert event_types == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_stop",
+    ]
+
+    tool_start = store.records[4]
+    assert tool_start["turn_index"] == 1
+    assert tool_start["data"] == {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {"type": "tool_use", "id": "call_skill_1", "name": "Skill"},
+    }
+
+    tool_delta = store.records[5]
+    assert json.loads(tool_delta["data"]["delta"]["partial_json"]) == {
+        "skill": "opendataworks-business-knowledge"
+    }
+
+    tool_result = store.records[-1]
+    assert tool_result["turn_index"] == 1
+    assert tool_result["record_type"] == "tool_result"
+    assert tool_result["data"] == {
+        "tool_use_id": "call_skill_1",
+        "content": "Launching skill: opendataworks-business-knowledge",
+        "is_error": False,
+    }
+
+
+def test_sdk_dataclass_tool_use_without_type_field_is_recorded() -> None:
+    from claude_agent_sdk import AssistantMessage as SdkAssistantMessage
+    from claude_agent_sdk import ToolUseBlock as SdkToolUseBlock
+
+    store = FakeStore()
+    writer = SdkBlockWriter(store, task_id="task-1", topic_id="topic-1")
+
+    writer.ingest(
+        SdkAssistantMessage(
+            content=[
+                SdkToolUseBlock(
+                    id="call_skill_1",
+                    name="Skill",
+                    input={"skill": "opendataworks-business-knowledge"},
+                )
+            ],
+            model="deepseek-v4-pro",
+        )
+    )
+
+    tool_starts = [
+        record
+        for record in store.records
+        if record["record_type"] == "stream"
+        and record["event_type"] == "content_block_start"
+        and record["data"]["content_block"]["type"] == "tool_use"
+    ]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["data"]["content_block"] == {
+        "type": "tool_use",
+        "id": "call_skill_1",
+        "name": "Skill",
+    }

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
@@ -144,12 +144,19 @@ describe('processV2Record — tool_result', () => {
     expect(state.blocks[0]).toMatchObject({ output: 'boom', is_error: true })
   })
 
-  it('ignores a tool_result with no matching block', () => {
+  it('creates a synthetic tool block for a tool_result with no matching block', () => {
     const state = feed(createChatState(), [
-      stream({ type: 'message_start' }),
-      toolResult({ tool_use_id: 'missing', content: 'x' }),
+      toolResult({ tool_use_id: 'call_skill_1', content: 'Launching skill: opendataworks-business-knowledge' }),
     ])
-    expect(state.blocks).toHaveLength(0)
+    expect(state.blocks).toHaveLength(1)
+    expect(state.blocks[0]).toMatchObject({
+      type: 'tool_use',
+      id: 'call_skill_1',
+      name: 'Skill',
+      input: { skill: 'opendataworks-business-knowledge' },
+      output: 'Launching skill: opendataworks-business-knowledge',
+      status: 'done',
+    })
   })
 })
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
@@ -10,6 +10,8 @@
  *   done record (after ResultMessage)
  */
 
+const SKILL_LAUNCH_OUTPUT_RE = /^Launching skill(?::\s*(.+))?$/i
+
 /**
  * Create a fresh chat state for one assistant message.
  * One state object maps to one user question + all AI reply turns.
@@ -124,10 +126,50 @@ function _handleStreamEvent(state, evt) {
 function _handleToolResult(state, data) {
   const toolUseId = data.tool_use_id
   if (!toolUseId) return
-  const block = state.blocks.find((b) => b.type === 'tool_use' && b.id === toolUseId)
-  if (!block) return
+  let block = state.blocks.find((b) => b.type === 'tool_use' && b.id === toolUseId)
+  if (!block) {
+    block = _createSyntheticToolBlock(state, data)
+  }
   block.output = data.content
   block.is_error = Boolean(data.is_error)
+}
+
+function _createSyntheticToolBlock(state, data) {
+  const currentTurn = _ensureCurrentTurn(state)
+  const skillName = _extractSkillLaunchName(data.content)
+  const block = {
+    turnIndex: currentTurn.turnIndex,
+    blockIndex: currentTurn.blocks.length,
+    type: 'tool_use',
+    content: '',
+    status: 'done',
+    id: data.tool_use_id,
+    name: skillName != null ? 'Skill' : 'Tool',
+    inputJson: '',
+    input: skillName ? { skill: skillName } : null,
+    output: null,
+    is_error: false,
+  }
+  currentTurn.blocks.push(block)
+  state.blocks.push(block)
+  return block
+}
+
+function _ensureCurrentTurn(state) {
+  let currentTurn = state.turns.at(-1)
+  if (!currentTurn || currentTurn.status === 'done') {
+    currentTurn = { turnIndex: state.turns.length, blocks: [], status: 'streaming' }
+    state.turns.push(currentTurn)
+    if (state.status === 'idle') state.status = 'streaming'
+  }
+  return currentTurn
+}
+
+function _extractSkillLaunchName(output) {
+  if (typeof output !== 'string') return null
+  const match = output.trim().match(SKILL_LAUNCH_OUTPUT_RE)
+  if (!match) return null
+  return String(match[1] || '').trim()
 }
 
 function _findBlock(turn, index) {

--- a/docs/design/2026-05-31-chat-v2-design.md
+++ b/docs/design/2026-05-31-chat-v2-design.md
@@ -193,6 +193,69 @@ Data model — `da_agent_sdk_record` (Alembic `20260529_000012`):
 (`stream`/`tool_result`/`done`/`error`), `event_type` (`message_start`, …, nullable),
 `data` (JSON, raw SDK event/metadata), `created_at`; index `(task_id, id)`.
 
+### SDK-record V2 partial behavior
+
+`ClaudeAgentOptions.include_partial_messages` is derived from provider
+configuration (`supports_partial_messages`). Chat V2 treats this as an SDK input
+shape difference only. The durable `da_agent_sdk_record` model and the frontend /
+backend projection contract must be the same for both modes.
+
+When `supports_partial_messages=true`:
+
+- The SDK yields `StreamEvent` messages for Anthropic partial events.
+- `sdk_block_writer` persists each `StreamEvent.event` directly as
+  `record_type='stream'`.
+- Typical event flow is:
+  `message_start -> content_block_start -> content_block_delta* ->
+  content_block_stop -> message_delta? -> message_stop`.
+- Tool results still arrive as `UserMessage(ToolResultBlock...)` and are
+  persisted separately as `record_type='tool_result'`.
+- `ResultMessage` is persisted as `record_type='done'` or, if terminal error
+  metadata is present, accompanied by `record_type='error'`.
+
+When `supports_partial_messages=false`:
+
+- The SDK may not emit partial `StreamEvent` records for assistant content.
+  Instead it yields whole `AssistantMessage` objects containing SDK content
+  dataclasses such as `TextBlock`, `ThinkingBlock`, `ToolUseBlock`, and
+  `ServerToolUseBlock`.
+- `sdk_block_writer` normalizes those whole-message blocks into the same
+  `record_type='stream'` protocol used by the partial path:
+  - one synthetic `message_start`;
+  - for each text block: `content_block_start(type='text')`,
+    `content_block_delta(type='text_delta')`, `content_block_stop`;
+  - for each thinking block: `content_block_start(type='thinking')`,
+    `content_block_delta(type='thinking_delta')`, `content_block_stop`;
+  - for each tool-use block: `content_block_start(type='tool_use', id, name)`,
+    optional `content_block_delta(type='input_json_delta', partial_json=...)`,
+    `content_block_stop`;
+  - one synthetic `message_stop`.
+- `UserMessage(ToolResultBlock...)` and `ResultMessage` keep the same persistence
+  behavior as the partial path.
+
+This means consumers never need to branch on `supports_partial_messages`.
+`v2StreamParser.processV2Record` and
+`topic_task_store._project_sdk_records` replay one durable SDK-record protocol:
+
+| SDK source | Persisted record | Projection effect |
+| --- | --- | --- |
+| `StreamEvent.event` (`partial=true`) | `stream` with raw event `data` | Creates or updates `thinking`, `text`, or `tool_use` blocks |
+| `AssistantMessage(TextBlock/ThinkingBlock/ToolUseBlock)` (`partial=false`) | synthetic `stream` events | Same block output as the partial path |
+| `UserMessage(ToolResultBlock)` | `tool_result` with `tool_use_id`, `content`, `is_error` | Attaches output/error to the matching `tool_use` block |
+| `ResultMessage` | `done` | Marks stream terminal |
+| Writer/runtime exception | `error` | Marks stream error and exposes `errorText` |
+
+Projection has one defensive compatibility rule for old or malformed records:
+if a `tool_result` row has a `tool_use_id` but no preceding `tool_use` block, the
+backend and frontend projections synthesize a `tool_use` block so historical UI
+does not hide the process. `Launching skill: <name>` outputs are rendered as
+`tool_name='Skill'` with `input={skill:<name>}`; other orphan results render as a
+generic `Tool`.
+
+Do not use `supports_partial_messages=true` as a workaround for missing tool
+process records. It only switches the SDK input path. The persisted V2 record
+model must remain complete for both `partial=true` and `partial=false` providers.
+
 ## Risks / Alternatives
 
 - **Native SDK-event stream vs magic-event stream.** V2 streams the native SDK
@@ -213,12 +276,12 @@ Data model — `da_agent_sdk_record` (Alembic `20260529_000012`):
 ## Verification
 
 - Frontend unit (run after `nvm use`): `IntelligentQueryView.spec.js`,
-  `NL2SqlChat.spec.js`, and the widget `WidgetChat.spec.js` (which mocks
-  `deliverMessage`/`streamSdkEvents` and exercises the shared render path). A
-  dedicated `NL2SqlChatV2.spec.js` / `v2StreamParser.spec.js` does not yet exist
-  and is a recommended follow-up.
-- DataAgent: focused coverage for `sdk_block_writer` ingest and
-  `topic_task_store._project_sdk_records` projection.
+  `NL2SqlChatV2.spec.js`, `v2StreamParser.spec.js`,
+  `sdkBlockProjection.contract.spec.js`, and widget `WidgetChat.spec.js`.
+- DataAgent: focused coverage for `sdk_block_writer` ingest, including
+  `partial=false` whole `AssistantMessage` tool-use normalization, plus
+  `topic_task_store._project_sdk_records` projection and the shared
+  SDK-block projection contract.
 - End-to-end smoke (per AGENTS.md intelligent-query smoke method): on the
   `chat-v2` tab, submit a real NL2SQL question; verify `deliver-message` returns
   a `task_id`, SDK records stream and render incrementally, the run reaches a

--- a/docs/design/2026-06-08-dataagent-sandbox-warm-container-reuse-design.md
+++ b/docs/design/2026-06-08-dataagent-sandbox-warm-container-reuse-design.md
@@ -96,8 +96,12 @@ The runner maintains an in-process pool of warm children keyed by container
 name, with a signature index, a busy flag, and a `last_used` timestamp:
 
 - **acquire**: under a pool lock, reuse an alive, idle child with a matching
-  signature; otherwise create a new child (evicting an idle LRU child first if
-  the pool is at capacity). The acquired child is marked busy.
+  signature. If the same topic already has a busy child, wait until it releases
+  because one topic represents one conversation/session. If the topic has an
+  idle child with a different signature, close that old child before starting a
+  replacement. For other topics, create a new child only when the pool is below
+  capacity; if the pool is at capacity, evict an idle LRU child to make room or
+  wait when every child is busy. The acquired child is marked busy.
 - **run**: write the payload line to the child's stdin (kept open), stream
   stdout `record`/`result` lines for this task, and stop at the `result` line,
   leaving the child idle for the next task.
@@ -108,8 +112,10 @@ name, with a signature index, a busy flag, and a `last_used` timestamp:
 - **shutdown**: kill and remove all warm children on runner shutdown; the
   existing label-based startup cleanup still reaps stragglers.
 
-A warm child serves one task at a time. Concurrent tasks with the same signature
-simply create additional warm children, bounded by the max-pool-size cap.
+A warm child serves one task at a time. Concurrent tasks for the same topic are
+serialized onto that topic's warm child. Additional warm children are only
+created for other topics/signatures while the pool is below the max-pool-size
+cap; once the cap is reached, later acquires wait for a release.
 
 ### Cancellation
 
@@ -162,8 +168,9 @@ New runner/runtime configuration (all under the existing sandbox namespace):
   today's one-shot-per-task container path.
 - `DATAAGENT_SANDBOX_IDLE_TTL_SECONDS` (int, default `600`): idle lifetime of a
   warm child before the reaper removes it.
-- `DATAAGENT_SANDBOX_MAX_WARM_CONTAINERS` (int, default `32`): soft cap on warm
-  children; idle LRU children are evicted to make room.
+- `DATAAGENT_SANDBOX_MAX_WARM_CONTAINERS` (int, default `32`): hard cap on warm
+  children; idle LRU children are evicted to make room, and all-busy pools apply
+  backpressure by waiting for a child to release.
 - `DATAAGENT_SANDBOX_REAPER_INTERVAL_SECONDS` (int, default `30`): how often the
   reaper scans the pool.
 
@@ -171,8 +178,8 @@ Internal runtime contract additions:
 
 - The runner sets `DATAAGENT_SANDBOX_CHILD_IDLE_TIMEOUT` on warm children to
   switch the child into serve-loop mode; the value is the idle TTL plus a buffer.
-- Warm children are named `dataagent-warm-<topic>-<sig>` and labelled with the
-  existing sandbox labels (task id label is `warm`), so the existing
+- Warm children are named `dataagent-warm-<topic>-<sig>` and labelled with
+  the existing sandbox labels (task id label is `warm`), so the existing
   label-based startup cleanup continues to reap them.
 - The runner sends each warm payload as one newline-terminated JSON line and
   keeps the child's stdin open across tasks.
@@ -184,8 +191,8 @@ Internal runtime contract additions:
   bind-mount sharing and is desirable for session continuity; reuse never
   crosses topics or isolation profiles.
 - Warm children hold resources during the idle window. This is bounded by the
-  idle TTL, the max-pool-size cap with idle LRU eviction, and the child-side
-  self-idle exit.
+  idle TTL, the hard max-pool-size cap with idle LRU eviction / busy backpressure,
+  and the child-side self-idle exit.
 - The change is gated behind `DATAAGENT_SANDBOX_REUSE_ENABLED`. Disabling it
   restores the exact current one-shot container behavior as a single-layer
   fallback.

--- a/docs/plans/2026-05-31-chat-v2-plan.md
+++ b/docs/plans/2026-05-31-chat-v2-plan.md
@@ -26,7 +26,16 @@ alignment to the same model.
    `core/topic_task_store.py`, `api/routes.py`,
    `alembic/versions/20260529_000012_sdk_block_records.py`
    - `da_agent_sdk_record` table; `append_sdk_record` / `list_sdk_records`.
+   - `supports_partial_messages=true`: persist SDK `StreamEvent.event` rows as
+     `record_type=stream`.
+   - `supports_partial_messages=false`: normalize whole `AssistantMessage`
+     `TextBlock` / `ThinkingBlock` / `ToolUseBlock` content into the same
+     `record_type=stream` lifecycle before projection.
+   - Persist `UserMessage(ToolResultBlock...)` as `record_type=tool_result` and
+     `ResultMessage` as `record_type=done` in both modes.
    - `_project_sdk_records` replays records into rendered `blocks` for history.
+   - Orphan `tool_result` rows are projected as synthetic `tool_use` blocks so
+     historical UI still exposes process records.
    - SSE `GET /tasks/{id}/sdk-events/stream?after_id=` and JSON
      `GET /tasks/{id}/sdk-events`.
 2. **Shared SDK-stream parser** — `frontend/src/views/intelligence/v2StreamParser.js`
@@ -63,9 +72,12 @@ alignment to the same model.
 ## Verification
 
 - `nvm use`, then run focused frontend unit tests: `IntelligentQueryView.spec.js`,
-  `NL2SqlChat.spec.js`, `WidgetChat.spec.js`.
+  `NL2SqlChatV2.spec.js`, `v2StreamParser.spec.js`,
+  `sdkBlockProjection.contract.spec.js`, `WidgetChat.spec.js`.
 - DataAgent: focused coverage for `sdk_block_writer` ingest and
-  `topic_task_store._project_sdk_records` projection.
+  `topic_task_store._project_sdk_records` projection, including both
+  `partial=true` stream-event records and `partial=false` whole
+  `AssistantMessage` tool-use records.
 - End-to-end smoke (per AGENTS.md): on `chat-v2`, submit a real NL2SQL question;
   verify `deliver-message` → `task_id`, SDK-event stream rendering, terminal
   state, persistence to `da_agent_sdk_record`, and history rebuild via

--- a/docs/plans/2026-06-08-dataagent-sandbox-warm-container-reuse-plan.md
+++ b/docs/plans/2026-06-08-dataagent-sandbox-warm-container-reuse-plan.md
@@ -43,12 +43,18 @@ File: `sandbox_runner_main.py`
 - `_container_spec_signature(params)`: stable hash over backend, image, topic
   workspace path, sorted enabled skill folders, isolation knobs, uid/gid.
 - Extend `_build_container_command` with optional `container_name`,
-  `task_id_label`, and `extra_env` so warm children get a stable name and the
-  child idle-timeout env without changing the default (3-tuple) contract.
-- `WarmChild` dataclass + `WARM_POOL` + `WARM_POOL_LOCK` + signature reuse.
+  `task_id_label`, and `extra_env` so warm children get a deterministic warm-pool name
+  and the child idle-timeout env without changing the default (3-tuple) contract.
+- `WarmChild` dataclass + `WARM_POOL` + `WARM_POOL_LOCK`/condition + signature reuse.
 - `_acquire_warm_child` / `_run_on_warm_child` / `_release_warm_child`,
   `_start_warm_child`, `_close_warm_child`, `_drain_warm_stderr`,
   `_watch_cancel_warm`, `_evict_idle_over_cap_locked`.
+- Enforce one active warm child per topic: same-topic concurrent acquires wait,
+  and same-topic idle children with a stale signature are closed before a
+  replacement starts.
+- Enforce `dataagent_sandbox_max_warm_containers` as a hard cap: evict idle LRU
+  children when possible, otherwise wait for a busy child to release before
+  starting another child.
 - `_execute_task_stream_warm` orchestrates acquire/run/release.
 - Dispatch in `run_sandbox_task.execute()`: warm path when
   `_should_reuse_containers()`, else existing `_execute_task_stream_container`.
@@ -86,6 +92,12 @@ File: `tests/test_sandbox_runner_main.py`
   different topic or enabled-skill set.
 - warm reuse: two sequential tasks with a stub loop child create one container
   and reuse it (pool holds a single child, reused on the second run).
+- same-topic concurrent acquires wait for the current child to release even when
+  the pool has spare capacity.
+- same-topic signature changes close the old idle warm child before starting a
+  replacement.
+- max-cap backpressure: with `max_warm_containers=1`, a second acquire waits
+  until the busy child is released instead of creating a second child.
 - idle reaper kills and removes an idle warm child past the TTL.
 - cancel kills the warm child and the run returns suspended.
 - `_build_container_command` honors `container_name`, `task_id_label`, and


### PR DESCRIPTION
## Summary

This follows up on PR #321 and tightens warm sandbox reuse semantics so one topic behaves like one conversation/session:

- same-topic concurrent acquires now wait for the active warm child to release instead of starting another child
- same-topic signature changes evict the idle warm child and start a replacement
- `dataagent_sandbox_max_warm_containers` remains a global hard cap across topics

## Validation

- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_sandbox_runner_main.py dataagent/dataagent-backend/tests/test_sandbox_task_main.py dataagent/dataagent-backend/tests/test_topic_workspace.py dataagent/dataagent-backend/tests/test_topic_files.py -q`
- `git diff --check -- dataagent/dataagent-backend/sandbox_runner_main.py dataagent/dataagent-backend/tests/test_sandbox_runner_main.py docs/design/2026-06-08-dataagent-sandbox-warm-container-reuse-design.md docs/plans/2026-06-08-dataagent-sandbox-warm-container-reuse-plan.md`

## Risk / Rollback

Risk is limited to sandbox runner pool scheduling and reuse semantics. Roll back by reverting commit `caf92db` or disabling reuse with `DATAAGENT_SANDBOX_REUSE_ENABLED=false` if operationally needed.
