### PR TITLE
fix(deploy): ship ontology-modeling-assistant in the offline package

### DIFF
--- a/scripts/create-offline-package.sh
+++ b/scripts/create-offline-package.sh
@@ -151,7 +151,7 @@ fi
 
 if [[ -d "$REPO_ROOT/dataagent/.claude/skills" ]]; then
     log "Copying DataAgent editable skills"
-    tar -C "$REPO_ROOT/dataagent/.claude/skills" --exclude='*-assistant' -cf - . | tar -C "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills" -xf -
+    tar -C "$REPO_ROOT/dataagent/.claude/skills" -cf - . | tar -C "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills" -xf -
 fi
 
 # 离线部署包必须保证 skills 目录树对容器内非 root 用户（uid 1000）可访问：
@@ -159,8 +159,8 @@ fi
 # - 所有文件至少可读（a+r）
 # - odw-cli 需要执行权限
 chmod -R a+rX "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills"
-if [[ -f "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills/dataagent-nl2sql/bin/odw-cli" ]]; then
-    chmod +x "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills/dataagent-nl2sql/bin/odw-cli"
+if [[ -f "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills/opendataworks-platform-tools/bin/odw-cli" ]]; then
+    chmod +x "$PACKAGED_DATAAGENT_RUNTIME_DIR/skills/opendataworks-platform-tools/bin/odw-cli"
     log "Ensured skills directory permissions and odw-cli execute bit for offline package"
 fi
 


### PR DESCRIPTION
## Summary

The offline package script copied DataAgent skills with `--exclude='*-assistant'`, a defensive pattern added before any such folder existed in the repo. After the builtin `ontology-modeling-assistant` skill landed together with the `agent_ontology_modeling` profile migration, offline deployments ended up with the assistant profile registered in the database but without its skill folder under `deploy/dataagent-runtime/skills/`, breaking the ontology modeling assistant at runtime.

## Changes

- Drop the `*-assistant` exclude in `scripts/create-offline-package.sh`: skills checked into the repo are all builtin and should all ship in the offline package; gating what enters the repo is already handled by the `.gitignore` allowlist, so a second pattern-based filter only adds a stale guard branch.
- Point the `odw-cli` execute-bit fixup at the current `opendataworks-platform-tools/bin/odw-cli` path. The old `dataagent-nl2sql/bin/odw-cli` path no longer exists, so that chmod never ran; it was masked by the `start.sh` startup chmod and the `sh odw-cli` runtime fallback.

## Verification

- `bash -n scripts/create-offline-package.sh` passes.
- Simulated the script's skill copy + permission steps into a temp directory: `ontology-modeling-assistant` is now included alongside `opendataworks-business-knowledge` and `opendataworks-platform-tools`, and `odw-cli` ends up with the execute bit set.
- Full offline package build (Docker image export) was not run.

https://claude.ai/code/session_01QBQenZko5i2D6QMGQtmacq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBQenZko5i2D6QMGQtmacq)_