### PR TITLE
Force DeepEval telemetry opt-out to prevent intranet hangs

### DIFF
--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -296,6 +296,24 @@ def test_deepeval_runner_opts_out_of_cloud_telemetry(monkeypatch):
     assert os.environ.get("DEEPEVAL_UPDATE_WARNING_OPT_OUT") == "YES"
 
 
+def test_deepeval_runner_forces_opt_out_over_falsy_environment(monkeypatch):
+    # DeepEval treats any falsy/empty value as telemetry ON, which reopens the
+    # cloud connection and hangs the run on an intranet after every case. A stray
+    # value already present in the environment must not survive import.
+    _install_fake_deepeval(monkeypatch)
+
+    import os
+
+    for falsy in ("", "0", "false", "no"):
+        monkeypatch.setenv("DEEPEVAL_TELEMETRY_OPT_OUT", falsy)
+        monkeypatch.setenv("DEEPEVAL_UPDATE_WARNING_OPT_OUT", falsy)
+
+        _load_runner()
+
+        assert os.environ.get("DEEPEVAL_TELEMETRY_OPT_OUT") == "YES"
+        assert os.environ.get("DEEPEVAL_UPDATE_WARNING_OPT_OUT") == "YES"
+
+
 def test_deepeval_judge_request_embeds_system_prompt_in_user_content(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -20,8 +20,17 @@ from typing import Any
 # before importing deepeval so the import never triggers telemetry, update
 # checks, or Confident AI cloud coupling. The runner drives the judge metric
 # itself and does not depend on any deepeval.com / Confident AI service.
-os.environ.setdefault("DEEPEVAL_TELEMETRY_OPT_OUT", "YES")
-os.environ.setdefault("DEEPEVAL_UPDATE_WARNING_OPT_OUT", "YES")
+#
+# The telemetry opt-out is FORCED rather than set via setdefault: DeepEval keeps
+# telemetry ON for any falsy/empty value ("", "0", "false", "no"), so a stray
+# value already present in the container / CI / compose environment would
+# silently reopen the Sentry, PostHog and anonymous-IP cloud connections. On an
+# intranet those outbound requests are dropped and block until socket timeout,
+# which is exactly the "hangs after every case has finished" symptom. This tool
+# is offline by contract, so it must not be re-enabled by the ambient
+# environment. The progress bar is cosmetic and stays overridable.
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "YES"
+os.environ["DEEPEVAL_UPDATE_WARNING_OPT_OUT"] = "YES"
 os.environ.setdefault("DEEPEVAL_DISABLE_PROGRESS_BAR", "YES")
 
 try:


### PR DESCRIPTION
## Summary
Force DeepEval telemetry and update warning environment variables to "YES" instead of using `setdefault()`, preventing stray falsy values in the environment from silently re-enabling cloud connections that cause hangs on intranet systems.

## Key Changes
- Changed `os.environ.setdefault()` to direct assignment (`os.environ[...]`) for `DEEPEVAL_TELEMETRY_OPT_OUT` and `DEEPEVAL_UPDATE_WARNING_OPT_OUT` in `tools/dataagent-evals/deepeval/run.py`
- Added comprehensive test case `test_deepeval_runner_forces_opt_out_over_falsy_environment()` to verify the fix handles falsy environment values ("", "0", "false", "no")
- Updated inline documentation explaining why forced assignment is necessary

## Implementation Details
DeepEval treats any falsy or empty value as telemetry ON, which reopens Sentry, PostHog, and anonymous-IP cloud connections. On intranet systems where outbound requests are blocked, these connections hang until socket timeout, causing the "hangs after every case" symptom. By forcing the opt-out values rather than using `setdefault()`, we ensure that stray values from the container/CI/compose environment cannot silently re-enable telemetry. The progress bar setting remains overridable via `setdefault()` since it's cosmetic.

https://claude.ai/code/session_01UFfXqYfZmEJS77DV9yh4ya