### PR TITLE
Suppress AssistantMessage projection when StreamEvents are present

### DIFF
--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -16,6 +16,7 @@ class SdkBlockWriter:
         self._task_id = task_id
         self._topic_id = topic_id
         self._turn_index = 0
+        self._saw_stream_event = False
 
     def ingest(self, msg: Any) -> None:
         """Process one SDK message from the claude_query() stream."""
@@ -28,6 +29,7 @@ class SdkBlockWriter:
         type_name = type(msg).__name__
 
         if type_name == "StreamEvent":
+            self._saw_stream_event = True
             evt = getattr(msg, "event", None) or {}
             self._append_stream_event(evt)
 
@@ -80,6 +82,13 @@ class SdkBlockWriter:
                 )
 
     def _ingest_assistant_message(self, msg: Any) -> None:
+        # In partial-streaming mode the SDK already emitted StreamEvent records
+        # carrying every block of this message. Projecting the whole
+        # AssistantMessage on top of that would duplicate thinking, tool calls,
+        # and conclusion blocks. Only normalize whole messages when no partial
+        # StreamEvent was observed (supports_partial_messages=false providers).
+        if self._saw_stream_event:
+            return
         content = getattr(msg, "content", None)
         if isinstance(content, str):
             blocks = [{"type": "text", "text": content}]

--- a/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
@@ -29,6 +29,11 @@ class UserMessage:
         self.content = content
 
 
+class StreamEvent:
+    def __init__(self, event):
+        self.event = event
+
+
 class TextBlock:
     type = "text"
 
@@ -114,6 +119,51 @@ def test_assistant_message_tool_use_is_recorded_as_stream_events() -> None:
         "content": "Launching skill: opendataworks-business-knowledge",
         "is_error": False,
     }
+
+
+def test_partial_stream_events_suppress_assistant_message_projection() -> None:
+    """When the SDK streams partial StreamEvents, the trailing whole
+    AssistantMessage must not be projected again, otherwise thinking, tool
+    calls, and conclusion blocks would be duplicated."""
+    store = FakeStore()
+    writer = SdkBlockWriter(store, task_id="task-1", topic_id="topic-1")
+
+    # Partial-streaming path: SDK emits raw StreamEvents for the same content.
+    writer.ingest(StreamEvent({"type": "message_start"}))
+    writer.ingest(
+        StreamEvent(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text"},
+            }
+        )
+    )
+    writer.ingest(
+        StreamEvent(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "结论。"},
+            }
+        )
+    )
+    writer.ingest(StreamEvent({"type": "content_block_stop", "index": 0}))
+    writer.ingest(StreamEvent({"type": "message_stop"}))
+
+    records_before = len(store.records)
+
+    # The SDK also yields the assembled AssistantMessage for the same turn.
+    writer.ingest(AssistantMessage([TextBlock("结论。")]))
+
+    # No additional records should be produced by the AssistantMessage.
+    assert len(store.records) == records_before
+    message_starts = [
+        record
+        for record in store.records
+        if record["record_type"] == "stream" and record["event_type"] == "message_start"
+    ]
+    assert len(message_starts) == 1
 
 
 def test_sdk_dataclass_tool_use_without_type_field_is_recorded() -> None:


### PR DESCRIPTION
## Summary
Fixes duplicate block recording when the SDK streams partial `StreamEvent` objects followed by a complete `AssistantMessage` for the same turn. The writer now detects partial streaming mode and skips projecting the assembled message to avoid duplicating thinking, tool calls, and conclusion blocks.

## Changes
- Added `StreamEvent` test helper class to simulate SDK streaming behavior
- Added `_saw_stream_event` flag to `SdkBlockWriter` to track when partial streaming is active
- Modified `_ingest_assistant_message()` to skip processing when `StreamEvent` records have already been ingested for the turn
- Added comprehensive test case `test_partial_stream_events_suppress_assistant_message_projection()` validating that only one `message_start` event is recorded when both streaming and assembled message paths are used

## Implementation Details
The fix leverages the fact that partial-streaming providers (those with `supports_partial_messages=true`) emit individual `StreamEvent` objects for each block delta, then also yield the fully assembled `AssistantMessage`. By detecting the presence of any `StreamEvent` in the current turn, we can safely skip the message projection step and rely on the already-recorded stream events instead.

https://claude.ai/code/session_013NJyH6NLyKhTE6DEcvHNLn