### PR TITLE
Improve visibility of result grid scrollbars

### DIFF
--- a/frontend/src/views/datastudio/components/DataStudioResultGrid.vue
+++ b/frontend/src/views/datastudio/components/DataStudioResultGrid.vue
@@ -15,6 +15,7 @@
           :header-height="HEADER_HEIGHT"
           :row-key="RESULT_GRID_ROW_KEY"
           :scrollbar-always-on="true"
+          :fixed="true"
           class="result-grid__table"
         />
       </template>
@@ -180,6 +181,21 @@ defineExpose({
 .result-grid :deep(.result-grid__resizer:active) {
   background: var(--el-color-primary, #409eff);
   opacity: 0.5;
+}
+
+/* el-table-v2 draws its own thin overlay scrollbars; make them easier to
+   notice and grab, especially the horizontal one under wide result sets. */
+.result-grid :deep(.el-vl__horizontal) {
+  height: 10px !important;
+  bottom: 0 !important;
+}
+
+.result-grid :deep(.el-virtual-scrollbar .el-scrollbar__thumb) {
+  opacity: 0.45;
+}
+
+.result-grid :deep(.el-virtual-scrollbar .el-scrollbar__thumb:hover) {
+  opacity: 0.75;
 }
 
 .result-grid :deep(.result-grid__cell-text) {


### PR DESCRIPTION
## Summary
Enhanced the scrollbar styling in the DataStudioResultGrid component to make scrollbars more visible and easier to interact with, particularly for wide result sets.

## Changes
- Enabled fixed layout mode on the el-table-v2 component
- Increased horizontal scrollbar height from default to 10px for better visibility
- Added opacity styling to scrollbar thumbs (0.45 default, 0.75 on hover) to make them more noticeable
- Positioned horizontal scrollbar at the bottom of the viewport

## Implementation Details
The changes use Vue's `:deep()` selector to style the virtual scrollbar components provided by el-table-v2. The increased height and opacity adjustments make the scrollbars more discoverable without being intrusive, while the hover state provides visual feedback for interactivity.

https://claude.ai/code/session_01NhsR8hx5YxYBYeA1grxiok