### PR TITLE
Support re-importing Skills with version updates

### DIFF
--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -1155,25 +1155,11 @@ def _safe_extract_skill_zip(content: bytes, extract_root: Path):
         raise ValueError("ZIP 包未包含可导入文件")
 
 
-def _skill_name_from_front_matter(skill_md: Path) -> str:
+def _front_matter_value(skill_md: Path, key: str) -> str:
     try:
         lines = skill_md.read_text(encoding="utf-8").splitlines()
-    except UnicodeDecodeError as exc:
-        raise ValueError("SKILL.md must be UTF-8 encoded") from exc
-    if not lines or lines[0].strip() != "---":
-        raise ValueError("根目录 SKILL.md 必须包含 front matter name")
-    for line in lines[1:]:
-        if line.strip() == "---":
-            break
-        key, separator, value = line.partition(":")
-        if separator and key.strip() == "name":
-            return value.strip().strip("'\"")
-    raise ValueError("根目录 SKILL.md 必须包含 front matter name")
-
-
-def _optional_skill_name_from_front_matter(skill_md: Path) -> str:
-    try:
-        lines = skill_md.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return ""
     except UnicodeDecodeError as exc:
         raise ValueError("SKILL.md must be UTF-8 encoded") from exc
     if not lines or lines[0].strip() != "---":
@@ -1181,10 +1167,25 @@ def _optional_skill_name_from_front_matter(skill_md: Path) -> str:
     for line in lines[1:]:
         if line.strip() == "---":
             break
-        key, separator, value = line.partition(":")
-        if separator and key.strip() == "name":
+        candidate_key, separator, value = line.partition(":")
+        if separator and candidate_key.strip() == key:
             return value.strip().strip("'\"")
     return ""
+
+
+def _skill_name_from_front_matter(skill_md: Path) -> str:
+    name = _front_matter_value(skill_md, "name")
+    if not name:
+        raise ValueError("根目录 SKILL.md 必须包含 front matter name")
+    return name
+
+
+def _optional_skill_name_from_front_matter(skill_md: Path) -> str:
+    return _front_matter_value(skill_md, "name")
+
+
+def _skill_version_from_front_matter(skill_md: Path) -> str:
+    return _front_matter_value(skill_md, "version")
 
 
 def _resolve_imported_skill_root(extract_root: Path) -> tuple[Path, str]:
@@ -1234,18 +1235,31 @@ def import_skill_from_zip(file_name: str, content: bytes) -> dict[str, Any]:
         skill_root, folder = _resolve_imported_skill_root(extract_root)
 
         target = _resolve_skill_target_dir(folder)
+        incoming_version = _skill_version_from_front_matter(skill_root / "SKILL.md")
+        previous_version = ""
+        replaced = False
         if target.exists() or target.is_symlink():
-            raise ValueError("skill folder already exists")
+            if _is_builtin_skill_folder(folder):
+                raise ValueError("内置 Skill 不支持覆盖导入")
+            if not target.is_dir() or target.is_symlink():
+                raise ValueError("invalid skill folder path")
+            previous_version = _skill_version_from_front_matter(target / "SKILL.md")
+            if incoming_version == previous_version:
+                raise ValueError("同名 Skill 已存在且版本相同，请更新 SKILL.md front matter 中的 version 后重新导入")
+            shutil.rmtree(target)
+            replaced = True
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(skill_root), str(target))
 
     current = current_settings_payload()
     primary_folder = _folder_from_skills_output_dir(str(current.get("skills_output_dir") or "")) or _current_skill_folder()
     skill_runtime = _normalize_skill_runtime(current.get("skill_runtime"), fallback_folder=primary_folder)
-    skill_runtime[folder] = {"enabled": False}
+    enabled = bool((skill_runtime.get(folder) or {}).get("enabled")) if replaced else False
+    skill_runtime[folder] = {"enabled": enabled}
     persist_admin_settings({"skill_runtime": skill_runtime})
 
