### PR TITLE
Add DataAgent branding to intelligent query sidebar

### DIFF
--- a/dataagent/dataagent-frontend/index.html
+++ b/dataagent/dataagent-frontend/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="./opendataworks-icon.svg" />
+    <link rel="alternate icon" type="image/x-icon" href="./opendataworks-icon.ico" />
+    <link rel="apple-touch-icon" href="./opendataworks-icon-192.png" />
     <title>DataAgent</title>
   </head>
   <body>

--- a/dataagent/dataagent-frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="intelligent-query-view">
     <aside class="intelligent-query-sidebar">
+      <div class="intelligent-query-brand">
+        <img
+          class="intelligent-query-brand__logo"
+          :src="brandLogo"
+          alt="DataAgent"
+        />
+        <span class="intelligent-query-brand__title">DataAgent</span>
+      </div>
       <el-menu
         :default-active="activeMenu"
         class="intelligent-query-menu"
@@ -57,6 +65,8 @@ const route = useRoute()
 const router = useRouter()
 const validTabs = new Set(['chat-v2', 'skills', 'agents', 'models', 'widget'])
 
+const brandLogo = `${import.meta.env.BASE_URL}opendataworks-icon.svg`
+
 const isSkillDetailRoute = computed(() => (
   route.name === 'IntelligentQuerySkillDetail' || route.path.startsWith('/intelligent-query/skills/')
 ))
@@ -104,15 +114,43 @@ const handleMenuSelect = (index) => {
 
 .intelligent-query-sidebar {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
   border-right: 1px solid #dbe3ef;
   background: #ffffff;
   overflow: hidden;
 }
 
+.intelligent-query-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 16px;
+  border-bottom: 1px solid #eef2f8;
+}
+
+.intelligent-query-brand__logo {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+}
+
+.intelligent-query-brand__title {
+  min-width: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: #1f2d3d;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .intelligent-query-menu {
-  height: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
   border-right: none;
-  padding: 12px 0;
+  padding: 8px 0;
 }
 
 .intelligent-query-menu :deep(.el-menu-item) {
@@ -144,8 +182,13 @@ const handleMenuSelect = (index) => {
     border-bottom: 1px solid #dbe3ef;
   }
 
+  .intelligent-query-brand {
+    display: none;
+  }
+
   .intelligent-query-menu {
     display: flex;
+    flex: 0 0 auto;
     height: auto;
     padding: 6px;
     overflow-x: auto;


### PR DESCRIPTION
## Summary
Added DataAgent branding elements to the intelligent query view sidebar, including a logo and title, along with corresponding favicon links in the HTML head.

## Key Changes
- **Sidebar branding component**: Added a new brand section at the top of the intelligent query sidebar displaying the DataAgent logo and title
- **Logo asset reference**: Imported `opendataworks-icon.svg` from the public assets directory using `import.meta.env.BASE_URL`
- **Responsive layout**: Updated sidebar flexbox layout to accommodate the new brand section while maintaining proper menu scrolling behavior
- **Favicon support**: Added favicon links in `index.html` for SVG, ICO, and Apple touch icon formats pointing to the DataAgent icon assets
- **Mobile optimization**: Brand section is hidden on mobile/compact views to preserve screen space

## Implementation Details
- The brand section uses flexbox with centered alignment and includes proper spacing (18px vertical, 16px horizontal padding)
- Logo is sized at 32x32px with 8px border radius for a polished appearance
- Title uses ellipsis overflow handling to prevent layout breaking with long text
- Menu container now uses `flex: 1 1 auto` to fill available space while maintaining scrollability
- Mobile view hides the brand section and adjusts menu padding for compact display

https://claude.ai/code/session_012APghCCd9jfzoRWL3Pozgd