### PR TITLE
Add skill export functionality to download skills as ZIP

### DIFF
--- a/dataagent/dataagent-backend/api/admin_routes.py
+++ b/dataagent/dataagent-backend/api/admin_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi.responses import Response
 
 from core.agent_profile_service import (
     agent_capabilities,
@@ -16,6 +17,7 @@ from core.skill_admin_service import (
     compare_document_versions,
     current_settings_payload,
     detect_model_availability,
+    export_skill_as_zip,
     get_document_detail,
     import_skill_from_zip,
     list_documents,
@@ -290,6 +292,21 @@ async def import_skill(file: UploadFile = File(...)):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return SkillImportResponse.model_validate(result)
+
+
+@skills_router.get("/skills/{folder}/export")
+async def export_skill(folder: str):
+    try:
+        file_name, content = export_skill_as_zip(folder)
+    except ValueError as exc:
+        message = str(exc)
+        status_code = 404 if "not found" in message else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    return Response(
+        content=content,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+    )
 
 
 @skills_router.delete("/skills/{folder}", response_model=SkillUninstallResponse)

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -1278,6 +1278,27 @@ def import_skill_from_zip(file_name: str, content: bytes) -> dict[str, Any]:
     }
 
 
+def export_skill_as_zip(folder: str) -> tuple[str, bytes]:
+    target_folder = _validate_skill_folder_name(folder)
+
+    available_folders = _discovered_skill_folders()
+    if target_folder not in available_folders:
+        raise ValueError("skill folder not found")
+
+    target = _resolve_skill_target_dir(target_folder)
+    if not target.is_dir() or target.is_symlink():
+        raise ValueError("invalid skill folder path")
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(target.rglob("*")):
+            if path.is_symlink() or not path.is_file():
+                continue
+            arcname = f"{target_folder}/{path.relative_to(target).as_posix()}"
+            archive.write(path, arcname)
+    return f"{target_folder}.zip", buffer.getvalue()
+
+
 def uninstall_skill(folder: str) -> dict[str, Any]:
     target_folder = _validate_skill_folder_name(folder)
     if _is_builtin_skill_folder(target_folder):

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -896,6 +896,32 @@ def test_uninstall_skill_removes_managed_folder_and_runtime(monkeypatch, tmp_pat
     assert persisted["skills_output_dir"] == f"../.claude/skills/{BUSINESS_SKILL}"
 
 
+def test_export_skill_as_zip_packs_folder_contents(monkeypatch, tmp_path):
+    discovery_root, _, _ = configure_skill_filesystem(monkeypatch, tmp_path)
+    (discovery_root / "marketing-insights").mkdir()
+    (discovery_root / "marketing-insights" / "SKILL.md").write_text("# Marketing\n", encoding="utf-8")
+    (discovery_root / "marketing-insights" / "scripts").mkdir()
+    (discovery_root / "marketing-insights" / "scripts" / "run.py").write_text("print('ok')\n", encoding="utf-8")
+
+    file_name, content = skill_admin_service.export_skill_as_zip("marketing-insights")
+
+    assert file_name == "marketing-insights.zip"
+    with zipfile.ZipFile(io.BytesIO(content)) as archive:
+        names = set(archive.namelist())
+        assert names == {
+            "marketing-insights/SKILL.md",
+            "marketing-insights/scripts/run.py",
+        }
+        assert archive.read("marketing-insights/scripts/run.py").decode("utf-8") == "print('ok')\n"
+
+
+def test_export_skill_as_zip_rejects_unknown_folder(monkeypatch, tmp_path):
+    configure_skill_filesystem(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="skill folder not found"):
+        skill_admin_service.export_skill_as_zip("does-not-exist")
+
+
 def test_uninstall_skill_rejects_builtin(monkeypatch, tmp_path):
     configure_skill_filesystem(monkeypatch, tmp_path)
 

--- a/dataagent/dataagent-frontend/src/api/dataagent.js
+++ b/dataagent/dataagent-frontend/src/api/dataagent.js
@@ -62,6 +62,12 @@ export const dataagentApi = {
     })
   },
 
+  exportSkill(folder) {
+    return dataagentRequest.get(`/v1/dataagent/skills/${encodeURIComponent(folder)}/export`, {
+      responseType: 'blob'
+    })
+  },
+
   uninstallSkill(folder) {
     return dataagentRequest.delete(`/v1/dataagent/skills/${encodeURIComponent(folder)}`)
   },

--- a/dataagent/dataagent-frontend/src/demo/mockServer.js
+++ b/dataagent/dataagent-frontend/src/demo/mockServer.js
@@ -2685,6 +2685,11 @@ export const demoAdapter = async (config) => {
     return createResponse(config, { skill_id: 'demo-imported-skill' })
   }
 
+  if (method === 'get' && pathname.match(/^\/v1\/dataagent\/skills\/[^/]+\/export$/)) {
+    const folder = decodeURIComponent(pathname.split('/')[4])
+    return createResponse(config, new Blob([`demo skill ${folder}`], { type: 'application/zip' }))
+  }
+
   if (method === 'delete' && pathname.match(/^\/v1\/dataagent\/skills\/[^/]+$/)) {
     return createResponse(config, { status: 'ok' })
   }