-    imported = reindex_documents_from_disk(change_source="upload", change_summary=f"导入 Skill {folder}")
+    change_summary = f"更新 Skill {folder}" if replaced else f"导入 Skill {folder}"
+    imported = reindex_documents_from_disk(change_source="upload", change_summary=change_summary)
     imported_documents = [item for item in imported if item.get("folder") == folder]
     if not imported_documents:
         imported_documents = [_document_api_payload(item) for item in _raw_documents_for_skill(folder)]
@@ -1253,7 +1267,10 @@ def import_skill_from_zip(file_name: str, content: bytes) -> dict[str, Any]:
     return {
         "skill_id": folder,
         "source": _skill_source(folder),
-        "enabled": False,
+        "enabled": enabled,
+        "replaced": replaced,
+        "version": incoming_version,
+        "previous_version": previous_version,
         "imported_documents": imported_documents,
         "document_count": len(get_skill_admin_store().list_documents()),
     }

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -343,6 +343,9 @@ class SkillImportResponse(BaseModel):
     skill_id: str
     source: str = "managed"
     enabled: bool = False
+    replaced: bool = False
+    version: str = ""
+    previous_version: str = ""
     imported_documents: List[SkillDocumentSummary] = Field(default_factory=list)
     document_count: int = 0
 

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -707,6 +707,8 @@ def test_import_skill_from_root_zip_defaults_to_disabled(monkeypatch, tmp_path):
     assert payload["skill_id"] == "marketing-insights"
     assert payload["source"] == "managed"
     assert payload["enabled"] is False
+    assert payload["replaced"] is False
+    assert payload["previous_version"] == ""
     assert persisted["skill_runtime"]["marketing-insights"]["enabled"] is False
     assert "marketing-insights/SKILL.md" in store.documents
 
@@ -755,14 +757,99 @@ def test_import_skill_rejects_unsafe_zip_path(monkeypatch, tmp_path):
         )
 
 
