### PR TITLE
Add table metadata version history tracking and comparison

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/DataTableVersionController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/DataTableVersionController.java
@@ -1,0 +1,58 @@
+package com.onedata.portal.controller;
+
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.onedata.portal.dto.PageResult;
+import com.onedata.portal.dto.Result;
+import com.onedata.portal.dto.table.TableVersionCompareRequest;
+import com.onedata.portal.dto.table.TableVersionCompareResponse;
+import com.onedata.portal.entity.DataTableVersion;
+import com.onedata.portal.service.TableMetadataVersionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 表元数据版本历史 Controller
+ */
+@RestController
+@RequestMapping("/v1/tables")
+@RequiredArgsConstructor
+public class DataTableVersionController {
+
+    private final TableMetadataVersionService tableMetadataVersionService;
+
+    /**
+     * 分页查询表的版本历史（不含快照大字段）
+     */
+    @GetMapping("/{id}/versions")
+    public Result<PageResult<DataTableVersion>> listVersions(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "20") int pageSize) {
+        Page<DataTableVersion> page = tableMetadataVersionService.listVersions(id, pageNum, pageSize);
+        return Result.success(PageResult.of(page.getTotal(), page.getRecords()));
+    }
+
+    /**
+     * 获取单个版本详情（含快照 JSON）
+     */
+    @GetMapping("/{id}/versions/{versionId}")
+    public Result<DataTableVersion> getVersion(@PathVariable Long id, @PathVariable Long versionId) {
+        return Result.success(tableMetadataVersionService.getVersion(id, versionId));
+    }
+
+    /**
+     * 对比两个版本
+     */
+    @PostMapping("/{id}/versions/compare")
+    public Result<TableVersionCompareResponse> compareVersions(
+            @PathVariable Long id,
+            @RequestBody TableVersionCompareRequest request) {
+        return Result.success(tableMetadataVersionService.compare(id, request));
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/dto/table/TableVersionCompareRequest.java
+++ b/backend/src/main/java/com/onedata/portal/dto/table/TableVersionCompareRequest.java
@@ -1,0 +1,14 @@
+package com.onedata.portal.dto.table;
+
+import lombok.Data;
+
+/**
+ * 表元数据版本对比请求
+ */
+@Data
+public class TableVersionCompareRequest {
+
+    private Long leftVersionId;
+
+    private Long rightVersionId;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/table/TableVersionCompareResponse.java
+++ b/backend/src/main/java/com/onedata/portal/dto/table/TableVersionCompareResponse.java
@@ -1,0 +1,64 @@
+package com.onedata.portal.dto.table;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 表元数据版本对比结果
+ */
+@Data
+public class TableVersionCompareResponse {
+
+    private Long tableId;
+
+    private Long leftVersionId;
+
+    private Integer leftVersionNo;
+
+    private Long rightVersionId;
+
+    private Integer rightVersionNo;
+
+    private Boolean changed;
+
+    /**
+     * 表级属性变更（如 tableComment、bucketNum）
+     */
+    private List<AttributeChange> tableAttributeChanges = new ArrayList<>();
+
+    private List<String> columnsAdded = new ArrayList<>();
+
+    private List<String> columnsRemoved = new ArrayList<>();
+
+    private List<ColumnChange> columnsModified = new ArrayList<>();
+
+    private Summary summary = new Summary();
+
+    /**
+     * 基于快照 JSON 的 unified diff，供前端原始视图渲染
+     */
+    private String rawDiff;
+
+    @Data
+    public static class AttributeChange {
+        private String name;
+        private String oldValue;
+        private String newValue;
+    }
+
+    @Data
+    public static class ColumnChange {
+        private String fieldName;
+        private List<AttributeChange> changes = new ArrayList<>();
+    }
+
+    @Data
+    public static class Summary {
+        private int attributeChangedCount;
+        private int columnsAddedCount;
+        private int columnsRemovedCount;
+        private int columnsModifiedCount;
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/entity/DataTableVersion.java
+++ b/backend/src/main/java/com/onedata/portal/entity/DataTableVersion.java
@@ -1,0 +1,44 @@
+package com.onedata.portal.entity;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 表元数据版本快照
+ */
+@Data
+@TableName("data_table_version")
+public class DataTableVersion {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+
+    private Long tableId;
+
+    private Integer versionNo;
+
+    /**
+     * 规范化快照 SHA-256，用于"元数据未变化则不记新版本"的比对
+     */
+    private String snapshotHash;
+
+    private String metadataSnapshot;
+
+    private String changeSummary;
+
+    /**
+     * table_create / manual_edit / metadata_sync / inspection_fix
+     */
+    private String triggerSource;
+
+    private String createdBy;
+
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/onedata/portal/mapper/DataTableVersionMapper.java
+++ b/backend/src/main/java/com/onedata/portal/mapper/DataTableVersionMapper.java
@@ -1,0 +1,12 @@
+package com.onedata.portal.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.onedata.portal.entity.DataTableVersion;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 表元数据版本 Mapper
+ */
+@Mapper
+public interface DataTableVersionMapper extends BaseMapper<DataTableVersion> {
+}

--- a/backend/src/main/java/com/onedata/portal/service/DataTableService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataTableService.java
@@ -49,6 +49,7 @@ public class DataTableService {
     private final DataLineageMapper dataLineageMapper;
     private final DorisClusterMapper dorisClusterMapper;
     private final DorisConnectionService dorisConnectionService;
+    private final TableMetadataVersionService tableMetadataVersionService;
 
     /**
      * 分页查询表列表
@@ -239,6 +240,8 @@ public class DataTableService {
 
         dataTableMapper.insert(dataTable);
         log.info("Created data table: {}", dataTable.getTableName());
+        tableMetadataVersionService.captureVersion(dataTable.getId(),
+                TableMetadataVersionService.TRIGGER_TABLE_CREATE, null);
         return dataTable;
     }
 
@@ -276,6 +279,8 @@ public class DataTableService {
 
         dataTableMapper.updateById(dataTable);
         log.info("Updated data table: {}", dataTable.getTableName());
+        tableMetadataVersionService.captureVersion(dataTable.getId(),
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
         return dataTable;
     }
 
@@ -371,6 +376,8 @@ public class DataTableService {
         update.setDeprecatedAt(null);
         update.setPurgeAt(null);
         dataTableMapper.updateById(update);
+        tableMetadataVersionService.captureVersion(table.getId(),
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
         return dataTableMapper.selectById(table.getId());
     }
 
@@ -518,6 +525,8 @@ public class DataTableService {
 
         dataFieldMapper.insert(field);
         log.info("Created field: {} for table: {}", field.getFieldName(), field.getTableId());
+        tableMetadataVersionService.captureVersion(field.getTableId(),
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
         return field;
     }
 
@@ -577,6 +586,8 @@ public class DataTableService {
 
         dataFieldMapper.updateById(toUpdate);
         log.info("Updated field: {}", toUpdate.getFieldName());
+        tableMetadataVersionService.captureVersion(toUpdate.getTableId(),
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
         return toUpdate;
     }
 
@@ -598,6 +609,8 @@ public class DataTableService {
         }
         dataFieldMapper.deleteById(fieldId);
         log.info("Deleted field: {}", fieldId);
+        tableMetadataVersionService.captureVersion(exists.getTableId(),
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
     }
 
     private boolean isDorisTable(DataTable table) {

--- a/backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DorisMetadataSyncService.java
@@ -41,6 +41,7 @@ public class DorisMetadataSyncService {
     private final TableTaskRelationMapper tableTaskRelationMapper;
     private final DataLineageMapper dataLineageMapper;
     private final TableStatisticsHistoryMapper tableStatisticsHistoryMapper;
+    private final TableMetadataVersionService tableMetadataVersionService;
 
     private static final Set<String> IGNORED_DATABASES = new HashSet<>(Arrays.asList("performance_schema", "sys"));
     private static final int MAX_COMMENT_LENGTH = 5000;
@@ -1153,6 +1154,9 @@ public class DorisMetadataSyncService {
 
         // 同步字段
         syncTableFields(newTable.getId(), database, tableName, columns, result);
+
+        tableMetadataVersionService.captureVersion(newTable.getId(),
+                TableMetadataVersionService.TRIGGER_METADATA_SYNC, "system");
     }
 
     /**
@@ -1355,6 +1359,12 @@ public class DorisMetadataSyncService {
             syncTimeUpdate.setId(localTable.getId());
             syncTimeUpdate.setSyncTime(LocalDateTime.now());
             dataTableMapper.updateById(syncTimeUpdate);
+        }
+
+        // 仅对同步真正触碰的表尝试捕获版本；volatile-only 变更由快照白名单兜底（哈希不变则不记版本）
+        if (tableMetadataUpdated || fieldChanges.hasChanges()) {
+            tableMetadataVersionService.captureVersion(localTable.getId(),
+                    TableMetadataVersionService.TRIGGER_METADATA_SYNC, "system");
         }
     }
 

--- a/backend/src/main/java/com/onedata/portal/service/InspectionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/InspectionService.java
@@ -37,6 +37,7 @@ public class InspectionService {
     private final HealthCheckService healthCheckService;
     private final DorisClusterService dorisClusterService;
     private final DorisConnectionService dorisConnectionService;
+    private final TableMetadataVersionService tableMetadataVersionService;
 
     private static final Pattern RECOMMENDED_REPLICA_PATTERN = Pattern.compile("推荐\\s*[:：]?\\s*(\\d+)");
     private static final Pattern RANGE_REPLICA_PATTERN = Pattern.compile("(\\d+)\\s*-\\s*(\\d+)");
@@ -1627,6 +1628,8 @@ public class InspectionService {
         dataTableMapper.updateById(updateTable);
 
         String operator = StringUtils.hasText(fixedBy) ? fixedBy.trim() : "system";
+        tableMetadataVersionService.captureVersion(context.getTable().getId(),
+                TableMetadataVersionService.TRIGGER_INSPECTION_FIX, operator);
         issue.setStatus("resolved");
         issue.setResolvedBy(operator);
         issue.setResolvedTime(LocalDateTime.now());

--- a/backend/src/main/java/com/onedata/portal/service/TableCreateService.java
+++ b/backend/src/main/java/com/onedata/portal/service/TableCreateService.java
@@ -37,6 +37,7 @@ public class TableCreateService {
     private final DataFieldMapper dataFieldMapper;
     private final TableNameGeneratorService tableNameGeneratorService;
     private final DorisConnectionService dorisConnectionService;
+    private final TableMetadataVersionService tableMetadataVersionService;
 
     /**
      * 预览表设计（生成表名与 DDL）
@@ -75,6 +76,8 @@ public class TableCreateService {
 
         dataTableMapper.updateById(dataTable);
         log.info("Created data table {} and synchronized to Doris: {}", dataTable.getTableName(), dataTable.getIsSynced());
+        tableMetadataVersionService.captureVersion(dataTable.getId(),
+                TableMetadataVersionService.TRIGGER_TABLE_CREATE, null);
         return dataTableMapper.selectById(dataTable.getId());
     }
 

--- a/backend/src/main/java/com/onedata/portal/service/TableMetadataVersionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/TableMetadataVersionService.java
@@ -1,0 +1,509 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.auth.context.UserContextHolder;
+import com.onedata.portal.dto.table.TableVersionCompareRequest;
+import com.onedata.portal.dto.table.TableVersionCompareResponse;
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DataTableVersion;
+import com.onedata.portal.mapper.DataFieldMapper;
+import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DataTableVersionMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * 表元数据版本服务：仅当白名单元数据（表属性 + 字段列表）真正变化时记录新版本。
+ * 版本历史作为审计线索永久保留，本服务不提供删除能力。
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TableMetadataVersionService {
+
+    public static final String TRIGGER_TABLE_CREATE = "table_create";
+    public static final String TRIGGER_MANUAL_EDIT = "manual_edit";
+    public static final String TRIGGER_METADATA_SYNC = "metadata_sync";
+    public static final String TRIGGER_INSPECTION_FIX = "inspection_fix";
+
+    private static final int SNAPSHOT_SCHEMA_VERSION = 1;
+    private static final int CHANGE_SUMMARY_MAX_LENGTH = 500;
+
+    private final DataTableMapper dataTableMapper;
+    private final DataFieldMapper dataFieldMapper;
+    private final DataTableVersionMapper dataTableVersionMapper;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 捕获一次版本：从 DB 重载表与字段（调用方实体可能是部分更新，不可信），
+     * 构建规范化快照并与最新版本哈希比对，仅在变化时插入新版本。
+     * 任何异常只记日志不上抛——同步路径运行在大事务中，版本记录失败不允许回滚业务写入。
+     *
+     * @param operator 操作人，传 null 时回退到当前登录用户，再回退到 system
+     * @return 新插入的版本；元数据未变化或捕获失败时返回 null
+     */
+    public DataTableVersion captureVersion(Long tableId, String triggerSource, String operator) {
+        if (tableId == null) {
+            return null;
+        }
+        try {
+            DataTable table = dataTableMapper.selectById(tableId);
+            if (table == null) {
+                return null;
+            }
+            Map<String, Object> snapshot = buildSnapshot(table, loadOrderedFields(tableId));
+            String snapshotJson = objectMapper.writeValueAsString(snapshot);
+            String hash = sha256(canonicalizeJson(objectMapper.readTree(snapshotJson)));
+
+            DataTableVersion latest = selectLatestVersion(tableId);
+            if (latest != null && Objects.equals(latest.getSnapshotHash(), hash)) {
+                return null;
+            }
+
+            DataTableVersion version = new DataTableVersion();
+            version.setTableId(tableId);
+            version.setVersionNo(latest == null ? 1 : latest.getVersionNo() + 1);
+            version.setSnapshotHash(hash);
+            version.setMetadataSnapshot(snapshotJson);
+            version.setChangeSummary(latest == null
+                    ? "初始版本快照"
+                    : buildChangeSummary(latest.getMetadataSnapshot(), snapshotJson));
+            version.setTriggerSource(triggerSource);
+            version.setCreatedBy(resolveOperator(operator));
+            dataTableVersionMapper.insert(version);
+            return version;
+        } catch (DuplicateKeyException e) {
+            // 手动编辑与定时同步并发捕获同一表时由唯一键兜底，跳过本次记录
+            log.warn("Concurrent version capture skipped for table {}", tableId);
+            return null;
+        } catch (Exception e) {
+            log.warn("Failed to capture metadata version for table {}", tableId, e);
+            return null;
+        }
+    }
+
+    /**
+     * 分页查询版本列表，不返回快照大字段
+     */
+    public Page<DataTableVersion> listVersions(Long tableId, int pageNum, int pageSize) {
+        Page<DataTableVersion> page = new Page<>(pageNum, pageSize);
+        LambdaQueryWrapper<DataTableVersion> wrapper = new LambdaQueryWrapper<DataTableVersion>()
+                .select(DataTableVersion.class, info -> !"metadata_snapshot".equals(info.getColumn()))
+                .eq(DataTableVersion::getTableId, tableId)
+                .orderByDesc(DataTableVersion::getVersionNo);
+        return dataTableVersionMapper.selectPage(page, wrapper);
+    }
+
+    public DataTableVersion getVersion(Long tableId, Long versionId) {
+        DataTableVersion version = dataTableVersionMapper.selectById(versionId);
+        if (version == null || !Objects.equals(version.getTableId(), tableId)) {
+            throw new IllegalArgumentException("版本不存在: " + versionId);
+        }
+        return version;
+    }
+
+    public TableVersionCompareResponse compare(Long tableId, TableVersionCompareRequest request) {
+        if (request == null || request.getLeftVersionId() == null || request.getRightVersionId() == null) {
+            throw new IllegalArgumentException("对比需要指定左右两个版本");
+        }
+        DataTableVersion left = getVersion(tableId, request.getLeftVersionId());
+        DataTableVersion right = getVersion(tableId, request.getRightVersionId());
+        // 统一让 left 为较旧版本，对比方向稳定
+        if (left.getVersionNo() != null && right.getVersionNo() != null
+                && left.getVersionNo() > right.getVersionNo()) {
+            DataTableVersion tmp = left;
+            left = right;
+            right = tmp;
+        }
+
+        TableVersionCompareResponse response = new TableVersionCompareResponse();
+        response.setTableId(tableId);
+        response.setLeftVersionId(left.getId());
+        response.setLeftVersionNo(left.getVersionNo());
+        response.setRightVersionId(right.getId());
+        response.setRightVersionNo(right.getVersionNo());
+
+        JsonNode leftRoot = readSnapshot(left.getMetadataSnapshot());
+        JsonNode rightRoot = readSnapshot(right.getMetadataSnapshot());
+
+        diffTableAttributes(leftRoot, rightRoot, response);
+        diffColumns(leftRoot, rightRoot, response);
+
+        TableVersionCompareResponse.Summary summary = response.getSummary();
+        summary.setAttributeChangedCount(response.getTableAttributeChanges().size());
+        summary.setColumnsAddedCount(response.getColumnsAdded().size());
+        summary.setColumnsRemovedCount(response.getColumnsRemoved().size());
+        summary.setColumnsModifiedCount(response.getColumnsModified().size());
+        response.setChanged(summary.getAttributeChangedCount() > 0
+                || summary.getColumnsAddedCount() > 0
+                || summary.getColumnsRemovedCount() > 0
+                || summary.getColumnsModifiedCount() > 0);
+
+        response.setRawDiff(buildUnifiedRawDiff(leftRoot, rightRoot, left, right));
+        return response;
+    }
+
+    // ---------------- 快照构建 ----------------
+
+    private List<DataField> loadOrderedFields(Long tableId) {
+        List<DataField> fields = dataFieldMapper.selectList(
+                new LambdaQueryWrapper<DataField>()
+                        .eq(DataField::getTableId, tableId));
+        fields.sort(Comparator
+                .comparing(DataField::getFieldOrder, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(DataField::getFieldName, Comparator.nullsLast(Comparator.naturalOrder())));
+        return fields;
+    }
+
+    /**
+     * 白名单快照：仅含结构性/描述性元数据。统计与同步类字段
+     * （rowCount/storageSize/syncTime/dorisDdl 等）被排除，确保其波动永不产生版本。
+     */
+    private Map<String, Object> buildSnapshot(DataTable table, List<DataField> fields) {
+        Map<String, Object> tableNode = new LinkedHashMap<>();
+        tableNode.put("tableName", table.getTableName());
+        tableNode.put("dbName", table.getDbName());
+        tableNode.put("tableComment", table.getTableComment());
+        tableNode.put("tableType", table.getTableType());
+        tableNode.put("layer", table.getLayer());
+        tableNode.put("businessDomain", table.getBusinessDomain());
+        tableNode.put("dataDomain", table.getDataDomain());
+        tableNode.put("owner", table.getOwner());
+        tableNode.put("status", table.getStatus());
+        tableNode.put("tableModel", table.getTableModel());
+        tableNode.put("partitionColumn", table.getPartitionColumn());
+        tableNode.put("distributionColumn", table.getDistributionColumn());
+        tableNode.put("keyColumns", table.getKeyColumns());
+        tableNode.put("bucketNum", table.getBucketNum());
+        tableNode.put("replicaNum", table.getReplicaNum());
+
+        List<Map<String, Object>> fieldNodes = new ArrayList<>();
+        for (DataField field : fields) {
+            Map<String, Object> fieldNode = new LinkedHashMap<>();
+            fieldNode.put("fieldName", field.getFieldName());
+            fieldNode.put("fieldType", field.getFieldType());
+            fieldNode.put("fieldComment", field.getFieldComment());
+            fieldNode.put("isNullable", field.getIsNullable());
+            fieldNode.put("isPrimary", field.getIsPrimary());
+            fieldNode.put("isPartition", field.getIsPartition());
+            fieldNode.put("defaultValue", field.getDefaultValue());
+            fieldNode.put("fieldOrder", field.getFieldOrder());
+            fieldNodes.add(fieldNode);
+        }
+
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("schemaVersion", SNAPSHOT_SCHEMA_VERSION);
+        snapshot.put("table", tableNode);
+        snapshot.put("fields", fieldNodes);
+        return snapshot;
+    }
+
+    private DataTableVersion selectLatestVersion(Long tableId) {
+        return dataTableVersionMapper.selectOne(
+                new LambdaQueryWrapper<DataTableVersion>()
+                        .eq(DataTableVersion::getTableId, tableId)
+                        .orderByDesc(DataTableVersion::getVersionNo)
+                        .last("limit 1"));
+    }
+
+    private String resolveOperator(String operator) {
+        if (StringUtils.hasText(operator)) {
+            return operator;
+        }
+        String currentUser = UserContextHolder.getCurrentUserId();
+        return StringUtils.hasText(currentUser) ? currentUser : "system";
+    }
+
+    // ---------------- 变更摘要 ----------------
+
+    private String buildChangeSummary(String previousSnapshotJson, String currentSnapshotJson) {
+        try {
+            JsonNode previous = readSnapshot(previousSnapshotJson);
+            JsonNode current = readSnapshot(currentSnapshotJson);
+
+            TableVersionCompareResponse diff = new TableVersionCompareResponse();
+            diffTableAttributes(previous, current, diff);
+            diffColumns(previous, current, diff);
+
+            List<String> parts = new ArrayList<>();
+            if (!diff.getTableAttributeChanges().isEmpty()) {
+                List<String> names = new ArrayList<>();
+                for (TableVersionCompareResponse.AttributeChange change : diff.getTableAttributeChanges()) {
+                    names.add(change.getName());
+                }
+                parts.add("表属性: " + String.join(", ", names));
+            }
+            List<String> fieldParts = new ArrayList<>();
+            for (String name : diff.getColumnsAdded()) {
+                fieldParts.add("+" + name);
+            }
+            for (String name : diff.getColumnsRemoved()) {
+                fieldParts.add("-" + name);
+            }
+            for (TableVersionCompareResponse.ColumnChange change : diff.getColumnsModified()) {
+                fieldParts.add("~" + change.getFieldName());
+            }
+            if (!fieldParts.isEmpty()) {
+                parts.add("字段: " + String.join(", ", fieldParts));
+            }
+            String summary = parts.isEmpty() ? "元数据变更" : String.join("; ", parts);
+            return summary.length() > CHANGE_SUMMARY_MAX_LENGTH
+                    ? summary.substring(0, CHANGE_SUMMARY_MAX_LENGTH - 3) + "..."
+                    : summary;
+        } catch (Exception e) {
+            log.warn("Failed to build change summary", e);
+            return "元数据变更";
+        }
+    }
+
+    // ---------------- 结构化 diff ----------------
+
+    private JsonNode readSnapshot(String snapshotJson) {
+        try {
+            return objectMapper.readTree(snapshotJson == null ? "{}" : snapshotJson);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("快照内容无法解析");
+        }
+    }
+
+    private void diffTableAttributes(JsonNode leftRoot, JsonNode rightRoot,
+                                     TableVersionCompareResponse response) {
+        JsonNode leftTable = leftRoot.path("table");
+        JsonNode rightTable = rightRoot.path("table");
+        Set<String> names = new TreeSet<>();
+        leftTable.fieldNames().forEachRemaining(names::add);
+        rightTable.fieldNames().forEachRemaining(names::add);
+        for (String name : names) {
+            String leftValue = textValue(leftTable.get(name));
+            String rightValue = textValue(rightTable.get(name));
+            if (!Objects.equals(leftValue, rightValue)) {
+                TableVersionCompareResponse.AttributeChange change = new TableVersionCompareResponse.AttributeChange();
+                change.setName(name);
+                change.setOldValue(leftValue);
+                change.setNewValue(rightValue);
+                response.getTableAttributeChanges().add(change);
+            }
+        }
+    }
+
+    private void diffColumns(JsonNode leftRoot, JsonNode rightRoot,
+                             TableVersionCompareResponse response) {
+        Map<String, JsonNode> leftFields = fieldsByName(leftRoot);
+        Map<String, JsonNode> rightFields = fieldsByName(rightRoot);
+
+        Set<String> allNames = new LinkedHashSet<>(leftFields.keySet());
+        allNames.addAll(rightFields.keySet());
+        for (String name : allNames) {
+            JsonNode leftField = leftFields.get(name);
+            JsonNode rightField = rightFields.get(name);
+            if (leftField == null) {
+                response.getColumnsAdded().add(name);
+                continue;
+            }
+            if (rightField == null) {
+                response.getColumnsRemoved().add(name);
+                continue;
+            }
+            TableVersionCompareResponse.ColumnChange columnChange = new TableVersionCompareResponse.ColumnChange();
+            columnChange.setFieldName(name);
+            Set<String> attrNames = new TreeSet<>();
+            leftField.fieldNames().forEachRemaining(attrNames::add);
+            rightField.fieldNames().forEachRemaining(attrNames::add);
+            for (String attrName : attrNames) {
+                String leftValue = textValue(leftField.get(attrName));
+                String rightValue = textValue(rightField.get(attrName));
+                if (!Objects.equals(leftValue, rightValue)) {
+                    TableVersionCompareResponse.AttributeChange change = new TableVersionCompareResponse.AttributeChange();
+                    change.setName(attrName);
+                    change.setOldValue(leftValue);
+                    change.setNewValue(rightValue);
+                    columnChange.getChanges().add(change);
+                }
+            }
+            if (!columnChange.getChanges().isEmpty()) {
+                response.getColumnsModified().add(columnChange);
+            }
+        }
+    }
+
+    private Map<String, JsonNode> fieldsByName(JsonNode root) {
+        Map<String, JsonNode> result = new LinkedHashMap<>();
+        JsonNode fields = root.path("fields");
+        if (fields.isArray()) {
+            for (JsonNode field : fields) {
+                String name = textValue(field.get("fieldName"));
+                if (name != null) {
+                    result.put(name, field);
+                }
+            }
+        }
+        return result;
+    }
+
+    private String textValue(JsonNode node) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return null;
+        }
+        return node.isTextual() ? node.asText() : node.toString();
+    }
+
+    // ---------------- 规范化与哈希 ----------------
+
+    private String canonicalizeJson(JsonNode node) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return "null";
+        }
+        if (node.isObject()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append('{');
+            boolean first = true;
+            TreeSet<String> fieldNames = new TreeSet<>();
+            node.fieldNames().forEachRemaining(fieldNames::add);
+            for (String fieldName : fieldNames) {
+                if (!first) {
+                    sb.append(',');
+                }
+                first = false;
+                sb.append('"').append(fieldName).append('"').append(':');
+                sb.append(canonicalizeJson(node.get(fieldName)));
+            }
+            sb.append('}');
+            return sb.toString();
+        }
+        if (node.isArray()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append('[');
+            for (int i = 0; i < node.size(); i++) {
+                if (i > 0) {
+                    sb.append(',');
+                }
+                sb.append(canonicalizeJson(node.get(i)));
+            }
+            sb.append(']');
+            return sb.toString();
+        }
+        return node.toString();
+    }
+
+    private String sha256(String text) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(text.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("无法生成 hash", e);
+        }
+    }
+
+    // ---------------- raw diff ----------------
+
+    private String buildUnifiedRawDiff(JsonNode leftRoot, JsonNode rightRoot,
+                                       DataTableVersion leftVersion, DataTableVersion rightVersion) {
+        String leftText = toPrettyJson(leftRoot);
+        String rightText = toPrettyJson(rightRoot);
+
+        List<String> leftLines = Arrays.asList(leftText.split("\\R", -1));
+        List<String> rightLines = Arrays.asList(rightText.split("\\R", -1));
+        int[][] lcs = buildLcsMatrix(leftLines, rightLines);
+        LinkedList<String> diffLines = buildDiffLines(leftLines, rightLines, lcs);
+
+        String leftLabel = leftVersion.getVersionNo() != null ? "v" + leftVersion.getVersionNo() : "unknown";
+        String rightLabel = rightVersion.getVersionNo() != null ? "v" + rightVersion.getVersionNo() : "unknown";
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("--- ").append(leftLabel).append('\n');
+        builder.append("+++ ").append(rightLabel).append('\n');
+        builder.append("@@ JSON Snapshot @@").append('\n');
+        for (String line : diffLines) {
+            builder.append(line).append('\n');
+        }
+        return builder.toString();
+    }
+
+    private int[][] buildLcsMatrix(List<String> leftLines, List<String> rightLines) {
+        int leftSize = leftLines.size();
+        int rightSize = rightLines.size();
+        int[][] matrix = new int[leftSize + 1][rightSize + 1];
+        for (int i = 1; i <= leftSize; i++) {
+            for (int j = 1; j <= rightSize; j++) {
+                if (Objects.equals(leftLines.get(i - 1), rightLines.get(j - 1))) {
+                    matrix[i][j] = matrix[i - 1][j - 1] + 1;
+                } else {
+                    matrix[i][j] = Math.max(matrix[i - 1][j], matrix[i][j - 1]);
+                }
+            }
+        }
+        return matrix;
+    }
+
+    private LinkedList<String> buildDiffLines(List<String> leftLines,
+                                              List<String> rightLines,
+                                              int[][] lcsMatrix) {
+        int i = leftLines.size();
+        int j = rightLines.size();
+        LinkedList<String> diffLines = new LinkedList<>();
+        while (i > 0 && j > 0) {
+            String leftLine = leftLines.get(i - 1);
+            String rightLine = rightLines.get(j - 1);
+            if (Objects.equals(leftLine, rightLine)) {
+                diffLines.addFirst(" " + leftLine);
+                i--;
+                j--;
+                continue;
+            }
+            if (lcsMatrix[i - 1][j] >= lcsMatrix[i][j - 1]) {
+                diffLines.addFirst("-" + leftLine);
+                i--;
+            } else {
+                diffLines.addFirst("+" + rightLine);
+                j--;
+            }
+        }
+        while (i > 0) {
+            diffLines.addFirst("-" + leftLines.get(i - 1));
+            i--;
+        }
+        while (j > 0) {
+            diffLines.addFirst("+" + rightLines.get(j - 1));
+            j--;
+        }
+        return diffLines;
+    }
+
+    private String toPrettyJson(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(node);
+        } catch (Exception ex) {
+            return node.toString();
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V45__create_data_table_version.sql
+++ b/backend/src/main/resources/db/migration/V45__create_data_table_version.sql
@@ -1,0 +1,15 @@
+-- 表元数据版本快照：仅当白名单元数据（表属性 + 字段列表）哈希变化时追加一行
+CREATE TABLE IF NOT EXISTS `data_table_version` (
+    `id` BIGINT NOT NULL AUTO_INCREMENT,
+    `table_id` BIGINT NOT NULL COMMENT '关联 data_table.id',
+    `version_no` INT NOT NULL COMMENT '表内自增版本号，从 1 开始',
+    `snapshot_hash` CHAR(64) NOT NULL COMMENT '规范化快照 SHA-256',
+    `metadata_snapshot` MEDIUMTEXT COMMENT '规范化元数据快照 JSON',
+    `change_summary` VARCHAR(500) DEFAULT NULL COMMENT '相对上一版本的变更摘要',
+    `trigger_source` VARCHAR(50) DEFAULT NULL COMMENT 'table_create/manual_edit/metadata_sync/inspection_fix',
+    `created_by` VARCHAR(100) DEFAULT NULL,
+    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_table_version` (`table_id`, `version_no`),
+    KEY `idx_table_id_created` (`table_id`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='表元数据版本快照';

--- a/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DorisMetadataSyncServiceTest.java
@@ -61,6 +61,9 @@ class DorisMetadataSyncServiceTest {
     @Mock
     private TableStatisticsHistoryMapper tableStatisticsHistoryMapper;
 
+    @Mock
+    private TableMetadataVersionService tableMetadataVersionService;
+
     @InjectMocks
     private DorisMetadataSyncService service;
 

--- a/backend/src/test/java/com/onedata/portal/service/TableMetadataVersionServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/TableMetadataVersionServiceTest.java
@@ -1,0 +1,314 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.table.TableVersionCompareRequest;
+import com.onedata.portal.dto.table.TableVersionCompareResponse;
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DataTableVersion;
+import com.onedata.portal.mapper.DataFieldMapper;
+import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DataTableVersionMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TableMetadataVersionServiceTest {
+
+    static {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new MybatisConfiguration(), "");
+        TableInfoHelper.initTableInfo(assistant, DataTable.class);
+        TableInfoHelper.initTableInfo(assistant, DataField.class);
+        TableInfoHelper.initTableInfo(assistant, DataTableVersion.class);
+    }
+
+    private static final Long TABLE_ID = 100L;
+
+    @Mock
+    private DataTableMapper dataTableMapper;
+
+    @Mock
+    private DataFieldMapper dataFieldMapper;
+
+    @Mock
+    private DataTableVersionMapper dataTableVersionMapper;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private TableMetadataVersionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TableMetadataVersionService(
+                dataTableMapper, dataFieldMapper, dataTableVersionMapper, objectMapper);
+        lenient().when(dataTableVersionMapper.insert(any(DataTableVersion.class))).thenReturn(1);
+    }
+
+    @Test
+    void firstCaptureCreatesVersionOne() {
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(sampleTable());
+        when(dataFieldMapper.selectList(any())).thenReturn(sampleFields());
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion version = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_TABLE_CREATE, "alice");
+
+        assertNotNull(version);
+        assertEquals(1, version.getVersionNo());
+        assertEquals(TABLE_ID, version.getTableId());
+        assertEquals("初始版本快照", version.getChangeSummary());
+        assertEquals("alice", version.getCreatedBy());
+        assertNotNull(version.getSnapshotHash());
+        assertEquals(64, version.getSnapshotHash().length());
+        assertTrue(version.getMetadataSnapshot().contains("\"tableName\""));
+        verify(dataTableVersionMapper).insert(any(DataTableVersion.class));
+    }
+
+    @Test
+    void identicalMetadataDoesNotCreateNewVersion() {
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(sampleTable());
+        when(dataFieldMapper.selectList(any())).thenReturn(sampleFields());
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion first = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+        assertNotNull(first);
+
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(first);
+        DataTableVersion second = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        assertNull(second);
+        verify(dataTableVersionMapper, times(1)).insert(any(DataTableVersion.class));
+    }
+
+    @Test
+    void volatileStatisticsChangeDoesNotCreateNewVersion() {
+        DataTable table = sampleTable();
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(table);
+        when(dataFieldMapper.selectList(any())).thenReturn(sampleFields());
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion first = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_METADATA_SYNC, "system");
+        assertNotNull(first);
+
+        // 统计/同步类字段波动：不在快照白名单内，不得产生新版本
+        table.setRowCount(999999L);
+        table.setStorageSize(123456789L);
+        table.setDorisDdl("CREATE TABLE ... PARTITION p20260611 ...");
+        table.setSyncTime(LocalDateTime.now());
+        table.setIsSynced(0);
+        table.setDorisUpdateTime(LocalDateTime.now());
+
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(first);
+        DataTableVersion second = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_METADATA_SYNC, "system");
+
+        assertNull(second);
+        verify(dataTableVersionMapper, times(1)).insert(any(DataTableVersion.class));
+    }
+
+    @Test
+    void fieldCommentChangeCreatesNextVersionWithSummary() {
+        DataTable table = sampleTable();
+        List<DataField> fields = sampleFields();
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(table);
+        when(dataFieldMapper.selectList(any())).thenReturn(fields);
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion first = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+        assertNotNull(first);
+
+        fields.get(0).setFieldComment("主键ID（更新后）");
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(first);
+
+        DataTableVersion second = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        assertNotNull(second);
+        assertEquals(2, second.getVersionNo());
+        assertTrue(second.getChangeSummary().contains("~id"),
+                "summary should mark modified field: " + second.getChangeSummary());
+    }
+
+    @Test
+    void tableAttributeChangeCreatesNextVersionWithSummary() {
+        DataTable table = sampleTable();
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(table);
+        when(dataFieldMapper.selectList(any())).thenReturn(sampleFields());
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion first = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        table.setTableComment("订单明细表（新注释）");
+        table.setBucketNum(20);
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(first);
+
+        DataTableVersion second = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        assertNotNull(second);
+        assertEquals(2, second.getVersionNo());
+        assertTrue(second.getChangeSummary().contains("tableComment"));
+        assertTrue(second.getChangeSummary().contains("bucketNum"));
+    }
+
+    @Test
+    void fieldLoadOrderDoesNotAffectHash() {
+        DataTable table = sampleTable();
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(table);
+        when(dataFieldMapper.selectList(any())).thenReturn(sampleFields());
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        DataTableVersion first = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+        assertNotNull(first);
+
+        List<DataField> reversed = new ArrayList<>(sampleFields());
+        Collections.reverse(reversed);
+        when(dataFieldMapper.selectList(any())).thenReturn(reversed);
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(first);
+
+        DataTableVersion second = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        assertNull(second);
+    }
+
+    @Test
+    void deletedOrMissingTableIsNoOp() {
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(null);
+
+        DataTableVersion version = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+
+        assertNull(version);
+        verify(dataTableVersionMapper, never()).insert(any(DataTableVersion.class));
+    }
+
+    @Test
+    void captureNeverThrows() {
+        when(dataTableMapper.selectById(TABLE_ID)).thenThrow(new RuntimeException("db down"));
+
+        DataTableVersion version = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_METADATA_SYNC, "system");
+
+        assertNull(version);
+    }
+
+    @Test
+    void compareReturnsStructuredDiff() {
+        DataTable table = sampleTable();
+        List<DataField> fields = sampleFields();
+        when(dataTableMapper.selectById(TABLE_ID)).thenReturn(table);
+        when(dataFieldMapper.selectList(any())).thenReturn(fields);
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(null);
+
+        ArgumentCaptor<DataTableVersion> captor = ArgumentCaptor.forClass(DataTableVersion.class);
+        DataTableVersion v1 = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_TABLE_CREATE, null);
+        v1.setId(1L);
+
+        table.setTableComment("新注释");
+        DataField added = field("new_col", "VARCHAR(64)", "新增列", 3);
+        fields.add(added);
+        when(dataTableVersionMapper.selectOne(any())).thenReturn(v1);
+        DataTableVersion v2 = service.captureVersion(TABLE_ID,
+                TableMetadataVersionService.TRIGGER_MANUAL_EDIT, null);
+        v2.setId(2L);
+        verify(dataTableVersionMapper, times(2)).insert(captor.capture());
+
+        when(dataTableVersionMapper.selectById(1L)).thenReturn(v1);
+        when(dataTableVersionMapper.selectById(2L)).thenReturn(v2);
+
+        TableVersionCompareRequest request = new TableVersionCompareRequest();
+        // 故意把新版本放在 left，验证服务端会按版本号交换方向
+        request.setLeftVersionId(2L);
+        request.setRightVersionId(1L);
+        TableVersionCompareResponse response = service.compare(TABLE_ID, request);
+
+        assertEquals(1, response.getLeftVersionNo());
+        assertEquals(2, response.getRightVersionNo());
+        assertTrue(response.getChanged());
+        assertEquals(1, response.getTableAttributeChanges().size());
+        assertEquals("tableComment", response.getTableAttributeChanges().get(0).getName());
+        assertEquals(Collections.singletonList("new_col"), response.getColumnsAdded());
+        assertTrue(response.getColumnsRemoved().isEmpty());
+        assertTrue(response.getColumnsModified().isEmpty());
+        assertEquals(1, response.getSummary().getColumnsAddedCount());
+        assertNotNull(response.getRawDiff());
+        assertTrue(response.getRawDiff().contains("+++ v2"));
+    }
+
+    private DataTable sampleTable() {
+        DataTable table = new DataTable();
+        table.setId(TABLE_ID);
+        table.setClusterId(1L);
+        table.setTableName("dwd_order_detail");
+        table.setDbName("dwd");
+        table.setTableComment("订单明细表");
+        table.setTableType("BASE TABLE");
+        table.setLayer("DWD");
+        table.setBusinessDomain("trade");
+        table.setDataDomain("order");
+        table.setOwner("alice");
+        table.setStatus("active");
+        table.setTableModel("UNIQUE");
+        table.setPartitionColumn("dt");
+        table.setDistributionColumn("id");
+        table.setKeyColumns("id");
+        table.setBucketNum(10);
+        table.setReplicaNum(3);
+        table.setRowCount(1000L);
+        table.setStorageSize(2048L);
+        table.setDorisDdl("CREATE TABLE dwd_order_detail (...)");
+        table.setIsSynced(1);
+        return table;
+    }
+
+    private List<DataField> sampleFields() {
+        return new ArrayList<>(Arrays.asList(
+                field("id", "BIGINT", "主键ID", 1),
+                field("order_no", "VARCHAR(64)", "订单号", 2)));
+    }
+
+    private DataField field(String name, String type, String comment, int order) {
+        DataField field = new DataField();
+        field.setTableId(TABLE_ID);
+        field.setFieldName(name);
+        field.setFieldType(type);
+        field.setFieldComment(comment);
+        field.setIsNullable(0);
+        field.setIsPrimary("id".equals(name) ? 1 : 0);
+        field.setIsPartition(0);
+        field.setFieldOrder(order);
+        return field;
+    }
+}

--- a/docs/design/2026-06-11-table-metadata-version-design.md
+++ b/docs/design/2026-06-11-table-metadata-version-design.md
@@ -1,0 +1,82 @@
+# 表资产元数据版本历史设计
+
+- 日期：2026-06-11
+- 主题：table-metadata-version
+- 影响范围：backend（schema / 服务 / API）、frontend（Data Studio 右侧面板）
+
+## 1. 现状与问题
+
+表资产元数据（`data_table` / `data_field`）目前被多条路径直接覆盖更新，没有任何版本历史：
+
+- 手动路径：`DataTableService.create/update/createField/updateField/deleteField`、`restoreDeprecatedTable`，以及建表向导 `TableCreateService.create`、巡检一键修复 `InspectionService.fixReplicaCountIssue`（直改 `replicaNum`）。
+- 自动路径：`DorisMetadataSyncService.syncNewTable/syncExistingTable`（手动触发与 `DataSourceMetadataAutoSyncTask` 定时触发共用此漏斗）。
+
+用户无法回答"这张表的元数据何时、被谁、改成了什么"。已有的 `metadata_sync_history` 只按"一次同步操作"聚合记录，不支持按表查询，也不覆盖手动编辑。
+
+## 2. 目标与范围
+
+- 每张表可查看自己的版本历史；**仅当元数据真正变化时记录新版本**。
+- 仅查看 + 版本对比，不支持回滚（不在本次范围）。
+- 统计类波动（行数、存储大小、Doris 更新时间等）不得产生版本。
+
+## 3. 方案
+
+镜像仓库中已验证的 `workflow_version` 快照模式：
+
+- 新增追加式表 `data_table_version`，存储规范化元数据快照 JSON 与 SHA-256 哈希（`snapshot_hash`）。
+- 统一入口 `TableMetadataVersionService.captureVersion(tableId, triggerSource, operator)`：从 DB 重载表 + 字段（调用方实体可能是部分更新，不可信）→ 构建白名单快照 → 规范化序列化（对象键排序，复用 `WorkflowService` 的 canonicalize/sha256 实现模式）→ 与最新版本哈希比对，相同则 no-op，不同则插入 `version_no + 1` 并生成变更摘要。
+- `captureVersion` 内部吞掉所有异常仅记日志：同步路径运行在 `@Transactional(rollbackFor = Exception.class)` 大事务中，版本记录失败不允许回滚业务写入。
+- `(table_id, version_no)` 唯一键防并发重复插入（手动编辑与定时同步竞争时捕获重复键异常跳过）。
+
+### 3.1 快照内容（schemaVersion=1）
+
+- `table` 节点（白名单）：tableName、dbName、tableComment、tableType、layer、businessDomain、dataDomain、owner、status、tableModel、partitionColumn、distributionColumn、keyColumns、bucketNum、replicaNum。
+- `fields` 数组：按 `fieldOrder, fieldName` 排序，每项含 fieldName、fieldType、fieldComment、isNullable、isPrimary、isPartition、defaultValue、fieldOrder。
+- **排除（永不触发版本）**：rowCount、storageSize、dorisUpdateTime、dorisCreateTime、syncTime、isSynced、clusterId、customIdentifier、statisticsCycle、updateType、lifecycleDays、originTableName、deprecatedAt、purgeAt、时间戳、deleted，以及 **dorisDdl**——Doris `SHOW CREATE TABLE` 输出包含动态分区列表，分区表每日变化，纳入快照会造成版本噪声；真正的结构变化（列/键/分桶）必然同时反映在白名单字段中。
+
+### 3.2 Hook 全图
+
+| 入口 | trigger_source | 说明 |
+| --- | --- | --- |
+| `DataTableService.create` | table_create | 插入后捕获（此路径字段单独创建，v1 可能无字段） |
+| `TableCreateService.create` | table_create | 建表向导，最终 updateById 后捕获（v1 含全部字段） |
+| `DataTableService.update` | manual_edit | 同时覆盖 updateTableComment / softDeleteTable 路由 |
+| `DataTableService.restoreDeprecatedTable` | manual_edit | 恢复软删表（改名 + status） |
+| `DataTableService.createField/updateField/deleteField` | manual_edit | 每次字段变更一次捕获 |
+| `InspectionService.fixReplicaCountIssue` | inspection_fix | 直改 replicaNum 的旁路 |
+| `DorisMetadataSyncService.syncNewTable` | metadata_sync | 字段同步完成后捕获 → v1 |
+| `DorisMetadataSyncService.syncExistingTable` | metadata_sync | 守卫 `tableMetadataUpdated \|\| fieldChanges.hasChanges()`，每张变化表恰好一次 |
+
+- 统计-only 路径（`syncAllStatistics` / `syncDatabaseStatistics` / `syncTableStatisticsOnly`）不加 hook；即使误入捕获，白名单也保证哈希不变（双重防护）。
+- 守卫中 `tableMetadataUpdated` 可能因 volatile-only 字段（isSynced/dorisDdl/clusterId 等）为 true，此时捕获后哈希相同、正确地不产生版本。
+
+### 3.3 初版语义（lazy baseline）
+
+不做存量回填。表在功能上线后第一次 `captureVersion` 时获得 v1（建表 / 首次手动编辑 / 首次同步检出变化）。存量表"变更前"的状态不会被记录，历史只向前生长。取舍：迁移零成本、部署期间不批量写入上万基线行；代价是首个版本即"变更后"状态。
+
+### 3.4 版本保留策略：永不清理（已确认）
+
+表的全部删除路径（`DataTableService.delete`、`purgeTableMetadata`、同步侧删除）均为 `@TableLogic` 软删除，`data_table` 行本身保留。版本历史作为审计线索同样**永久保留**，本次变更不包含任何版本删除逻辑（服务不提供删除方法）。表 ID 自增不复用，孤儿版本无副作用；若未来存储成为问题，另行设计独立清理任务。
+
+注意：软删除本身会产生一个版本（改名 + status=deprecated）——符合"状态属于元数据"的范围定义；恢复亦然。
+
+## 4. 接口
+
+新 controller `DataTableVersionController`（`/v1/tables`，避免膨胀已 1100+ 行的 `DataTableController`）：
+
+- `GET /v1/tables/{id}/versions?pageNum=1&pageSize=20` → `Result<PageResult<DataTableVersion>>`，列表不返回 `metadataSnapshot` 大字段
+- `GET /v1/tables/{id}/versions/{versionId}` → 含快照全文
+- `POST /v1/tables/{id}/versions/compare`，body `{leftVersionId, rightVersionId}` → 结构化 diff（表属性变更 / 字段增删改）+ unified rawDiff（复用 workflow 版本对比的 LCS diff 实现模式）
+
+## 5. 前端
+
+Data Studio 右侧面板（`DataStudioRightPanel.vue`）在"访问情况"后新增"版本"标签页（懒加载）：
+
+- `TableVersionHistoryPanel.vue`：版本列表（版本号 / 变更摘要 / 来源 / 操作人 / 时间）+ 分页 + 查看快照 + 选两个版本对比
+- `TableVersionCompareDialog.vue`：摘要计数 + 结构化分区（表属性变更、字段增删改）+ rawDiff 视图，改编自 `WorkflowVersionComparePanel.vue`
+
+## 6. 权衡与备选
+
+- 备选"记录 diff 而非全量快照"：被否决——全量快照 + 哈希实现简单、可独立查看任意版本、与 workflow_version 模式一致；快照体积（数百字段的宽表约几十 KB）由 MEDIUMTEXT 承担。
+- 备选"复用 metadata_sync_history"：被否决——其粒度是"一次同步操作"，不按表组织，且不覆盖手动编辑路径。
+- 服务端对比 vs 前端对比：选服务端，与 workflow 版本对比一致，前端只渲染。

--- a/docs/plans/2026-06-11-table-metadata-version-plan.md
+++ b/docs/plans/2026-06-11-table-metadata-version-plan.md
@@ -1,0 +1,45 @@
+# 表资产元数据版本历史实施计划
+
+- 日期：2026-06-11
+- 主题：table-metadata-version
+- 设计文档：`docs/design/2026-06-11-table-metadata-version-design.md`
+
+## 任务清单
+
+1. Schema 与实体
+   - 新增 `backend/src/main/resources/db/migration/V45__create_data_table_version.sql`
+   - 新增 `entity/DataTableVersion.java`、`mapper/DataTableVersionMapper.java`
+2. 核心服务
+   - 新增 `service/TableMetadataVersionService.java`：`captureVersion`（白名单快照 + canonical JSON + SHA-256 哈希比对，吞异常）、`listVersions`（排除快照大字段）、`getVersion`、`compare`
+   - 新增 `dto/table/TableVersionCompareRequest.java`、`dto/table/TableVersionCompareResponse.java`
+3. 单元测试
+   - 新增 `backend/src/test/java/com/onedata/portal/service/TableMetadataVersionServiceTest.java`（Mockito + `TableInfoHelper.initTableInfo` 模式）
+   - 用例：首捕获→v1；相同重捕获→不插入；volatile 字段变化→不插入；字段注释变化→v2；compare 结构化结果；已删表→no-op；capture 不抛异常
+4. Hook 接入
+   - `service/DataTableService.java`：create / update / restoreDeprecatedTable / createField / updateField / deleteField
+   - `service/TableCreateService.java`：create 末尾
+   - `service/InspectionService.java`：fixReplicaCountIssue
+   - `service/DorisMetadataSyncService.java`：syncNewTable 末尾、syncExistingTable 末尾（守卫）
+   - 删除路径不动（版本永不清理）
+5. API
+   - 新增 `controller/DataTableVersionController.java`
+6. 前端
+   - `frontend/src/api/table.js`：listVersions / getVersion / compareTableVersions
+   - 新增 `frontend/src/views/datastudio/components/TableVersionHistoryPanel.vue`、`TableVersionCompareDialog.vue`
+   - `DataStudioRightPanel.vue` 新增"版本"标签页（懒加载）
+
+## 触达文件
+
+- 新增：V45 迁移、DataTableVersion 实体/Mapper、TableMetadataVersionService、compare DTO×2、DataTableVersionController、服务单测、前端组件×2、本设计/计划文档
+- 修改：DataTableService、TableCreateService、InspectionService、DorisMetadataSyncService、DataStudioRightPanel.vue、api/table.js
+
+## 验证
+
+- 后端：`cd backend && mvn -q compile`；`mvn -q test -Dtest=TableMetadataVersionServiceTest`；回归 `mvn -q test -Dtest='WorkflowVersion*Test'`
+- 前端：`nvm use` 后 `npm --prefix frontend run build`
+- 跨层 smoke（环境可用时）：dev MySQL(127.0.0.1:3316) + 后端（Flyway 应用 V45）+ 前端。改表注释→版本 tab 出现 v1(manual_edit)；保存相同值→无新版本；同表 sync-metadata 两次→最多一个新版本；统计-only 同步→无版本；对比弹窗正常。无本地 Doris 时同步路径仅由单测覆盖，验证说明中如实声明。
+
+## 发布与回退
+
+- 发布：迁移为纯新增表，零停机；功能被动生效，无需开关。
+- 回退：移除各 hook 调用即可停止记录；`data_table_version` 表可保留，不影响业务。

--- a/frontend/src/api/table.js
+++ b/frontend/src/api/table.js
@@ -231,5 +231,20 @@ export const tableApi = {
         timeout: METADATA_SYNC_TIMEOUT
       }
     )
+  },
+
+  // 分页查询表元数据版本历史
+  listVersions(id, params = {}) {
+    return request.get(`/v1/tables/${id}/versions`, { params })
+  },
+
+  // 获取单个版本详情（含快照 JSON）
+  getVersion(id, versionId) {
+    return request.get(`/v1/tables/${id}/versions/${versionId}`)
+  },
+
+  // 对比两个元数据版本
+  compareTableVersions(id, payload) {
+    return request.post(`/v1/tables/${id}/versions/compare`, payload)
   }
 }

--- a/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
@@ -549,6 +549,22 @@
               </section>
             </div>
           </el-tab-pane>
+
+          <el-tab-pane name="versions" label="版本" lazy>
+            <div class="meta-section meta-section-fill">
+              <section class="section-block section-fill">
+                <div class="section-header">
+                  <div class="section-title">版本历史</div>
+                </div>
+                <el-scrollbar class="meta-scroll">
+                  <TableVersionHistoryPanel
+                    :table-id="state.table?.id"
+                    :active="state.metaTab === 'versions'"
+                  />
+                </el-scrollbar>
+              </section>
+            </div>
+          </el-tab-pane>
         </el-tabs>
       </section>
 
@@ -593,6 +609,7 @@ import { computed, inject, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { Warning } from '@element-plus/icons-vue'
 import { tableApi } from '@/api/table'
 import DataStudioRightPanelLineage from './DataStudioRightPanelLineage.vue'
+import TableVersionHistoryPanel from './TableVersionHistoryPanel.vue'
 import { isDemoMode } from '@/demo/runtime'
 import { loadEcharts } from '@/utils/loadEcharts'
 

--- a/frontend/src/views/datastudio/components/TableVersionCompareDialog.vue
+++ b/frontend/src/views/datastudio/components/TableVersionCompareDialog.vue
@@ -1,0 +1,252 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    title="版本对比"
+    width="760px"
+    append-to-body
+    destroy-on-close
+    @update:model-value="(val) => emit('update:modelValue', val)"
+  >
+    <div v-loading="loading" class="compare-body">
+      <template v-if="result">
+        <div class="compare-summary">
+          <span class="compare-versions">v{{ result.leftVersionNo }} → v{{ result.rightVersionNo }}</span>
+          <el-tag v-if="result.changed" type="warning" size="small">有变化</el-tag>
+          <el-tag v-else type="info" size="small">无变化</el-tag>
+          <el-tag v-if="result.summary?.attributeChangedCount" size="small">表属性 {{ result.summary.attributeChangedCount }}</el-tag>
+          <el-tag v-if="result.summary?.columnsAddedCount" type="success" size="small">新增字段 {{ result.summary.columnsAddedCount }}</el-tag>
+          <el-tag v-if="result.summary?.columnsRemovedCount" type="danger" size="small">删除字段 {{ result.summary.columnsRemovedCount }}</el-tag>
+          <el-tag v-if="result.summary?.columnsModifiedCount" type="warning" size="small">修改字段 {{ result.summary.columnsModifiedCount }}</el-tag>
+        </div>
+
+        <el-tabs v-model="activeTab" class="compare-tabs">
+          <el-tab-pane name="structured" label="结构化对比">
+            <el-scrollbar max-height="420px">
+              <template v-if="result.changed">
+                <template v-if="result.tableAttributeChanges?.length">
+                  <div class="compare-section-title">表属性变更</div>
+                  <el-table :data="result.tableAttributeChanges" border size="small">
+                    <el-table-column prop="name" label="属性" min-width="130" />
+                    <el-table-column label="旧值" min-width="180">
+                      <template #default="{ row }">
+                        <span class="value-old">{{ displayValue(row.oldValue) }}</span>
+                      </template>
+                    </el-table-column>
+                    <el-table-column label="新值" min-width="180">
+                      <template #default="{ row }">
+                        <span class="value-new">{{ displayValue(row.newValue) }}</span>
+                      </template>
+                    </el-table-column>
+                  </el-table>
+                </template>
+
+                <template v-if="result.columnsAdded?.length">
+                  <div class="compare-section-title">新增字段</div>
+                  <div class="tag-group">
+                    <el-tag v-for="name in result.columnsAdded" :key="`add-${name}`" type="success" size="small">
+                      {{ name }}
+                    </el-tag>
+                  </div>
+                </template>
+
+                <template v-if="result.columnsRemoved?.length">
+                  <div class="compare-section-title">删除字段</div>
+                  <div class="tag-group">
+                    <el-tag v-for="name in result.columnsRemoved" :key="`del-${name}`" type="danger" size="small">
+                      {{ name }}
+                    </el-tag>
+                  </div>
+                </template>
+
+                <template v-if="result.columnsModified?.length">
+                  <div class="compare-section-title">修改字段</div>
+                  <div v-for="column in result.columnsModified" :key="`mod-${column.fieldName}`" class="modified-column">
+                    <div class="modified-column-name">{{ column.fieldName }}</div>
+                    <el-table :data="column.changes" border size="small">
+                      <el-table-column prop="name" label="属性" min-width="120" />
+                      <el-table-column label="旧值" min-width="170">
+                        <template #default="{ row }">
+                          <span class="value-old">{{ displayValue(row.oldValue) }}</span>
+                        </template>
+                      </el-table-column>
+                      <el-table-column label="新值" min-width="170">
+                        <template #default="{ row }">
+                          <span class="value-new">{{ displayValue(row.newValue) }}</span>
+                        </template>
+                      </el-table-column>
+                    </el-table>
+                  </div>
+                </template>
+              </template>
+              <el-empty v-else description="两个版本的元数据完全一致" :image-size="60" />
+            </el-scrollbar>
+          </el-tab-pane>
+
+          <el-tab-pane name="raw" label="原始 Diff">
+            <el-scrollbar max-height="420px">
+              <pre class="raw-diff"><span
+                v-for="(line, index) in rawDiffLines"
+                :key="index"
+                :class="line.cls"
+              >{{ line.text }}</span></pre>
+            </el-scrollbar>
+          </el-tab-pane>
+        </el-tabs>
+      </template>
+      <el-empty v-else-if="!loading" :description="error || '暂无对比结果'" :image-size="60" />
+    </div>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { tableApi } from '@/api/table'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  tableId: {
+    type: [Number, String],
+    default: null
+  },
+  leftVersionId: {
+    type: [Number, String],
+    default: null
+  },
+  rightVersionId: {
+    type: [Number, String],
+    default: null
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const loading = ref(false)
+const result = ref(null)
+const error = ref('')
+const activeTab = ref('structured')
+
+const rawDiffLines = computed(() => {
+  const raw = result.value?.rawDiff || ''
+  return raw.split('\n').map((text) => {
+    let cls = 'line-context'
+    if (text.startsWith('+')) cls = 'line-added'
+    else if (text.startsWith('-')) cls = 'line-removed'
+    else if (text.startsWith('@@')) cls = 'line-hunk'
+    return { text, cls }
+  })
+})
+
+const displayValue = (value) => (value === null || value === undefined || value === '' ? '（空）' : value)
+
+const loadCompare = async () => {
+  if (!props.tableId || !props.leftVersionId || !props.rightVersionId) return
+  loading.value = true
+  result.value = null
+  error.value = ''
+  activeTab.value = 'structured'
+  try {
+    result.value = await tableApi.compareTableVersions(props.tableId, {
+      leftVersionId: props.leftVersionId,
+      rightVersionId: props.rightVersionId
+    })
+  } catch (e) {
+    error.value = e?.message || '对比失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (visible) => {
+    if (visible) loadCompare()
+  }
+)
+</script>
+
+<style scoped>
+.compare-body {
+  min-height: 200px;
+}
+
+.compare-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.compare-versions {
+  font-weight: 600;
+}
+
+.compare-section-title {
+  font-weight: 600;
+  font-size: 13px;
+  margin: 14px 0 8px;
+}
+
+.compare-section-title:first-child {
+  margin-top: 0;
+}
+
+.tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.modified-column {
+  margin-bottom: 12px;
+}
+
+.modified-column-name {
+  font-family: monospace;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.value-old {
+  color: #c45656;
+  text-decoration: line-through;
+}
+
+.value-new {
+  color: #529b2e;
+}
+
+.raw-diff {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.raw-diff span {
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.line-added {
+  background: #f0f9eb;
+  color: #529b2e;
+}
+
+.line-removed {
+  background: #fef0f0;
+  color: #c45656;
+}
+
+.line-hunk {
+  color: #909399;
+}
+
+.line-context {
+  color: #606266;
+}
+</style>

--- a/frontend/src/views/datastudio/components/TableVersionHistoryPanel.vue
+++ b/frontend/src/views/datastudio/components/TableVersionHistoryPanel.vue
@@ -1,0 +1,262 @@
+<template>
+  <div class="version-panel" v-loading="loading">
+    <div class="version-toolbar">
+      <div class="version-toolbar-left">
+        <el-tag v-if="compareLeft" size="small" closable @close="compareLeft = null">
+          左: v{{ compareLeft.versionNo }}
+        </el-tag>
+        <el-tag v-if="compareRight" size="small" type="warning" closable @close="compareRight = null">
+          右: v{{ compareRight.versionNo }}
+        </el-tag>
+        <span v-if="!compareLeft && !compareRight" class="version-hint">选择两个版本进行对比</span>
+      </div>
+      <div class="version-toolbar-right">
+        <el-button size="small" :disabled="!canCompare" type="primary" @click="compareVisible = true">
+          对比
+        </el-button>
+        <el-button size="small" :disabled="loading" @click="loadVersions">刷新</el-button>
+      </div>
+    </div>
+
+    <template v-if="versions.length">
+      <el-table :data="versions" border size="small" class="version-table">
+        <el-table-column label="版本" width="70">
+          <template #default="{ row }">v{{ row.versionNo }}</template>
+        </el-table-column>
+        <el-table-column prop="changeSummary" label="变更摘要" min-width="200" show-overflow-tooltip />
+        <el-table-column label="来源" width="110">
+          <template #default="{ row }">
+            <el-tag :type="triggerTagType(row.triggerSource)" size="small">
+              {{ triggerLabel(row.triggerSource) }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="createdBy" label="操作人" width="100" show-overflow-tooltip />
+        <el-table-column label="时间" width="160">
+          <template #default="{ row }">{{ formatDateTime(row.createdAt) }}</template>
+        </el-table-column>
+        <el-table-column label="操作" width="190" fixed="right">
+          <template #default="{ row }">
+            <el-button link type="primary" size="small" @click="showSnapshot(row)">快照</el-button>
+            <el-button
+              link
+              size="small"
+              :type="compareLeft?.id === row.id ? 'warning' : 'primary'"
+              @click="selectLeft(row)"
+            >
+              设为左
+            </el-button>
+            <el-button
+              link
+              size="small"
+              :type="compareRight?.id === row.id ? 'warning' : 'primary'"
+              @click="selectRight(row)"
+            >
+              设为右
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-if="total > pageSize"
+        v-model:current-page="pageNum"
+        :page-size="pageSize"
+        :total="total"
+        layout="prev, pager, next, total"
+        small
+        class="version-pagination"
+        @current-change="loadVersions"
+      />
+    </template>
+    <el-empty
+      v-else-if="!loading"
+      description="暂无版本记录（首次元数据变更后开始记录）"
+      :image-size="60"
+    />
+
+    <el-dialog
+      v-model="snapshotVisible"
+      :title="snapshotTitle"
+      width="640px"
+      append-to-body
+      destroy-on-close
+    >
+      <el-scrollbar max-height="480px">
+        <pre class="snapshot-json" v-loading="snapshotLoading">{{ snapshotJson }}</pre>
+      </el-scrollbar>
+    </el-dialog>
+
+    <TableVersionCompareDialog
+      v-model="compareVisible"
+      :table-id="tableId"
+      :left-version-id="compareLeft?.id"
+      :right-version-id="compareRight?.id"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { tableApi } from '@/api/table'
+import TableVersionCompareDialog from './TableVersionCompareDialog.vue'
+
+const props = defineProps({
+  tableId: {
+    type: [Number, String],
+    default: null
+  },
+  active: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const loading = ref(false)
+const versions = ref([])
+const total = ref(0)
+const pageNum = ref(1)
+const pageSize = 20
+const loadedTableId = ref(null)
+
+const compareLeft = ref(null)
+const compareRight = ref(null)
+const compareVisible = ref(false)
+
+const snapshotVisible = ref(false)
+const snapshotLoading = ref(false)
+const snapshotJson = ref('')
+const snapshotTitle = ref('版本快照')
+
+const canCompare = computed(
+  () => compareLeft.value && compareRight.value && compareLeft.value.id !== compareRight.value.id
+)
+
+const TRIGGER_LABELS = {
+  table_create: { label: '建表', type: 'info' },
+  manual_edit: { label: '手动编辑', type: 'primary' },
+  metadata_sync: { label: '元数据同步', type: 'success' },
+  inspection_fix: { label: '巡检修复', type: 'warning' }
+}
+
+const triggerLabel = (source) => TRIGGER_LABELS[source]?.label || source || '未知'
+const triggerTagType = (source) => TRIGGER_LABELS[source]?.type || 'info'
+
+const formatDateTime = (value) => {
+  if (!value) return '-'
+  return String(value).replace('T', ' ').slice(0, 19)
+}
+
+const loadVersions = async () => {
+  if (!props.tableId) return
+  loading.value = true
+  try {
+    const data = await tableApi.listVersions(props.tableId, {
+      pageNum: pageNum.value,
+      pageSize
+    })
+    versions.value = data?.records || []
+    total.value = Number(data?.total || 0)
+    loadedTableId.value = props.tableId
+  } catch (e) {
+    versions.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+const resetState = () => {
+  versions.value = []
+  total.value = 0
+  pageNum.value = 1
+  compareLeft.value = null
+  compareRight.value = null
+  loadedTableId.value = null
+}
+
+const selectLeft = (row) => {
+  compareLeft.value = compareLeft.value?.id === row.id ? null : row
+}
+
+const selectRight = (row) => {
+  compareRight.value = compareRight.value?.id === row.id ? null : row
+}
+
+const showSnapshot = async (row) => {
+  snapshotTitle.value = `版本快照 v${row.versionNo}`
+  snapshotVisible.value = true
+  snapshotLoading.value = true
+  snapshotJson.value = ''
+  try {
+    const detail = await tableApi.getVersion(props.tableId, row.id)
+    const raw = detail?.metadataSnapshot
+    try {
+      snapshotJson.value = JSON.stringify(JSON.parse(raw), null, 2)
+    } catch {
+      snapshotJson.value = raw || '（无快照内容）'
+    }
+  } catch (e) {
+    snapshotJson.value = e?.message || '加载快照失败'
+  } finally {
+    snapshotLoading.value = false
+  }
+}
+
+watch(
+  () => props.tableId,
+  () => {
+    resetState()
+    if (props.active && props.tableId) loadVersions()
+  }
+)
+
+watch(
+  () => props.active,
+  (active) => {
+    if (active && props.tableId && loadedTableId.value !== props.tableId) loadVersions()
+  },
+  { immediate: true }
+)
+</script>
+
+<style scoped>
+.version-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 160px;
+}
+
+.version-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.version-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.version-hint {
+  font-size: 12px;
+  color: #909399;
+}
+
+.version-pagination {
+  justify-content: flex-end;
+}
+
+.snapshot-json {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>


### PR DESCRIPTION
## Summary

Implements comprehensive metadata version history tracking for data tables, enabling users to view and compare historical snapshots of table structure and properties. Versions are captured only when actual metadata changes occur, excluding volatile statistics like row counts and storage sizes.

## Key Changes

### Backend
- **New Service**: `TableMetadataVersionService` provides core versioning logic:
  - `captureVersion()`: Captures table+field metadata snapshots with SHA-256 hashing; compares against latest version to avoid duplicate records; gracefully handles exceptions without propagating to caller
  - `listVersions()`: Paginated version history (excludes large snapshot JSON)
  - `getVersion()`: Retrieves specific version with full snapshot
  - `compare()`: Generates structured and raw diffs between two versions
  
- **New Entity & Mapper**: `DataTableVersion` with `DataTableVersionMapper` for persistence

- **New DTOs**: `TableVersionCompareRequest` and `TableVersionCompareResponse` with nested change structures

- **New Controller**: `DataTableVersionController` exposes REST endpoints for version queries and comparisons

- **Database Schema**: `V45__create_data_table_version.sql` creates append-only version table with `(table_id, version_no)` unique constraint to prevent concurrent duplicate captures

- **Service Integration**: Hooks added to `DataTableService`, `TableCreateService`, `InspectionService`, and `DorisMetadataSyncService` to capture versions on metadata mutations

### Frontend
- **New Components**:
  - `TableVersionHistoryPanel.vue`: Lists versions with pagination, displays change summaries, allows selecting two versions for comparison
  - `TableVersionCompareDialog.vue`: Shows structured diff (table attributes, added/removed/modified columns) and raw unified diff view
  
- **UI Integration**: Added "版本" (Versions) tab to `DataStudioRightPanel.vue`

- **API Client**: Extended `tableApi` with `listVersions()`, `getVersion()`, and `compareTableVersions()` methods

### Testing
- Comprehensive unit tests in `TableMetadataVersionServiceTest` covering:
  - First capture creates v1
  - Identical metadata prevents duplicate versions
  - Volatile statistics (rowCount, storageSize, etc.) don't trigger versions
  - Field/attribute changes create new versions with accurate summaries
  - Field load order doesn't affect hash
  - Deleted/missing tables handled gracefully

## Implementation Details

- **Whitelist Snapshot**: Only structural/descriptive metadata captured (tableName, dbName, tableComment, layer, owner, fields with name/type/comment/nullability/keys). Statistics fields (rowCount, storageSize, syncTime, dorisDdl) explicitly excluded to prevent version noise.

- **Canonical JSON**: Snapshot keys sorted alphabetically before hashing to ensure consistent hashes regardless of serialization order

- **Change Summary**: Auto-generated from diff, truncated to 500 chars, includes counts of modified attributes and field changes (additions/removals/modifications)

- **Exception Handling**: `captureVersion()` catches all exceptions and logs warnings without throwing—critical for sync paths running in large transactions where version capture failure must not rollback business writes

- **Trigger Sources**: Tracked as `table_create`, `manual_edit`, `metadata_sync`, or `inspection_fix` for audit trail

- **Version History**: Append-only, no deletion capability—serves as permanent audit trail

https://claude.ai/code/session_01MKQbZCnXizYLVRMqmgyHdA