### PR TITLE
feat(dataagent): pre-install pytest for skill validation

### DIFF
--- a/dataagent/.claude/skills/ontology-modeling-assistant/reference/ontology-build-workflow.md
+++ b/dataagent/.claude/skills/ontology-modeling-assistant/reference/ontology-build-workflow.md
@@ -67,6 +67,7 @@
 - 每次修改 Pydantic 模型后运行 `validate_ontology.py --schema > assets/ontology.schema.json`，并确认 schema 文件同步。
 - 每次修改 `scripts/ontology_schema.py` 中的 `FIELD_DICTIONARY` 后运行 `validate_ontology.py --schema > assets/ontology.schema.json`，确认 schema 的 `x-field-dictionary` 同步。
 - 新增枚举值时先更新 `scripts/ontology_schema.py` 中的字段字典，再更新本体 JSON。
+- 交付领域 skill 前运行 `python -m pytest <skill>/tests -q`。DataAgent 后端和 sandbox runner 镜像预装 `pytest`，可直接用于生成后验证。
 - 再写 eval prompts：覆盖术语解释、关系查询、真实问数语义交接。
 - 每轮迭代后对照典型问题清单做反向验收，不能表达的问题登记 TODO。
 - 对照用户反馈迭代 `description`、本体索引和输出示例。

--- a/dataagent/dataagent-backend/requirements.txt
+++ b/dataagent/dataagent-backend/requirements.txt
@@ -16,3 +16,4 @@ redis>=5.2.0
 croniter>=2.0.5
 pandas>=2.1.0
 openpyxl>=3.1.0
+pytest>=8.0.0

--- a/dataagent/dataagent-backend/tests/test_dataagent_requirements.py
+++ b/dataagent/dataagent-backend/tests/test_dataagent_requirements.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+
+def test_dataagent_runtime_preinstalls_pytest_for_skill_validation():
+    requirements = REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+
+    assert any(line.strip().startswith("pytest") for line in requirements)


### PR DESCRIPTION
Pre-install pytest in requirements.txt and update ontology build workflow to validate skills using pytest. Added unit test to verify pytest requirement.