### PR TITLE
Fix task lease renewal during queue wait to prevent false cancellations

### DIFF
--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -98,27 +98,38 @@ class TaskCoordinator:
             worker.add_done_callback(lambda done, current_task_id=task_id: self._active_tasks.pop(current_task_id, None))
 
     async def _run_task(self, task_id: str) -> None:
-        async with self._semaphore:
-            task = self.store.get_task(task_id)
-            if not task:
-                await self._release_lease(task_id)
-                return
-            if str(task.get("task_status") or "") not in {"waiting", "running"}:
-                await self._release_lease(task_id)
-                return
+        topic_id = ""
+        stop_heartbeat = asyncio.Event()
+        lease_lost = asyncio.Event()
+        running = asyncio.Event()
+        # Keep the Redis lease renewed from the moment the task is queued, not only
+        # once it starts executing. A task that waits behind the concurrency
+        # semaphore longer than the lease TTL would otherwise lose its lease while
+        # still queued and be wrongly treated as cancelled/expired the instant it
+        # starts. While queued (running not set) the loop only renews the lease;
+        # the DB heartbeat is written once the task is actually running.
+        heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(task_id, stop_event=stop_heartbeat, lease_lost=lease_lost, running=running),
+            name=f"dataagent-task-heartbeat-{task_id}",
+        )
+        try:
+            async with self._semaphore:
+                task = self.store.get_task(task_id)
+                if not task:
+                    return
+                if str(task.get("task_status") or "") not in {"waiting", "running"}:
+                    return
+                if lease_lost.is_set():
+                    # Lease was lost while queued; let the recovery loop re-pick the
+                    # task up instead of running without a valid lease.
+                    return
 
-            topic_id = str(task.get("topic_id") or "")
-            resume_session_id = self.store.get_resumable_conversation_id(topic_id)
-            self.store.mark_task_running(task_id)
-            self.store.ensure_assistant_message(topic_id=topic_id, task_id=task_id, status="running")
-            stop_heartbeat = asyncio.Event()
-            lease_lost = asyncio.Event()
-            heartbeat_task = asyncio.create_task(
-                self._heartbeat_loop(task_id, stop_event=stop_heartbeat, lease_lost=lease_lost),
-                name=f"dataagent-task-heartbeat-{task_id}",
-            )
+                topic_id = str(task.get("topic_id") or "")
+                resume_session_id = self.store.get_resumable_conversation_id(topic_id)
+                self.store.mark_task_running(task_id)
+                running.set()
+                self.store.ensure_assistant_message(topic_id=topic_id, task_id=task_id, status="running")
 
