### PR TITLE
Fix duplicate text in partial-streaming mode

### DIFF
--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -93,6 +93,7 @@ class SdkResultAccumulator:
         self.result_error = ""
         self.result_is_error = False
         self.provider_error_message = ""
+        self._saw_stream_event = False
         self._text_order: list[int] = []
         self._text_by_index: dict[int, str] = {}
         self._block_context: dict[int, dict[str, Any]] = {}
@@ -151,6 +152,7 @@ class SdkResultAccumulator:
             return
 
         if msg_type == "StreamEvent":
+            self._saw_stream_event = True
             raw_event = getattr(msg, "event", None)
             if isinstance(raw_event, dict):
                 self._ingest_stream_event(raw_event)
@@ -161,6 +163,13 @@ class SdkResultAccumulator:
             assistant_error = str(getattr(msg, "error", "") or "").strip()
             if assistant_error:
                 self._remember_provider_error(assistant_error)
+            # In partial-streaming mode the SDK already accumulated every text
+            # block from StreamEvent deltas. The trailing AssistantMessage repeats
+            # the same content, so projecting it again would duplicate the final
+            # answer text. Only ingest whole-message content when no partial
+            # StreamEvent was observed (supports_partial_messages=false providers).
+            if self._saw_stream_event:
+                return
             self._ingest_assistant_content(content)
 
     def _ingest_assistant_content(self, content: Any) -> None:

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -587,6 +587,55 @@ def test_execute_task_stream_preserves_native_partial_text_blocks_without_magic_
     assert emitted == []
 
 
+def test_execute_task_stream_does_not_duplicate_trailing_assistant_message_after_partial_stream(monkeypatch, tmp_path: Path):
+    # In partial-streaming mode the SDK emits per-block StreamEvent deltas and
+    # then a trailing AssistantMessage carrying the same full content. The final
+    # answer must not contain the streamed text twice.
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            StreamEvent({"type": "message_start", "message": {"id": "req-3"}}),
+            StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+            StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "最近 30 天累计发布 4 次。"},
+                }
+            ),
+            StreamEvent({"type": "content_block_stop", "index": 0}),
+            StreamEvent({"type": "message_stop"}),
+            AssistantMessage([TextBlock("最近 30 天累计发布 4 次。")]),
+            ResultMessage("success", session_id="sdk-session-3"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": provider_id,
+            "model": model,
+            "api_key": "",
+            "auth_token": "",
+            "base_url": "https://example.invalid",
+            "supports_partial_messages": True,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    emitted: list[dict] = []
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: emitted.append(record))
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    assert result.content == "最近 30 天累计发布 4 次。"
+    assert result.session_id == "sdk-session-3"
+    assert emitted == []
+
+
 def test_execute_task_stream_uses_message_level_sdk_text_when_partial_disabled(monkeypatch, tmp_path: Path):
     _install_fake_sdk(
         monkeypatch,


### PR DESCRIPTION
## Summary
Fixes an issue where task execution in partial-streaming mode was duplicating the final answer text by processing both the streamed content blocks and the trailing AssistantMessage that repeats the same content.

## Changes
- Added `_saw_stream_event` flag to `TaskExecutor` to track whether partial streaming has been used
- Modified `ingest()` method to skip processing the trailing AssistantMessage when partial streaming is active, since the SDK already accumulated all text from the StreamEvent deltas
- Added test case `test_execute_task_stream_does_not_duplicate_trailing_assistant_message_after_partial_stream` to verify the fix

## Implementation Details
When `supports_partial_messages=True`, the SDK emits:
1. Individual `StreamEvent` deltas for each text block (which are accumulated)
2. A trailing `AssistantMessage` with the complete content

The fix detects when StreamEvents have been processed and skips the redundant AssistantMessage ingestion, preventing text duplication in the final answer. For providers with `supports_partial_messages=False`, the AssistantMessage is still processed normally.

https://claude.ai/code/session_012ixWjZGvao6cCYp634RnwE