### PR TITLE
Fix widget drag activation to prevent unintended repositioning

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/__tests__/useWidgetGeometry.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/useWidgetGeometry.spec.js
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { reactive, ref } from 'vue'
 
 import {
   clampPosition,
   clampSize,
   geometryStorageKey,
+  launcherStorageKey,
   loadGeometry,
   saveGeometry,
-  clearGeometry
+  clearGeometry,
+  useWidgetGeometry
 } from '../useWidgetGeometry'
 
 describe('clampPosition', () => {
@@ -99,5 +102,82 @@ describe('localStorage persistence', () => {
     saveGeometry('site_1', { left: 1, top: 1, width: 400, height: 500 })
     clearGeometry('site_1')
     expect(loadGeometry('site_1')).toBeNull()
+  })
+})
+
+describe('useWidgetGeometry drag activation', () => {
+  const makeRect = (left, top, width, height) => ({ left, top, width, height })
+
+  const setup = ({ isOpen = false } = {}) => {
+    const rootEl = ref({ getBoundingClientRect: () => makeRect(100, 100, 56, 56) })
+    const panelEl = ref({ getBoundingClientRect: () => makeRect(100, 50, 440, 600) })
+    const config = { displayMode: 'floating', websiteId: 'site_drag' }
+    const state = reactive({ isOpen })
+    return { api: useWidgetGeometry({ rootEl, panelEl, config, state }), state }
+  }
+
+  const pointerDown = (clientX, clientY) => ({
+    clientX,
+    clientY,
+    target: null,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  })
+
+  const fire = (type, clientX = 0, clientY = 0) => {
+    window.dispatchEvent(new MouseEvent(type, { clientX, clientY }))
+  }
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('keeps the launcher anchored on a plain click (pointerdown + pointerup, no move)', () => {
+    const { api } = setup()
+    api.startLauncherDrag(pointerDown(110, 110))
+    expect(api.isDragged.value).toBe(false)
+    expect(api.rootStyle.value).toEqual({})
+    fire('pointerup')
+    expect(api.isDragged.value).toBe(false)
+    expect(api.isLauncherDragMoved()).toBe(false)
+    expect(window.localStorage.getItem(launcherStorageKey('site_drag'))).toBeNull()
+  })
+
+  it('ignores launcher movement below the drag threshold', () => {
+    const { api } = setup()
+    api.startLauncherDrag(pointerDown(110, 110))
+    fire('pointermove', 112, 111)
+    expect(api.isDragged.value).toBe(false)
+    expect(api.rootStyle.value).toEqual({})
+    fire('pointerup')
+  })
+
+  it('marks the launcher dragged with coordinates once the threshold is crossed', () => {
+    const { api } = setup()
+    api.startLauncherDrag(pointerDown(110, 110))
+    fire('pointermove', 150, 140)
+    expect(api.isDragged.value).toBe(true)
+    expect(api.rootStyle.value).toEqual({ left: '140px', top: '130px' })
+    fire('pointerup')
+    expect(api.isLauncherDragMoved()).toBe(true)
+    expect(JSON.parse(window.localStorage.getItem(launcherStorageKey('site_drag')))).toEqual({ left: 140, top: 130 })
+  })
+
+  it('keeps the panel anchored on a plain header click', () => {
+    const { api } = setup({ isOpen: true })
+    api.startDrag(pointerDown(120, 60))
+    expect(api.isDragged.value).toBe(false)
+    expect(api.rootStyle.value).toEqual({})
+    fire('pointerup')
+    expect(api.isDragged.value).toBe(false)
+  })
+
+  it('marks the panel dragged with coordinates once it moves', () => {
+    const { api } = setup({ isOpen: true })
+    api.startDrag(pointerDown(120, 60))
+    fire('pointermove', 160, 90)
+    expect(api.isDragged.value).toBe(true)
+    expect(api.rootStyle.value).toEqual({ left: '140px', top: '80px' })
+    fire('pointerup')
   })
 })

--- a/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
+++ b/dataagent/dataagent-frontend/src/widget/useWidgetGeometry.js
@@ -152,6 +152,7 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     )
     geom.left = next.left
     geom.top = next.top
+    geom.dragged = true
   }
 
   const endDrag = () => {
@@ -168,7 +169,9 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     const rect = panelEl.value?.getBoundingClientRect?.()
     if (!rect) return
     dragStart = { x: event.clientX, y: event.clientY, left: rect.left, top: rect.top, width: rect.width, height: rect.height }
-    geom.dragged = true
+    // `dragged` flips the CSS anchor (bottom/right -> left/top); it must only be
+    // set together with real left/top values in the move handlers, otherwise a
+    // plain pointerdown makes the widget jump before any coordinates exist.
     geom.interacting = true
     window.addEventListener('pointermove', onDragMove)
     window.addEventListener('pointerup', endDrag)
@@ -185,6 +188,7 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     const dy = event.clientY - launcherDragStart.y
     if (!launcherDragMoved && Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return
     launcherDragMoved = true
+    launcherGeom.dragged = true
     const { vw, vh } = viewport()
     const nextLeft = Math.min(Math.max(0, launcherDragStart.left + dx), vw - LAUNCHER_SIZE)
     const nextTop = Math.min(Math.max(0, launcherDragStart.top + dy), vh - LAUNCHER_SIZE)
@@ -209,7 +213,8 @@ export function useWidgetGeometry({ rootEl, panelEl, config, state }) {
     const rect = el.getBoundingClientRect()
     launcherDragStart = { x: event.clientX, y: event.clientY, left: rect.left, top: rect.top }
     launcherDragMoved = false
-    launcherGeom.dragged = true
+    // Same constraint as panel drag: `dragged` only flips once the move handler
+    // has populated left/top, so a plain click never unanchors the launcher.
     launcherGeom.interacting = true
     window.addEventListener('pointermove', onLauncherDragMove)
     window.addEventListener('pointerup', endLauncherDrag)


### PR DESCRIPTION
## Summary
Fixed a bug where the widget launcher and panel would unintentionally reposition themselves on a simple pointer down event, before any actual dragging occurred. The `dragged` flag is now only set once movement exceeds the drag threshold or occurs, preventing the CSS anchor from flipping prematurely.

## Key Changes
- **Panel drag**: Moved `geom.dragged = true` from `startDrag()` to `onDragMove()` so the flag is only set when actual movement occurs
- **Launcher drag**: Moved `launcherGeom.dragged = true` from `startLauncherDrag()` to `onLauncherDragMove()` and only after the drag threshold is crossed
- **Test coverage**: Added comprehensive test suite for drag activation behavior, including:
  - Plain clicks that should not trigger repositioning
  - Movement below the drag threshold that should be ignored
  - Threshold crossing that should activate dragging and persist position to localStorage

## Implementation Details
The `dragged` flag controls CSS anchoring (switching from `bottom/right` to `left/top`). Setting it prematurely on pointer down caused the widget to jump to position `(0, 0)` before any coordinates were available. Now it's only set when:
- For the launcher: movement exceeds `DRAG_THRESHOLD` pixels
- For the panel: any movement occurs after pointer down

This ensures a plain click (pointer down + up with no movement) keeps the widget anchored in its original position.

https://claude.ai/code/session_012G9oYgb3JCe2uErQtumhYu