### PR TITLE
Sort conversations by server-provided updated_at timestamp

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
@@ -162,6 +162,30 @@ describe('useNl2SqlChat engine', () => {
     }))
   })
 
+  it('re-sorts conversations on refresh by the server updated_at (reply recency)', async () => {
+    const api = makeApi()
+    // The backend bumps a topic's updated_at when messages persist, when a
+    // task starts, and when a run terminates; refreshing the list is what
+    // reorders conversations by their latest reply.
+    api.topicApi.listTopics
+      .mockResolvedValueOnce([
+        { topic_id: 'topic-a', title: '会话 A', updated_at: '2026-06-02T00:00:00' },
+        { topic_id: 'topic-b', title: '会话 B', updated_at: '2026-06-01T00:00:00' },
+      ])
+      .mockResolvedValueOnce([
+        { topic_id: 'topic-a', title: '会话 A', updated_at: '2026-06-02T00:00:00' },
+        { topic_id: 'topic-b', title: '会话 B', updated_at: '2026-06-03T09:00:00' },
+      ])
+    const chat = await ready(api)
+
+    await chat.refreshTopics()
+    expect(chat.topics.value.map((t) => t.topic_id)).toEqual(['topic-a', 'topic-b'])
+
+    // topic-b's reply finished on the server: the next refresh floats it.
+    await chat.refreshTopics()
+    expect(chat.topics.value.map((t) => t.topic_id)).toEqual(['topic-b', 'topic-a'])
+  })
+
   it('cancel aborts locally and cancels the backend task (suspended)', async () => {
     const api = makeApi()
     // Honor the abort signal so the in-flight send unwinds like a real fetch.

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -119,6 +119,11 @@ export function useNl2SqlChat(options) {
     if (target) target.current_task_status = String(status || '')
   }
 
+  // Recency comes from the server's updated_at only: the backend bumps it when
+  // messages persist, when a task starts running, and when a run reaches a
+  // terminal state, so refreshing the list (working-topic poll / afterRun) is
+  // what keeps the order current. No local timestamps are mixed in, avoiding
+  // client/server clock skew and timestamp-format mismatches.
   const sortTopics = () => {
     topics.value = [...topics.value].sort(compareTopicsByRecency)
   }


### PR DESCRIPTION
## Summary
This change ensures conversations are sorted by their recency based on the server's `updated_at` timestamp, which is updated when messages persist, tasks start, or runs terminate. This provides a reliable ordering mechanism that avoids client/server clock skew issues.

## Changes
- **useNl2SqlChat.js**: Added clarifying comments explaining that conversation recency is determined solely by the server's `updated_at` field, and that local timestamps are intentionally avoided to prevent clock skew and format mismatches.
- **useNl2SqlChat.spec.js**: Added test case verifying that conversations are re-sorted correctly when `refreshTopics()` is called and the server's `updated_at` values change, demonstrating that a conversation with a more recent server timestamp floats to the top of the list.

## Implementation Details
The sorting behavior leverages the existing `compareTopicsByRecency` comparator and `sortTopics()` function. The key insight is that the backend manages timestamp updates across multiple operations (message persistence, task lifecycle events), so refreshing the topic list is the mechanism that keeps the conversation order current without requiring client-side timestamp management.

https://claude.ai/code/session_01Cr2CRq2s83ZV4rikQwbe9h