--- a/dataagent/dataagent-frontend/src/views/settings/SkillStudio.vue
+++ b/dataagent/dataagent-frontend/src/views/settings/SkillStudio.vue
@@ -58,6 +58,14 @@
         <div class="skill-card__footer">
           <el-button text type="primary" @click="openSkillDetail(skill.folder)">查看详情</el-button>
           <el-button
+            text
+            type="primary"
+            :loading="downloadingFolder === skill.folder"
+            @click="downloadSkill(skill)"
+          >
+            下载
+          </el-button>
+          <el-button
             v-if="skill.source === 'managed'"
             text
             type="danger"
@@ -91,6 +99,7 @@ const importLoading = ref(false)
 const searchKeyword = ref('')
 const documents = ref([])
 const runtimeUpdatingFolder = ref('')
+const downloadingFolder = ref('')
 
 const skillItems = computed(() => buildSkillItems(documents.value))
 const enabledSkillCount = computed(() => skillItems.value.filter((item) => item.enabled).length)
@@ -192,6 +201,27 @@ const handleSkillUpload = async ({ file }) => {
     notifyError(error, '导入 Skill 失败')
   } finally {
     importLoading.value = false
+  }
+}
+
+const downloadSkill = async (skill) => {
+  if (!skill?.folder || downloadingFolder.value) return
+  downloadingFolder.value = skill.folder
+  try {
+    const blob = await dataagentApi.exportSkill(skill.folder)
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${skill.folder}.zip`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+    ElMessage.success(`Skill「${skill.folder}」已下载`)
+  } catch (error) {
+    notifyError(error, '下载 Skill 失败')
+  } finally {
+    downloadingFolder.value = ''
   }
 }
 

--- a/dataagent/dataagent-frontend/src/views/settings/__tests__/SkillStudio.spec.js
+++ b/dataagent/dataagent-frontend/src/views/settings/__tests__/SkillStudio.spec.js
@@ -5,6 +5,7 @@ const apiMocks = vi.hoisted(() => ({
   listSkillDocuments: vi.fn(),
   updateSkillRuntime: vi.fn(),
   importSkill: vi.fn(),
+  exportSkill: vi.fn(),
   uninstallSkill: vi.fn()
 }))
 
@@ -115,6 +116,7 @@ describe('SkillStudio', () => {
     apiMocks.listSkillDocuments.mockReset()
     apiMocks.updateSkillRuntime.mockReset()
     apiMocks.importSkill.mockReset()
+    apiMocks.exportSkill.mockReset()
     apiMocks.uninstallSkill.mockReset()
     messageMocks.success.mockReset()
     messageMocks.warning.mockReset()
@@ -135,6 +137,7 @@ describe('SkillStudio', () => {
       imported_documents: [],
       document_count: 3
     })
+    apiMocks.exportSkill.mockResolvedValue(new Blob(['zip'], { type: 'application/zip' }))
     apiMocks.uninstallSkill.mockResolvedValue({
       skill_id: 'marketing-insights',
       removed_documents: [],
@@ -242,6 +245,29 @@ describe('SkillStudio', () => {
     await flushPromises()
 
     expect(messageMocks.success).toHaveBeenCalledWith('Skill「marketing-insights」已更新（版本 2.0.0）')
+  })
+
+  it('downloads a skill as a zip through the export api', async () => {
+    const createObjectURL = vi.fn(() => 'blob:demo')
+    const revokeObjectURL = vi.fn()
+    window.URL.createObjectURL = createObjectURL
+    window.URL.revokeObjectURL = revokeObjectURL
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const targetSkill = wrapper.vm.filteredSkills.find((item) => item.folder === 'marketing-insights')
+    await wrapper.vm.downloadSkill(targetSkill)
+    await flushPromises()
+
+    expect(apiMocks.exportSkill).toHaveBeenCalledWith('marketing-insights')
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:demo')
+    expect(messageMocks.success).toHaveBeenCalledWith('Skill「marketing-insights」已下载')
+
+    clickSpy.mockRestore()
   })
 
   it('uninstalls managed skills only after folder confirmation', async () => {


### PR DESCRIPTION
## Summary
This PR adds the ability to export and download skills as ZIP files from the Skill Studio interface. Users can now download any skill to their local machine through a new "下载" (Download) button on each skill card.

## Key Changes
- **Frontend UI**: Added download button to skill cards that triggers skill export with loading state
- **Frontend API**: Added `exportSkill()` method to call the new backend export endpoint
- **Backend Service**: Implemented `export_skill_as_zip()` function that validates the skill folder and creates a ZIP archive of its contents
- **Backend API**: Added GET `/skills/{folder}/export` endpoint that returns the ZIP file as a downloadable attachment
- **Tests**: Added comprehensive test coverage for the export functionality including:
  - ZIP file creation with correct folder structure and contents
  - Validation that non-existent skills are rejected
  - Frontend integration test verifying the download flow
- **Demo Mode**: Added mock server support for the export endpoint

## Implementation Details
- The export function validates the skill folder name and path to prevent directory traversal attacks
- ZIP files are created with deflate compression and include the skill folder as the root directory
- The frontend uses the Blob API to trigger browser downloads with proper filename
- Loading state prevents multiple simultaneous downloads of the same skill
- Error handling provides user-friendly messages for both frontend and backend failures

https://claude.ai/code/session_01BUWpqNw8PptknWepZYt1uS