### PR TITLE
fix(dataagent): write runner topic prep to container volume so custom DATAAGENT_HOST_ROOT works

### DIFF
--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -24,7 +24,7 @@ from config import get_settings
 from core.agent_profile_service import normalize_agent_snapshot
 from core.skill_admin_service import resolve_enabled_skill_runtime
 from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
-from core.topic_workspace import LOGS_DIRNAME, sanitize_topic_id
+from core.topic_workspace import CONTAINER_RUNTIME_ROOT, LOGS_DIRNAME, sanitize_topic_id
 
 logger = logging.getLogger(__name__)
 
@@ -268,18 +268,57 @@ def _safe_container_fragment(value: str) -> str:
 
 
 def _host_sandbox_root() -> Path:
+    """Host-side runtime root, used ONLY as the child bind-mount ``source=``.
+
+    This is ``DATAAGENT_HOST_ROOT`` as seen by the host Docker/Podman daemon. It
+    must NOT be used for filesystem operations the runner performs itself: the
+    runner sees the same persistent volume at the fixed container path
+    ``/dataagent_runtime`` (see ``_container_runtime_root``), which equals this
+    host path only in the default deployment. Mixing the two breaks custom
+    ``DATAAGENT_HOST_ROOT`` values, because the runner would mkdir/chown/write
+    against a path that does not exist inside its own container.
+    """
     cfg = get_settings()
     raw = str(getattr(cfg, "dataagent_host_root", "") or "").strip()
     return Path(raw or "/dataagent_runtime").expanduser().resolve()
 
 
+def _container_runtime_root() -> Path:
+    """Runtime root as seen INSIDE the runner container (the mounted volume).
+
+    Compose mounts ``DATAAGENT_HOST_ROOT`` to this fixed container path for the
+    runner, so every directory the runner creates/owns/writes for a topic must be
+    rooted here. The host equivalent (``_host_sandbox_root``) is only the child
+    bind-mount source resolved by the host daemon.
+    """
+    return CONTAINER_RUNTIME_ROOT
+
+
+def _topic_container_workspace(topic_id: str) -> Path:
+    # Agent cwd as seen inside the runner: <container_root>/<topic>/workspace.
+    # Used for the runner's own mkdir/skill-target prep/chown.
+    return _container_runtime_root() / sanitize_topic_id(topic_id) / "workspace"
+
+
+def _topic_container_home(topic_id: str) -> Path:
+    # Per-topic Claude HOME as seen inside the runner: <container_root>/<topic>/home.
+    return _container_runtime_root() / sanitize_topic_id(topic_id) / "home"
+
+
+def _topic_container_logs(topic_id: str) -> Path:
+    # Per-task sandbox logs as seen inside the runner. Logs are written by the
+    # runner process itself, so they live under the container runtime root (the
+    # mounted volume), never the host-path string.
+    return _container_runtime_root() / sanitize_topic_id(topic_id) / LOGS_DIRNAME
+
+
 def _topic_host_workspace(topic_id: str) -> Path:
-    # Agent cwd bind source: <sandbox_root>/<topic>/workspace.
+    # Agent cwd bind source resolved by the host daemon: <host_root>/<topic>/workspace.
     return _host_sandbox_root() / sanitize_topic_id(topic_id) / "workspace"
 
 
 def _topic_host_home(topic_id: str) -> Path:
-    """Per-topic persisted Claude HOME on the host.
+    """Per-topic persisted Claude HOME bind source on the host.
 
     Claude stores resume session transcripts under ``$HOME/.claude/projects``.
     A child-local tmpfs HOME would drop them when the container is recreated
@@ -288,7 +327,7 @@ def _topic_host_home(topic_id: str) -> Path:
     resume working across the child container lifecycle.
 
     It is a sibling of ``workspace`` under the topic root