-            try:
                 history = self._build_history(topic_id=topic_id, task_id=task_id)
                 result = await execute_task_stream(
                     TaskExecutionInput(
@@ -154,11 +165,12 @@ class TaskCoordinator:
                 if result.session_id:
                     self.store.update_topic_conversation_id(topic_id, conversation_id=result.session_id)
                 self.store.finish_task(task_id=task_id, task_status=result.task_status, error=result.error)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.exception("Task execution crashed task_id=%s", task_id)
-                error = {"code": "task_execution_failed", "message": str(exc)}
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("Task execution crashed task_id=%s", task_id)
+            error = {"code": "task_execution_failed", "message": str(exc)}
+            if topic_id:
                 self.store.update_assistant_message(
                     topic_id=topic_id,
                     task_id=task_id,
@@ -167,15 +179,15 @@ class TaskCoordinator:
                     usage=None,
                     error=error,
                 )
-                self.store.finish_task(task_id=task_id, task_status="error", error=error)
-            finally:
-                stop_heartbeat.set()
-                heartbeat_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await heartbeat_task
-                await self._release_lease(task_id)
-                if self._redis is not None:
-                    await self._redis.delete(self._cancel_key(task_id))
+            self.store.finish_task(task_id=task_id, task_status="error", error=error)
+        finally:
+            stop_heartbeat.set()
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
+            await self._release_lease(task_id)
+            if self._redis is not None:
+                await self._redis.delete(self._cancel_key(task_id))
 
     def _persist_emitted_sdk_record(self, *, topic_id: str, task_id: str, record: dict[str, Any]) -> None:
         if not isinstance(record, dict):
@@ -201,15 +213,28 @@ class TaskCoordinator:
             data=data,
         )
 
-    async def _heartbeat_loop(self, task_id: str, *, stop_event: asyncio.Event, lease_lost: asyncio.Event) -> None:
+    async def _heartbeat_loop(
+        self,
+        task_id: str,
+        *,
+        stop_event: asyncio.Event,
+        lease_lost: asyncio.Event,
+        running: asyncio.Event,
+    ) -> None:
         interval = max(1, int(self.settings.task_heartbeat_seconds or 5))
         while not stop_event.is_set():
             await asyncio.sleep(interval)
-            self.store.heartbeat_task(task_id)
-            renewed = await self._renew_lease(task_id)
-            if not renewed:
+            if not await self._heartbeat_tick(task_id, running=running):
                 lease_lost.set()
                 return
+
+    async def _heartbeat_tick(self, task_id: str, *, running: asyncio.Event) -> bool:
+        # Persist a DB heartbeat only once the task is actually executing. While it
+        # is still queued behind the concurrency limit we only keep the Redis lease
+        # alive so the task is not mistaken for an expired/abandoned run.
+        if running.is_set():
+            self.store.heartbeat_task(task_id)
+        return await self._renew_lease(task_id)
 
     async def _should_stop_task(self, task_id: str, lease_lost: asyncio.Event) -> bool:
         if lease_lost.is_set():

--- a/dataagent/dataagent-backend/tests/test_task_coordinator.py
+++ b/dataagent/dataagent-backend/tests/test_task_coordinator.py
@@ -1,6 +1,65 @@
 from __future__ import annotations
 
+import asyncio
+
+import anyio
+
 from core.task_coordinator import TaskCoordinator
+
+
+class _FakeRedis:
+    def __init__(self, lease_owner: str):
+        self._lease_owner = lease_owner
+        self.expire_calls = 0
+
+    async def get(self, key: str):
+        return self._lease_owner
+
+    async def expire(self, key: str, ttl: int):
+        self.expire_calls += 1
+        return True
+
+
+def test_heartbeat_tick_renews_lease_while_queued_without_db_heartbeat():
+    class FakeStore:
+        def __init__(self):
+            self.heartbeats = 0
+
+        def heartbeat_task(self, task_id):
+            self.heartbeats += 1
+
+    coordinator = TaskCoordinator(store=FakeStore())
+    coordinator._redis = _FakeRedis(coordinator.instance_id)
+    running = asyncio.Event()
+
+    async def run():
+        queued = await coordinator._heartbeat_tick("task-1", running=running)
+        running.set()
+        active = await coordinator._heartbeat_tick("task-1", running=running)
+        return queued, active
+
+    queued, active = anyio.run(run)
+
+    # Lease is renewed in both phases ...
+    assert queued is True
+    assert active is True
+    assert coordinator._redis.expire_calls == 2
+    # ... but the DB heartbeat is only written once the task is actually running.
+    assert coordinator.store.heartbeats == 1
+
+
+def test_heartbeat_tick_reports_lost_lease():
+    class FakeStore:
+        def heartbeat_task(self, task_id):
+            pass
+
+    coordinator = TaskCoordinator(store=FakeStore())
+    # Lease is held by a different instance -> renewal must fail.
+    coordinator._redis = _FakeRedis("another-instance")
+    running = asyncio.Event()
+    running.set()
+
+    assert anyio.run(lambda: coordinator._heartbeat_tick("task-1", running=running)) is False
 
 
 def test_task_coordinator_persists_only_emitted_sdk_records():

--- a/docs/design/2026-06-09-dataagent-task-lease-queue-renewal-design.md
+++ b/docs/design/2026-06-09-dataagent-task-lease-queue-renewal-design.md
@@ -1,0 +1,66 @@
+# DataAgent 任务租约排队续租修复设计
+
+- 日期: 2026-06-09
+- 范围: `dataagent/dataagent-backend` 任务协调运行时(`core/task_coordinator.py`)
+- 影响级别: 中(运行时契约 / 并发与可靠性行为)
+
+## 现状
+
+`TaskCoordinator` 用一个 Redis 租约(`da:task:lease:{task_id}`)表示"本实例正在持有并执行该任务",TTL 由 `task_lease_ttl_seconds` 控制(默认 30s)。并发上限由 `task_max_concurrency`(默认 4)的 `asyncio.Semaphore` 控制。
+
+执行链路:
+
+1. `submit_task` 通过 `_acquire_lease(nx=True)` 抢到租约,把 `task_id` 放入内存队列。
+2. `_queue_loop` 立即为该任务创建 `_run_task` 协程。
+3. `_run_task` 先 `async with self._semaphore` 排队等待并发槽位。
+4. 拿到槽位后才 `mark_task_running` 并启动 `_heartbeat_loop`,由心跳负责续租。
+
+租约续租只在第 4 步之后发生。
+
+## 问题
+
+当**提交并发大于后端并发上限**(例如评测并发 8 > `task_max_concurrency` 4)时,超出的任务在第 3 步阻塞在信号量上。此阶段:
+
+- 任务仍持有第 1 步抢到的租约,但**没有任何续租**;
+- 单次 NL2SQL 运行通常需要数分钟,排队等待很容易超过 30s 的租约 TTL;
+- 租约到期被 Redis 自动删除。
+
+后果:
+
+- 任务终于拿到槽位开始执行时,`_heartbeat_loop` 第一次 `_renew_lease` 发现租约已不存在,置 `lease_lost`,执行器据此在 `core/task_executor.py` 以 `task_status="suspended"`、`error.code="task_cancelled"`(文案"任务已取消")收尾;
+- 同时 `_recover_expired_tasks` 发现该 running 任务无租约,创建恢复子任务(`task_recovered`),子任务重新排队后撞同一堵墙,形成"恢复链";
+- 评测/调用方观察到"排在后面的任务连续若干次被 cancel/recover,最终报 task cancelled"。
+
+根因:**租约的生命周期没有覆盖"排队等待并发槽位"这一阶段**,导致排队中的任务被误判为过期/被取消。
+
+## 方案
+
+让租约续租覆盖从入队到执行结束的整个生命周期,而不仅是执行阶段。
+
+- 在 `_run_task` 开头(进入信号量**之前**)就启动续租循环,持续 `_renew_lease` 维持本实例对该任务的租约。
+- 引入 `running` 事件区分"排队中"与"执行中"两个阶段:
+  - 排队中:只续约 Redis 租约,不写 DB 心跳(`heartbeat_at` 保持准确,仅在真正执行时更新);
+  - 执行中:续约 + 写 DB 心跳,行为与现状一致。
+- 拿到信号量后,若 `lease_lost` 已置位(排队期间租约确实因 Redis 异常等原因丢失),则直接退让,交由恢复循环重新接管,而不是无租约硬跑。
+- 将租约释放与取消标记清理统一收敛到 `finally`,保证所有提前返回路径都会释放租约。
+
+不在本次改动内:
+
+- 不调整 `task_max_concurrency` / `task_lease_ttl_seconds` 默认值。运维上仍建议将 `TASK_MAX_CONCURRENCY` 设为不低于期望提交并发;本设计修复的是"即便并发压过槽位也不应误判取消"的正确性问题。
+- 不改动 `core/task_executor.py` 的取消语义。
+
+## 接口与契约影响
+
+- `_heartbeat_loop` 内部签名新增 `running` 事件参数;`_run_task` 内部结构调整。均为协调器私有方法,不涉及对外 HTTP/持久化契约。
+- 租约语义更精确:"本实例从入队到完成持续持有租约",跨实例去重行为不变(入队实例全程持有租约)。
+- DB `heartbeat_at` 语义不变(仍只在执行阶段更新)。
+
+## 取舍
+
+- 选择"排队期间持续续租"而非"延后到执行后再抢租约":前者改动最小,且保留了 `submit_task` 阶段租约带来的跨实例入队去重;后者会在入队与执行之间产生无租约窗口,增加跨实例重复入队的复杂度。
+- 排队中的任务会各自占用一个轻量心跳协程,绝大多数时间在 sleep,开销可忽略。
+
+## 验证
+
+- 新增针对 `_heartbeat_tick` 的单元测试:排队阶段(`running` 未置位)只续约不写 DB 心跳;执行阶段两者都做;租约被他人持有时返回续约失败。
+- 受环境限制无法启动完整 Redis + MySQL 全链路时,在报告中明确说明未跑端到端冒烟。

--- a/docs/plans/2026-06-09-dataagent-task-lease-queue-renewal-plan.md
+++ b/docs/plans/2026-06-09-dataagent-task-lease-queue-renewal-plan.md
@@ -1,0 +1,31 @@
+# DataAgent 任务租约排队续租修复执行计划
+
+- 配套设计: `docs/design/2026-06-09-dataagent-task-lease-queue-renewal-design.md`
+- 日期: 2026-06-09
+
+## 任务
+
+1. 调整 `dataagent/dataagent-backend/core/task_coordinator.py`:
+   - `_run_task`:在进入并发信号量之前启动心跳/续租循环;新增 `running` 事件;拿到信号量后若 `lease_lost` 已置位则退让;将 `_release_lease` 与取消键清理收敛到统一 `finally`。
+   - 拆分续租与 DB 心跳:新增 `_heartbeat_tick`,排队阶段只续约 Redis 租约,执行阶段同时写 DB 心跳。
+   - `_heartbeat_loop` 新增 `running` 参数,循环体改为调用 `_heartbeat_tick`。
+2. 新增回归测试 `dataagent/dataagent-backend/tests/test_task_coordinator.py`:
+   - 排队阶段不写 DB 心跳、但续约 Redis 租约;
+   - 执行阶段写 DB 心跳并续约;
+   - 租约被他人持有时 `_heartbeat_tick` 返回 `False`。
+
+## 触达文件
+
+- `dataagent/dataagent-backend/core/task_coordinator.py`
+- `dataagent/dataagent-backend/tests/test_task_coordinator.py`
+- `docs/design/2026-06-09-dataagent-task-lease-queue-renewal-design.md`
+- `docs/plans/2026-06-09-dataagent-task-lease-queue-renewal-plan.md`
+
+## 验证
+
+- 运行 `pytest tests/test_task_coordinator.py`(无需真实 Redis/MySQL,使用 fake)。
+- 若本地可启动 Redis + MySQL,补充并发压过槽位的全链路冒烟:提交 > `task_max_concurrency` 个后台任务,确认排队任务最终 `success`,不再出现 `task_cancelled` 误判。
+
+## 回滚
+
+- 改动集中在 `_run_task` / `_heartbeat_loop` 与新增测试,直接 revert 对应提交即可恢复原行为。


### PR DESCRIPTION
## Summary

Fixes a critical issue where tasks waiting in the concurrency queue lose their Redis lease and are incorrectly marked as cancelled when queue wait time exceeds the lease TTL. This occurs when submitted concurrency exceeds `task_max_concurrency`, causing tasks to block on the semaphore without lease renewal.

## Problem

The task execution flow was:
1. `submit_task` acquires a Redis lease and queues the task
2. `_run_task` waits on the concurrency semaphore (no lease renewal during this phase)
3. Once the semaphore is acquired, the heartbeat loop starts and renews the lease

When queue wait time > lease TTL (default 30s), the lease expires while the task is still queued. When execution finally begins, the first lease renewal fails, triggering false task cancellation and recovery loops.

## Changes

**`core/task_coordinator.py`:**
- Move heartbeat loop initialization **before** entering the concurrency semaphore, so lease renewal begins immediately upon queueing
- Introduce a `running` event to distinguish between "queued" and "executing" phases:
  - While queued: only renew Redis lease, skip DB heartbeat writes
  - While executing: renew lease AND write DB heartbeat (original behavior)
- Add `lease_lost` check after acquiring the semaphore; if the lease was lost during queue wait, gracefully return and let the recovery loop handle the task
- Consolidate `_release_lease` and cancel key cleanup into a single `finally` block to ensure cleanup on all exit paths
- Extract lease renewal logic into new `_heartbeat_tick` method that conditionally writes DB heartbeat based on execution phase

**`tests/test_task_coordinator.py`:**
- Add `test_heartbeat_tick_renews_lease_while_queued_without_db_heartbeat`: verifies lease is renewed during queue phase without DB writes, and DB heartbeat is written once executing
- Add `test_heartbeat_tick_reports_lost_lease`: verifies detection when lease is held by another instance

**Documentation:**
- Add design document explaining the problem, solution, and trade-offs
- Add execution plan documenting the changes and verification steps

## Implementation Details

- The `running` event is set only after `mark_task_running` is called, ensuring the DB heartbeat reflects actual execution time
- Lease renewal during queue wait is lightweight (just Redis `expire` calls), with minimal overhead
- The change preserves the cross-instance deduplication behavior of the lease acquired at submit time
- DB `heartbeat_at` semantics remain unchanged (only updated during execution phase)

https://claude.ai/code/session_011CfCrHeWzqMHT4Wmy9KamM