-def test_import_skill_rejects_duplicate_folder(monkeypatch, tmp_path):
+def test_import_skill_rejects_duplicate_folder_with_same_version(monkeypatch, tmp_path):
+    discovery_root, _, _ = configure_skill_filesystem(monkeypatch, tmp_path)
+    (discovery_root / "marketing-insights").mkdir()
+    (discovery_root / "marketing-insights" / "SKILL.md").write_text(
+        "---\nname: marketing-insights\nversion: 1.0.0\n---\n# Marketing\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="版本相同"):
+        skill_admin_service.import_skill_from_zip(
+            "marketing-insights.zip",
+            make_zip(
+                {"marketing-insights/SKILL.md": "---\nname: marketing-insights\nversion: 1.0.0\n---\n# Marketing\n"}
+            ),
+        )
+
+
+def test_import_skill_rejects_duplicate_folder_without_version(monkeypatch, tmp_path):
     discovery_root, _, _ = configure_skill_filesystem(monkeypatch, tmp_path)
     (discovery_root / "marketing-insights").mkdir()
 
-    with pytest.raises(ValueError, match="already exists"):
+    with pytest.raises(ValueError, match="版本相同"):
         skill_admin_service.import_skill_from_zip(
             "marketing-insights.zip",
             make_zip({"marketing-insights/SKILL.md": "# Marketing\n"}),
+        )
+
+
+def test_import_skill_replaces_existing_when_version_differs(monkeypatch, tmp_path):
+    settings = {
+        "skills_output_dir": f"../.claude/skills/{BUSINESS_SKILL}",
+        "skill_runtime": {
+            BUSINESS_SKILL: {"enabled": True},
+            "marketing-insights": {"enabled": True},
+        },
+    }
+    discovery_root, store, persisted = configure_skill_filesystem(monkeypatch, tmp_path, settings=settings)
+    existing = discovery_root / "marketing-insights"
+    existing.mkdir()
+    (existing / "SKILL.md").write_text(
+        "---\nname: marketing-insights\nversion: 1.0.0\n---\n# Marketing v1\n",
+        encoding="utf-8",
+    )
+    (existing / "reference").mkdir()
+    (existing / "reference" / "legacy.md").write_text("# Legacy\n", encoding="utf-8")
+    store.save_document(
+        relative_path="marketing-insights/SKILL.md",
+        content="---\nname: marketing-insights\nversion: 1.0.0\n---\n# Marketing v1\n",
+        change_source="upload",
+    )
+    store.save_document(
+        relative_path="marketing-insights/reference/legacy.md",
+        content="# Legacy\n",
+        change_source="upload",
+    )
+
+    payload = skill_admin_service.import_skill_from_zip(
+        "marketing-insights.zip",
+        make_zip(
+            {
+                "marketing-insights/SKILL.md": "---\nname: marketing-insights\nversion: 2.0.0\n---\n# Marketing v2\n",
+                "marketing-insights/reference/guide.md": "# Guide\n",
+            }
+        ),
+    )
+
+    assert payload["skill_id"] == "marketing-insights"
+    assert payload["replaced"] is True
+    assert payload["version"] == "2.0.0"
+    assert payload["previous_version"] == "1.0.0"
+    assert payload["enabled"] is True
+    assert persisted["skill_runtime"]["marketing-insights"]["enabled"] is True
+    assert (discovery_root / "marketing-insights" / "reference" / "guide.md").exists()
+    assert not (discovery_root / "marketing-insights" / "reference" / "legacy.md").exists()
+    assert "marketing-insights/reference/legacy.md" not in store.documents
+    assert "marketing-insights/reference/guide.md" in store.documents
+    assert "2.0.0" in store.documents["marketing-insights/SKILL.md"]["current_content"]
+
+
+def test_import_skill_rejects_overwriting_builtin_folder(monkeypatch, tmp_path):
+    discovery_root, _, _ = configure_skill_filesystem(monkeypatch, tmp_path)
+    (discovery_root / BUSINESS_SKILL).mkdir()
+    (discovery_root / BUSINESS_SKILL / "SKILL.md").write_text(
+        f"---\nname: {BUSINESS_SKILL}\nversion: 1.0.0\n---\n# Builtin\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="内置 Skill 不支持覆盖导入"):
+        skill_admin_service.import_skill_from_zip(
+            "builtin.zip",
+            make_zip(
+                {f"{BUSINESS_SKILL}/SKILL.md": f"---\nname: {BUSINESS_SKILL}\nversion: 2.0.0\n---\n# Builtin\n"}
+            ),
         )
 
 

--- a/dataagent/dataagent-frontend/src/views/settings/SkillStudio.vue
+++ b/dataagent/dataagent-frontend/src/views/settings/SkillStudio.vue
@@ -182,7 +182,12 @@ const handleSkillUpload = async ({ file }) => {
   try {
     const payload = await dataagentApi.importSkill(file)
     await loadDocuments()
-    ElMessage.success(`Skill「${payload.skill_id}」已导入，默认未启用`)
+    if (payload.replaced) {
+      const versionText = payload.version ? `（版本 ${payload.version}）` : ''
+      ElMessage.success(`Skill「${payload.skill_id}」已更新${versionText}`)
+    } else {
+      ElMessage.success(`Skill「${payload.skill_id}」已导入，默认未启用`)
+    }
   } catch (error) {
     notifyError(error, '导入 Skill 失败')
   } finally {

--- a/dataagent/dataagent-frontend/src/views/settings/__tests__/SkillStudio.spec.js
+++ b/dataagent/dataagent-frontend/src/views/settings/__tests__/SkillStudio.spec.js
@@ -223,6 +223,27 @@ describe('SkillStudio', () => {
     expect(messageMocks.success).toHaveBeenCalledWith('Skill「customer-care」已导入，默认未启用')
   })
 
+  it('reimports an existing skill with a new version and reports the update', async () => {
+    apiMocks.importSkill.mockResolvedValue({
+      skill_id: 'marketing-insights',
+      source: 'managed',
+      enabled: true,
+      replaced: true,
+      version: '2.0.0',
+      previous_version: '1.0.0',
+      imported_documents: [],
+      document_count: 3
+    })
+    const wrapper = mountView()
+    await flushPromises()
+
+    const file = new File(['zip'], 'marketing-insights.zip', { type: 'application/zip' })
+    await wrapper.vm.handleSkillUpload({ file })
+    await flushPromises()
+
+    expect(messageMocks.success).toHaveBeenCalledWith('Skill「marketing-insights」已更新（版本 2.0.0）')
+  })
+
   it('uninstalls managed skills only after folder confirmation', async () => {
     const wrapper = mountView()
     await flushPromises()

--- a/docs/design/2026-04-17-admin-skill-management-design.md
+++ b/docs/design/2026-04-17-admin-skill-management-design.md
@@ -20,6 +20,7 @@ Administrators also need a controlled way to add local Skills without editing th
 - Reject disabling the last enabled Skill. If disabling the current primary Skill, move `skills_output_dir` to the first remaining enabled Skill.
 - Resolve document `enabled` from `skill_runtime`, not from `skills_output_dir`.
 - Allow uploading one ZIP package containing either `<folder>/SKILL.md` or a root `SKILL.md` with front matter `name`; imported Skills are copied under the discovery root, indexed into `da_skill_document`, marked `source=managed`, and default to disabled.
+- Allow re-importing an existing managed Skill when the front matter `version` differs; the import replaces the Skill files, prunes stale document index rows, and preserves the Skill's enabled state. Same-version re-import and overwriting built-in Skills are rejected.
 - Allow uninstalling only `source=managed` Skills. Uninstall removes the Skill directory, document index rows and version rows, and its `skill_runtime` entry. Built-in `dataagent-nl2sql` can be disabled but cannot be uninstalled.
 - During background NL2SQL execution, `core/task_executor.py` uses shared helpers in `core/agent_runtime.py` to create a runtime project under `dataagent/dataagent-backend/.runtime/enabled-skills` and expose only enabled Skills through `.claude/skills` symlinks.
 - Keep `DATAAGENT_SKILL_ROOT` pointed at the primary Skill and add `DATAAGENT_ENABLED_SKILLS` plus `DATAAGENT_ENABLED_SKILL_ROOTS` for multi-Skill-aware scripts.
@@ -61,11 +62,17 @@ Request:
 
 Response:
 
-- `{ "skill_id": "<folder>", "source": "managed", "enabled": false, "imported_documents": [...], "document_count": n }`
+- `{ "skill_id": "<folder>", "source": "managed", "enabled": false, "replaced": false, "version": "<front matter version or empty>", "previous_version": "", "imported_documents": [...], "document_count": n }`
+
+Re-import semantics:
+
+- If the Skill folder already exists and the incoming `SKILL.md` front matter `version` differs from the installed one, the import replaces the Skill files in place; the response carries `replaced=true`, `previous_version`, and `enabled` keeps the Skill's current runtime state instead of resetting to disabled.
+- If the versions are identical (including both missing), the import is rejected.
+- Built-in Skill folders can never be overwritten by import.
 
 Failure:
 
-- `400` for non-ZIP files, unsafe archive paths, symlinks, missing `SKILL.md`, invalid folder names, multiple Skills in one package, or folder conflicts.
+- `400` for non-ZIP files, unsafe archive paths, symlinks, missing `SKILL.md`, invalid folder names, multiple Skills in one package, same-version folder conflicts, or attempts to overwrite a built-in Skill.
 
 Uninstall API:
 

--- a/docs/plans/2026-04-17-admin-skill-management-plan.md
+++ b/docs/plans/2026-04-17-admin-skill-management-plan.md
@@ -13,7 +13,8 @@ Upgrade Skill management from a single-active Skill model to multi-active Skill 
 - Add `DATAAGENT_ENABLED_SKILLS` and `DATAAGENT_ENABLED_SKILL_ROOTS`; keep `DATAAGENT_SKILL_ROOT` for existing scripts.
 - Extract shared provider/prompt/env helpers into `core/agent_runtime.py` and remove the unused direct `stream_agent_reply` executor so only the task executor owns agent execution.
 - Simplify frontend copy and layout: `已启用 / 未启用`, compact cards, custom detail title bar, merged left overview/file tree, `SKILL.md` first, lower-weight version history.
-- Add `POST /api/v1/dataagent/skills/imports` for ZIP upload. Safely extract one Skill, reject unsafe paths/symlinks/folder conflicts, index files, and keep the imported Skill disabled by default.
+- Add `POST /api/v1/dataagent/skills/imports` for ZIP upload. Safely extract one Skill, reject unsafe paths/symlinks, index files, and keep a first-time imported Skill disabled by default.
+- Support re-import of an existing managed Skill when the front matter `version` differs: replace files in place, prune stale document rows, and preserve the enabled state. Reject same-version re-import and built-in Skill overwrite.
 - Add `DELETE /api/v1/dataagent/skills/{folder}` for managed Skill uninstall. Reject built-in Skill removal and last-enabled removal, remove indexed documents, clean `skill_runtime`, and reassign primary Skill when needed.
 - Add list/detail UI actions for importing ZIP packages and uninstalling `source=managed` Skills with typed folder confirmation.
 
@@ -22,7 +23,7 @@ Upgrade Skill management from a single-active Skill model to multi-active Skill 
 - Backend:
   - contract tests for enriched document fields, runtime toggle API, import API, uninstall API, and uninstall error mapping
   - service tests for multi-enable, disabling one Skill, rejecting last-disable, and primary Skill reassignment
-  - service tests for root ZIP import, folder ZIP import, unsafe archive rejection, duplicate folder rejection, missing `SKILL.md`, managed uninstall cleanup, built-in uninstall rejection, and last-enabled uninstall rejection
+  - service tests for root ZIP import, folder ZIP import, unsafe archive rejection, same-version duplicate rejection, version-bump replacement, built-in overwrite rejection, missing `SKILL.md`, managed uninstall cleanup, built-in uninstall rejection, and last-enabled uninstall rejection
   - loader test proving runtime cwd exposes only enabled Skills
   - agent runtime-env test for enabled Skill env variables
   - task executor test covering the generated multi-Skill runtime cwd


### PR DESCRIPTION
## Summary
Enable administrators to update existing managed Skills by re-importing them when the front matter `version` differs. The import now replaces Skill files in place, prunes stale document index rows, and preserves the Skill's enabled state, while rejecting same-version re-imports and preventing overwrites of built-in Skills.

## Key Changes

**Backend (`skill_admin_service.py`)**
- Refactored front matter parsing into a generic `_front_matter_value()` helper to extract any key from SKILL.md
- Added `_skill_version_from_front_matter()` to read the version field
- Modified `import_skill_from_zip()` to:
  - Check if a Skill folder already exists and compare versions
  - Reject built-in Skill overwrites with a specific error message
  - Reject same-version re-imports (including when both versions are missing)
  - Replace existing Skill files when versions differ, preserving the enabled state
  - Return `replaced`, `version`, and `previous_version` in the response payload
  - Update the change summary to distinguish between "导入" (import) and "更新" (update)

**Frontend (`SkillStudio.vue`)**
- Updated the success message to show "已更新（版本 X.Y.Z）" for re-imports and "已导入，默认未启用" for new imports
- Added conditional logic to display version information when `replaced=true`

**API Schema (`schemas.py`)**
- Extended `SkillImportResponse` with three new fields:
  - `replaced: bool` — indicates whether an existing Skill was replaced
  - `version: str` — the imported Skill's version from front matter
  - `previous_version: str` — the previously installed version (empty for new imports)

**Tests**
- Renamed and split the duplicate folder test into two cases:
  - `test_import_skill_rejects_duplicate_folder_with_same_version` — rejects re-import with identical version
  - `test_import_skill_rejects_duplicate_folder_without_version` — rejects re-import when both lack version
- Added `test_import_skill_replaces_existing_when_version_differs` — verifies successful replacement, file cleanup, document index updates, and enabled state preservation
- Added `test_import_skill_rejects_overwriting_builtin_folder` — ensures built-in Skills cannot be overwritten
- Added frontend test for the updated success message on re-import

**Documentation**
- Updated design and plan documents to reflect the new re-import semantics and constraints

https://claude.ai/code/session_01DfGCZvTeuFWgW82MurzvLc