-    (``<sandbox_root>/<topic>/home``), so it sits next to the topic's other
+    (``<host_root>/<topic>/home``), so it sits next to the topic's other
     files (easy to find, cleaned up with the topic) but is NOT inside the agent
     workspace bind. The child mounts it at the distinct path ``/mnt/home`` (not
     ``/mnt/workspace``), so HOME never equals cwd, project skill registration is
@@ -297,14 +336,8 @@ def _topic_host_home(topic_id: str) -> Path:
     return _host_sandbox_root() / sanitize_topic_id(topic_id) / "home"
 
 
-def _topic_host_logs(topic_id: str) -> Path:
-    # Per-task sandbox logs live under <sandbox_root>/<topic>/logs, a sibling of
-    # workspace/ and home/. Host-side only (never bind-mounted into the child).
-    return _host_sandbox_root() / sanitize_topic_id(topic_id) / LOGS_DIRNAME
-
-
 def _sandbox_task_log_path(params: TaskExecutionInput) -> Path:
-    return _topic_host_logs(params.topic_id) / f"{_safe_container_fragment(params.task_id)}.log"
+    return _topic_container_logs(params.topic_id) / f"{_safe_container_fragment(params.task_id)}.log"
 
 
 def _append_task_log(log_path: Path | None, line: str) -> None:
@@ -448,15 +481,21 @@ def _build_container_command(
     if not image:
         raise RuntimeError("DATAAGENT_SANDBOX_IMAGE is required for container sandbox backend")
 
-    topic_workspace = _topic_host_workspace(params.topic_id)
-    topic_workspace.mkdir(parents=True, exist_ok=True)
-    topic_home = _topic_host_home(params.topic_id)
-    topic_home.mkdir(parents=True, exist_ok=True)
+    # Filesystem prep runs inside the runner container, so it must target the
+    # mounted volume at the container runtime root. The child bind-mount sources
+    # below use the host-path equivalents (resolved by the host daemon); the two
+    # only coincide when DATAAGENT_HOST_ROOT == the fixed container root.
+    container_workspace = _topic_container_workspace(params.topic_id)
+    container_workspace.mkdir(parents=True, exist_ok=True)
+    container_home = _topic_container_home(params.topic_id)
+    container_home.mkdir(parents=True, exist_ok=True)
+    host_workspace = _topic_host_workspace(params.topic_id)
+    host_home = _topic_host_home(params.topic_id)
     enabled_folders = _enabled_skill_folders_for_task(params)
     skill_mounts = _build_skill_mounts(cfg, enabled_folders)
-    _prepare_child_skill_mount_targets(topic_workspace, enabled_folders)
-    _ensure_topic_workspace_owner(topic_workspace)
-    _ensure_host_path_owner(topic_home)
+    _prepare_child_skill_mount_targets(container_workspace, enabled_folders)
+    _ensure_topic_workspace_owner(container_workspace)
+    _ensure_host_path_owner(container_home)
     container_name = container_name or (
         f"dataagent-task-{_safe_container_fragment(params.topic_id)[:32]}-"
         f"{_safe_container_fragment(params.task_id)[:32]}"
@@ -483,9 +522,9 @@ def _build_container_command(
         "--workdir",
         CHILD_WORKSPACE_ROOT,
         "--mount",
-        f"type=bind,source={topic_workspace},target={CHILD_WORKSPACE_ROOT}",
+        f"type=bind,source={host_workspace},target={CHILD_WORKSPACE_ROOT}",
         "--mount",
-        f"type=bind,source={topic_home},target={CHILD_CLAUDE_HOME}",
+        f"type=bind,source={host_home},target={CHILD_CLAUDE_HOME}",
     ]
     # Runtime isolation hardening. The workspace bind-mount, the per-topic HOME
     # bind-mount, and read-only skill mounts are the only host paths the child can

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
@@ -18,6 +19,22 @@ from core.task_executor import TaskExecutionResult
 
 
 OLD_SANDBOX_ROOT_ENV_PREFIX = "DATAAGENT_" "SANDBOX_ROOT="
+
+
+@pytest.fixture(autouse=True)
+def _isolate_container_runtime_root(tmp_path_factory, monkeypatch):
+    """Redirect the in-container runtime root to a writable temp dir.
+
+    The runner performs its own filesystem prep (mkdir/skill-target prep/chown/
+    logs) under the container runtime root, which in production is the mounted
+    volume at ``/dataagent_runtime`` — distinct from the host bind source
+    (``DATAAGENT_HOST_ROOT``). Tests run outside a container, so point the
+    container root at a temp dir to avoid touching the real ``/dataagent_runtime``
+    and to keep host vs container roots genuinely separate.
+    """
+    container_root = tmp_path_factory.mktemp("container-runtime")
+    monkeypatch.setattr(sandbox_runner_main, "CONTAINER_RUNTIME_ROOT", container_root)
+    return container_root
 
 
 def _agent_snapshot(skill_folders: list[str] | None = None) -> dict:
@@ -119,23 +136,29 @@ def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatc
 
     assert backend == "docker"
     assert container_name.startswith("dataagent-task-topic-1-task-1")
-    # The topic root holds two separately mounted subdirs: workspace/ and home/.
-    topic_workspace = host_root / "topic-1" / "workspace"
-    assert topic_workspace == tmp_path / "topics" / "topic-1" / "workspace"
-    assert topic_workspace.is_dir()
-    assert (topic_workspace / ".claude" / "skills").is_dir()
-    assert f"type=bind,source={topic_workspace},target=/mnt/workspace" in command
+    # The runner prepares files under the container runtime root (the mounted
+    # volume it sees), NOT under the host bind source. With a custom host root the
+    # two differ, which is exactly what broke before: prep must hit the volume.
+    container_root = sandbox_runner_main.CONTAINER_RUNTIME_ROOT
+    assert container_root != host_root
+    created_workspace = container_root / "topic-1" / "workspace"
+    assert created_workspace.is_dir()
+    assert (created_workspace / ".claude" / "skills").is_dir()
+    created_home = container_root / "topic-1" / "home"
+    assert created_home.is_dir()
+    # Child bind sources are the HOST-path equivalents, resolved by the host daemon.
+    host_workspace = host_root / "topic-1" / "workspace"
+    host_home = host_root / "topic-1" / "home"
+    assert f"type=bind,source={host_workspace},target=/mnt/workspace" in command
+    assert f"type=bind,source={host_home},target=/mnt/home" in command
+    # The container-path (where prep landed) must never leak in as a bind source.
+    assert f"type=bind,source={created_workspace},target=/mnt/workspace" not in command
     assert f"type=bind,source={host_root / 'topic-1'},target=/mnt/workspace" not in command
     assert f"type=bind,source={host_root},target=/mnt/workspace" not in command
-    # HOME is a per-topic persisted bind-mount at <topic>/home, a sibling of
-    # workspace (not inside it), mounted at the distinct path /mnt/home so resume
-    # transcripts survive child container recreation and the agent never sees them.
-    topic_home = host_root / "topic-1" / "home"
-    assert topic_home.is_dir()
-    assert f"type=bind,source={topic_home},target=/mnt/home" in command
-    # home is NOT under the workspace bind source, so it cannot appear in /mnt/workspace.
-    assert topic_home.parent == topic_workspace.parent
-    assert topic_home not in topic_workspace.parents
+    # home is a sibling of workspace under the same topic root, never inside it.
+    assert host_home.parent == host_workspace.parent
+    assert host_home not in host_workspace.parents
+    assert created_home.parent == created_workspace.parent
     workdir_index = command.index("--workdir")
     assert command[workdir_index + 1] == "/mnt/workspace"
     assert "--network" in command
@@ -368,7 +391,9 @@ sys.exit(7)
         sandbox_runner_main.CANCELLED_TASK_IDS.discard("task-1")
         update_settings(originals)
 
-    log_path = host_root / "topic-1" / "logs" / "task-1.log"
+    # Logs are written by the runner process itself, so they land under the
+    # container runtime root (the mounted volume), not the host-path string.
+    log_path = sandbox_runner_main.CONTAINER_RUNTIME_ROOT / "topic-1" / "logs" / "task-1.log"
     assert result.task_status == "error"
     assert result.error == {
         "code": "sandbox_container_no_result",

--- a/docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
+++ b/docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
@@ -18,57 +18,77 @@ tell the host Docker/Podman daemon where to bind-mount each topic's
 (`sandbox_runner_main._host_sandbox_root()` →
 `Path(raw).expanduser().resolve()`).
 
-An **absolute** custom `DATAAGENT_HOST_ROOT` works end to end. A **relative**
-custom value does not:
+Any custom `DATAAGENT_HOST_ROOT` (even an absolute one) is broken, and a
+relative value is doubly broken. There are two independent defects:
 
-- Compose resolves a relative bind source relative to the project directory
-  (`deploy/`), so `dataagent-backend` persists topics under
-  `deploy/<rel>` correctly.
-- The runner forwards the same raw relative string and resolves it inside its
-  own container, whose CWD is `/app`. `./runtime` becomes `/app/runtime`, a
-  container-local path, so the child bind source is wrong and sandbox tasks
-  fail.
+1. Runner conflates two roots. `sandbox_runner_main` used `DATAAGENT_HOST_ROOT`
+   for both (a) the filesystem prep it performs *inside its own container*
+   (`mkdir` the topic workspace/home, create child skill mount-target dirs,
+   `chown`, write per-task logs) and (b) the bind-mount `source=` for child
+   containers (resolved by the host Docker daemon). The runner sees the
+   persistent volume at the fixed container path `/dataagent_runtime`, so the
+   filesystem prep must target that path. These coincide only when
+   `DATAAGENT_HOST_ROOT == /dataagent_runtime` — the default. With any custom
+   root, the runner's `mkdir`/`chown`/log writes hit a non-existent path in its
+   own overlay filesystem instead of the mounted volume: nothing is written
+   under the custom host dir, the child's `.claude/skills/<folder>` mount targets
+   never get created, and the child exits with "warm sandbox container exited
+   without a result".
 
-`scripts/start.sh` already normalizes `DATAAGENT_SKILLS_DIR` to an absolute host
-path via `resolve_dataagent_skills_dir()`, but there is no equivalent for
-`DATAAGENT_HOST_ROOT`. The offline package and `.env.example` use relative paths
-for other mounts, so a relative `DATAAGENT_HOST_ROOT` is a natural thing for an
-operator to try, and it silently breaks the sandbox path.
+2. Relative values are re-resolved in the wrong place. Compose resolves a
+   relative bind source relative to the project directory (`deploy/`), so
+   `dataagent-backend` persists under `deploy/<rel>`. But the runner forwards the
+   raw relative string and resolves it inside its own container (CWD `/app`), so
+   `./runtime` becomes the container-local `/app/runtime` — a wrong child bind
+   source. `scripts/start.sh` already normalizes `DATAAGENT_SKILLS_DIR` via
+   `resolve_dataagent_skills_dir()` but had no equivalent for the runtime root.
 
 ## Problem
 
-Operators cannot reliably point the DataAgent runtime root at a custom host
-directory: absolute paths work, but relative paths break the sandbox runner's
-child bind mounts because the runner re-resolves the value against its own
-container filesystem instead of the host.
+Operators cannot point the DataAgent runtime root at a custom host directory:
+the sandbox runner writes its topic prep to the wrong (container-local) path, so
+the custom directory stays empty and sandbox tasks fail. Relative values fail
+additionally because the runner re-resolves them against its own filesystem.
 
 ## Scope
 
-- Make `DATAAGENT_HOST_ROOT` support custom host directories, including relative
-  paths, consistently across `dataagent-home-init`, `dataagent-backend`, and the
-  sandbox runner's child binds.
-- Keep the container-visible runtime root fixed at `/dataagent_runtime`.
-- No backend code or compose contract changes; the fix lives in the launcher and
-  documentation.
+- Separate the two roots in the sandbox runner: a fixed container runtime root
+  (`/dataagent_runtime`) for the runner's own filesystem operations, and the
+  host root (`DATAAGENT_HOST_ROOT`) only for child bind-mount sources.
+- Normalize a relative `DATAAGENT_HOST_ROOT` to an absolute host path in
+  `scripts/start.sh` before invoking compose, mirroring the skills-dir handling.
+- Keep the container-visible runtime root fixed at `/dataagent_runtime` and the
+  compose contract unchanged.
 
-Affected stacks: deployment (`scripts/start.sh`, `deploy/.env.example`,
-`deploy/README.md`). DataAgent backend/runner code is unchanged.
+Affected stacks: DataAgent runner (`dataagent/dataagent-backend/sandbox_runner_main.py`)
+and deployment (`scripts/start.sh`, `deploy/.env.example`, `deploy/README.md`).
 
 ## Solution
 
-Resolve `DATAAGENT_HOST_ROOT` to a host absolute path in `scripts/start.sh`
-before invoking compose, mirroring `resolve_dataagent_skills_dir()`:
+Primary fix — runner root separation (`sandbox_runner_main.py`):
 
-- Absolute values are normalized as-is.
-- Relative values are resolved against `deploy/`.
-- The resolved value is `export`ed so Compose interpolation (which gives shell
-  environment variables precedence over the `--env-file`) uses the same absolute
-  host path for every `${DATAAGENT_HOST_ROOT:-/dataagent_runtime}` mount and for
-  the runner's forwarded `DATAAGENT_HOST_ROOT` env. The runner therefore resolves
-  the same absolute host path it would bind for child containers.
+- Add `_container_runtime_root()` returning the fixed `CONTAINER_RUNTIME_ROOT`
+  (`/dataagent_runtime`) and container-path helpers
+  `_topic_container_workspace/home/logs`. Use these for every filesystem
+  operation the runner performs itself: workspace/home `mkdir`, child skill
+  mount-target prep, `chown`, and per-task log writes.
+- Keep `_host_sandbox_root()` (`DATAAGENT_HOST_ROOT`) and `_topic_host_workspace/home`
+  strictly for the child bind-mount `source=` strings handed to the host daemon.
+- Because the runner mounts the same volume the backend does, files it writes to
+  `/dataagent_runtime/<topic>/...` land on the host at
+  `DATAAGENT_HOST_ROOT/<topic>/...`, which is exactly the child bind source.
 
-This keeps a single source of truth: the operator sets one value in `.env`, and
-all three services plus the per-task child binds agree on one host directory.
+Supporting fix — launcher normalization (`scripts/start.sh`):
+
+- `resolve_dataagent_host_root()` normalizes absolute values and resolves
+  relative values against `deploy/`; the resolved value is `export`ed so Compose
+  interpolation (shell env beats `--env-file`) gives every
+  `${DATAAGENT_HOST_ROOT:-/dataagent_runtime}` mount and the runner's forwarded
+  env the same absolute host path.
+
+Together: the operator sets one value in `.env`; all services and per-task child
+binds agree on one host directory, and the runner's own prep always lands on the
+mounted volume regardless of where that volume is on the host.
 
 Direct `docker compose` invocations that bypass `start.sh` still require an
 absolute value; this is documented in `.env.example` and `deploy/README.md`.
@@ -78,13 +98,16 @@ absolute value; this is documented in `.env.example` and `deploy/README.md`.
 - No new or removed `.env` variables. `DATAAGENT_HOST_ROOT` semantics widen from
   "absolute host path" to "absolute or `deploy/`-relative host path when launched
   via `start.sh`".
-- Container runtime root stays fixed at `/dataagent_runtime`.
+- Container runtime root stays fixed at `/dataagent_runtime` (an internal module
+  constant, not an `.env` knob).
 
 ## Tradeoffs
 
 - The relative-path convenience only applies through `start.sh`. Resolving a
-  relative host path inside the runner container is not possible (the container
+  relative host path inside the runner container is impossible (the container
   cannot know the host's `deploy/` location), so the launcher is the correct
-  single place to normalize it. Documenting the absolute-path requirement for
-  raw `docker compose` keeps the contract explicit instead of adding a second,
-  unreliable resolution layer.
+  single place to normalize it; raw `docker compose` keeps the explicit
+  absolute-path requirement instead of a second, unreliable resolution layer.
+- The container runtime root is kept as a fixed constant (test-overridable by
+  monkeypatch) rather than a new setting, honoring the consolidation design's
+  "container root is not an external knob" rule.

--- a/docs/plans/2026-06-09-dataagent-host-root-custom-path-plan.md
+++ b/docs/plans/2026-06-09-dataagent-host-root-custom-path-plan.md
@@ -4,26 +4,41 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
 
 ## Tasks
 
-1. Launcher resolution (`scripts/start.sh`).
+1. Runner root separation (`dataagent/dataagent-backend/sandbox_runner_main.py`).
+   - Import `CONTAINER_RUNTIME_ROOT`; add `_container_runtime_root()` and
+     `_topic_container_workspace/home/logs` helpers.
+   - In `_build_container_command`, perform `mkdir`/skill-target prep/`chown` on
+     the container-path workspace and home; use the host-path workspace and home
+     only for the child `--mount source=` strings.
+   - Point `_sandbox_task_log_path` at the container logs path so the runner's own
+     log writes land on the mounted volume.
+
+2. Launcher resolution (`scripts/start.sh`).
    - Add `resolve_dataagent_host_root()` mirroring `resolve_dataagent_skills_dir()`:
      read `DATAAGENT_HOST_ROOT` from `.env` (default `/dataagent_runtime`),
      normalize absolute values, resolve relative values against `deploy/`.
    - Before the compose `up`, set and `export DATAAGENT_HOST_ROOT` to the
      resolved absolute path and echo it so the chosen host directory is visible.
 
-2. Documentation.
+3. Documentation.
    - `deploy/.env.example`: document that `DATAAGENT_HOST_ROOT` accepts a custom
      absolute path or a `deploy/`-relative path (expanded by `start.sh`), and
      that raw `docker compose` needs an absolute value.
    - `deploy/README.md`: same note on both DataAgent runtime-root bullets.
 
-3. Tests.
+4. Tests.
+   - `dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`: add an
+     autouse fixture redirecting `CONTAINER_RUNTIME_ROOT` to a temp dir; assert
+     the runner creates topic workspace/home/logs under the container root while
+     child bind sources use the (distinct) host root, and that the container path
+     never leaks in as a bind source.
    - `tests/test_deepeval_packaging_hooks.py`: assert `start.sh` defines
-     `resolve_dataagent_host_root` and exports the resolved value before compose,
-     guarding against regressing the launcher contract.
+     `resolve_dataagent_host_root` and exports the resolved value before compose.
 
 ## Touched files
 
+- `dataagent/dataagent-backend/sandbox_runner_main.py`
+- `dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`
 - `scripts/start.sh`
 - `deploy/.env.example`
 - `deploy/README.md`
@@ -33,20 +48,25 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
 
 ## Verification
 
+- `pytest dataagent/dataagent-backend/tests/test_sandbox_runner_main.py` (host vs
+  container root separation).
+- `pytest tests/test_deepeval_packaging_hooks.py` for the packaging/launcher
+  assertions.
 - `bash -n scripts/start.sh` and a shell unit check that
   `resolve_dataagent_host_root` returns an absolute path for both an absolute and
   a relative input.
-- `pytest tests/test_deepeval_packaging_hooks.py` for the packaging/launcher
-  assertions.
-- Manual: with `DATAAGENT_HOST_ROOT=./dataagent-runtime/runtime`, confirm
-  `start.sh` prints an absolute host path under `deploy/`.
+- Local full-flow smoke (when Docker/MySQL/Redis available): set a custom
+  `DATAAGENT_HOST_ROOT`, run one NL2SQL request, and confirm
+  `<custom>/<topic>/{workspace,home,logs}` are populated on the host and the
+  child completes with a result. Not run in this environment (no Docker daemon).
 
 ## Rollout
 
-- Pure launcher + docs change; no image rebuild required. Existing deployments
-  with an absolute `DATAAGENT_HOST_ROOT` are unaffected.
+- Runner code + launcher + docs change. The runner image must be rebuilt to pick
+  up the `sandbox_runner_main.py` fix. Deployments using the default
+  `/dataagent_runtime` are behavior-unchanged.
 
 ## Backout
 
-- Revert the `scripts/start.sh`, `.env.example`, and `README.md` edits. No data
-  migration is involved.
+- Revert the `sandbox_runner_main.py`, `scripts/start.sh`, `.env.example`, and
+  `README.md` edits. No data migration is involved.


### PR DESCRIPTION
## Summary

Follow-up to #326 (which merged only the `start.sh` path-resolution part). That alone was **not enough**: a custom `DATAAGENT_HOST_ROOT` still failed because the sandbox runner wrote its topic prep to the wrong filesystem. This PR fixes the actual root cause in the runner.

## Problem

The sandbox runner used `DATAAGENT_HOST_ROOT` for **two different things**:

1. The filesystem prep it performs **inside its own container** — `mkdir` the topic `workspace/` and `home/`, create the child's `.claude/skills/<folder>` mount-target dirs, `chown`, and write per-task logs.
2. The child bind-mount `source=` resolved by the **host** Docker daemon.

These coincide **only** when `DATAAGENT_HOST_ROOT == /dataagent_runtime` (the default). With any custom root, the runner's `mkdir`/`chown`/log writes hit a non-existent path in its own overlay filesystem instead of the mounted volume:

- nothing gets written under the custom host directory
- the child's skill mount-target dirs never get created
- the child exits with **"warm sandbox container exited without a result"**

This matches the reported symptom: custom path → empty dir + error; `/dataagent_runtime` → works.

## Changes

- **`dataagent/dataagent-backend/sandbox_runner_main.py`**:
  - Add `_container_runtime_root()` (the fixed in-container `/dataagent_runtime`, the mounted volume) and `_topic_container_workspace/home/logs` helpers.
  - Route all runner-side filesystem operations (workspace/home `mkdir`, child skill mount-target prep, `chown`, per-task log writes) through the **container** paths.
  - Keep `_host_sandbox_root()` / `_topic_host_workspace/home` strictly for child bind-mount `source=` strings.
  - Because the runner mounts the same volume as the backend, files written under the container root land on the host at `DATAAGENT_HOST_ROOT/<topic>/...`, which is exactly the child bind source.

- **`dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`**:
  - Autouse fixture redirects `CONTAINER_RUNTIME_ROOT` to a temp dir so tests never touch the real `/dataagent_runtime` and host vs container roots stay genuinely distinct.
  - Assert the runner creates topic `workspace/home/logs` under the container root while child bind sources use the (distinct) host root, and that the container path never leaks in as a bind source.

- **`docs/design`/`docs/plans`**: updated the paired design/plan to capture the host-vs-container root separation as the primary fix.

## Verification

- `pytest dataagent/dataagent-backend/tests/test_sandbox_runner_main.py` → 22 passed
- `pytest dataagent/dataagent-backend/tests/test_topic_workspace.py tests/test_sandbox_task_main.py` → 10 passed
- `pytest tests/test_deepeval_packaging_hooks.py` → 10 passed

Not run (no Docker daemon in this environment): real custom-`DATAAGENT_HOST_ROOT` end-to-end smoke. **Note:** this changes runner image code, so the `opendataworks-dataagent-runner` image must be rebuilt/repulled for the fix to take effect.

https://claude.ai/code/session_01QTE5DDTL6LYQv3Kg9GDGPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTE5DDTL6LYQv3Kg9GDGPJ)_