### PR TITLE
Merge data development assistant into platform assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ dolphinscheduler-service/*.egg-info/
 !/dataagent/.claude/skills/opendataworks-platform-tools/**
 !/dataagent/.claude/skills/ontology-modeling-assistant/
 !/dataagent/.claude/skills/ontology-modeling-assistant/**
+!/dataagent/.claude/skills/opendataworks-data-dev/
+!/dataagent/.claude/skills/opendataworks-data-dev/**
 *.swp
 *.swo
 *~

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentSqlController.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentSqlController.java
@@ -1,0 +1,23 @@
+package com.onedata.portal.agentapi.controller;
+
+import com.onedata.portal.agentapi.dto.AgentSqlAnalyzeRequest;
+import com.onedata.portal.agentapi.service.AgentSqlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai/sql")
+public class AgentSqlController {
+
+    private final AgentSqlService agentSqlService;
+
+    @PostMapping("/analyze")
+    public Object analyze(@Validated @RequestBody AgentSqlAnalyzeRequest request) {
+        return agentSqlService.analyze(request);
+    }
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentTaskController.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentTaskController.java
@@ -1,0 +1,51 @@
+package com.onedata.portal.agentapi.controller;
+
+import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
+import com.onedata.portal.agentapi.service.AgentTaskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai/task")
+public class AgentTaskController {
+
+    private final AgentTaskService agentTaskService;
+
+    @PostMapping
+    public Object create(
+            @Validated @RequestBody AgentTaskUpsertRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentTaskService.createTask(request, operator);
+    }
+
+    @PutMapping("/{id}")
+    public Object update(
+            @PathVariable("id") Long id,
+            @Validated @RequestBody AgentTaskUpsertRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentTaskService.updateTask(id, request, operator);
+    }
+
+    @GetMapping("/{id}")
+    public Object get(@PathVariable("id") Long id) {
+        return agentTaskService.getTask(id);
+    }
+
+    @GetMapping("/list")
+    public Object list(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "50") int limit) {
+        return agentTaskService.listTasks(keyword, status, limit);
+    }
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentWorkflowController.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentWorkflowController.java
@@ -1,0 +1,91 @@
+package com.onedata.portal.agentapi.controller;
+
+import com.onedata.portal.agentapi.dto.AgentPublishPreviewResponse;
+import com.onedata.portal.agentapi.dto.AgentPublishRequest;
+import com.onedata.portal.agentapi.dto.AgentScheduleOnlineRequest;
+import com.onedata.portal.agentapi.dto.AgentScheduleUpsertRequest;
+import com.onedata.portal.agentapi.dto.AgentWorkflowUpsertRequest;
+import com.onedata.portal.agentapi.service.AgentWorkflowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai/workflow")
+public class AgentWorkflowController {
+
+    private final AgentWorkflowService agentWorkflowService;
+
+    @PostMapping
+    public Object create(
+            @Validated @RequestBody AgentWorkflowUpsertRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.createWorkflow(request, operator);
+    }
+
+    @PutMapping("/{id}")
+    public Object update(
+            @PathVariable("id") Long id,
+            @Validated @RequestBody AgentWorkflowUpsertRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.updateWorkflow(id, request, operator);
+    }
+
+    @GetMapping("/{id}")
+    public Object get(@PathVariable("id") Long id) {
+        return agentWorkflowService.getWorkflow(id);
+    }
+
+    @GetMapping("/list")
+    public Object list(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "50") int limit) {
+        return agentWorkflowService.listWorkflows(keyword, status, limit);
+    }
+
+    @GetMapping("/{id}/publish/preview")
+    public AgentPublishPreviewResponse previewPublish(@PathVariable("id") Long id) {
+        return agentWorkflowService.previewPublish(id);
+    }
+
+    @PostMapping("/{id}/publish")
+    public Object publish(
+            @PathVariable("id") Long id,
+            @Validated @RequestBody AgentPublishRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.publish(id, request, operator);
+    }
+
+    @PutMapping("/{id}/schedule")
+    public Object upsertSchedule(
+            @PathVariable("id") Long id,
+            @Validated @RequestBody AgentScheduleUpsertRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.upsertSchedule(id, request, operator);
+    }
+
+    @PostMapping("/{id}/schedule/online")
+    public Object scheduleOnline(
+            @PathVariable("id") Long id,
+            @Validated @RequestBody AgentScheduleOnlineRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.scheduleOnline(id, request.getPreviewToken(), operator);
+    }
+
+    @PostMapping("/{id}/schedule/offline")
+    public Object scheduleOffline(
+            @PathVariable("id") Long id,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentWorkflowService.scheduleOffline(id, operator);
+    }
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentPublishPreviewResponse.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentPublishPreviewResponse.java
@@ -1,0 +1,21 @@
+package com.onedata.portal.agentapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * Wraps the platform publish-preview result and adds a one-time {@code previewToken}
+ * that must be passed back to deploy/online (API-layer "preview first" guard).
+ */
+@Data
+public class AgentPublishPreviewResponse {
+
+    /** The platform WorkflowPublishPreviewResponse, serialized as-is. */
+    private Object preview;
+
+    @JsonProperty("preview_token")
+    private String previewToken;
+
+    @JsonProperty("can_publish")
+    private boolean canPublish;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentPublishRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentPublishRequest.java
@@ -1,0 +1,19 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Agent-facing workflow publish request. {@code operation} is deploy/online/offline.
+ * {@code previewToken} is the one-time token returned by the publish preview and is
+ * required for deploy/online so a publish can never run without a fresh preview.
+ */
+@Data
+public class AgentPublishRequest {
+
+    @NotBlank(message = "operation 不能为空")
+    private String operation;
+
+    private String previewToken;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentScheduleOnlineRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentScheduleOnlineRequest.java
@@ -1,0 +1,15 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Bringing a schedule online is high-risk and requires a preview token, like publish.
+ */
+@Data
+public class AgentScheduleOnlineRequest {
+
+    @NotBlank(message = "previewToken 不能为空")
+    private String previewToken;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentScheduleUpsertRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentScheduleUpsertRequest.java
@@ -1,0 +1,17 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+/**
+ * Agent-facing schedule upsert payload. {@code schedule} mirrors the platform
+ * WorkflowScheduleRequest fields (scheduleCron, scheduleTimezone, ...).
+ */
+@Data
+public class AgentScheduleUpsertRequest {
+
+    @NotNull(message = "schedule 不能为空")
+    private Map<String, Object> schedule;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentSqlAnalyzeRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentSqlAnalyzeRequest.java
@@ -1,0 +1,20 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * Agent-facing SQL analysis request: input/output tables, operation type, and
+ * risk warnings (used for SQL polish and lineage suggestion).
+ */
+@Data
+public class AgentSqlAnalyzeRequest {
+
+    @NotBlank(message = "sql 不能为空")
+    private String sql;
+
+    private String database;
+
+    private Long clusterId;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentTaskUpsertRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentTaskUpsertRequest.java
@@ -1,0 +1,24 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Agent-facing task create/update payload. {@code task} mirrors the platform
+ * DataTask fields (taskName, dolphinNodeType, taskSql, datasourceName, ...) and
+ * is mapped to the entity by the backend implementation; lineage ids keep the
+ * impact graph correct.
+ */
+@Data
+public class AgentTaskUpsertRequest {
+
+    @NotNull(message = "task 不能为空")
+    private Map<String, Object> task;
+
+    private List<Long> inputTableIds;
+
+    private List<Long> outputTableIds;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentWorkflowUpsertRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentWorkflowUpsertRequest.java
@@ -1,0 +1,18 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+/**
+ * Agent-facing workflow create/update payload. {@code workflow} mirrors the
+ * platform WorkflowDefinitionRequest (workflowName, tasks, edges, globalParams,
+ * ...) and is mapped by the backend implementation.
+ */
+@Data
+public class AgentWorkflowUpsertRequest {
+
+    @NotNull(message = "workflow 不能为空")
+    private Map<String, Object> workflow;
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentSqlService.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentSqlService.java
@@ -1,0 +1,12 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.dto.AgentSqlAnalyzeRequest;
+
+/**
+ * Agent-facing SQL analysis API. Implemented in the backend module by delegating
+ * to DataQueryService.analyzeQuery.
+ */
+public interface AgentSqlService {
+
+    Object analyze(AgentSqlAnalyzeRequest request);
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentTaskService.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentTaskService.java
@@ -1,0 +1,20 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
+
+/**
+ * Agent-facing data task write API. Implemented in the backend module by
+ * delegating to the existing DataTaskService; agent-api stays free of business
+ * logic. {@code operator} is the audit identity carried by the X-Agent-Operator
+ * header.
+ */
+public interface AgentTaskService {
+
+    Object createTask(AgentTaskUpsertRequest request, String operator);
+
+    Object updateTask(Long taskId, AgentTaskUpsertRequest request, String operator);
+
+    Object getTask(Long taskId);
+
+    Object listTasks(String keyword, String status, int limit);
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentWorkflowService.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentWorkflowService.java
@@ -1,0 +1,33 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.dto.AgentPublishPreviewResponse;
+import com.onedata.portal.agentapi.dto.AgentPublishRequest;
+import com.onedata.portal.agentapi.dto.AgentScheduleUpsertRequest;
+import com.onedata.portal.agentapi.dto.AgentWorkflowUpsertRequest;
+
+/**
+ * Agent-facing workflow write API. Implemented in the backend module by
+ * delegating to WorkflowService / WorkflowPublishService / WorkflowScheduleService.
+ * Deploy/online and schedule-online require a valid preview token (API-layer
+ * "preview first" guard).
+ */
+public interface AgentWorkflowService {
+
+    Object createWorkflow(AgentWorkflowUpsertRequest request, String operator);
+
+    Object updateWorkflow(Long workflowId, AgentWorkflowUpsertRequest request, String operator);
+
+    Object getWorkflow(Long workflowId);
+
+    Object listWorkflows(String keyword, String status, int limit);
+
+    AgentPublishPreviewResponse previewPublish(Long workflowId);
+
+    Object publish(Long workflowId, AgentPublishRequest request, String operator);
+
+    Object upsertSchedule(Long workflowId, AgentScheduleUpsertRequest request, String operator);
+
+    Object scheduleOnline(Long workflowId, String previewToken, String operator);
+
+    Object scheduleOffline(Long workflowId, String operator);
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/AgentPreviewTokenSupport.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/AgentPreviewTokenSupport.java
@@ -1,0 +1,106 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.config.AgentApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Base64;
+
+/**
+ * Issues and verifies one-time publish preview tokens.
+ *
+ * <p>The token binds a publish to a specific workflow version that was just
+ * previewed, so deploy/online cannot run without a fresh preview (API-layer
+ * "preview first" guard) — independent of the agent-side permission mode. The
+ * token is an HMAC over {@code workflowId:versionId:expiry} keyed by the agent
+ * service token, so it is stateless and survives across the request pair.
+ */
+@Component
+@RequiredArgsConstructor
+public class AgentPreviewTokenSupport {
+
+    private static final Base64.Encoder B64 = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder B64D = Base64.getUrlDecoder();
+    private static final String FALLBACK_SECRET = "odw-agent-preview-token-secret";
+
+    private final AgentApiProperties agentApiProperties;
+
+    @Value("${agent.api.preview-token-ttl-seconds:600}")
+    private long ttlSeconds = 600;
+
+    /** Issue a token for the workflow's current version. */
+    public String issue(long workflowId, Long versionId) {
+        long expiry = Instant.now().getEpochSecond() + Math.max(60, ttlSeconds);
+        String payload = workflowId + ":" + (versionId == null ? "" : versionId) + ":" + expiry;
+        String encodedPayload = B64.encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        String sig = B64.encodeToString(hmac(payload));
+        return encodedPayload + "." + sig;
+    }
+
+    /**
+     * Verify a token against the workflow's current state. Throws if the token is
+     * malformed, tampered, expired, for a different workflow, or for a version
+     * that no longer matches the current one (i.e. the workflow changed since the
+     * preview).
+     */
+    public void verify(long workflowId, Long currentVersionId, String token) {
+        if (!StringUtils.hasText(token) || !token.contains(".")) {
+            throw new IllegalArgumentException("发布预览凭证缺失或无效，请先调用发布预览");
+        }
+        String[] parts = token.split("\\.", 2);
+        String payload;
+        try {
+            payload = new String(B64D.decode(parts[0]), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("发布预览凭证无效");
+        }
+        String expectedSig = B64.encodeToString(hmac(payload));
+        if (!MessageDigest.isEqual(expectedSig.getBytes(StandardCharsets.UTF_8),
+                parts[1].getBytes(StandardCharsets.UTF_8))) {
+            throw new IllegalArgumentException("发布预览凭证签名校验失败");
+        }
+        String[] fields = payload.split(":", -1);
+        if (fields.length != 3) {
+            throw new IllegalArgumentException("发布预览凭证格式错误");
+        }
+        long tokenWorkflowId;
+        long expiry;
+        try {
+            tokenWorkflowId = Long.parseLong(fields[0]);
+            expiry = Long.parseLong(fields[2]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("发布预览凭证格式错误");
+        }
+        if (tokenWorkflowId != workflowId) {
+            throw new IllegalArgumentException("发布预览凭证与目标工作流不匹配");
+        }
+        if (Instant.now().getEpochSecond() > expiry) {
+            throw new IllegalArgumentException("发布预览凭证已过期，请重新预览");
+        }
+        String tokenVersion = fields[1];
+        String currentVersion = currentVersionId == null ? "" : String.valueOf(currentVersionId);
+        if (!tokenVersion.equals(currentVersion)) {
+            throw new IllegalStateException("工作流自预览后已变更，请重新预览再发布");
+        }
+    }
+
+    private byte[] hmac(String payload) {
+        String secret = StringUtils.hasText(agentApiProperties.getServiceToken())
+                ? agentApiProperties.getServiceToken()
+                : FALLBACK_SECRET;
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("无法生成发布预览凭证", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentSqlService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentSqlService.java
@@ -1,0 +1,33 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.dto.AgentSqlAnalyzeRequest;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
+import com.onedata.portal.dto.SqlAnalyzeRequest;
+import com.onedata.portal.service.DataQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Agent-facing SQL analysis, delegating to {@link DataQueryService#analyzeQuery}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BackendAgentSqlService implements AgentSqlService {
+
+    private final DataQueryService dataQueryService;
+
+    @Override
+    public Object analyze(AgentSqlAnalyzeRequest request) {
+        if (StringUtils.hasText(request.getDatabase())) {
+            AgentDataScopeContext.requireDatabaseNameAllowed(request.getDatabase());
+        }
+        SqlAnalyzeRequest delegate = new SqlAnalyzeRequest();
+        delegate.setSql(request.getSql());
+        delegate.setDatabase(request.getDatabase());
+        delegate.setClusterId(request.getClusterId());
+        return dataQueryService.analyzeQuery(delegate);
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
@@ -1,0 +1,74 @@
+package com.onedata.portal.agentapi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.service.DataTaskService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Agent-facing task write API, delegating to {@link DataTaskService}. Tasks are
+ * created as drafts; the X-Agent-Operator identity is recorded as the owner.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BackendAgentTaskService implements AgentTaskService {
+
+    private static final int MAX_LIMIT = 200;
+
+    private final DataTaskService dataTaskService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Object createTask(AgentTaskUpsertRequest request, String operator) {
+        DataTask task = toTask(request);
+        applyAuditDefaults(task, operator, true);
+        return dataTaskService.create(task, nullSafe(request.getInputTableIds()), nullSafe(request.getOutputTableIds()));
+    }
+
+    @Override
+    public Object updateTask(Long taskId, AgentTaskUpsertRequest request, String operator) {
+        DataTask task = toTask(request);
+        task.setId(taskId);
+        applyAuditDefaults(task, operator, false);
+        return dataTaskService.update(task, nullSafe(request.getInputTableIds()), nullSafe(request.getOutputTableIds()));
+    }
+
+    @Override
+    public Object getTask(Long taskId) {
+        return dataTaskService.getById(taskId);
+    }
+
+    @Override
+    public Object listTasks(String keyword, String status, int limit) {
+        int pageSize = limit <= 0 ? 50 : Math.min(limit, MAX_LIMIT);
+        return dataTaskService.list(1, pageSize, null, null,
+                StringUtils.hasText(status) ? status : null,
+                StringUtils.hasText(keyword) ? keyword : null,
+                null, null, null);
+    }
+
+    private DataTask toTask(AgentTaskUpsertRequest request) {
+        return objectMapper.convertValue(request.getTask(), DataTask.class);
+    }
+
+    private void applyAuditDefaults(DataTask task, String operator, boolean creating) {
+        if (StringUtils.hasText(operator)) {
+            task.setOwner(operator);
+        }
+        if (creating && !StringUtils.hasText(task.getStatus())) {
+            task.setStatus("draft");
+        }
+    }
+
+    private List<Long> nullSafe(List<Long> ids) {
+        return ids == null ? Collections.emptyList() : ids;
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
@@ -1,0 +1,144 @@
+package com.onedata.portal.agentapi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentPublishPreviewResponse;
+import com.onedata.portal.agentapi.dto.AgentPublishRequest;
+import com.onedata.portal.agentapi.dto.AgentScheduleUpsertRequest;
+import com.onedata.portal.agentapi.dto.AgentWorkflowUpsertRequest;
+import com.onedata.portal.dto.workflow.WorkflowDefinitionRequest;
+import com.onedata.portal.dto.workflow.WorkflowDetailResponse;
+import com.onedata.portal.dto.workflow.WorkflowPublishRequest;
+import com.onedata.portal.dto.workflow.WorkflowQueryRequest;
+import com.onedata.portal.dto.workflow.WorkflowScheduleRequest;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.service.WorkflowPublishService;
+import com.onedata.portal.service.WorkflowScheduleService;
+import com.onedata.portal.service.WorkflowService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+/**
+ * Agent-facing workflow write API, delegating to the existing workflow services.
+ * Deploy/online and schedule-online require a valid preview token bound to the
+ * workflow's current version, so a publish can never run without a fresh preview.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BackendAgentWorkflowService implements AgentWorkflowService {
+
+    private static final int MAX_LIMIT = 200;
+
+    private final WorkflowService workflowService;
+    private final WorkflowPublishService workflowPublishService;
+    private final WorkflowScheduleService workflowScheduleService;
+    private final AgentPreviewTokenSupport previewTokenSupport;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Object createWorkflow(AgentWorkflowUpsertRequest request, String operator) {
+        WorkflowDefinitionRequest definition = toDefinition(request, operator);
+        return workflowService.createWorkflow(definition);
+    }
+
+    @Override
+    public Object updateWorkflow(Long workflowId, AgentWorkflowUpsertRequest request, String operator) {
+        WorkflowDefinitionRequest definition = toDefinition(request, operator);
+        return workflowService.updateWorkflow(workflowId, definition);
+    }
+
+    @Override
+    public Object getWorkflow(Long workflowId) {
+        return workflowService.getDetail(workflowId);
+    }
+
+    @Override
+    public Object listWorkflows(String keyword, String status, int limit) {
+        WorkflowQueryRequest query = new WorkflowQueryRequest();
+        query.setPageNum(1);
+        query.setPageSize(limit <= 0 ? 50 : Math.min(limit, MAX_LIMIT));
+        if (StringUtils.hasText(keyword)) {
+            query.setKeyword(keyword);
+        }
+        if (StringUtils.hasText(status)) {
+            query.setStatus(status);
+        }
+        return workflowService.list(query);
+    }
+
+    @Override
+    public AgentPublishPreviewResponse previewPublish(Long workflowId) {
+        Object preview = workflowPublishService.previewPublish(workflowId);
+        AgentPublishPreviewResponse response = new AgentPublishPreviewResponse();
+        response.setPreview(preview);
+        response.setPreviewToken(previewTokenSupport.issue(workflowId, currentVersionId(workflowId)));
+        response.setCanPublish(readCanPublish(preview));
+        return response;
+    }
+
+    @Override
+    public Object publish(Long workflowId, AgentPublishRequest request, String operator) {
+        String operation = normalize(request.getOperation());
+        if (requiresPreviewToken(operation)) {
+            previewTokenSupport.verify(workflowId, currentVersionId(workflowId), request.getPreviewToken());
+        }
+        WorkflowPublishRequest publishRequest = new WorkflowPublishRequest();
+        publishRequest.setOperation(operation);
+        publishRequest.setOperator(operator);
+        publishRequest.setConfirmDiff(Boolean.TRUE);
+        return workflowPublishService.publish(workflowId, publishRequest);
+    }
+
+    @Override
+    public Object upsertSchedule(Long workflowId, AgentScheduleUpsertRequest request, String operator) {
+        WorkflowScheduleRequest scheduleRequest =
+                objectMapper.convertValue(request.getSchedule(), WorkflowScheduleRequest.class);
+        return workflowScheduleService.upsertSchedule(workflowId, scheduleRequest);
+    }
+
+    @Override
+    public Object scheduleOnline(Long workflowId, String previewToken, String operator) {
+        previewTokenSupport.verify(workflowId, currentVersionId(workflowId), previewToken);
+        return workflowScheduleService.onlineSchedule(workflowId);
+    }
+
+    @Override
+    public Object scheduleOffline(Long workflowId, String operator) {
+        return workflowScheduleService.offlineSchedule(workflowId);
+    }
+
+    private WorkflowDefinitionRequest toDefinition(AgentWorkflowUpsertRequest request, String operator) {
+        WorkflowDefinitionRequest definition =
+                objectMapper.convertValue(request.getWorkflow(), WorkflowDefinitionRequest.class);
+        if (StringUtils.hasText(operator)) {
+            definition.setOperator(operator);
+        }
+        return definition;
+    }
+
+    private Long currentVersionId(Long workflowId) {
+        WorkflowDetailResponse detail = workflowService.getDetail(workflowId);
+        DataWorkflow workflow = detail == null ? null : detail.getWorkflow();
+        return workflow == null ? null : workflow.getCurrentVersionId();
+    }
+
+    private boolean requiresPreviewToken(String operation) {
+        return "deploy".equals(operation) || "online".equals(operation);
+    }
+
+    private boolean readCanPublish(Object preview) {
+        try {
+            return Boolean.TRUE.equals(objectMapper.convertValue(preview, java.util.Map.class).get("canPublish"));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String normalize(String operation) {
+        return operation == null ? "" : operation.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/agentapi/AgentPreviewTokenSupportTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/AgentPreviewTokenSupportTest.java
@@ -1,0 +1,69 @@
+package com.onedata.portal.agentapi;
+
+import com.onedata.portal.agentapi.config.AgentApiProperties;
+import com.onedata.portal.agentapi.service.AgentPreviewTokenSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AgentPreviewTokenSupportTest {
+
+    private AgentPreviewTokenSupport support;
+
+    @BeforeEach
+    void setUp() {
+        AgentApiProperties props = new AgentApiProperties();
+        props.setServiceToken("unit-secret");
+        support = new AgentPreviewTokenSupport(props);
+        ReflectionTestUtils.setField(support, "ttlSeconds", 600L);
+    }
+
+    @Test
+    void issuedTokenVerifiesForSameWorkflowAndVersion() {
+        String token = support.issue(12L, 5L);
+        assertDoesNotThrow(() -> support.verify(12L, 5L, token));
+    }
+
+    @Test
+    void verifyRejectsMissingOrMalformedToken() {
+        assertThrows(IllegalArgumentException.class, () -> support.verify(12L, 5L, null));
+        assertThrows(IllegalArgumentException.class, () -> support.verify(12L, 5L, "not-a-token"));
+    }
+
+    @Test
+    void verifyRejectsTamperedSignature() {
+        String token = support.issue(12L, 5L);
+        String tampered = token.substring(0, token.indexOf('.') + 1) + "AAAA";
+        assertThrows(IllegalArgumentException.class, () -> support.verify(12L, 5L, tampered));
+    }
+
+    @Test
+    void verifyRejectsDifferentWorkflow() {
+        String token = support.issue(12L, 5L);
+        assertThrows(IllegalArgumentException.class, () -> support.verify(99L, 5L, token));
+    }
+
+    @Test
+    void verifyRejectsChangedVersion() {
+        // Workflow changed since preview -> version drift -> reject (must re-preview).
+        String token = support.issue(12L, 5L);
+        assertThrows(IllegalStateException.class, () -> support.verify(12L, 6L, token));
+    }
+
+    // Note: issue() floors the TTL at 60s, so an expired token cannot be minted
+    // via issue() in a unit test; the expiry check (now > expiry) is covered by
+    // the integration/smoke path.
+
+    @Test
+    void tokenFromDifferentSecretIsRejected() {
+        String token = support.issue(12L, 5L);
+        AgentApiProperties other = new AgentApiProperties();
+        other.setServiceToken("different-secret");
+        AgentPreviewTokenSupport otherSupport = new AgentPreviewTokenSupport(other);
+        ReflectionTestUtils.setField(otherSupport, "ttlSeconds", 600L);
+        assertThrows(IllegalArgumentException.class, () -> otherSupport.verify(12L, 5L, token));
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentWorkflowServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentWorkflowServiceTest.java
@@ -1,0 +1,91 @@
+package com.onedata.portal.agentapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentPublishRequest;
+import com.onedata.portal.agentapi.service.AgentPreviewTokenSupport;
+import com.onedata.portal.agentapi.service.BackendAgentWorkflowService;
+import com.onedata.portal.dto.workflow.WorkflowDetailResponse;
+import com.onedata.portal.dto.workflow.WorkflowPublishRequest;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.service.WorkflowPublishService;
+import com.onedata.portal.service.WorkflowScheduleService;
+import com.onedata.portal.service.WorkflowService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BackendAgentWorkflowServiceTest {
+
+    @Mock
+    private WorkflowService workflowService;
+    @Mock
+    private WorkflowPublishService workflowPublishService;
+    @Mock
+    private WorkflowScheduleService workflowScheduleService;
+    @Mock
+    private AgentPreviewTokenSupport previewTokenSupport;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private BackendAgentWorkflowService service() {
+        return new BackendAgentWorkflowService(
+                workflowService, workflowPublishService, workflowScheduleService,
+                previewTokenSupport, objectMapper);
+    }
+
+    private void stubCurrentVersion(long workflowId, Long versionId) {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setCurrentVersionId(versionId);
+        when(workflowService.getDetail(workflowId))
+                .thenReturn(WorkflowDetailResponse.builder().workflow(workflow).build());
+    }
+
+    @Test
+    void deployVerifiesPreviewTokenBeforePublishing() {
+        BackendAgentWorkflowService svc = service();
+        stubCurrentVersion(12L, 5L);
+        AgentPublishRequest req = new AgentPublishRequest();
+        req.setOperation("deploy");
+        req.setPreviewToken("tok");
+
+        svc.publish(12L, req, "agent:topic-1");
+
+        verify(previewTokenSupport).verify(eq(12L), eq(5L), eq("tok"));
+        verify(workflowPublishService).publish(eq(12L), any(WorkflowPublishRequest.class));
+    }
+
+    @Test
+    void deployWithInvalidTokenDoesNotPublish() {
+        BackendAgentWorkflowService svc = service();
+        stubCurrentVersion(12L, 5L);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("bad token"))
+                .when(previewTokenSupport).verify(eq(12L), eq(5L), any());
+        AgentPublishRequest req = new AgentPublishRequest();
+        req.setOperation("online");
+        req.setPreviewToken("bad");
+
+        assertThrows(IllegalArgumentException.class, () -> svc.publish(12L, req, "agent:t"));
+        verify(workflowPublishService, never()).publish(any(), any());
+    }
+
+    @Test
+    void offlineDoesNotRequirePreviewToken() {
+        BackendAgentWorkflowService svc = service();
+        AgentPublishRequest req = new AgentPublishRequest();
+        req.setOperation("offline");
+
+        svc.publish(12L, req, "agent:t");
+
+        verify(previewTokenSupport, never()).verify(any(Long.class), any(), any());
+        verify(workflowPublishService).publish(eq(12L), any(WorkflowPublishRequest.class));
+    }
+}

--- a/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: opendataworks-data-dev
+description: "当请求需要在 OpenDataWorks 上进行数据开发时使用：生成/润色 SQL、创建数据任务、组装工作流、发布与上线、配置调度。依赖 portal MCP 的写工具与对话内权限确认。不用于纯问数、业务语义或本体建模。"
+compatibility: "需要可见的 portal MCP 写工具(portal_create_task/portal_create_workflow/portal_preview_publish/portal_publish_workflow 等)。高危操作(发布/上线)在 default/acceptEdits 权限模式下会触发对话内确认。"
+tools: [Bash, Read]
+---
+
+# OpenDataWorks 数据开发助手技能
+
+数据开发 Skill。OpenDataWorks Data Development Skill。
+
+把"为某张表写一段 SQL → 建任务 → 加入工作流 → 发布 → 上线 → 配调度"的开发链路，通过 portal MCP 写工具安全地编排出来。SQL 就绪规则与平台事实由 `opendataworks-platform-tools` 提供；业务含义由语义技能提供；本技能只负责**开发动作的编排与安全发布流程**。
+
+## 范围
+
+负责：
+
+- 生成与润色 SQL（先核实表结构与输入/输出表，再产出）。
+- 创建/更新数据任务（draft 优先），维护输入/输出表血缘。
+- 组装工作流（绑定任务、设置依赖边）。
+- 发布(deploy)、上线/下线(online/offline)、调度配置与上线/下线。
+- 发布前强制预览，把差异/告警交给用户确认。
+
+不负责：
+
+- 纯问数与结果可视化（交给 `opendataworks-platform-tools`）。
+- 业务术语、指标口径、歧义消解（交给语义技能）。
+- 本体建模（交给 `ontology-modeling-assistant`）。
+- 直接执行含写操作的 SQL（写 SQL 只进任务定义，绝不通过只读查询工具试跑）。
+
+## 工具
+
+本技能以 portal MCP 写工具为主，配方见 `reference/30-tool-recipes.md`。关键工具：
+
+- 探查：`portal_search_tables`、`portal_get_table_ddl`、`portal_analyze_sql`（平台工具技能提供前两者）。
+- 任务：`portal_create_task`、`portal_update_task`、`portal_get_task`、`portal_list_tasks`。
+- 工作流：`portal_create_workflow`、`portal_update_workflow`、`portal_get_workflow`、`portal_list_workflows`。
+- 发布：`portal_preview_publish` →（确认）→ `portal_publish_workflow`。
+- 调度：`portal_upsert_schedule`、`portal_workflow_schedule_online`、`portal_workflow_schedule_offline`。
+
+字段契约见 `reference/10-task-fields.md`，生命周期与状态机见 `reference/20-workflow-lifecycle.md`，命名/校验规则见 `assets/dev-policies.json`，任务模板见 `assets/task-template.json`。
+
+## Playbook（核心规则）
+
+1. **SQL 生成 / 润色**
+   - 生成前用 `portal_search_tables` / `portal_get_table_ddl` 核实库、表、字段，不臆造表名或字段。
+   - 润色或落任务前，先 `portal_analyze_sql` 识别输入/输出表与操作类型；据此推荐 `inputTableIds` / `outputTableIds`。
+   - 含写操作的 SQL（INSERT/UPDATE/INSERT OVERWRITE 等）只允许写进任务定义，**不要**用只读查询工具试跑。
+
+2. **创建任务**
+   - 一律以 draft 创建（`status: draft`）。
+   - 必填字段参照 `reference/10-task-fields.md` 与 `assets/task-template.json`；命名遵循 `assets/dev-policies.json`。
+   - 传入 analyze 得到的输入/输出表 ID，保持血缘完整。
+
+3. **组装工作流**
+   - 绑定任务、设置依赖边后，向用户复述 DAG 结构（节点 + 依赖），口头确认无误再进入发布。
+   - 工作流必须处于 draft 才能改结构。
+
+4. **发布与上线（高危，强制顺序）**
+   - 先 `portal_preview_publish`，把 `diffSummary` / `errors` / `warnings` 摘要展示给用户；存在 error 级 issue 时**禁止**继续，转为修复建议。
+   - 调用 `portal_publish_workflow(operation="deploy", preview_token=<上一步返回>)`。`deploy`/`online` 必须携带 preview 返回的 `preview_token`。
+   - deploy 成功后再 `portal_publish_workflow(operation="online", preview_token=...)` 上线。
+   - 在 default / acceptEdits 权限模式下，发布/上线会触发对话内权限确认卡片；请把操作目标与差异摘要放进工具参数的 `title` / `summary`，便于用户判断。
+
+5. **调度**
+   - `portal_upsert_schedule` 配置 cron/时区等；`portal_workflow_schedule_online`（需 preview_token，高危）启用；`portal_workflow_schedule_offline` 停用。
+
+6. **失败恢复**
+   - 发布失败时读取后端返回的报错与 `workflow_publish_record` 信息，判断是结构问题（回 draft 修改后重走预览）还是引擎问题（提示用户检查 DolphinScheduler 配置）；不要盲目重试同一请求。
+
+## 安全边界
+
+- 永远不要绕过 `portal_preview_publish` 直接发布/上线。
+- 不要把权限模式或确认流程当作可跳过的步骤——高危确认由运行时强制，模型无法绕过。
+- 写工具的可用性取决于会话权限模式：`plan` 模式下写工具不可用，只能产出方案。

--- a/dataagent/.claude/skills/opendataworks-data-dev/assets/dev-policies.json
+++ b/dataagent/.claude/skills/opendataworks-data-dev/assets/dev-policies.json
@@ -1,0 +1,23 @@
+{
+  "description": "数据开发命名与校验规则(供生成任务/工作流时遵循)。",
+  "naming": {
+    "task_name_pattern": "^[a-z][a-z0-9_]{2,63}$",
+    "layer_prefixes": ["ods", "dwd", "dws", "dim", "ads"],
+    "note": "任务名建议 <层>_<主题>_<刷新方式>,如 dwd_user_order_di(di=按日增量,df=按日全量)"
+  },
+  "required_task_fields": ["taskName", "taskType", "engine", "dolphinNodeType", "datasourceName", "status"],
+  "required_sql_task_fields": ["taskSql", "datasourceType"],
+  "forbidden": [
+    "通过只读查询工具试跑含写操作(INSERT/UPDATE/DELETE/OVERWRITE)的 SQL",
+    "绕过 portal_preview_publish 直接 deploy/online",
+    "对存在 error 级 preview issue 的工作流继续发布"
+  ],
+  "lineage": {
+    "require_input_output_ids": true,
+    "note": "inputTableIds/outputTableIds 从 portal_analyze_sql + portal_search_tables 推导"
+  },
+  "publish": {
+    "require_preview_token_for": ["deploy", "online", "schedule_online"],
+    "stop_on_preview_errors": true
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-data-dev/assets/task-template.json
+++ b/dataagent/.claude/skills/opendataworks-data-dev/assets/task-template.json
@@ -1,0 +1,21 @@
+{
+  "description": "SQL 数据任务创建模板(portal_create_task 的 task 字段)。占位符用 <> 标注,填写前替换。",
+  "task": {
+    "taskName": "<dwd_layer_table_di>",
+    "taskType": "batch",
+    "engine": "dolphin",
+    "dolphinNodeType": "SQL",
+    "datasourceName": "<doris_prod>",
+    "datasourceType": "DORIS",
+    "taskSql": "INSERT INTO <db>.<output_table>\nSELECT ...\nFROM <db>.<input_table>\nWHERE dt = '${bizdate}'",
+    "taskDesc": "<任务用途一句话>",
+    "taskGroupName": "<可选>",
+    "priority": 5,
+    "timeoutSeconds": 3600,
+    "retryTimes": 3,
+    "retryInterval": 60,
+    "status": "draft"
+  },
+  "input_table_ids": [],
+  "output_table_ids": []
+}

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/10-task-fields.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/10-task-fields.md
@@ -1,0 +1,34 @@
+# 任务字段契约（DataTask）
+
+`portal_create_task` / `portal_update_task` 的 `task` 字段对齐平台 `DataTask` 实体。后端 agent 写接口是字段的权威来源；本表用于指导填写。
+
+## 常用字段
+
+| 字段 | 说明 | 示例 |
+| --- | --- | --- |
+| `taskName` | 任务名（唯一，遵循命名规范） | `dwd_user_order_di` |
+| `taskCode` | 任务编码（可选，未填由后端生成） | `task_user_order_001` |
+| `taskType` | `batch`（批）或 `stream`（流） | `batch` |
+| `engine` | `dolphin` 或 `dinky` | `dolphin` |
+| `dolphinNodeType` | 节点类型：`SQL` / `SHELL` / `PYTHON` / `SPARK` / `FLINK` | `SQL` |
+| `taskSql` | SQL 节点的 SQL 文本（含写操作的 SQL 只进这里） | `INSERT INTO ... SELECT ...` |
+| `datasourceName` | 数据源名 | `doris_prod` |
+| `datasourceType` | `MYSQL` / `DORIS` / ... | `DORIS` |
+| `taskDesc` | 描述 | `用户订单明细每日加工` |
+| `taskGroupName` | 任务组（可选） | `etl_user` |
+| `priority` | 优先级（数字，可选） | `5` |
+| `timeoutSeconds` | 超时（秒，可选） | `3600` |
+| `retryTimes` / `retryInterval` | 重试次数 / 间隔（可选） | `3` / `60` |
+| `owner` | 负责人（agent 调用时由后端按 operator 审计标注） | — |
+| `status` | 创建一律 `draft` | `draft` |
+
+## 血缘字段（与 task 平级）
+
+- `inputTableIds`: 输入表 ID 列表（来自 `portal_analyze_sql` 的输入表）。
+- `outputTableIds`: 输出表 ID 列表（来自 analyze 的输出表）。
+
+血缘 ID 必填以保证影响分析与血缘图正确；用 `portal_search_tables` 把表名解析为表 ID。
+
+## 本期范围
+
+- 本期 playbook 只保证 `dolphinNodeType: SQL` 的完整开发流；其他节点类型接口可用，但参数细节请向用户确认或参考平台文档。

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/20-workflow-lifecycle.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/20-workflow-lifecycle.md
@@ -1,0 +1,38 @@
+# 工作流生命周期与状态机
+
+```
+draft ──(portal_preview_publish)──> 预览(diff/errors/warnings)
+   │                                      │ 有 error 级 issue → 停止，转修复
+   │                                      ▼
+   └──(portal_publish_workflow deploy, preview_token)──> 已部署(publishStatus=success)
+                                          │
+                                          ▼
+                          (portal_publish_workflow online, preview_token)
+                                          │
+                                          ▼
+                                       online ──(offline)──> offline
+```
+
+## 阶段说明
+
+1. **draft**：工作流可改结构（绑定/解绑任务、设置依赖边）。只有 draft 能改结构。
+2. **preview**：`portal_preview_publish` 返回：
+   - `canPublish` / `requireConfirm`
+   - `errors`（阻断项）、`warnings`（提示项）
+   - `diffSummary`（与运行态的差异）
+   - `preview_token`（一次性短时效凭证，发布/调度上线必须带上）
+   存在 `errors` 时不得继续。
+3. **deploy（发布，高危）**：`portal_publish_workflow(operation="deploy", preview_token=...)`，把平台定义同步到 DolphinScheduler，分配 `workflow_code`。
+4. **online（上线，高危）**：`portal_publish_workflow(operation="online", preview_token=...)`，工作流变为可调度/可执行。
+5. **offline（下线）**：`portal_publish_workflow(operation="offline")` 停止新的调度执行。
+
+## 调度
+
+- `portal_upsert_schedule`：配置 cron、时区、失败策略、worker 组等（draft 即可配）。
+- `portal_workflow_schedule_online`（高危，需 preview_token）：按 cron 触发。
+- `portal_workflow_schedule_offline`：停用调度。
+
+## 约束
+
+- 发布/上线依赖工作流已绑定 DolphinScheduler 配置（`dolphin_config_id`）；缺失时发布会失败，应提示用户先在平台完成调度引擎配置。
+- 每次结构保存会生成版本快照；误发布可由用户在平台 UI 回滚（本技能不提供回滚工具）。

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
@@ -1,0 +1,64 @@
+# 工具配方（调用顺序与参数）
+
+全部为 portal MCP 工具。高危工具（`portal_publish_workflow`、`portal_workflow_schedule_online`）在 default/acceptEdits 权限模式下触发对话内确认。
+
+## 1. 探查表与 SQL
+
+```
+portal_search_tables {database?, table?, keyword?, table_limit?}
+portal_get_table_ddl {database, table}   # 或 {table_id}
+portal_analyze_sql   {sql, database?, cluster_id?}
+  -> 返回输入/输出表、操作类型、风险告警
+```
+
+## 2. 创建任务（draft）
+
+```
+portal_create_task {
+  task: { taskName, taskType:"batch", engine:"dolphin",
+          dolphinNodeType:"SQL", taskSql, datasourceName, datasourceType,
+          taskDesc, status:"draft" },
+  input_table_ids:  [<来自 analyze>],
+  output_table_ids: [<来自 analyze>]
+}
+```
+更新：`portal_update_task {task_id, task, input_table_ids, output_table_ids}`（仅 draft）。
+
+## 3. 组装工作流（draft）
+
+```
+portal_create_workflow { workflow: { workflowName, tasks:[...], edges:[...], globalParams? } }
+portal_update_workflow { workflow_id, workflow: {...} }
+```
+绑定后向用户复述 DAG，确认后进入发布。
+
+## 4. 发布与上线（强制顺序）
+
+```
+portal_preview_publish { workflow_id }
+  -> 展示 diffSummary / errors / warnings；有 error 则停止
+  -> 取得 preview_token
+
+# 把操作目标与差异摘要放进 title/summary，便于确认卡片展示
+portal_publish_workflow {
+  workflow_id, operation:"deploy", preview_token,
+  title?:"发布工作流 #<id>", summary?:"<diff 摘要>"
+}
+# 成功后
+portal_publish_workflow { workflow_id, operation:"online", preview_token }
+```
+下线：`portal_publish_workflow { workflow_id, operation:"offline" }`。
+
+## 5. 调度
+
+```
+portal_upsert_schedule { workflow_id, schedule: { scheduleCron, scheduleTimezone, ... } }
+portal_workflow_schedule_online  { workflow_id, preview_token }   # 高危
+portal_workflow_schedule_offline { workflow_id }
+```
+
+## 失败恢复
+
+- `portal_publish_workflow` 失败 → 读取返回报错；结构问题回 draft 改后重走 preview；引擎问题提示检查 DolphinScheduler 配置。
+- preview 的 `errors` 非空 → 不发布，逐条转成修复建议。
+- preview_token 过期或工作流版本已变 → 重新 `portal_preview_publish` 取新 token。

--- a/dataagent/contracts/sdk-block-projection/cases.json
+++ b/dataagent/contracts/sdk-block-projection/cases.json
@@ -4,117 +4,919 @@
     {
       "name": "text answer only",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello "}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "world"}}},
-        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 6, "record_type": "stream", "data": {"type": "message_stop"}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "Hello "
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "world"
+            }
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "stream",
+          "data": {
+            "type": "message_stop"
+          }
+        }
       ],
       "expected": [
-        {"kind": "text", "text": "Hello world"}
+        {
+          "kind": "text",
+          "text": "Hello world"
+        }
       ]
     },
     {
       "name": "thinking then text",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "let me think"}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
-        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "answer"}}},
-        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "thinking"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "thinking_delta",
+              "thinking": "let me think"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {
+              "type": "text_delta",
+              "text": "answer"
+            }
+          }
+        },
+        {
+          "seq_id": 7,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 1
+          }
+        }
       ],
       "expected": [
-        {"kind": "thinking", "text": "let me think"},
-        {"kind": "text", "text": "answer"}
+        {
+          "kind": "thinking",
+          "text": "let me think"
+        },
+        {
+          "kind": "text",
+          "text": "answer"
+        }
       ]
     },
     {
       "name": "tool_use with success result then text",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"sql\":"}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "\"select 1\"}"}}},
-        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 6, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": [{"type": "text", "text": "rows: 3"}], "is_error": false}},
-        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
-        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "done"}}},
-        {"seq_id": 9, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "tool_use",
+              "id": "toolu_1",
+              "name": "run_sql"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "input_json_delta",
+              "partial_json": "{\"sql\":"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "input_json_delta",
+              "partial_json": "\"select 1\"}"
+            }
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "tool_result",
+          "data": {
+            "tool_use_id": "toolu_1",
+            "content": [
+              {
+                "type": "text",
+                "text": "rows: 3"
+              }
+            ],
+            "is_error": false
+          }
+        },
+        {
+          "seq_id": 7,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 8,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {
+              "type": "text_delta",
+              "text": "done"
+            }
+          }
+        },
+        {
+          "seq_id": 9,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 1
+          }
+        }
       ],
       "expected": [
-        {"kind": "tool_use", "tool_name": "run_sql", "input": {"sql": "select 1"}, "output": [{"type": "text", "text": "rows: 3"}], "is_error": false},
-        {"kind": "text", "text": "done"}
+        {
+          "kind": "tool_use",
+          "tool_name": "run_sql",
+          "input": {
+            "sql": "select 1"
+          },
+          "output": [
+            {
+              "type": "text",
+              "text": "rows: 3"
+            }
+          ],
+          "is_error": false
+        },
+        {
+          "kind": "text",
+          "text": "done"
+        }
       ]
     },
     {
       "name": "tool_use with error result",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"sql\":\"bad\"}"}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 5, "record_type": "tool_result", "data": {"tool_use_id": "toolu_1", "content": "boom", "is_error": true}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "tool_use",
+              "id": "toolu_1",
+              "name": "run_sql"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "input_json_delta",
+              "partial_json": "{\"sql\":\"bad\"}"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "tool_result",
+          "data": {
+            "tool_use_id": "toolu_1",
+            "content": "boom",
+            "is_error": true
+          }
+        }
       ],
       "expected": [
-        {"kind": "tool_use", "tool_name": "run_sql", "input": {"sql": "bad"}, "output": "boom", "is_error": true}
+        {
+          "kind": "tool_use",
+          "tool_name": "run_sql",
+          "input": {
+            "sql": "bad"
+          },
+          "output": "boom",
+          "is_error": true
+        }
       ]
     },
     {
       "name": "orphan tool_result records become synthetic tool blocks",
       "records": [
-        {"seq_id": 1, "record_type": "tool_result", "data": {"tool_use_id": "call_skill_1", "content": "Launching skill: opendataworks-business-knowledge", "is_error": false}},
-        {"seq_id": 2, "record_type": "tool_result", "data": {"tool_use_id": "call_read_1", "content": "1\t# 业务知识地图", "is_error": false}}
+        {
+          "seq_id": 1,
+          "record_type": "tool_result",
+          "data": {
+            "tool_use_id": "call_skill_1",
+            "content": "Launching skill: opendataworks-business-knowledge",
+            "is_error": false
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "tool_result",
+          "data": {
+            "tool_use_id": "call_read_1",
+            "content": "1\t# 业务知识地图",
+            "is_error": false
+          }
+        }
       ],
       "expected": [
-        {"kind": "tool_use", "tool_name": "Skill", "input": {"skill": "opendataworks-business-knowledge"}, "output": "Launching skill: opendataworks-business-knowledge", "is_error": false},
-        {"kind": "tool_use", "tool_name": "Tool", "input": null, "output": "1\t# 业务知识地图", "is_error": false}
+        {
+          "kind": "tool_use",
+          "tool_name": "Skill",
+          "input": {
+            "skill": "opendataworks-business-knowledge"
+          },
+          "output": "Launching skill: opendataworks-business-knowledge",
+          "is_error": false
+        },
+        {
+          "kind": "tool_use",
+          "tool_name": "Tool",
+          "input": null,
+          "output": "1\t# 业务知识地图",
+          "is_error": false
+        }
       ]
     },
     {
       "name": "empty text block is dropped",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_start", "index": 1, "content_block": {"type": "text"}}},
-        {"seq_id": 5, "record_type": "stream", "data": {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "real"}}},
-        {"seq_id": 6, "record_type": "stream", "data": {"type": "content_block_stop", "index": 1}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {
+              "type": "text_delta",
+              "text": "real"
+            }
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 1
+          }
+        }
       ],
       "expected": [
-        {"kind": "text", "text": "real"}
+        {
+          "kind": "text",
+          "text": "real"
+        }
       ]
     },
     {
       "name": "two turns are flattened in order",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "a"}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}},
-        {"seq_id": 5, "record_type": "stream", "data": {"type": "message_stop"}},
-        {"seq_id": 6, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 7, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}},
-        {"seq_id": 8, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "b"}}},
-        {"seq_id": 9, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "a"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "stream",
+          "data": {
+            "type": "message_stop"
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 7,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 8,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "b"
+            }
+          }
+        },
+        {
+          "seq_id": 9,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        }
       ],
       "expected": [
-        {"kind": "text", "text": "a"},
-        {"kind": "text", "text": "b"}
+        {
+          "kind": "text",
+          "text": "a"
+        },
+        {
+          "kind": "text",
+          "text": "b"
+        }
       ]
     },
     {
       "name": "malformed tool input json falls back to raw string",
       "records": [
-        {"seq_id": 1, "record_type": "stream", "data": {"type": "message_start"}},
-        {"seq_id": 2, "record_type": "stream", "data": {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "run_sql"}}},
-        {"seq_id": 3, "record_type": "stream", "data": {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{bad"}}},
-        {"seq_id": 4, "record_type": "stream", "data": {"type": "content_block_stop", "index": 0}}
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "tool_use",
+              "id": "toolu_1",
+              "name": "run_sql"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "input_json_delta",
+              "partial_json": "{bad"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        }
       ],
       "expected": [
-        {"kind": "tool_use", "tool_name": "run_sql", "input": "{bad", "output": null, "is_error": false}
+        {
+          "kind": "tool_use",
+          "tool_name": "run_sql",
+          "input": "{bad",
+          "output": null,
+          "is_error": false
+        }
+      ]
+    },
+    {
+      "name": "permission request pending",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "准备发布工作流"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "permission_request",
+          "data": {
+            "request_id": "req-1",
+            "tool_name": "mcp__portal__portal_publish_workflow",
+            "risk_level": "critical",
+            "title": "发布工作流 #12",
+            "summary": "operation=deploy",
+            "payload_preview": {
+              "operation": "deploy",
+              "workflow_id": 12
+            }
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "text",
+          "text": "准备发布工作流"
+        },
+        {
+          "kind": "permission_request",
+          "tool_name": "mcp__portal__portal_publish_workflow",
+          "risk_level": "critical",
+          "title": "发布工作流 #12",
+          "summary": "operation=deploy",
+          "decision": "pending"
+        }
+      ]
+    },
+    {
+      "name": "permission request allowed",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "准备发布工作流"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "permission_request",
+          "data": {
+            "request_id": "req-1",
+            "tool_name": "mcp__portal__portal_publish_workflow",
+            "risk_level": "critical",
+            "title": "发布工作流 #12",
+            "summary": "operation=deploy",
+            "payload_preview": {
+              "operation": "deploy",
+              "workflow_id": 12
+            }
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "permission_decision",
+          "data": {
+            "request_id": "req-1",
+            "decision": "allowed",
+            "note": "",
+            "decided_at": "2026-06-13T00:00:00"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "text",
+          "text": "准备发布工作流"
+        },
+        {
+          "kind": "permission_request",
+          "tool_name": "mcp__portal__portal_publish_workflow",
+          "risk_level": "critical",
+          "title": "发布工作流 #12",
+          "summary": "operation=deploy",
+          "decision": "allowed"
+        }
+      ]
+    },
+    {
+      "name": "permission request denied",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "准备发布工作流"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "permission_request",
+          "data": {
+            "request_id": "req-1",
+            "tool_name": "mcp__portal__portal_publish_workflow",
+            "risk_level": "critical",
+            "title": "发布工作流 #12",
+            "summary": "operation=deploy",
+            "payload_preview": {
+              "operation": "deploy",
+              "workflow_id": 12
+            }
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "permission_decision",
+          "data": {
+            "request_id": "req-1",
+            "decision": "denied",
+            "note": "",
+            "decided_at": "2026-06-13T00:00:00"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "text",
+          "text": "准备发布工作流"
+        },
+        {
+          "kind": "permission_request",
+          "tool_name": "mcp__portal__portal_publish_workflow",
+          "risk_level": "critical",
+          "title": "发布工作流 #12",
+          "summary": "operation=deploy",
+          "decision": "denied"
+        }
+      ]
+    },
+    {
+      "name": "permission request timeout",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+              "type": "text"
+            }
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+              "type": "text_delta",
+              "text": "准备发布工作流"
+            }
+          }
+        },
+        {
+          "seq_id": 4,
+          "record_type": "stream",
+          "data": {
+            "type": "content_block_stop",
+            "index": 0
+          }
+        },
+        {
+          "seq_id": 5,
+          "record_type": "permission_request",
+          "data": {
+            "request_id": "req-1",
+            "tool_name": "mcp__portal__portal_publish_workflow",
+            "risk_level": "critical",
+            "title": "发布工作流 #12",
+            "summary": "operation=deploy",
+            "payload_preview": {
+              "operation": "deploy",
+              "workflow_id": 12
+            }
+          }
+        },
+        {
+          "seq_id": 6,
+          "record_type": "permission_decision",
+          "data": {
+            "request_id": "req-1",
+            "decision": "timeout",
+            "note": "",
+            "decided_at": "2026-06-13T00:00:00"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "text",
+          "text": "准备发布工作流"
+        },
+        {
+          "kind": "permission_request",
+          "tool_name": "mcp__portal__portal_publish_workflow",
+          "risk_level": "critical",
+          "title": "发布工作流 #12",
+          "summary": "operation=deploy",
+          "decision": "timeout"
+        }
       ]
     }
   ]

--- a/dataagent/dataagent-backend/alembic/versions/20260613_000017_topic_permission_mode.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260613_000017_topic_permission_mode.py
@@ -1,0 +1,71 @@
+"""move permission_mode from agent profile to topic (session) level
+
+Revision ID: 20260613_000017
+Revises: 20260611_000016
+Create Date: 2026-06-13 00:00:00
+
+Permission mode is a per-session choice (aligned with the Claude Agent SDK
+permission modes), not an agent attribute. It moves to ``da_agent_topic`` where
+it stores only the latest selection (mutable, may switch mid-conversation), and
+is removed from ``da_agent_profile``.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260613_000017"
+down_revision = "20260611_000016"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = inspect(op.get_bind())
+    return any(column.get("name") == column_name for column in inspector.get_columns(table_name))
+
+
+def upgrade() -> None:
+    if _has_table("da_agent_topic") and not _has_column("da_agent_topic", "permission_mode"):
+        op.add_column(
+            "da_agent_topic",
+            sa.Column(
+                "permission_mode",
+                sa.String(length=32),
+                nullable=False,
+                server_default="default",
+                comment="会话权限模式(SDK 对齐:default/acceptEdits/plan/bypassPermissions),只存最新选择",
+            ),
+        )
+        # Existing sessions default to ``default``; the column default covers
+        # backfill for already-present rows.
+        op.execute(
+            "UPDATE da_agent_topic SET permission_mode = 'default' "
+            "WHERE permission_mode IS NULL OR permission_mode = ''"
+        )
+
+    if _has_table("da_agent_profile") and _has_column("da_agent_profile", "permission_mode"):
+        op.drop_column("da_agent_profile", "permission_mode")
+
+
+def downgrade() -> None:
+    if _has_table("da_agent_profile") and not _has_column("da_agent_profile", "permission_mode"):
+        op.add_column(
+            "da_agent_profile",
+            sa.Column(
+                "permission_mode",
+                sa.String(length=32),
+                nullable=False,
+                server_default="inherit",
+                comment="权限模式",
+            ),
+        )
+
+    if _has_table("da_agent_topic") and _has_column("da_agent_topic", "permission_mode"):
+        op.drop_column("da_agent_topic", "permission_mode")

--- a/dataagent/dataagent-backend/alembic/versions/20260613_000018_opendataworks_data_dev_skill.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260613_000018_opendataworks_data_dev_skill.py
@@ -1,0 +1,103 @@
+"""enable opendataworks-data-dev skill on the builtin platform assistant
+
+Revision ID: 20260613_000018
+Revises: 20260613_000017
+Create Date: 2026-06-13 01:00:00
+
+Appends the data-development skill folder to the builtin ``agent_opendataworks``
+profile and refreshes its system prompt to mention data development. Guarded so
+admin-customized profiles are not overwritten:
+- only the builtin row (``is_builtin = 1``) is touched;
+- the skill is appended only if not already present;
+- the system prompt is updated only when it still equals the previous builtin
+  default (otherwise an operator has customized it and we leave it alone).
+"""
+from __future__ import annotations
+
+import json
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260613_000018"
+down_revision = "20260613_000017"
+branch_labels = None
+depends_on = None
+
+AGENT_ID = "agent_opendataworks"
+SKILL = "opendataworks-data-dev"
+
+_PREV_PROMPT = "你是 OpenDataWorks 数据门户助手，优先围绕平台元数据、工作流、血缘、数据质量和智能问数场景提供帮助。"
+_NEW_PROMPT = (
+    "你是 OpenDataWorks 数据门户助手，优先围绕平台元数据、工作流、血缘、数据质量和智能问数场景提供帮助。"
+    "你同时具备数据开发能力：可以生成与润色 SQL、创建数据任务、组装工作流、发布与上线、配置调度。"
+    "数据开发以问数为主、开发为辅；执行开发动作时严格遵循 opendataworks-data-dev 技能的 playbook，"
+    "发布与上线等高危操作必须先预览再经用户确认，绝不跳过。"
+)
+
+
+def _has_table(name: str) -> bool:
+    return inspect(op.get_bind()).has_table(name)
+
+
+def _load_folders(raw) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(x) for x in raw]
+    try:
+        value = json.loads(str(raw))
+        return [str(x) for x in value] if isinstance(value, list) else []
+    except Exception:
+        return []
+
+
+def upgrade() -> None:
+    if not _has_table("da_agent_profile"):
+        return
+    bind = op.get_bind()
+    row = bind.exec_driver_sql(
+        "SELECT skill_folders_json, system_prompt, is_builtin FROM da_agent_profile WHERE agent_id = %s",
+        (AGENT_ID,),
+    ).fetchone()
+    if not row:
+        return
+    skill_raw, system_prompt, is_builtin = row[0], row[1], row[2]
+    if not is_builtin:
+        return
+
+    folders = _load_folders(skill_raw)
+    if SKILL not in folders:
+        folders.append(SKILL)
+        bind.exec_driver_sql(
+            "UPDATE da_agent_profile SET skill_folders_json = %s, updated_at = CURRENT_TIMESTAMP WHERE agent_id = %s",
+            (json.dumps(folders, ensure_ascii=False, sort_keys=True), AGENT_ID),
+        )
+    if str(system_prompt or "").strip() == _PREV_PROMPT:
+        bind.exec_driver_sql(
+            "UPDATE da_agent_profile SET system_prompt = %s, updated_at = CURRENT_TIMESTAMP WHERE agent_id = %s",
+            (_NEW_PROMPT, AGENT_ID),
+        )
+
+
+def downgrade() -> None:
+    if not _has_table("da_agent_profile"):
+        return
+    bind = op.get_bind()
+    row = bind.exec_driver_sql(
+        "SELECT skill_folders_json, system_prompt, is_builtin FROM da_agent_profile WHERE agent_id = %s",
+        (AGENT_ID,),
+    ).fetchone()
+    if not row or not row[2]:
+        return
+    folders = [f for f in _load_folders(row[0]) if f != SKILL]
+    bind.exec_driver_sql(
+        "UPDATE da_agent_profile SET skill_folders_json = %s, updated_at = CURRENT_TIMESTAMP WHERE agent_id = %s",
+        (json.dumps(folders, ensure_ascii=False, sort_keys=True), AGENT_ID),
+    )
+    if str(row[1] or "").strip() == _NEW_PROMPT:
+        bind.exec_driver_sql(
+            "UPDATE da_agent_profile SET system_prompt = %s, updated_at = CURRENT_TIMESTAMP WHERE agent_id = %s",
+            (_PREV_PROMPT, AGENT_ID),
+        )

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -20,6 +20,8 @@ from core.topic_task_store import get_topic_task_store
 from models.schemas import (
     CancelTaskResponse,
     CreateTaskRequest,
+    PermissionDecisionRequest,
+    PermissionDecisionResponse,
     CreateTopicRequest,
     DeliverMessageRequest,
     FollowupSuggestionsResponse,
@@ -608,6 +610,30 @@ async def api_cancel_task(task_id: str, request: Request):
     await get_task_coordinator().request_cancel(task_id)
     task = store.get_task(task_id, context=context) or task
     return CancelTaskResponse.model_validate(task)
+
+
+@task_router.post("/{task_id}/permission-decision", response_model=PermissionDecisionResponse)
+async def api_submit_permission_decision(task_id: str, payload: PermissionDecisionRequest, request: Request):
+    store = _get_store()
+    context = _request_context(request)
+    task = store.get_task(task_id, context=context)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    request_id = str(payload.request_id or "").strip()
+    if not request_id:
+        raise HTTPException(status_code=400, detail="request_id is required")
+    decision = str(payload.decision or "").strip().lower()
+    if decision not in {"allow", "deny"}:
+        raise HTTPException(status_code=400, detail="decision must be allow or deny")
+    # Only a run paused at a confirmation can accept a decision.
+    if str(task.get("task_status") or "") != "waiting_permission":
+        raise HTTPException(status_code=409, detail="task is not awaiting a permission decision")
+    # Signal the waiting executor; first decision wins (idempotent). The executor
+    # writes the durable permission_decision record when it observes this.
+    effective = await get_task_coordinator().submit_permission_decision(task_id, request_id, decision)
+    return PermissionDecisionResponse.model_validate(
+        {"task_id": task_id, "request_id": request_id, "decision": effective}
+    )
 
 
 @queue_router.post("/queries", response_model=MessageQueuePageResponse)

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -251,6 +251,7 @@ async def api_create_topic(http_request: Request, request: CreateTopicRequest | 
     topic = store.create_topic(
         title=str(payload.title or "").strip() or "新话题",
         agent_snapshot=build_agent_snapshot(profile),
+        permission_mode=payload.permission_mode,
         context=context,
     )
     return TopicDetail.model_validate(topic)
@@ -272,11 +273,21 @@ async def api_get_topic(topic_id: str, request: Request):
 @topic_router.put("/{topic_id}", response_model=TopicDetail)
 async def api_update_topic(topic_id: str, payload: UpdateTopicRequest, request: Request):
     context = _request_context(request)
-    title = str(payload.title or "").strip()
-    if not title:
-        raise HTTPException(status_code=400, detail="title is required")
+    title: str | None = None
+    if payload.title is not None:
+        title = str(payload.title).strip()
+        if not title:
+            raise HTTPException(status_code=400, detail="title is required")
+    permission_mode = payload.permission_mode
+    if title is None and permission_mode is None:
+        raise HTTPException(status_code=400, detail="title or permission_mode is required")
     _require_topic(topic_id, context)
-    topic = _get_store().update_topic(topic_id, title=title, context=context)
+    topic = _get_store().update_topic(
+        topic_id,
+        title=title,
+        permission_mode=permission_mode,
+        context=context,
+    )
     if not topic:
         raise HTTPException(status_code=404, detail="Topic not found")
     return TopicDetail.model_validate(topic)
@@ -436,6 +447,14 @@ async def api_deliver_message(payload: DeliverMessageRequest, request: Request):
     if not content:
         raise HTTPException(status_code=400, detail="content is required")
     _require_topic(topic_id, context)
+    # Permission mode is a session-level choice; applying it here updates the
+    # topic's latest selection so the next task runs under it.
+    if payload.permission_mode is not None:
+        _get_store().update_topic(
+            topic_id,
+            permission_mode=payload.permission_mode,
+            context=context,
+        )
     try:
         submitted = await submit_message_task(
             topic_id=topic_id,

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -44,6 +44,8 @@ class Settings(BaseSettings):
     task_heartbeat_seconds: int = 5
     task_recovery_scan_interval_seconds: int = 2
     task_recovery_batch_size: int = 20
+    # Max time a run waits at a permission confirmation before timing out (deny).
+    task_permission_wait_seconds: int = 600
     schedule_scan_interval_seconds: int = 10
     schedule_scan_batch_size: int = 10
     schedule_lock_ttl_seconds: int = 60

--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -304,11 +304,20 @@ def opendataworks_agent_payload() -> dict[str, Any]:
     return {
         "agent_id": OPENDATAWORKS_AGENT_ID,
         "name": OPENDATAWORKS_AGENT_NAME,
-        "description": "面向 OpenDataWorks 数据门户、元数据、血缘、工作流和智能问数场景。",
-        "system_prompt": "你是 OpenDataWorks 数据门户助手，优先围绕平台元数据、工作流、血缘、数据质量和智能问数场景提供帮助。",
+        "description": "面向 OpenDataWorks 数据门户、元数据、血缘、工作流、智能问数与数据开发场景。",
+        "system_prompt": (
+            "你是 OpenDataWorks 数据门户助手，优先围绕平台元数据、工作流、血缘、数据质量和智能问数场景提供帮助。"
+            "你同时具备数据开发能力：可以生成与润色 SQL、创建数据任务、组装工作流、发布与上线、配置调度。"
+            "数据开发以问数为主、开发为辅；执行开发动作时严格遵循 opendataworks-data-dev 技能的 playbook，"
+            "发布与上线等高危操作必须先预览再经用户确认，绝不跳过。"
+        ),
         "allowed_tools": list(SAFE_AGENT_TOOLS),
         "mcp_server_ids": [PORTAL_MCP_SERVER_ID],
-        "skill_folders": ["opendataworks-business-knowledge", "opendataworks-platform-tools"],
+        "skill_folders": [
+            "opendataworks-business-knowledge",
+            "opendataworks-platform-tools",
+            "opendataworks-data-dev",
+        ],
         "max_turns": 0,
         "env_vars": {},
         "data_scope": {"allowed_scopes": []},

--- a/dataagent/dataagent-backend/core/agent_profile_service.py
+++ b/dataagent/dataagent-backend/core/agent_profile_service.py
@@ -18,7 +18,12 @@ OPENDATAWORKS_AGENT_ID = "agent_opendataworks"
 OPENDATAWORKS_AGENT_NAME = "OpenDataWorks平台助手"
 ONTOLOGY_MODELING_AGENT_ID = "agent_ontology_modeling"
 ONTOLOGY_MODELING_AGENT_NAME = "本体建模助手"
-PERMISSION_MODES = {"inherit", "default", "bypassPermissions"}
+
+# Session-level permission modes, aligned with the Claude Agent SDK. Legacy
+# values (the removed ``inherit`` or anything unknown) normalize to ``default``.
+PERMISSION_MODES: tuple[str, ...] = ("default", "acceptEdits", "plan", "bypassPermissions")
+DEFAULT_PERMISSION_MODE = "default"
+
 SAFE_AGENT_TOOLS = ["Skill", "Bash", "Read", "LS", "Glob", "Grep"]
 GENERAL_AGENT_TOOLS = ["Read", "LS", "Glob", "Grep"]
 PORTAL_MCP_SERVER_ID = "portal"
@@ -95,11 +100,16 @@ def _validate_name(value: Any) -> str:
     return text
 
 
-def _validate_permission_mode(value: Any) -> str:
-    text = str(value or "inherit").strip() or "inherit"
-    if text not in PERMISSION_MODES:
-        raise ValueError("permission_mode must be inherit, default, or bypassPermissions")
-    return text
+def normalize_permission_mode(permission_mode: Any) -> str:
+    """Coerce any stored/requested value to a valid SDK permission mode.
+
+    The removed legacy ``inherit`` value and any unknown input collapse to
+    ``default``.
+    """
+    requested = str(permission_mode or "").strip()
+    if requested in PERMISSION_MODES:
+        return requested
+    return DEFAULT_PERMISSION_MODE
 
 
 def _validate_tools(values: Any) -> list[str]:
@@ -199,7 +209,6 @@ def normalize_agent_profile_payload(
     name = _validate_name(data.get("name", base.get("name") if has_existing else ""))
     description = str(data.get("description", base.get("description") or "") or "").strip()
     system_prompt = str(data.get("system_prompt", base.get("system_prompt") or "") or "").strip()
-    permission_mode = _validate_permission_mode(data.get("permission_mode", base.get("permission_mode") or "inherit"))
     allowed_tools = _validate_tools(data.get("allowed_tools", base.get("allowed_tools") or list(SAFE_AGENT_TOOLS)))
     mcp_server_ids = _validate_members(
         data.get("mcp_server_ids", base.get("mcp_server_ids") or []),
@@ -221,7 +230,6 @@ def normalize_agent_profile_payload(
         "name": name,
         "description": description,
         "system_prompt": system_prompt,
-        "permission_mode": permission_mode,
         "allowed_tools": allowed_tools,
         "mcp_server_ids": mcp_server_ids,
         "skill_folders": skill_folders,
@@ -238,7 +246,6 @@ def build_agent_snapshot(profile: dict[str, Any]) -> dict[str, Any]:
         "name": str(profile.get("name") or DEFAULT_AGENT_NAME),
         "description": str(profile.get("description") or ""),
         "system_prompt": str(profile.get("system_prompt") or ""),
-        "permission_mode": str(profile.get("permission_mode") or "inherit"),
         "allowed_tools": _dedupe_strings(profile.get("allowed_tools")),
         "mcp_server_ids": _dedupe_strings(profile.get("mcp_server_ids")),
         "skill_folders": _dedupe_strings(profile.get("skill_folders")),
@@ -282,7 +289,6 @@ def default_agent_payload() -> dict[str, Any]:
         "name": DEFAULT_AGENT_NAME,
         "description": "通用对话与分析入口，不预置 OpenDataWorks 专属 Skills。",
         "system_prompt": "",
-        "permission_mode": "default",
         "allowed_tools": list(GENERAL_AGENT_TOOLS),
         "mcp_server_ids": [],
         "skill_folders": [],
@@ -300,7 +306,6 @@ def opendataworks_agent_payload() -> dict[str, Any]:
         "name": OPENDATAWORKS_AGENT_NAME,
         "description": "面向 OpenDataWorks 数据门户、元数据、血缘、工作流和智能问数场景。",
         "system_prompt": "你是 OpenDataWorks 数据门户助手，优先围绕平台元数据、工作流、血缘、数据质量和智能问数场景提供帮助。",
-        "permission_mode": "inherit",
         "allowed_tools": list(SAFE_AGENT_TOOLS),
         "mcp_server_ids": [PORTAL_MCP_SERVER_ID],
         "skill_folders": ["opendataworks-business-knowledge", "opendataworks-platform-tools"],
@@ -318,7 +323,6 @@ def ontology_modeling_agent_payload() -> dict[str, Any]:
         "name": ONTOLOGY_MODELING_AGENT_NAME,
         "description": "根据业务需求、上传文档和数据库表字段创建特定业务域本体语义 Skill。",
         "system_prompt": "你是 OpenDataWorks 本体建模助手，专注把用户需求、上传文档和数据库表字段整理成可复用的领域本体语义 Skill。",
-        "permission_mode": "inherit",
         "allowed_tools": list(SAFE_AGENT_TOOLS),
         "mcp_server_ids": [PORTAL_MCP_SERVER_ID],
         "skill_folders": ["ontology-modeling-assistant"],
@@ -380,7 +384,6 @@ class AgentProfileStore:
             "name": str(row.get("name") or ""),
             "description": str(row.get("description") or ""),
             "system_prompt": str(row.get("system_prompt") or ""),
-            "permission_mode": str(row.get("permission_mode") or "inherit"),
             "allowed_tools": _dedupe_strings(_safe_json_load(row.get("allowed_tools_json"), [])),
             "mcp_server_ids": _dedupe_strings(_safe_json_load(row.get("mcp_server_ids_json"), [])),
             "skill_folders": _dedupe_strings(_safe_json_load(row.get("skill_folders_json"), [])),
@@ -402,7 +405,7 @@ class AgentProfileStore:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT agent_id, name, description, system_prompt, permission_mode,
+                    SELECT agent_id, name, description, system_prompt,
                            allowed_tools_json, mcp_server_ids_json, skill_folders_json,
                            max_turns, env_vars_json, data_scope_json, preset_questions_json,
                            is_default, is_builtin, created_at, updated_at
@@ -422,7 +425,7 @@ class AgentProfileStore:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT agent_id, name, description, system_prompt, permission_mode,
+                    SELECT agent_id, name, description, system_prompt,
                            allowed_tools_json, mcp_server_ids_json, skill_folders_json,
                            max_turns, env_vars_json, data_scope_json, preset_questions_json,
                            is_default, is_builtin, created_at, updated_at
@@ -450,16 +453,15 @@ class AgentProfileStore:
                 cur.execute(
                     """
                     INSERT INTO da_agent_profile (
-                        agent_id, name, description, system_prompt, permission_mode,
+                        agent_id, name, description, system_prompt,
                         allowed_tools_json, mcp_server_ids_json, skill_folders_json,
                         max_turns, env_vars_json, data_scope_json, preset_questions_json,
                         is_default, is_builtin
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
                         name = VALUES(name),
                         description = VALUES(description),
                         system_prompt = VALUES(system_prompt),
-                        permission_mode = VALUES(permission_mode),
                         allowed_tools_json = VALUES(allowed_tools_json),
                         mcp_server_ids_json = VALUES(mcp_server_ids_json),
                         skill_folders_json = VALUES(skill_folders_json),
@@ -476,7 +478,6 @@ class AgentProfileStore:
                         str(profile.get("name") or ""),
                         str(profile.get("description") or ""),
                         str(profile.get("system_prompt") or ""),
-                        str(profile.get("permission_mode") or "inherit"),
                         _json_dump(_dedupe_strings(profile.get("allowed_tools"))),
                         _json_dump(_dedupe_strings(profile.get("mcp_server_ids"))),
                         _json_dump(_dedupe_strings(profile.get("skill_folders"))),
@@ -654,7 +655,6 @@ def agent_capabilities(skill_documents: list[dict[str, Any]]) -> dict[str, Any]:
         "tools": list(SAFE_AGENT_TOOLS),
         "mcp_servers": available_mcp_servers(),
         "skills": sorted(folders.values(), key=lambda item: item["folder"]),
-        "permission_modes": sorted(PERMISSION_MODES),
     }
 
 

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -17,6 +17,7 @@ from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
 from core.agent_profile_service import normalize_permission_mode
+from core.permission_gate import WRITE_TOOL_NAMES, plan_denies_tool
 from core.data_scope import encode_scope_header, normalize_data_scope
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
 from core.skill_discovery import (
@@ -463,13 +464,19 @@ def _build_portal_mcp_servers(
 def _build_allowed_tools(
     mcp_servers: dict[str, Any] | None = None,
     allowed_tools: list[str] | tuple[str, ...] | None = None,
+    permission_mode: str | None = None,
 ) -> list[str]:
     allowed = _dedupe_strings(allowed_tools) if allowed_tools is not None else list(SAFE_AUTO_ALLOWED_TOOLS)
+    mode = normalize_permission_mode(permission_mode)
     if mcp_servers and PORTAL_MCP_SERVER_NAME in mcp_servers:
-        allowed.extend(
-            f"mcp__{PORTAL_MCP_SERVER_NAME}__{tool_name}"
-            for tool_name in PORTAL_MCP_TOOL_NAMES
-        )
+        tool_names = list(PORTAL_MCP_TOOL_NAMES) + sorted(WRITE_TOOL_NAMES)
+        for tool_name in tool_names:
+            qualified = f"mcp__{PORTAL_MCP_SERVER_NAME}__{tool_name}"
+            # plan mode is read-only: never mount write tools (defense in depth
+            # alongside the can_use_tool denial).
+            if mode == "plan" and plan_denies_tool(qualified):
+                continue
+            allowed.append(qualified)
 
     deduped: list[str] = []
     seen: set[str] = set()

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -16,6 +16,7 @@ from typing import Any
 from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
+from core.agent_profile_service import normalize_permission_mode
 from core.data_scope import encode_scope_header, normalize_data_scope
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
 from core.skill_discovery import (
@@ -409,15 +410,15 @@ def _is_running_as_root() -> bool:
 
 
 def _resolve_sdk_permission_mode(permission_mode: str | None = None) -> str:
-    requested = str(permission_mode or "inherit").strip() or "inherit"
-    if requested == "default":
-        return "default"
+    # Per-mode enforcement (plan strips write tools; default/acceptEdits route
+    # high-risk tools through can_use_tool) lands with the confirmation flow.
+    # Until then, allowed_tools remains the real capability boundary, so every
+    # mode runs effectively bypassPermissions, with the root fallback preserved.
+    normalize_permission_mode(permission_mode)
     if _is_running_as_root():
         # Claude Code rejects bypassPermissions under root/sudo. Fall back to the
         # standard mode and rely on allowed_tools for the read-only + script path.
         return "default"
-    if requested == "bypassPermissions":
-        return "bypassPermissions"
     return "bypassPermissions"
 
 

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -1,0 +1,88 @@
+"""Session permission gating for tool calls.
+
+Skill-agnostic policy shared by the runtime (``_build_allowed_tools`` strips
+write tools under ``plan``) and the ``can_use_tool`` confirmation callback
+(``default``/``acceptEdits`` route write/high-risk tools through user
+confirmation). The high-risk and write tool sets are the single source of
+truth; any agent or MCP server can register tools here without the runtime
+learning their business meaning.
+
+Tool names are matched against both the bare MCP tool name (e.g.
+``portal_publish_workflow``) and the SDK-qualified form
+(``mcp__portal__portal_publish_workflow``).
+"""
+from __future__ import annotations
+
+from core.agent_profile_service import normalize_permission_mode
+
+# High-risk tools always require confirmation in default/acceptEdits and are
+# denied under plan. These mutate deployed/production state.
+HIGH_RISK_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "portal_publish_workflow",
+        "portal_workflow_schedule_online",
+    }
+)
+
+# Draft-level write tools: confirmed under default, auto-allowed under
+# acceptEdits, denied under plan.
+DRAFT_WRITE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "portal_create_task",
+        "portal_update_task",
+        "portal_create_workflow",
+        "portal_update_workflow",
+        "portal_upsert_schedule",
+        "portal_workflow_schedule_offline",
+    }
+)
+
+WRITE_TOOL_NAMES: frozenset[str] = HIGH_RISK_TOOL_NAMES | DRAFT_WRITE_TOOL_NAMES
+
+
+def _bare_tool_name(tool_name: str) -> str:
+    """Reduce an SDK-qualified MCP tool name to its bare tool name.
+
+    ``mcp__portal__portal_publish_workflow`` -> ``portal_publish_workflow``.
+    """
+    name = str(tool_name or "").strip()
+    if name.startswith("mcp__"):
+        parts = name.split("__")
+        if parts:
+            return parts[-1]
+    return name
+
+
+def is_write_tool(tool_name: str) -> bool:
+    return _bare_tool_name(tool_name) in WRITE_TOOL_NAMES
+
+
+def is_high_risk_tool(tool_name: str) -> bool:
+    return _bare_tool_name(tool_name) in HIGH_RISK_TOOL_NAMES
+
+
+def plan_denies_tool(tool_name: str) -> bool:
+    """Under ``plan`` no write tool may run (defense in depth alongside the
+    runtime not mounting them)."""
+    return is_write_tool(tool_name)
+
+
+def requires_confirmation(tool_name: str, permission_mode: str | None) -> bool:
+    """Whether ``tool_name`` must be confirmed by the user under ``permission_mode``.
+
+    - ``bypassPermissions``: never (auto-allow; the API layer still enforces
+      preview tokens for deploy/online).
+    - ``plan``: never *confirmed* — write tools are denied outright; callers
+      check :func:`plan_denies_tool` first.
+    - ``default``: every write tool (drafts included).
+    - ``acceptEdits``: only high-risk tools (drafts auto-allowed).
+    """
+    mode = normalize_permission_mode(permission_mode)
+    if mode == "bypassPermissions":
+        return False
+    if mode == "plan":
+        return False
+    if mode == "acceptEdits":
+        return is_high_risk_tool(tool_name)
+    # default
+    return is_write_tool(tool_name)

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -40,6 +40,15 @@ DRAFT_WRITE_TOOL_NAMES: frozenset[str] = frozenset(
 WRITE_TOOL_NAMES: frozenset[str] = HIGH_RISK_TOOL_NAMES | DRAFT_WRITE_TOOL_NAMES
 
 
+def permission_decision_redis_key(task_id: str, request_id: str) -> str:
+    """Redis key carrying a user's permission decision for a waiting run.
+
+    Single source of truth shared by the coordinator (writer) and the executor's
+    confirmation wait (reader), mirroring the cancel-flag key pattern.
+    """
+    return f"da:task:permission:{task_id}:{request_id}"
+
+
 def _bare_tool_name(tool_name: str) -> str:
     """Reduce an SDK-qualified MCP tool name to its bare tool name.
 

--- a/dataagent/dataagent-backend/core/permission_wait.py
+++ b/dataagent/dataagent-backend/core/permission_wait.py
@@ -1,0 +1,77 @@
+"""Wait for a user permission decision during a run.
+
+Used by the ``can_use_tool`` confirmation callback. Self-connects to Redis from
+settings so it works both in the in-process executor and in the sandbox runner
+subprocess (neither needs to thread a callback through). The decision is written
+by the API decision endpoint via the coordinator under the shared key
+:func:`core.permission_gate.permission_decision_redis_key`.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from config import get_settings
+from core.permission_gate import permission_decision_redis_key
+
+logger = logging.getLogger(__name__)
+
+
+async def wait_for_decision(
+    task_id: str,
+    request_id: str,
+    *,
+    timeout_seconds: int,
+    poll_interval_seconds: float = 1.0,
+    is_cancel_requested: Any = None,
+) -> str:
+    """Poll Redis for the user's decision; return ``allow`` / ``deny`` / ``timeout``.
+
+    A cancellation observed while waiting resolves to ``deny`` so the run can
+    unwind promptly. If Redis is unavailable the wait fails closed (``deny``).
+    """
+    cfg = get_settings()
+    key = permission_decision_redis_key(task_id, request_id)
+    try:
+        import redis.asyncio as redis
+
+        client = redis.Redis(
+            host=cfg.redis_host,
+            port=int(cfg.redis_port or 6379),
+            password=cfg.redis_password or None,
+            db=int(cfg.redis_db or 0),
+            decode_responses=True,
+        )
+    except Exception:
+        logger.exception("permission_wait: redis unavailable; denying request_id=%s", request_id)
+        return "deny"
+
+    deadline = asyncio.get_event_loop().time() + max(1, int(timeout_seconds or 600))
+    try:
+        while True:
+            try:
+                value = await client.get(key)
+            except Exception:
+                logger.exception("permission_wait: redis read failed; denying request_id=%s", request_id)
+                return "deny"
+            if value:
+                decision = str(value).strip().lower()
+                return decision if decision in {"allow", "deny"} else "deny"
+            if is_cancel_requested is not None:
+                try:
+                    cancelled = is_cancel_requested()
+                    if asyncio.iscoroutine(cancelled):
+                        cancelled = await cancelled
+                    if cancelled:
+                        return "deny"
+                except Exception:
+                    pass
+            if asyncio.get_event_loop().time() >= deadline:
+                return "timeout"
+            await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -179,6 +179,65 @@ class SdkBlockWriter:
             data=evt,
         )
 
+    def append_permission_request(
+        self,
+        *,
+        request_id: str,
+        tool_name: str,
+        risk_level: str = "high",
+        title: str = "",
+        summary: str = "",
+        payload_preview: Any = None,
+    ) -> None:
+        """Record a generic Chat V2 permission-request block.
+
+        Skill-agnostic: ``payload_preview`` is opaque JSON shown verbatim by the
+        confirmation card. Projected into a ``permission_request`` block that the
+        portal chat and widget render identically.
+        """
+        self._store.append_sdk_record(
+            task_id=self._task_id,
+            topic_id=self._topic_id,
+            turn_index=self._turn_index,
+            record_type="permission_request",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "tool_name": str(tool_name or ""),
+                "risk_level": str(risk_level or "high"),
+                "title": str(title or ""),
+                "summary": str(summary or ""),
+                "payload_preview": payload_preview,
+            },
+        )
+
+    def append_permission_decision(
+        self,
+        *,
+        request_id: str,
+        decision: str,
+        note: str = "",
+        decided_at: str = "",
+    ) -> None:
+        """Record the user's decision for a prior permission request.
+
+        ``decision`` is one of ``allowed`` / ``denied`` / ``timeout``; it merges
+        onto the matching ``permission_request`` block during projection.
+        """
+        self._store.append_sdk_record(
+            task_id=self._task_id,
+            topic_id=self._topic_id,
+            turn_index=self._turn_index,
+            record_type="permission_decision",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "decision": str(decision or "pending"),
+                "note": str(note or ""),
+                "decided_at": str(decided_at or ""),
+            },
+        )
+
     def append_done(self, *, is_error: bool, subtype: str = "") -> None:
         self._append_terminal_record(
             record_type="done",

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -11,6 +11,7 @@ from typing import Any
 import redis.asyncio as redis
 
 from config import get_settings
+from core.permission_gate import permission_decision_redis_key
 from core.task_submission_service import compute_next_run_at, current_utc_naive, submit_message_task
 from core.task_executor import TaskExecutionInput, execute_task_stream
 from core.topic_files import diff_generated_files, snapshot_workspace_state
@@ -491,7 +492,7 @@ class TaskCoordinator:
         return f"da:task:cancel:{task_id}"
 
     def _permission_key(self, task_id: str, request_id: str) -> str:
-        return f"da:task:permission:{task_id}:{request_id}"
+        return permission_decision_redis_key(task_id, request_id)
 
     def _recovery_key(self) -> str:
         return "da:task:recovery:lock"

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -88,6 +88,29 @@ class TaskCoordinator:
             return True
         return self.store.is_task_cancel_requested(task_id)
 
+    async def submit_permission_decision(self, task_id: str, request_id: str, decision: str) -> str:
+        """Publish a user permission decision for a waiting run (allow/deny).
+
+        Idempotent: the first decision for a ``request_id`` wins; later calls
+        return the recorded value. Mirrors the cancel-flag pattern so both the
+        in-process executor and the sandbox runner can observe it via Redis.
+        Returns the effective decision.
+        """
+        effective = str(decision or "denied")
+        if self._redis is None:
+            return effective
+        key = self._permission_key(task_id, request_id)
+        ttl = max(60, int(self.settings.task_permission_wait_seconds or 600) + 60)
+        await self._redis.set(key, effective, ex=ttl, nx=True)
+        current = await self._redis.get(key)
+        return str(current) if current is not None else effective
+
+    async def read_permission_decision(self, task_id: str, request_id: str) -> str | None:
+        if self._redis is None:
+            return None
+        value = await self._redis.get(self._permission_key(task_id, request_id))
+        return str(value) if value is not None else None
+
     async def _queue_loop(self) -> None:
         while not self._closing:
             task_id = await self._queue.get()
@@ -466,6 +489,9 @@ class TaskCoordinator:
 
     def _cancel_key(self, task_id: str) -> str:
         return f"da:task:cancel:{task_id}"
+
+    def _permission_key(self, task_id: str, request_id: str) -> str:
+        return f"da:task:permission:{task_id}:{request_id}"
 
     def _recovery_key(self) -> str:
         return "da:task:recovery:lock"

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -148,6 +148,7 @@ class TaskCoordinator:
                         sql_read_timeout_seconds=int(task.get("sql_read_timeout_seconds") or 0),
                         sql_write_timeout_seconds=int(task.get("sql_write_timeout_seconds") or 0),
                         agent_snapshot=task.get("agent_snapshot"),
+                        permission_mode=self.store.get_topic_permission_mode(topic_id),
                     ),
                     emit=lambda record: self._persist_emitted_sdk_record(
                         topic_id=topic_id,

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -5,7 +5,9 @@ import inspect
 import json
 import logging
 import os
+import uuid
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -14,6 +16,8 @@ import httpx
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, normalize_permission_mode
+from core.permission_gate import is_high_risk_tool, plan_denies_tool, requires_confirmation
+from core.permission_wait import wait_for_decision
 from core.agent_runtime import (
     _build_allowed_tools,
     _build_portal_mcp_servers,
@@ -332,6 +336,112 @@ class SdkResultAccumulator:
         )
 
 
+def _permission_result_types():
+    """Return (Allow, Deny) result classes from the SDK, or (None, None).
+
+    Imported lazily because the package is optional in some environments; when
+    unavailable the callback falls back to the dict permission protocol.
+    """
+    try:
+        from claude_agent_sdk import PermissionResultAllow, PermissionResultDeny
+
+        return PermissionResultAllow, PermissionResultDeny
+    except Exception:
+        return None, None
+
+
+def _allow_result(tool_input: dict[str, Any]):
+    Allow, _ = _permission_result_types()
+    if Allow is not None:
+        try:
+            return Allow(updated_input=tool_input)
+        except Exception:
+            try:
+                return Allow()
+            except Exception:
+                pass
+    return {"behavior": "allow", "updatedInput": tool_input}
+
+
+def _deny_result(message: str):
+    _, Deny = _permission_result_types()
+    if Deny is not None:
+        try:
+            return Deny(message=message)
+        except Exception:
+            pass
+    return {"behavior": "deny", "message": message}
+
+
+def _build_can_use_tool_callback(
+    *,
+    sdk_writer: SdkBlockWriter,
+    store: Any,
+    task_id: str,
+    permission_mode: str,
+    wait_seconds: int,
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+):
+    """Build the SDK can_use_tool callback enforcing session permission policy.
+
+    Read/analysis tools auto-allow. Write/high-risk tools (per session mode) pause
+    the run: a permission_request block is recorded, the task moves to
+    waiting_permission, and the run waits for the user's decision (Redis) before
+    recording the decision and resuming. Plan-denied tools are rejected outright.
+    """
+
+    async def can_use_tool(tool_name: str, tool_input: dict[str, Any] | None = None, context: Any = None):
+        tool_input = dict(tool_input or {})
+        if permission_mode == "plan" and plan_denies_tool(tool_name):
+            return _deny_result("当前为规划(plan)模式，不允许执行写操作。")
+        if not requires_confirmation(tool_name, permission_mode):
+            return _allow_result(tool_input)
+
+        request_id = uuid.uuid4().hex
+        bare = tool_name.split("__")[-1] if tool_name.startswith("mcp__") else tool_name
+        summary = str(tool_input.get("summary") or "").strip()
+        title = str(tool_input.get("title") or "").strip() or f"请确认操作:{bare}"
+        risk_level = "critical" if is_high_risk_tool(tool_name) else "high"
+        try:
+            sdk_writer.append_permission_request(
+                request_id=request_id,
+                tool_name=tool_name,
+                risk_level=risk_level,
+                title=title,
+                summary=summary,
+                payload_preview=tool_input,
+            )
+            store.set_task_status(task_id, "waiting_permission")
+        except Exception:
+            logger.exception("can_use_tool: failed to record permission request task_id=%s", task_id)
+            return _deny_result("无法发起确认请求。")
+
+        decision = await wait_for_decision(
+            task_id,
+            request_id,
+            timeout_seconds=wait_seconds,
+            is_cancel_requested=is_cancel_requested,
+        )
+        recorded = "allowed" if decision == "allow" else ("timeout" if decision == "timeout" else "denied")
+        try:
+            sdk_writer.append_permission_decision(
+                request_id=request_id,
+                decision=recorded,
+                decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            )
+            store.set_task_status(task_id, "running")
+        except Exception:
+            logger.exception("can_use_tool: failed to record permission decision task_id=%s", task_id)
+
+        if decision == "allow":
+            return _allow_result(tool_input)
+        if decision == "timeout":
+            return _deny_result("等待确认超时，已自动拒绝该操作。")
+        return _deny_result("用户拒绝了该操作。")
+
+    return can_use_tool
+
+
 async def execute_task_stream(
     params: TaskExecutionInput,
     *,
@@ -520,9 +630,8 @@ async def _execute_task_stream_local(
     if requested_permission_mode is None:
         requested_permission_mode = (agent_snapshot or {}).get("permission_mode")
     # logical_permission_mode is the session choice (plan/default/acceptEdits/
-    # bypassPermissions) used for tool gating; permission_mode is what the SDK runs.
+    # bypassPermissions); the SDK permission_mode is decided after tool mounting.
     logical_permission_mode = normalize_permission_mode(requested_permission_mode)
-    permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
     max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]
     mcp_servers = _build_portal_mcp_servers(
@@ -535,6 +644,24 @@ async def _execute_task_stream_local(
         (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None,
         permission_mode=logical_permission_mode,
     )
+    # Gating fires only when there are guardable write tools (portal MCP) and the
+    # session mode asks for confirmation. When gating, the SDK must run in
+    # "default" mode so can_use_tool is consulted; otherwise preserve the
+    # established bypassPermissions behavior (allowed_tools is the boundary).
+    needs_gating = bool(mcp_servers) and logical_permission_mode in {"default", "acceptEdits"}
+    can_use_tool = None
+    if needs_gating:
+        permission_mode = "default"
+        can_use_tool = _build_can_use_tool_callback(
+            sdk_writer=sdk_writer,
+            store=get_topic_task_store(),
+            task_id=params.task_id,
+            permission_mode=logical_permission_mode,
+            wait_seconds=int(getattr(cfg, "task_permission_wait_seconds", 600) or 600),
+            is_cancel_requested=is_cancel_requested,
+        )
+    else:
+        permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
     options_kwargs = dict(
         system_prompt=system_prompt,
         model=model,
@@ -560,6 +687,8 @@ async def _execute_task_stream_local(
         options_kwargs["resume"] = params.resume_session_id
     if permission_mode:
         options_kwargs["permission_mode"] = permission_mode
+    if can_use_tool is not None:
+        options_kwargs["can_use_tool"] = can_use_tool
     cli_path = resolve_claude_cli_path(cfg)
     if cli_path:
         options_kwargs["cli_path"] = cli_path

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -64,6 +64,7 @@ class TaskExecutionInput:
     sql_write_timeout_seconds: int | None = None
     execution_mode: str = "background"
     agent_snapshot: dict[str, Any] | None = None
+    permission_mode: str | None = None
 
 
 @dataclass
@@ -513,7 +514,12 @@ async def _execute_task_stream_local(
     runtime_env.update(workspace_env)
     for key, value in workspace_env.items():
         os.environ[key] = value
-    permission_mode = _resolve_sdk_permission_mode(str((agent_snapshot or {}).get("permission_mode") or "inherit"))
+    # Permission mode is a session-level choice carried on TaskExecutionInput.
+    # Older snapshots may still embed permission_mode; honor it only as a fallback.
+    requested_permission_mode = params.permission_mode
+    if requested_permission_mode is None:
+        requested_permission_mode = (agent_snapshot or {}).get("permission_mode")
+    permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
     max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]
     mcp_servers = _build_portal_mcp_servers(

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -13,7 +13,7 @@ import anyio
 import httpx
 
 from config import get_settings
-from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot
+from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, normalize_permission_mode
 from core.agent_runtime import (
     _build_allowed_tools,
     _build_portal_mcp_servers,
@@ -519,6 +519,9 @@ async def _execute_task_stream_local(
     requested_permission_mode = params.permission_mode
     if requested_permission_mode is None:
         requested_permission_mode = (agent_snapshot or {}).get("permission_mode")
+    # logical_permission_mode is the session choice (plan/default/acceptEdits/
+    # bypassPermissions) used for tool gating; permission_mode is what the SDK runs.
+    logical_permission_mode = normalize_permission_mode(requested_permission_mode)
     permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
     max_turns = _resolve_max_turns(cfg, params.execution_mode, int((agent_snapshot or {}).get("max_turns") or 0))
     setting_sources = ["project"]
@@ -527,7 +530,11 @@ async def _execute_task_stream_local(
         (agent_snapshot or {}).get("mcp_server_ids") if agent_snapshot else None,
         agent_snapshot=agent_snapshot,
     )
-    allowed_tools = _build_allowed_tools(mcp_servers, (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None)
+    allowed_tools = _build_allowed_tools(
+        mcp_servers,
+        (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None,
+        permission_mode=logical_permission_mode,
+    )
     options_kwargs = dict(
         system_prompt=system_prompt,
         model=model,

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -11,7 +11,13 @@ from typing import Any
 import pymysql
 
 from config import get_settings
-from core.agent_profile_service import DEFAULT_AGENT_ID, agent_summary_from_snapshot, default_agent_payload, normalize_agent_snapshot
+from core.agent_profile_service import (
+    DEFAULT_AGENT_ID,
+    agent_summary_from_snapshot,
+    default_agent_payload,
+    normalize_agent_snapshot,
+    normalize_permission_mode,
+)
 from core.topic_workspace import delete_topic_workspace
 
 logger = logging.getLogger(__name__)
@@ -386,12 +392,14 @@ class TopicTaskStore:
         *,
         title: str,
         agent_snapshot: dict[str, Any] | None = None,
+        permission_mode: str | None = None,
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         self._ensure_ready()
         normalized_context = self._normalize_context(context)
         snapshot = normalize_agent_snapshot(agent_snapshot or default_agent_payload())
         agent_id = str(snapshot.get("agent_id") or DEFAULT_AGENT_ID)
+        resolved_permission_mode = normalize_permission_mode(permission_mode)
         topic_id = _new_id("topic")
         chat_topic_id = _new_id("chat_topic")
         chat_conversation_id = _new_id("chat_conv")
@@ -403,9 +411,9 @@ class TopicTaskStore:
                     INSERT INTO da_agent_topic (
                         topic_id, title, chat_topic_id, chat_conversation_id,
                         current_task_id, current_task_status, last_message_seq,
-                        agent_id, agent_snapshot_json,
+                        agent_id, agent_snapshot_json, permission_mode,
                         source, website_id, external_user_id, visitor_id
-                    ) VALUES (%s, %s, %s, %s, NULL, NULL, 0, %s, %s, %s, %s, %s, %s)
+                    ) VALUES (%s, %s, %s, %s, NULL, NULL, 0, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     (
                         topic_id,
@@ -414,6 +422,7 @@ class TopicTaskStore:
                         chat_conversation_id,
                         agent_id,
                         _json_dump(snapshot),
+                        resolved_permission_mode,
                         normalized_context["source"],
                         normalized_context["website_id"],
                         normalized_context["external_user_id"],
@@ -448,6 +457,7 @@ class TopicTaskStore:
                     SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
                            t.current_task_id, t.current_task_status, t.source, t.website_id,
                            t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.permission_mode,
                            t.created_at, t.updated_at,
                            COALESCE(stats.message_count, 0) AS message_count,
                            COALESCE(stats.last_message_preview, '') AS last_message_preview
@@ -550,6 +560,7 @@ class TopicTaskStore:
                     SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
                            t.current_task_id, t.current_task_status, t.source, t.website_id,
                            t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.permission_mode,
                            t.created_at, t.updated_at,
                            COALESCE(stats.message_count, 0) AS message_count,
                            COALESCE(stats.last_message_preview, '') AS last_message_preview
@@ -674,6 +685,7 @@ class TopicTaskStore:
                     SELECT t.topic_id, t.title, t.chat_topic_id, t.chat_conversation_id,
                            t.current_task_id, t.current_task_status, t.source, t.website_id,
                            t.external_user_id, t.visitor_id, t.agent_id, t.agent_snapshot_json,
+                           t.permission_mode,
                            t.created_at, t.updated_at,
                            COALESCE(stats.message_count, 0) AS message_count,
                            COALESCE(stats.last_message_preview, '') AS last_message_preview
@@ -703,21 +715,58 @@ class TopicTaskStore:
             return None
         return self._normalize_topic_row(row, include_messages=False)
 
-    def update_topic(self, topic_id: str, *, title: str, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    def get_topic_permission_mode(self, topic_id: str) -> str:
+        """Read the session's current permission mode (latest selection).
+
+        Used at task-execution assembly time so a run honors the mode active on
+        its topic without snapshotting it onto the task row.
+        """
         self._ensure_ready()
-        if not self.get_topic(topic_id, context=context):
-            return None
         conn = self._connect(database=self._schema_name())
         try:
             with conn.cursor() as cur:
                 cur.execute(
-                    """
+                    "SELECT permission_mode FROM da_agent_topic WHERE topic_id = %s LIMIT 1",
+                    (topic_id,),
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+        return normalize_permission_mode((row or {}).get("permission_mode"))
+
+    def update_topic(
+        self,
+        topic_id: str,
+        *,
+        title: str | None = None,
+        permission_mode: str | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        self._ensure_ready()
+        if not self.get_topic(topic_id, context=context):
+            return None
+        assignments: list[str] = []
+        params: list[Any] = []
+        if title is not None:
+            assignments.append("title = %s")
+            params.append(title or "新话题")
+        if permission_mode is not None:
+            assignments.append("permission_mode = %s")
+            params.append(normalize_permission_mode(permission_mode))
+        if not assignments:
+            return self.get_topic(topic_id, context=context)
+        assignments.append("updated_at = CURRENT_TIMESTAMP")
+        params.append(topic_id)
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
                     UPDATE da_agent_topic
-                    SET title = %s,
-                        updated_at = CURRENT_TIMESTAMP
+                    SET {", ".join(assignments)}
                     WHERE topic_id = %s
                     """,
-                    (title or "新话题", topic_id),
+                    tuple(params),
                 )
             conn.commit()
         finally:
@@ -2206,6 +2255,7 @@ class TopicTaskStore:
             "agent_id": str(row.get("agent_id") or snapshot.get("agent_id") or DEFAULT_AGENT_ID),
             "agent_snapshot": snapshot,
             "agent": agent_summary_from_snapshot(snapshot),
+            "permission_mode": normalize_permission_mode(row.get("permission_mode")),
             "current_task_id": str(row.get("current_task_id") or "") or None,
             "current_task_status": str(row.get("current_task_status") or "") or None,
             "source": str(row.get("source") or "portal"),

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -100,6 +100,7 @@ def _project_sdk_records(records: list[dict[str, Any]]) -> dict[str, Any]:
     current_turn_blocks: list[dict[str, Any]] | None = None
     block_by_index: dict[int, dict[str, Any]] = {}
     blocks_by_tool_id: dict[str, dict[str, Any]] = {}
+    perm_blocks_by_request_id: dict[str, dict[str, Any]] = {}
     max_seq_id = 0
 
     for record in records:
@@ -175,6 +176,35 @@ def _project_sdk_records(records: list[dict[str, Any]]) -> dict[str, Any]:
                             block["input"] = json.loads(input_json)
                         except Exception:
                             block["input"] = input_json
+
+        elif record_type == "permission_request":
+            request_id = str(data.get("request_id") or "")
+            block = {
+                "type": "permission_request",
+                "request_id": request_id,
+                "tool_name": str(data.get("tool_name") or ""),
+                "risk_level": str(data.get("risk_level") or "high"),
+                "title": str(data.get("title") or ""),
+                "summary": str(data.get("summary") or ""),
+                "payload_preview": data.get("payload_preview"),
+                "decision": "pending",
+                "note": "",
+                "decided_at": "",
+                "_idx": len(ordered_blocks),
+            }
+            ordered_blocks.append(block)
+            if current_turn_blocks is not None:
+                current_turn_blocks.append(block)
+            if request_id:
+                perm_blocks_by_request_id[request_id] = block
+
+        elif record_type == "permission_decision":
+            request_id = str(data.get("request_id") or "")
+            block = perm_blocks_by_request_id.get(request_id)
+            if block is not None:
+                block["decision"] = str(data.get("decision") or "pending")
+                block["note"] = str(data.get("note") or "")
+                block["decided_at"] = str(data.get("decided_at") or "")
 
         elif record_type == "tool_result":
             tool_use_id = str(data.get("tool_use_id") or "")
@@ -1325,6 +1355,44 @@ class TopicTaskStore:
                       AND t.current_task_id = k.task_id
                     """,
                     (task_id,),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        return self.get_task(task_id)
+
+    def set_task_status(self, task_id: str, status: str) -> dict[str, Any] | None:
+        """Set a non-terminal in-flight status (e.g. ``waiting_permission`` while
+        a run waits at a confirmation, then back to ``running``).
+
+        Terminal transitions go through the dedicated finalize paths; this is for
+        reversible in-flight states only.
+        """
+        self._ensure_ready()
+        safe_status = str(status or "running")
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE da_agent_task
+                    SET task_status = %s,
+                        heartbeat_at = CURRENT_TIMESTAMP,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE task_id = %s
+                    """,
+                    (safe_status, task_id),
+                )
+                cur.execute(
+                    """
+                    UPDATE da_agent_topic t
+                    JOIN da_agent_task k ON k.topic_id = t.topic_id
+                    SET t.current_task_status = %s,
+                        t.updated_at = CURRENT_TIMESTAMP
+                    WHERE k.task_id = %s
+                      AND t.current_task_id = k.task_id
+                    """,
+                    (safe_status, task_id),
                 )
             conn.commit()
         finally:

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -50,10 +50,12 @@ class QAExample(BaseModel):
 class CreateTopicRequest(BaseModel):
     title: Optional[str] = None
     agent_id: Optional[str] = None
+    permission_mode: Optional[str] = None
 
 
 class UpdateTopicRequest(BaseModel):
-    title: str
+    title: Optional[str] = None
+    permission_mode: Optional[str] = None
 
 
 class DeliverMessageRequest(BaseModel):
@@ -65,6 +67,7 @@ class DeliverMessageRequest(BaseModel):
     debug: bool = False
     database: Optional[str] = None
     execution_mode: Optional[str] = None
+    permission_mode: Optional[str] = None
 
 
 class CreateTaskRequest(BaseModel):
@@ -386,7 +389,6 @@ class AgentProfileBase(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     system_prompt: Optional[str] = None
-    permission_mode: Optional[str] = None
     allowed_tools: Optional[List[str]] = None
     mcp_server_ids: Optional[List[str]] = None
     skill_folders: Optional[List[str]] = None
@@ -421,7 +423,6 @@ class AgentCapabilitiesResponse(BaseModel):
     tools: List[str] = Field(default_factory=list)
     mcp_servers: List[AgentMcpServerCapability] = Field(default_factory=list)
     skills: List[AgentSkillCapability] = Field(default_factory=list)
-    permission_modes: List[str] = Field(default_factory=list)
 
 
 class AgentDataScopeOption(BaseModel):
@@ -436,7 +437,6 @@ class AgentProfile(BaseModel):
     name: str
     description: str = ""
     system_prompt: str = ""
-    permission_mode: str = "inherit"
     allowed_tools: List[str] = Field(default_factory=list)
     mcp_server_ids: List[str] = Field(default_factory=list)
     skill_folders: List[str] = Field(default_factory=list)
@@ -498,6 +498,7 @@ class TopicSummary(BaseModel):
     chat_conversation_id: str
     agent_id: str = ""
     agent: Optional[AgentSummary] = None
+    permission_mode: str = "default"
     current_task_id: Optional[str] = None
     current_task_status: Optional[str] = None
     message_count: int = 0
@@ -513,6 +514,7 @@ class TopicDetail(BaseModel):
     chat_conversation_id: str
     agent_id: str = ""
     agent: Optional[AgentSummary] = None
+    permission_mode: str = "default"
     current_task_id: Optional[str] = None
     current_task_status: Optional[str] = None
     created_at: str = ""

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -70,6 +70,18 @@ class DeliverMessageRequest(BaseModel):
     permission_mode: Optional[str] = None
 
 
+class PermissionDecisionRequest(BaseModel):
+    request_id: str
+    decision: str  # "allow" | "deny"
+    note: Optional[str] = None
+
+
+class PermissionDecisionResponse(BaseModel):
+    task_id: str
+    request_id: str
+    decision: str
+
+
 class CreateTaskRequest(BaseModel):
     topic_id: str
     message_type: str

--- a/dataagent/dataagent-backend/tests/test_agent_profile_service.py
+++ b/dataagent/dataagent-backend/tests/test_agent_profile_service.py
@@ -76,7 +76,7 @@ def test_normalize_agent_profile_payload_accepts_scoped_runtime_config():
     )
 
     assert payload["name"] == "质量巡检助手"
-    assert payload["permission_mode"] == "bypassPermissions"
+    assert "permission_mode" not in payload
     assert payload["allowed_tools"] == ["Read", "Skill", "Grep"]
     assert payload["mcp_server_ids"] == ["portal"]
     assert payload["skill_folders"] == ["opendataworks-business-knowledge"]
@@ -142,7 +142,6 @@ def test_build_agent_snapshot_keeps_runtime_fields_without_timestamps():
         "name": "质量巡检助手",
         "description": "只处理数据质量规则和巡检结果分析。",
         "system_prompt": "你是数据质量巡检场景的智能体。",
-        "permission_mode": "default",
         "allowed_tools": ["Skill", "Read"],
         "mcp_server_ids": ["portal"],
         "skill_folders": ["opendataworks-business-knowledge"],

--- a/dataagent/dataagent-backend/tests/test_agent_profile_service.py
+++ b/dataagent/dataagent-backend/tests/test_agent_profile_service.py
@@ -33,7 +33,11 @@ def test_opendataworks_agent_payload_is_builtin_with_platform_capabilities():
     assert payload["name"] == "OpenDataWorks平台助手"
     assert payload["allowed_tools"] == ["Skill", "Bash", "Read", "LS", "Glob", "Grep"]
     assert payload["mcp_server_ids"] == ["portal"]
-    assert payload["skill_folders"] == ["opendataworks-business-knowledge", "opendataworks-platform-tools"]
+    assert payload["skill_folders"] == [
+        "opendataworks-business-knowledge",
+        "opendataworks-platform-tools",
+        "opendataworks-data-dev",
+    ]
     assert payload["is_default"] is False
     assert payload["is_builtin"] is True
 

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -220,6 +220,32 @@ def test_build_allowed_tools_includes_portal_mcp_tools_once():
     assert len(allowed_tools) == len(set(allowed_tools))
 
 
+_PORTAL_MCP = {
+    "portal": {
+        "type": "http",
+        "url": "http://portal-mcp:8801/mcp/",
+        "headers": {"X-Portal-MCP-Token": "portal-token"},
+    }
+}
+
+
+def test_build_allowed_tools_mounts_write_tools_in_default_mode():
+    allowed = agent_runtime._build_allowed_tools(_PORTAL_MCP, permission_mode="default")
+    assert "mcp__portal__portal_create_task" in allowed
+    assert "mcp__portal__portal_publish_workflow" in allowed
+    assert "mcp__portal__portal_search_tables" in allowed
+
+
+def test_build_allowed_tools_plan_mode_strips_write_tools():
+    allowed = agent_runtime._build_allowed_tools(_PORTAL_MCP, permission_mode="plan")
+    # read tools remain mounted
+    assert "mcp__portal__portal_search_tables" in allowed
+    # write + high-risk tools are not mounted under plan
+    assert "mcp__portal__portal_create_task" not in allowed
+    assert "mcp__portal__portal_publish_workflow" not in allowed
+    assert "mcp__portal__portal_workflow_schedule_online" not in allowed
+
+
 def test_workspace_boundary_denies_parent_directory_file_lookup(tmp_path: Path):
     workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
     workspace.mkdir(parents=True)

--- a/dataagent/dataagent-backend/tests/test_permission_gate.py
+++ b/dataagent/dataagent-backend/tests/test_permission_gate.py
@@ -1,0 +1,51 @@
+"""Unit tests for session permission gating policy."""
+from __future__ import annotations
+
+from core import permission_gate as pg
+
+PUBLISH = "mcp__portal__portal_publish_workflow"
+SCHED_ONLINE = "mcp__portal__portal_workflow_schedule_online"
+CREATE_TASK = "mcp__portal__portal_create_task"
+ANALYZE = "mcp__portal__portal_analyze_sql"
+READ = "mcp__portal__portal_search_tables"
+
+
+def test_classification_by_bare_and_qualified_names() -> None:
+    assert pg.is_high_risk_tool(PUBLISH)
+    assert pg.is_high_risk_tool("portal_publish_workflow")
+    assert pg.is_write_tool(CREATE_TASK)
+    assert not pg.is_high_risk_tool(CREATE_TASK)
+    assert not pg.is_write_tool(ANALYZE)
+    assert not pg.is_write_tool(READ)
+
+
+def test_bypass_never_confirms() -> None:
+    for tool in (PUBLISH, CREATE_TASK, READ):
+        assert pg.requires_confirmation(tool, "bypassPermissions") is False
+
+
+def test_default_confirms_all_writes() -> None:
+    assert pg.requires_confirmation(PUBLISH, "default") is True
+    assert pg.requires_confirmation(CREATE_TASK, "default") is True
+    assert pg.requires_confirmation(ANALYZE, "default") is False
+    assert pg.requires_confirmation(READ, "default") is False
+
+
+def test_accept_edits_confirms_only_high_risk() -> None:
+    assert pg.requires_confirmation(PUBLISH, "acceptEdits") is True
+    assert pg.requires_confirmation(SCHED_ONLINE, "acceptEdits") is True
+    assert pg.requires_confirmation(CREATE_TASK, "acceptEdits") is False
+
+
+def test_plan_denies_writes_and_never_confirms() -> None:
+    # plan resolves write tools to outright denial, not confirmation.
+    assert pg.requires_confirmation(PUBLISH, "plan") is False
+    assert pg.plan_denies_tool(PUBLISH) is True
+    assert pg.plan_denies_tool(CREATE_TASK) is True
+    assert pg.plan_denies_tool(READ) is False
+
+
+def test_legacy_mode_normalizes_to_default() -> None:
+    # legacy 'inherit' / unknown -> default policy
+    assert pg.requires_confirmation(CREATE_TASK, "inherit") is True
+    assert pg.requires_confirmation(CREATE_TASK, "junk") is True

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -495,6 +495,15 @@ class _FakeCoordinator:
     async def request_cancel(self, task_id: str):
         self.cancelled.append(task_id)
 
+    def __init_decisions(self):
+        if not hasattr(self, "decisions"):
+            self.decisions = {}
+
+    async def submit_permission_decision(self, task_id: str, request_id: str, decision: str) -> str:
+        self.__init_decisions()
+        # first decision wins (idempotent)
+        return self.decisions.setdefault((task_id, request_id), decision)
+
 
 def _submit_message_task_factory(store: _FakeStore, calls: list[dict]):
     async def _submit_message_task(**kwargs):
@@ -734,6 +743,44 @@ def test_topic_permission_mode_lifecycle(monkeypatch):
         # PUT with neither field is a 400.
         empty = client.put(f"/api/v1/nl2sql/topics/{topic_id}", json={})
         assert empty.status_code == 400
+
+
+def test_permission_decision_endpoint(monkeypatch):
+    client, store, coordinator, _submit_calls = _build_client(monkeypatch)
+    with client:
+        topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "确认流"}).json()["topic_id"]
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={"topic_id": topic_id, "content": "发布工作流"},
+        ).json()
+        task_id = delivered["task_id"]
+
+        base = f"/api/v1/nl2sql/tasks/{task_id}/permission-decision"
+        # Not awaiting a decision yet -> 409.
+        assert client.post(base, json={"request_id": "req-1", "decision": "allow"}).status_code == 409
+
+        # Move the run into the waiting state.
+        store.tasks[task_id]["task_status"] = "waiting_permission"
+
+        # Invalid decision value -> 400.
+        assert client.post(base, json={"request_id": "req-1", "decision": "maybe"}).status_code == 400
+        # Missing request_id -> 400.
+        assert client.post(base, json={"request_id": "", "decision": "allow"}).status_code == 400
+
+        # Valid allow.
+        ok = client.post(base, json={"request_id": "req-1", "decision": "allow"})
+        assert ok.status_code == 200
+        assert ok.json() == {"task_id": task_id, "request_id": "req-1", "decision": "allow"}
+
+        # Idempotent: a later deny for the same request_id returns the first decision.
+        again = client.post(base, json={"request_id": "req-1", "decision": "deny"})
+        assert again.json()["decision"] == "allow"
+
+        # Unknown task -> 404.
+        assert client.post(
+            "/api/v1/nl2sql/tasks/task_missing/permission-decision",
+            json={"request_id": "req-1", "decision": "allow"},
+        ).status_code == 404
 
 
 def test_followup_suggestions_route_generates_without_changing_message_contract(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -13,6 +13,7 @@ if str(BACKEND_ROOT) not in sys.path:
 
 import api.routes as routes
 import main
+from core.agent_profile_service import normalize_permission_mode
 
 
 DEFAULT_AGENT = {
@@ -81,7 +82,7 @@ class _FakeStore:
         self._schedule_log_seq += 1
         return f"schedule_log_{self._schedule_log_seq}"
 
-    def create_topic(self, *, title: str, agent_snapshot=None, context=None):
+    def create_topic(self, *, title: str, agent_snapshot=None, permission_mode=None, context=None):
         topic_id = self._new_topic()
         snapshot = dict(agent_snapshot or DEFAULT_AGENT)
         self.topics[topic_id] = {
@@ -97,6 +98,7 @@ class _FakeStore:
                 "description": snapshot.get("description", ""),
                 "is_default": bool(snapshot.get("is_default")),
             },
+            "permission_mode": normalize_permission_mode(permission_mode),
             "current_task_id": None,
             "current_task_status": None,
             "message_count": 0,
@@ -125,12 +127,19 @@ class _FakeStore:
         row["last_message_preview"] = self.topic_messages.get(topic_id, [{}])[-1].get("content", "")[:120] if self.topic_messages.get(topic_id) else ""
         return row
 
-    def update_topic(self, topic_id: str, *, title: str, context=None):
+    def update_topic(self, topic_id: str, *, title=None, permission_mode=None, context=None):
         if topic_id not in self.topics:
             return None
-        self.topics[topic_id]["title"] = title
+        if title is not None:
+            self.topics[topic_id]["title"] = title
+        if permission_mode is not None:
+            self.topics[topic_id]["permission_mode"] = normalize_permission_mode(permission_mode)
         self.topics[topic_id]["updated_at"] = _now()
         return self.get_topic(topic_id)
+
+    def get_topic_permission_mode(self, topic_id: str) -> str:
+        topic = self.topics.get(topic_id) or {}
+        return normalize_permission_mode(topic.get("permission_mode"))
 
     def delete_topic(self, topic_id: str, context=None):
         self.topics.pop(topic_id, None)
@@ -683,6 +692,48 @@ def test_topics_tasks_and_v2_routes(monkeypatch):
         deleted = client.delete(f"/api/v1/nl2sql/topics/{topic_id}")
         assert deleted.status_code == 200
         assert store.get_topic(topic_id) is None
+
+
+def test_topic_permission_mode_lifecycle(monkeypatch):
+    client, store, _coordinator, _submit_calls = _build_client(monkeypatch)
+    with client:
+        # Create defaults to ``default``; explicit mode is honored.
+        default_topic = client.post("/api/v1/nl2sql/topics", json={"title": "默认模式"}).json()
+        assert default_topic["permission_mode"] == "default"
+
+        created = client.post(
+            "/api/v1/nl2sql/topics",
+            json={"title": "规划模式", "permission_mode": "plan"},
+        ).json()
+        topic_id = created["topic_id"]
+        assert created["permission_mode"] == "plan"
+
+        # PUT switches the latest selection mid-session.
+        switched = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}",
+            json={"permission_mode": "bypassPermissions"},
+        )
+        assert switched.status_code == 200
+        assert switched.json()["permission_mode"] == "bypassPermissions"
+
+        # Unknown values normalize to ``default``.
+        normalized = client.put(
+            f"/api/v1/nl2sql/topics/{topic_id}",
+            json={"permission_mode": "junk"},
+        )
+        assert normalized.json()["permission_mode"] == "default"
+
+        # deliver-message carrying a mode updates the topic's latest selection.
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={"topic_id": topic_id, "content": "你好", "permission_mode": "acceptEdits"},
+        )
+        assert delivered.status_code == 200
+        assert store.get_topic_permission_mode(topic_id) == "acceptEdits"
+
+        # PUT with neither field is a 400.
+        empty = client.put(f"/api/v1/nl2sql/topics/{topic_id}", json={})
+        assert empty.status_code == 400
 
 
 def test_followup_suggestions_route_generates_without_changing_message_contract(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
@@ -40,6 +40,17 @@ def _to_canonical(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "is_error": bool(block.get("is_error")),
                 }
             )
+        elif btype == "permission_request":
+            canonical.append(
+                {
+                    "kind": "permission_request",
+                    "tool_name": block.get("tool_name"),
+                    "risk_level": block.get("risk_level"),
+                    "title": block.get("title"),
+                    "summary": block.get("summary"),
+                    "decision": block.get("decision"),
+                }
+            )
         else:
             kind = "text" if btype == "main_text" else str(btype or "")
             text = str(block.get("text") or "")

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -115,7 +115,7 @@ def _install_fake_sdk(monkeypatch, messages, *, final_exception=None):
     )
 
 
-def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None):
+def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None, permission_mode=None):
     return task_executor.TaskExecutionInput(
         task_id="task-1",
         topic_id="topic-1",
@@ -130,6 +130,7 @@ def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None):
         sql_read_timeout_seconds=30,
         sql_write_timeout_seconds=30,
         agent_snapshot=agent_snapshot,
+        permission_mode=permission_mode,
     )
 
 
@@ -332,7 +333,9 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read"]
     assert ClaudeAgentOptions.last_kwargs["mcp_servers"] == {}
     assert ClaudeAgentOptions.last_kwargs["max_turns"] == 7
-    assert ClaudeAgentOptions.last_kwargs["permission_mode"] == "default"
+    # Permission mode resolves through the runtime helper (root vs non-root differ);
+    # assert against it rather than a hard-coded value.
+    assert ClaudeAgentOptions.last_kwargs["permission_mode"] == task_executor._resolve_sdk_permission_mode("default")
     assert ClaudeAgentOptions.last_kwargs["env"]["SAFE_FLAG"] == "1"
     assert "只返回自定义智能体结果。" in ClaudeAgentOptions.last_kwargs["system_prompt"]
     assert "PreToolUse" in ClaudeAgentOptions.last_kwargs["hooks"]
@@ -346,6 +349,61 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     )
     assert blocked["decision"] == "block"
     assert blocked["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_execute_task_stream_prefers_session_permission_mode_over_snapshot(monkeypatch, tmp_path: Path):
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            AssistantMessage([TextBlock("mode-ok")]),
+            ResultMessage("success", session_id="sdk-session-mode"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": provider_id,
+            "model": model,
+            "api_key": "",
+            "auth_token": "",
+            "base_url": "https://example.invalid",
+            "supports_partial_messages": False,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(task_executor, "prepare_topic_workspace", lambda topic_id, folders, **kwargs: tmp_path / "ws")
+
+    requested: dict[str, object] = {}
+
+    def fake_resolve(permission_mode=None):
+        requested["mode"] = permission_mode
+        return "bypassPermissions"
+
+    monkeypatch.setattr(task_executor, "_resolve_sdk_permission_mode", fake_resolve)
+
+    asyncio.run(
+        task_executor.execute_task_stream(
+            _build_input(
+                agent_snapshot={
+                    "agent_id": "agent_1",
+                    "name": "自定义智能体",
+                    "permission_mode": "bypassPermissions",
+                    "allowed_tools": ["Read"],
+                    "mcp_server_ids": [],
+                    "skill_folders": [],
+                    "max_turns": 0,
+                    "env_vars": {},
+                    "is_default": False,
+                },
+                permission_mode="plan",
+            ),
+            emit=lambda record: None,
+        )
+    )
+
+    # Session-level mode on TaskExecutionInput wins over the legacy snapshot value.
+    assert requested["mode"] == "plan"
 
 
 def test_execute_task_stream_uses_topic_workspace_for_sdk_cwd_and_keeps_home_distinct(monkeypatch, tmp_path: Path):

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -17,6 +17,86 @@ from config import get_settings, update_settings
 from core import task_executor
 
 
+class _RecordingWriter:
+    def __init__(self):
+        self.requests = []
+        self.decisions = []
+
+    def append_permission_request(self, **kwargs):
+        self.requests.append(kwargs)
+
+    def append_permission_decision(self, **kwargs):
+        self.decisions.append(kwargs)
+
+
+class _RecordingStore:
+    def __init__(self):
+        self.statuses = []
+
+    def set_task_status(self, task_id, status):
+        self.statuses.append(status)
+
+
+def _build_gate(monkeypatch, decision, *, mode="default"):
+    writer = _RecordingWriter()
+    store = _RecordingStore()
+
+    async def fake_wait(task_id, request_id, *, timeout_seconds, is_cancel_requested=None, **kw):
+        return decision
+
+    monkeypatch.setattr(task_executor, "wait_for_decision", fake_wait)
+    cb = task_executor._build_can_use_tool_callback(
+        sdk_writer=writer,
+        store=store,
+        task_id="task-1",
+        permission_mode=mode,
+        wait_seconds=5,
+        is_cancel_requested=None,
+    )
+    return cb, writer, store
+
+
+def test_can_use_tool_allows_read_tools_without_confirmation(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "deny")
+    result = asyncio.run(cb("mcp__portal__portal_search_tables", {}))
+    assert result["behavior"] == "allow"
+    assert writer.requests == []
+    assert store.statuses == []
+
+
+def test_can_use_tool_confirms_write_tool_allowed(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "allow")
+    result = asyncio.run(cb("mcp__portal__portal_create_task", {"summary": "建表任务"}))
+    assert result["behavior"] == "allow"
+    assert len(writer.requests) == 1
+    assert writer.requests[0]["tool_name"] == "mcp__portal__portal_create_task"
+    assert writer.decisions[0]["decision"] == "allowed"
+    assert store.statuses == ["waiting_permission", "running"]
+
+
+def test_can_use_tool_confirms_write_tool_denied(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "deny")
+    result = asyncio.run(cb("mcp__portal__portal_publish_workflow", {"summary": "发布", "operation": "deploy"}))
+    assert result["behavior"] == "deny"
+    assert writer.requests[0]["risk_level"] == "critical"
+    assert writer.decisions[0]["decision"] == "denied"
+    assert store.statuses == ["waiting_permission", "running"]
+
+
+def test_can_use_tool_timeout_denies(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "timeout")
+    result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
+    assert result["behavior"] == "deny"
+    assert writer.decisions[0]["decision"] == "timeout"
+
+
+def test_can_use_tool_plan_denies_writes_without_request(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
+    result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
+    assert result["behavior"] == "deny"
+    assert writer.requests == []
+
+
 class ClaudeAgentOptions:
     last_kwargs = None
 

--- a/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
+++ b/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
@@ -50,7 +50,7 @@ class FakeTopicStore:
     def init_schema(self):
         self.calls.append(("init_schema", None))
 
-    def create_topic(self, title="新话题", *, agent_snapshot=None, context=None):
+    def create_topic(self, title="新话题", *, agent_snapshot=None, permission_mode=None, context=None):
         self.calls.append(("create_topic", context, agent_snapshot))
         return topic_payload("topic-created", title)
 
@@ -64,9 +64,9 @@ class FakeTopicStore:
             return None
         return topic_payload(topic_id)
 
-    def update_topic(self, topic_id, *, title, context=None):
+    def update_topic(self, topic_id, *, title=None, permission_mode=None, context=None):
         self.calls.append(("update_topic", context))
-        return topic_payload(topic_id, title)
+        return topic_payload(topic_id, title or "新话题")
 
     def delete_topic(self, topic_id, *, context=None):
         self.calls.append(("delete_topic", context))

--- a/dataagent/dataagent-frontend/src/api/nl2sql.js
+++ b/dataagent/dataagent-frontend/src/api/nl2sql.js
@@ -197,6 +197,13 @@ export function createNl2SqlApiClient(options = {}) {
     cancelTask(taskId) {
       return runtimeRequest.post(`/tasks/${taskId}/cancel`)
     },
+    submitPermissionDecision(taskId, requestId, decision, note = '') {
+      return runtimeRequest.post(`/tasks/${taskId}/permission-decision`, {
+        request_id: requestId,
+        decision,
+        note,
+      })
+    },
     async streamSdkEvents(taskId, options = {}) {
       const { onRecord, signal, afterId = 0 } = options
       const response = await fetch(

--- a/dataagent/dataagent-frontend/src/views/intelligence/AgentDetailView.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/AgentDetailView.vue
@@ -75,26 +75,6 @@
               </el-form-item>
             </section>
 
-            <!-- 权限模式 -->
-            <section v-else-if="activeTab === 'permission'" key="permission" class="agent-panel-section">
-              <h3>权限模式</h3>
-              <div class="permission-card-list">
-                <div
-                  v-for="mode in capabilities.permission_modes"
-                  :key="mode"
-                  class="permission-card"
-                  :class="{ selected: form.permission_mode === mode }"
-                  @click="form.permission_mode = mode"
-                >
-                  <div class="permission-card-header">
-                    <span class="permission-card-name">{{ permissionModeLabel(mode) }}</span>
-                    <el-icon v-if="form.permission_mode === mode" class="permission-card-check"><CircleCheck /></el-icon>
-                  </div>
-                  <p class="permission-card-desc">{{ permissionModeDesc(mode) }}</p>
-                </div>
-              </div>
-            </section>
-
             <!-- 工具 -->
             <section v-else-if="activeTab === 'tools'" key="tools" class="agent-panel-section">
               <h3>预授权工具</h3>
@@ -185,7 +165,7 @@
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
-import { ArrowLeft, ChatLineRound, CircleCheck } from '@element-plus/icons-vue'
+import { ArrowLeft, ChatLineRound } from '@element-plus/icons-vue'
 import { dataagentApi } from '@/api/dataagent'
 
 const route = useRoute()
@@ -201,31 +181,16 @@ const tabs = [
   { key: 'basic', label: '基础信息' },
   { key: 'prompt', label: '提示词设置' },
   { key: 'questions', label: '预设问题' },
-  { key: 'permission', label: '权限模式' },
   { key: 'tools', label: '工具' },
   { key: 'skills', label: 'Skills' },
   { key: 'scope', label: '数据范围' },
   { key: 'advanced', label: '高级设置' }
 ]
 
-const permissionModeLabels = {
-  inherit: '继承模式',
-  default: '默认模式',
-  bypassPermissions: '全自动模式'
-}
-const permissionModeDescs = {
-  inherit: '继承父级或平台默认权限配置。',
-  default: '可自由读取文件，编辑或执行命令前会询问。',
-  bypassPermissions: '可执行任何操作，无需询问。请谨慎使用。'
-}
-const permissionModeLabel = (mode) => permissionModeLabels[mode] || mode
-const permissionModeDesc = (mode) => permissionModeDescs[mode] || ''
-
 const capabilities = reactive({
   tools: [],
   mcp_servers: [],
-  skills: [],
-  permission_modes: ['inherit', 'default', 'bypassPermissions']
+  skills: []
 })
 
 const form = reactive({
@@ -233,7 +198,6 @@ const form = reactive({
   name: '',
   description: '',
   system_prompt: '',
-  permission_mode: 'inherit',
   allowed_tools: [],
   mcp_server_ids: [],
   skill_folders: [],
@@ -286,7 +250,6 @@ const applyAgent = (agent) => {
     name: String(agent?.name || ''),
     description: String(agent?.description || ''),
     system_prompt: String(agent?.system_prompt || ''),
-    permission_mode: String(agent?.permission_mode || 'inherit'),
     allowed_tools: Array.isArray(agent?.allowed_tools) ? [...agent.allowed_tools] : [],
     mcp_server_ids: Array.isArray(agent?.mcp_server_ids) ? [...agent.mcp_server_ids] : [],
     skill_folders: Array.isArray(agent?.skill_folders) ? [...agent.skill_folders] : [],
@@ -316,8 +279,7 @@ const loadDetail = async () => {
     Object.assign(capabilities, {
       tools: caps?.tools || [],
       mcp_servers: caps?.mcp_servers || [],
-      skills: caps?.skills || [],
-      permission_modes: caps?.permission_modes || capabilities.permission_modes
+      skills: caps?.skills || []
     })
     dataScopeOptions.value = Array.isArray(scopeOptions) ? scopeOptions : []
     applyAgent(agent)
@@ -340,7 +302,6 @@ const buildPayload = () => {
     name: form.name,
     description: form.description,
     system_prompt: form.system_prompt,
-    permission_mode: form.permission_mode,
     allowed_tools: [...form.allowed_tools],
     mcp_server_ids: [...form.mcp_server_ids],
     skill_folders: [...form.skill_folders],

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -216,6 +216,14 @@
                         <ToolOutputRenderer :tool="blockToToolProp(block)" />
                       </div>
 
+                      <!-- Generic Chat V2 permission confirmation card -->
+                      <PermissionConfirmationCard
+                        v-else-if="block.type === 'permission_request'"
+                        :block="block"
+                        :disabled="msg._v2state.status !== 'streaming'"
+                        @decide="(payload) => handlePermissionDecision(msg, payload)"
+                      />
+
                       <!-- Text block (inline chart_spec rendered as a real chart) -->
                       <div v-else-if="block.type === 'text' && block.content" class="v2-text-block">
                         <template v-for="(seg, si) in answerSegments(block.content)" :key="si">
@@ -365,6 +373,22 @@
           <!-- Bottom toolbar -->
           <div class="v2-composer-toolbar">
             <div class="v2-composer-toolbar-left">
+              <el-dropdown trigger="click" @command="changePermissionMode">
+                <button type="button" class="v2-perm-pill" title="会话权限模式">
+                  <span class="v2-perm-pill-dot" :class="permissionMode"></span>
+                  {{ permissionModeLabel }}
+                </button>
+                <template #dropdown>
+                  <el-dropdown-menu>
+                    <el-dropdown-item
+                      v-for="opt in PERMISSION_MODE_OPTIONS"
+                      :key="opt.value"
+                      :command="opt.value"
+                      :class="{ 'is-active': opt.value === permissionMode }"
+                    >{{ opt.label }}</el-dropdown-item>
+                  </el-dropdown-menu>
+                </template>
+              </el-dropdown>
               <span class="v2-composer-hint">Enter 发送，Shift + Enter 换行</span>
             </div>
             <div class="v2-composer-toolbar-right">
@@ -495,6 +519,7 @@ import { createNl2SqlApiClient } from '@/api/nl2sql'
 import { dataagentApi } from '@/api/dataagent'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import ChartSpecView from './ChartSpecView.vue'
+import PermissionConfirmationCard from './PermissionConfirmationCard.vue'
 import { blockToToolProp } from './v2StreamParser'
 import { splitChartSpecText, stripChartSpecsFromText } from './chartSpec'
 import { topicStatusKind } from './topicStatus'
@@ -512,6 +537,14 @@ const { topicApi, agentApi } = api
 const agents = ref([])
 const settings = reactive({ providers: [], default_provider_id: '', default_model: '' })
 const agentSelectValue = ref('')
+// Session permission mode (latest selection). Default per design: 'default'.
+const permissionMode = ref('default')
+const PERMISSION_MODE_OPTIONS = [
+  { value: 'default', label: '逐步确认' },
+  { value: 'acceptEdits', label: '草稿自动·发布确认' },
+  { value: 'plan', label: '仅规划' },
+  { value: 'bypassPermissions', label: '全自动' },
+]
 const searchKeyword = ref('')
 const autoScroll = ref(true)
 
@@ -522,6 +555,7 @@ const autoScroll = ref(true)
 const chat = useNl2SqlChat({
   api,
   getAgentId: () => agentSelectValue.value || '',
+  getPermissionMode: () => permissionMode.value || '',
   topicTitleLength: 60,
   afterRun: () => loadTopics(),
   onTopicEnsured: (id) => { if (!isWidgetMode.value) replaceRouteTopic(id) },
@@ -1041,6 +1075,50 @@ function onEnterKey(event) {
 // Explicit stop: cancel the backend task (engine marks the topic suspended).
 function handleCancel() {
   void engineCancel()
+}
+
+// Generic Chat V2 permission confirmation: post the user's allow/deny for a
+// paused run. The streamed permission_decision record reconciles the card state.
+async function handlePermissionDecision(msg, payload) {
+  const taskId = String(msg?.task_id || activeTaskId.value || '').trim()
+  const requestId = String(payload?.requestId || '').trim()
+  const decision = payload?.decision
+  if (!taskId || !requestId || (decision !== 'allow' && decision !== 'deny')) return
+  try {
+    await api.taskApi.submitPermissionDecision(taskId, requestId, decision)
+  } catch (err) {
+    // Surface failure on the block so the user can retry.
+    const block = (msg?._v2state?.blocks || []).find(
+      (b) => b.type === 'permission_request' && b.requestId === requestId,
+    )
+    if (block && block.decision === 'pending') block.summary = (block.summary || '') + '\n[提交失败，请重试]'
+  }
+}
+
+// Permission mode pill: reflects the active topic's latest selection and pushes
+// switches immediately (the next task picks up the new mode; deliver-message also
+// carries it as a fallback). New (topic-less) sessions use the pill value at create.
+const permissionModeLabel = computed(() => {
+  const opt = PERMISSION_MODE_OPTIONS.find((o) => o.value === permissionMode.value)
+  return opt ? opt.label : '逐步确认'
+})
+const currentTopic = computed(() => (topics.value || []).find((t) => t.topic_id === activeTopicId.value) || null)
+watch(currentTopic, (topic) => {
+  if (topic && topic.permission_mode) permissionMode.value = topic.permission_mode
+}, { immediate: true })
+async function changePermissionMode(mode) {
+  if (!mode || mode === permissionMode.value) {
+    permissionMode.value = mode || permissionMode.value
+    return
+  }
+  permissionMode.value = mode
+  if (activeTopicId.value) {
+    try {
+      await topicApi.updateTopic(activeTopicId.value, { permission_mode: mode })
+    } catch (err) {
+      ElMessage.error('切换权限模式失败')
+    }
+  }
 }
 
 // Retry from a failed reply's error card: the engine re-asks the question that
@@ -2092,6 +2170,29 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 8px;
 }
+
+.v2-perm-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #dbe3ef;
+  background: #f4f7fb;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 12px;
+  color: #4a5568;
+  cursor: pointer;
+}
+.v2-perm-pill-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #e6a23c;
+}
+.v2-perm-pill-dot.bypassPermissions { background: #c0392b; }
+.v2-perm-pill-dot.plan { background: #909399; }
+.v2-perm-pill-dot.acceptEdits { background: #e6a23c; }
+.v2-perm-pill-dot.default { background: #409eff; }
 
 .v2-composer-hint {
   color: #9aa5b1;

--- a/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="v2-perm-card" :class="`risk-${block.risk_level || 'high'}`">
+    <div class="v2-perm-head">
+      <span class="v2-perm-badge">{{ riskLabel }}</span>
+      <span class="v2-perm-title">{{ block.title || ('请确认操作：' + bareTool) }}</span>
+    </div>
+    <div v-if="block.summary" class="v2-perm-summary">{{ block.summary }}</div>
+    <div class="v2-perm-tool">工具：<code>{{ bareTool }}</code></div>
+    <details v-if="hasPreview" class="v2-perm-preview">
+      <summary>参数详情</summary>
+      <pre>{{ prettyPreview }}</pre>
+    </details>
+
+    <div v-if="isPending" class="v2-perm-actions">
+      <button type="button" class="v2-perm-btn deny" :disabled="disabled || submitting" @click="decide('deny')">拒绝</button>
+      <button type="button" class="v2-perm-btn allow" :disabled="disabled || submitting" @click="decide('allow')">允许</button>
+    </div>
+    <div v-else class="v2-perm-result" :class="block.decision">{{ resultLabel }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  block: { type: Object, required: true },
+  disabled: { type: Boolean, default: false },
+})
+const emit = defineEmits(['decide'])
+
+const submitting = ref(false)
+
+const isPending = computed(() => (props.block.decision || 'pending') === 'pending')
+const bareTool = computed(() => {
+  const name = String(props.block.tool_name || '')
+  return name.startsWith('mcp__') ? name.split('__').pop() : name
+})
+const riskLabel = computed(() => (props.block.risk_level === 'critical' ? '高危操作' : '需要确认'))
+const hasPreview = computed(() => props.block.payload_preview != null && typeof props.block.payload_preview === 'object')
+const prettyPreview = computed(() => {
+  try {
+    return JSON.stringify(props.block.payload_preview, null, 2)
+  } catch {
+    return String(props.block.payload_preview)
+  }
+})
+const resultLabel = computed(() => {
+  switch (props.block.decision) {
+    case 'allowed':
+      return '✓ 已允许执行'
+    case 'denied':
+      return '✕ 已拒绝'
+    case 'timeout':
+      return '⏱ 等待确认超时，已自动拒绝'
+    default:
+      return ''
+  }
+})
+
+function decide(decision) {
+  if (props.disabled || submitting.value) return
+  submitting.value = true
+  // Optimistic: parent posts the decision; the streamed permission_decision
+  // record will reconcile the final state.
+  emit('decide', { requestId: props.block.requestId, decision })
+}
+</script>
+
+<style scoped>
+.v2-perm-card {
+  border: 1px solid #f0c36d;
+  border-radius: 10px;
+  background: #fffaf0;
+  padding: 12px 14px;
+  margin: 8px 0;
+}
+.v2-perm-card.risk-critical {
+  border-color: #e88;
+  background: #fff5f5;
+}
+.v2-perm-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.v2-perm-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  background: #e6a23c;
+  border-radius: 4px;
+  padding: 1px 8px;
+}
+.risk-critical .v2-perm-badge { background: #e05656; }
+.v2-perm-title { font-weight: 600; font-size: 14px; }
+.v2-perm-summary { font-size: 13px; color: #555; margin: 4px 0; white-space: pre-wrap; }
+.v2-perm-tool { font-size: 12px; color: #777; margin: 4px 0; }
+.v2-perm-tool code { background: #eef1f6; padding: 1px 5px; border-radius: 4px; }
+.v2-perm-preview { margin: 6px 0; }
+.v2-perm-preview pre {
+  max-height: 200px;
+  overflow: auto;
+  background: #f4f7fb;
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 12px;
+  margin: 6px 0 0;
+}
+.v2-perm-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
+.v2-perm-btn {
+  border: none;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.v2-perm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.v2-perm-btn.allow { background: #2c9c5a; color: #fff; }
+.v2-perm-btn.deny { background: #eef1f6; color: #333; }
+.v2-perm-result { margin-top: 6px; font-size: 13px; font-weight: 600; }
+.v2-perm-result.allowed { color: #2c9c5a; }
+.v2-perm-result.denied, .v2-perm-result.timeout { color: #c0392b; }
+</style>

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -459,7 +459,7 @@ describe('NL2SqlChatV2 URL location', () => {
     await wrapper.find('.v2-send-btn').trigger('click')
     await flushPromises()
 
-    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('hi there', { agent_id: 'agent_default' })
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('hi there', { agent_id: 'agent_default', permission_mode: 'default' })
     expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledWith(
       expect.objectContaining({ topic_id: 'topic-new', content: 'hi there', provider_id: 'provider-1', model: 'model-1' })
     )

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
@@ -22,6 +22,15 @@ function toCanonical(blocks) {
         output: block.output ?? null,
         is_error: Boolean(block.is_error),
       })
+    } else if (block.type === 'permission_request') {
+      canonical.push({
+        kind: 'permission_request',
+        tool_name: block.tool_name ?? null,
+        risk_level: block.risk_level ?? null,
+        title: block.title ?? null,
+        summary: block.summary ?? null,
+        decision: block.decision ?? null,
+      })
     } else {
       const text = String(block.content ?? '')
       if (!text.trim()) continue

--- a/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chatMessage.js
@@ -111,6 +111,10 @@ export function buildV2StateFromStoredBlocks(item) {
       const block = { turnIndex: 0, blockIndex: blockIdx++, type: 'tool_use', content: '', status: 'done', id: b.tool_id || null, name: b.tool_name || 'Tool', inputJson: '', input: b.input ?? null, output: b.output ?? null, is_error: Boolean(b.is_error) }
       turn.blocks.push(block)
       v2state.blocks.push(block)
+    } else if (kind === 'permission_request') {
+      const block = { turnIndex: 0, blockIndex: blockIdx++, type: 'permission_request', content: '', status: 'done', id: null, name: null, inputJson: '', input: null, output: null, is_error: false, requestId: b.request_id || '', tool_name: b.tool_name || '', risk_level: b.risk_level || 'high', title: b.title || '', summary: b.summary || '', payload_preview: b.payload_preview ?? null, decision: b.decision || 'pending', note: b.note || '', decided_at: b.decided_at || '' }
+      turn.blocks.push(block)
+      v2state.blocks.push(block)
     }
   }
   const content = String(item?.content || '')

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -33,6 +33,9 @@ export function useNl2SqlChat(options) {
   const {
     api,
     getAgentId = () => '',
+    // Session permission mode (default/acceptEdits/plan/bypassPermissions) for new
+    // topics and to carry mid-session switches; '' lets the backend default it.
+    getPermissionMode = () => '',
     messagePageSize = 200,
     topicTitleLength = 30,
     // Called after each real send settles. The portal refreshes its own faceted
@@ -229,7 +232,10 @@ export function useNl2SqlChat(options) {
 
   const ensureTopic = async (title) => {
     if (topicId.value) return topicId.value
-    const topic = normalizeTopic(await api.topicApi.createTopic(title || '新会话', { agent_id: getAgentId() || undefined }))
+    const topic = normalizeTopic(await api.topicApi.createTopic(title || '新会话', {
+      agent_id: getAgentId() || undefined,
+      permission_mode: getPermissionMode() || undefined,
+    }))
     if (!topic.topic_id) return ''
     upsertTopicAtTop(topic)
     topicId.value = topic.topic_id
@@ -403,6 +409,7 @@ export function useNl2SqlChat(options) {
         provider_id: selectedProvider.value || undefined,
         model: selectedModel.value || undefined,
         agent_id: getAgentId() || undefined,
+        permission_mode: getPermissionMode() || undefined,
         debug: false,
         execution_mode: 'auto',
       })

--- a/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
@@ -43,12 +43,47 @@ export function processV2Record(state, record) {
     _handleStreamEvent(state, record.data || {})
   } else if (record.record_type === 'tool_result') {
     _handleToolResult(state, record.data || {})
+  } else if (record.record_type === 'permission_request') {
+    _handlePermissionRequest(state, record.data || {})
+  } else if (record.record_type === 'permission_decision') {
+    _handlePermissionDecision(state, record.data || {})
   } else if (record.record_type === 'done') {
     state.status = (record.data || {}).is_error ? 'error' : 'done'
   } else if (record.record_type === 'error') {
     state.status = 'error'
     state.errorText = String((record.data || {}).message || '未知错误')
   }
+}
+
+function _handlePermissionRequest(state, data) {
+  const currentTurn = state.turns.at(-1)
+  const block = {
+    turnIndex: currentTurn ? currentTurn.turnIndex : 0,
+    blockIndex: currentTurn ? currentTurn.blocks.length : state.blocks.length,
+    type: 'permission_request',
+    content: '',
+    status: 'done',
+    requestId: data.request_id || '',
+    tool_name: data.tool_name || '',
+    risk_level: data.risk_level || 'high',
+    title: data.title || '',
+    summary: data.summary || '',
+    payload_preview: data.payload_preview ?? null,
+    decision: 'pending',
+    note: '',
+    decided_at: '',
+  }
+  if (currentTurn) currentTurn.blocks.push(block)
+  state.blocks.push(block)
+}
+
+function _handlePermissionDecision(state, data) {
+  const requestId = data.request_id || ''
+  const block = state.blocks.find((b) => b.type === 'permission_request' && b.requestId === requestId)
+  if (!block) return
+  block.decision = data.decision || 'pending'
+  block.note = data.note || ''
+  block.decided_at = data.decided_at || ''
 }
 
 function _handleStreamEvent(state, evt) {

--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -12,7 +12,7 @@ from starlette.routing import Mount, Route
 
 from .backend_client import BackendApiClient
 from .config import Settings, load_settings
-from .scope_context import set_data_scope_header
+from .scope_context import set_data_scope_header, set_operator_header
 from .service import PortalToolService
 
 
@@ -78,6 +78,91 @@ class QueryReadonlyInput(BaseModel):
     timeout_seconds: int = Field(default=30, ge=1, le=120, description="单次查询超时秒数")
 
 
+# --- data development assistant: write tool inputs ---------------------------
+# Nested task/workflow/schedule payloads are forwarded as-is to the backend
+# agent API, which owns the authoritative field schema (mirrors the web DTOs).
+
+
+class CreateTaskInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task: dict[str, Any] = Field(..., description="任务定义(对齐平台 DataTask 字段,如 taskName/dolphinNodeType/taskSql/datasourceName)")
+    input_table_ids: list[int] = Field(default_factory=list, description="输入表 ID 列表(维护血缘)")
+    output_table_ids: list[int] = Field(default_factory=list, description="输出表 ID 列表(维护血缘)")
+
+
+class UpdateTaskInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: int = Field(..., description="任务 ID")
+    task: dict[str, Any] = Field(..., description="任务定义(仅 draft 状态可更新)")
+    input_table_ids: list[int] = Field(default_factory=list)
+    output_table_ids: list[int] = Field(default_factory=list)
+
+
+class TaskIdInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: int = Field(..., description="任务 ID")
+
+
+class ListInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    keyword: str | None = Field(default=None, description="名称/编码关键字,可选")
+    status: str | None = Field(default=None, description="状态过滤,可选")
+    limit: int = Field(default=50, ge=1, le=200, description="返回数量上限")
+
+
+class CreateWorkflowInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: dict[str, Any] = Field(..., description="工作流定义(对齐 WorkflowDefinitionRequest:workflowName/tasks/edges/globalParams 等)")
+
+
+class UpdateWorkflowInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: int = Field(..., description="工作流 ID")
+    workflow: dict[str, Any] = Field(..., description="工作流结构(draft 状态)")
+
+
+class WorkflowIdInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: int = Field(..., description="工作流 ID")
+
+
+class PublishWorkflowInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    workflow_id: int = Field(..., description="工作流 ID")
+    operation: Literal["deploy", "online", "offline"] = Field(..., description="发布操作")
+    preview_token: str = Field(..., min_length=1, description="发布预览返回的一次性凭证;deploy/online 必填,确保已先预览")
+
+
+class UpsertScheduleInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: int = Field(..., description="工作流 ID")
+    schedule: dict[str, Any] = Field(..., description="调度配置(对齐 WorkflowScheduleRequest:scheduleCron/timezone 等)")
+
+
+class ScheduleOnlineInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    workflow_id: int = Field(..., description="工作流 ID")
+    preview_token: str = Field(..., min_length=1, description="发布预览返回的一次性凭证;调度上线必填")
+
+
+class AnalyzeSqlInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    sql: str = Field(..., min_length=1, description="待分析 SQL")
+    database: str | None = Field(default=None, description="数据库名,可选")
+    cluster_id: int | None = Field(default=None, description="集群 ID,可选")
+
+
 class FrontDoorTokenMiddleware:
     def __init__(self, app, settings: Settings):
         self.app = app
@@ -108,9 +193,11 @@ class FrontDoorTokenMiddleware:
             return
 
         reset_scope = set_data_scope_header(headers.get("x-agent-data-scope", ""))
+        reset_operator = set_operator_header(headers.get("x-agent-operator", ""))
         try:
             await self.app(scope, receive, send)
         finally:
+            reset_operator()
             reset_scope()
 
 
@@ -191,6 +278,139 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
         if "timeout_seconds" in payload:
             payload["timeoutSeconds"] = payload.pop("timeout_seconds")
         return await service.query_readonly(payload)
+
+    # --- data development assistant: write tools -----------------------------
+
+    @mcp.tool(
+        name="portal_create_task",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_create_task(params: CreateTaskInput) -> dict[str, Any]:
+        """Create a draft data-development task (e.g. a SQL task). Requires input/output table ids for lineage."""
+        return await service.create_task(
+            {
+                "task": params.task,
+                "inputTableIds": params.input_table_ids,
+                "outputTableIds": params.output_table_ids,
+            }
+        )
+
+    @mcp.tool(
+        name="portal_update_task",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_update_task(params: UpdateTaskInput) -> dict[str, Any]:
+        """Update a draft task definition."""
+        return await service.update_task(
+            params.task_id,
+            {
+                "task": params.task,
+                "inputTableIds": params.input_table_ids,
+                "outputTableIds": params.output_table_ids,
+            },
+        )
+
+    @mcp.tool(
+        name="portal_get_task",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_get_task(params: TaskIdInput) -> dict[str, Any]:
+        """Get a task's detail by id."""
+        return await service.get_task(params.task_id)
+
+    @mcp.tool(
+        name="portal_list_tasks",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_list_tasks(params: ListInput) -> dict[str, Any]:
+        """List tasks with optional keyword/status filters."""
+        return await service.list_tasks(params.model_dump(exclude_none=True))
+
+    @mcp.tool(
+        name="portal_create_workflow",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_create_workflow(params: CreateWorkflowInput) -> dict[str, Any]:
+        """Create a draft workflow with its task bindings and edges."""
+        return await service.create_workflow(params.workflow)
+
+    @mcp.tool(
+        name="portal_update_workflow",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_update_workflow(params: UpdateWorkflowInput) -> dict[str, Any]:
+        """Update a draft workflow's structure."""
+        return await service.update_workflow(params.workflow_id, params.workflow)
+
+    @mcp.tool(
+        name="portal_get_workflow",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_get_workflow(params: WorkflowIdInput) -> dict[str, Any]:
+        """Get a workflow's detail (tasks, edges, latest instance)."""
+        return await service.get_workflow(params.workflow_id)
+
+    @mcp.tool(
+        name="portal_list_workflows",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_list_workflows(params: ListInput) -> dict[str, Any]:
+        """List workflows with optional keyword/status filters."""
+        return await service.list_workflows(params.model_dump(exclude_none=True))
+
+    @mcp.tool(
+        name="portal_preview_publish",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_preview_publish(params: WorkflowIdInput) -> dict[str, Any]:
+        """Preview a workflow publish: validation, diff, warnings, and a one-time preview_token used by publish/schedule-online."""
+        return await service.preview_publish(params.workflow_id)
+
+    @mcp.tool(
+        name="portal_publish_workflow",
+        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    )
+    async def portal_publish_workflow(params: PublishWorkflowInput) -> dict[str, Any]:
+        """HIGH-RISK: deploy/online/offline a workflow to the scheduler. Requires user confirmation. Call portal_preview_publish first and pass its preview_token."""
+        return await service.publish_workflow(
+            params.workflow_id,
+            {"operation": params.operation, "previewToken": params.preview_token},
+        )
+
+    @mcp.tool(
+        name="portal_upsert_schedule",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_upsert_schedule(params: UpsertScheduleInput) -> dict[str, Any]:
+        """Create or update a workflow's schedule configuration (cron/timezone/etc.)."""
+        return await service.upsert_schedule(params.workflow_id, params.schedule)
+
+    @mcp.tool(
+        name="portal_workflow_schedule_online",
+        annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": True},
+    )
+    async def portal_workflow_schedule_online(params: ScheduleOnlineInput) -> dict[str, Any]:
+        """HIGH-RISK: enable a workflow's schedule so it triggers on cron. Requires user confirmation and a preview_token."""
+        return await service.schedule_online(params.workflow_id, {"previewToken": params.preview_token})
+
+    @mcp.tool(
+        name="portal_workflow_schedule_offline",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_workflow_schedule_offline(params: WorkflowIdInput) -> dict[str, Any]:
+        """Disable a workflow's schedule."""
+        return await service.schedule_offline(params.workflow_id)
+
+    @mcp.tool(
+        name="portal_analyze_sql",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_analyze_sql(params: AnalyzeSqlInput) -> dict[str, Any]:
+        """Analyze a SQL statement: input/output tables, operation type, and warnings (for SQL polish and lineage)."""
+        payload = params.model_dump(exclude_none=True)
+        if "cluster_id" in payload:
+            payload["clusterId"] = payload.pop("cluster_id")
+        return await service.analyze_sql(payload)
 
     return mcp
 

--- a/dataagent/portal-mcp/portal_mcp/backend_client.py
+++ b/dataagent/portal-mcp/portal_mcp/backend_client.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 
 from .config import Settings
-from .scope_context import get_data_scope_header
+from .scope_context import get_data_scope_header, get_operator_header
 
 
 class BackendApiError(RuntimeError):
@@ -37,6 +37,50 @@ class BackendApiClient:
     async def query_readonly(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._request("POST", "/v1/ai/query/read", json=payload)
 
+    # --- write surface (data development assistant) ---------------------------
+
+    async def create_task(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/ai/task", json=payload)
+
+    async def update_task(self, task_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("PUT", f"/v1/ai/task/{task_id}", json=payload)
+
+    async def get_task(self, task_id: int) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/ai/task/{task_id}")
+
+    async def list_tasks(self, **params: Any) -> dict[str, Any]:
+        return await self._request("GET", "/v1/ai/task/list", params=params)
+
+    async def create_workflow(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/ai/workflow", json=payload)
+
+    async def update_workflow(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("PUT", f"/v1/ai/workflow/{workflow_id}", json=payload)
+
+    async def get_workflow(self, workflow_id: int) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/ai/workflow/{workflow_id}")
+
+    async def list_workflows(self, **params: Any) -> dict[str, Any]:
+        return await self._request("GET", "/v1/ai/workflow/list", params=params)
+
+    async def preview_publish(self, workflow_id: int) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/ai/workflow/{workflow_id}/publish/preview")
+
+    async def publish_workflow(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", f"/v1/ai/workflow/{workflow_id}/publish", json=payload)
+
+    async def upsert_schedule(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("PUT", f"/v1/ai/workflow/{workflow_id}/schedule", json=payload)
+
+    async def schedule_online(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", f"/v1/ai/workflow/{workflow_id}/schedule/online", json=payload)
+
+    async def schedule_offline(self, workflow_id: int) -> dict[str, Any]:
+        return await self._request("POST", f"/v1/ai/workflow/{workflow_id}/schedule/offline", json={})
+
+    async def analyze_sql(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/ai/sql/analyze", json=payload)
+
     async def _request(
         self,
         method: str,
@@ -52,6 +96,9 @@ class BackendApiClient:
         data_scope = get_data_scope_header()
         if data_scope:
             headers["X-Agent-Data-Scope"] = data_scope
+        operator = get_operator_header()
+        if operator:
+            headers["X-Agent-Operator"] = operator
         timeout = httpx.Timeout(self.settings.backend_timeout_seconds)
         async with httpx.AsyncClient(timeout=timeout) as client:
             try:

--- a/dataagent/portal-mcp/portal_mcp/scope_context.py
+++ b/dataagent/portal-mcp/portal_mcp/scope_context.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 
 _data_scope_header: ContextVar[str] = ContextVar("data_scope_header", default="")
+_operator_header: ContextVar[str] = ContextVar("operator_header", default="")
 
 
 def get_data_scope_header() -> str:
@@ -16,5 +17,18 @@ def set_data_scope_header(value: str | None) -> Callable[[], None]:
 
     def reset() -> None:
         _data_scope_header.reset(token)
+
+    return reset
+
+
+def get_operator_header() -> str:
+    return _operator_header.get("")
+
+
+def set_operator_header(value: str | None) -> Callable[[], None]:
+    token = _operator_header.set(str(value or "").strip())
+
+    def reset() -> None:
+        _operator_header.reset(token)
 
     return reset

--- a/dataagent/portal-mcp/portal_mcp/service.py
+++ b/dataagent/portal-mcp/portal_mcp/service.py
@@ -27,6 +27,50 @@ class PortalToolService:
     async def query_readonly(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._wrap(self.backend_client.query_readonly(payload))
 
+    # --- write surface (data development assistant) ---------------------------
+
+    async def create_task(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.create_task(payload))
+
+    async def update_task(self, task_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.update_task(task_id, payload))
+
+    async def get_task(self, task_id: int) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.get_task(task_id))
+
+    async def list_tasks(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.list_tasks(**payload))
+
+    async def create_workflow(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.create_workflow(payload))
+
+    async def update_workflow(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.update_workflow(workflow_id, payload))
+
+    async def get_workflow(self, workflow_id: int) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.get_workflow(workflow_id))
+
+    async def list_workflows(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.list_workflows(**payload))
+
+    async def preview_publish(self, workflow_id: int) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.preview_publish(workflow_id))
+
+    async def publish_workflow(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.publish_workflow(workflow_id, payload))
+
+    async def upsert_schedule(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.upsert_schedule(workflow_id, payload))
+
+    async def schedule_online(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.schedule_online(workflow_id, payload))
+
+    async def schedule_offline(self, workflow_id: int) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.schedule_offline(workflow_id))
+
+    async def analyze_sql(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.analyze_sql(payload))
+
     async def _wrap(self, awaitable):
         try:
             return await awaitable

--- a/dataagent/portal-mcp/tests/test_app.py
+++ b/dataagent/portal-mcp/tests/test_app.py
@@ -171,14 +171,16 @@ async def test_mcp_tools_are_exposed_and_parameter_mapping_is_preserved():
         tool_name="portal_search_tables",
         arguments={"database": "opendataworks", "keyword": "发布", "table_limit": 2},
     )
-    assert set(tool_names) == {
+    # Read tools remain exposed (write tools from the data-dev surface are
+    # additionally registered and covered in test_write_tools.py).
+    assert {
         "portal_search_tables",
         "portal_get_lineage",
         "portal_resolve_datasource",
         "portal_export_metadata",
         "portal_get_table_ddl",
         "portal_query_readonly",
-    }
+    }.issubset(set(tool_names))
     assert backend.calls[-1] == (
         "inspect",
         {"database": "opendataworks", "keyword": "发布", "tableLimit": 2},

--- a/dataagent/portal-mcp/tests/test_write_tools.py
+++ b/dataagent/portal-mcp/tests/test_write_tools.py
@@ -1,0 +1,120 @@
+"""Contract tests for the data-development write surface (Stage 3)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from portal_mcp import app as app_module
+from portal_mcp.app import PublishWorkflowInput, ScheduleOnlineInput, build_mcp_server
+from portal_mcp.service import PortalToolService
+
+
+class RecordingBackend:
+    def __init__(self):
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name):
+        async def _call(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return {"ok": True, "method": name}
+
+        return _call
+
+
+@pytest.mark.anyio
+async def test_write_service_methods_delegate_to_backend():
+    backend = RecordingBackend()
+    service = PortalToolService(backend)
+
+    await service.create_task({"task": {"taskName": "t"}, "inputTableIds": [1], "outputTableIds": [2]})
+    await service.update_task(7, {"task": {"taskName": "t2"}})
+    await service.get_task(7)
+    await service.list_tasks({"keyword": "etl", "limit": 10})
+    await service.create_workflow({"workflowName": "wf"})
+    await service.update_workflow(3, {"workflowName": "wf2"})
+    await service.get_workflow(3)
+    await service.list_workflows({"limit": 5})
+    await service.preview_publish(3)
+    await service.publish_workflow(3, {"operation": "deploy", "previewToken": "tok"})
+    await service.upsert_schedule(3, {"scheduleCron": "0 0 * * *"})
+    await service.schedule_online(3, {"previewToken": "tok"})
+    await service.schedule_offline(3)
+    await service.analyze_sql({"sql": "select 1"})
+
+    names = [c[0] for c in backend.calls]
+    assert names == [
+        "create_task",
+        "update_task",
+        "get_task",
+        "list_tasks",
+        "create_workflow",
+        "update_workflow",
+        "get_workflow",
+        "list_workflows",
+        "preview_publish",
+        "publish_workflow",
+        "upsert_schedule",
+        "schedule_online",
+        "schedule_offline",
+        "analyze_sql",
+    ]
+
+
+def test_publish_requires_preview_token():
+    with pytest.raises(ValidationError):
+        PublishWorkflowInput(workflow_id=1, operation="deploy")
+    with pytest.raises(ValidationError):
+        ScheduleOnlineInput(workflow_id=1)
+    # valid with token
+    ok = PublishWorkflowInput(workflow_id=1, operation="online", preview_token="tok")
+    assert ok.preview_token == "tok"
+
+
+def test_publish_operation_is_constrained():
+    with pytest.raises(ValidationError):
+        PublishWorkflowInput(workflow_id=1, operation="destroy", preview_token="tok")
+
+
+@pytest.mark.anyio
+async def test_build_mcp_server_registers_write_tools():
+    mcp = build_mcp_server(PortalToolService(RecordingBackend()))
+    tools = await mcp.list_tools()
+    names = {t.name for t in tools}
+    for expected in {
+        "portal_create_task",
+        "portal_update_task",
+        "portal_get_task",
+        "portal_list_tasks",
+        "portal_create_workflow",
+        "portal_update_workflow",
+        "portal_get_workflow",
+        "portal_list_workflows",
+        "portal_preview_publish",
+        "portal_publish_workflow",
+        "portal_upsert_schedule",
+        "portal_workflow_schedule_online",
+        "portal_workflow_schedule_offline",
+        "portal_analyze_sql",
+    }:
+        assert expected in names, f"missing tool {expected}"
+    # read tools still present
+    assert "portal_search_tables" in names
+
+
+def test_operator_contextvar_propagates_into_request_headers(monkeypatch):
+    # The backend client must attach X-Agent-Operator when the contextvar is set.
+    from portal_mcp import scope_context
+
+    reset = scope_context.set_operator_header("agent:topic-1")
+    try:
+        assert scope_context.get_operator_header() == "agent:topic-1"
+    finally:
+        reset()
+    assert scope_context.get_operator_header() == ""

--- a/docs/design/2026-06-12-data-dev-assistant-design.md
+++ b/docs/design/2026-06-12-data-dev-assistant-design.md
@@ -1,0 +1,275 @@
+# 数据开发助手(合并入平台助手)设计
+
+- 日期:2026-06-12
+- 主题:data-dev-assistant
+- 影响范围:dataagent-backend(权限模式模型 / 任务执行 / API)、portal-mcp(新增写工具)、backend-agent-api 与 backend(agent 专用工作流写接口)、dataagent 技能包(新增 skill)、dataagent-frontend(会话权限模式与确认卡片)、数据库 schema(`dataagent` 会话库)
+- 配套计划:`docs/plans/2026-06-12-data-dev-assistant-plan.md`
+
+## 1. 现状与问题
+
+当前 OpenDataWorks 平台助手(`agent_opendataworks`)是一个只读的智能问数助手:
+
+- 能力面只读:通过 `dataagent/portal-mcp` 暴露的 6 个只读 MCP 工具(`portal_search_tables` / `portal_get_lineage` / `portal_resolve_datasource` / `portal_export_metadata` / `portal_get_table_ddl` / `portal_query_readonly`,见 `dataagent/portal-mcp/portal_mcp/app.py`)和 `opendataworks-platform-tools` 技能脚本,只能查元数据、血缘和执行只读 SELECT。
+- 数据开发链路全靠人工:生成 SQL → 创建任务(`POST /v1/tasks`)→ 组装工作流(`POST/PUT /v1/workflows`)→ 发布(`POST /v1/workflows/{id}/publish`,operation=deploy)→ 上线(operation=online)→ 配置调度,每一步都需要用户在 Web UI 手工完成。
+- agent 专用通道(`backend-agent-api` 模块,`/v1/ai/metadata/*`、`/v1/ai/query/read`)没有任何写接口;工作流/任务 Web API 走会话 JWT 鉴权(`odw_session`),不适合智能体机器调用。
+- 权限模式设计不合理:`da_agent_profile.permission_mode` 挂在智能体配置级,取值 `inherit|default|bypassPermissions` 含自造的 `inherit`,与 Claude Agent SDK 的权限模式不对齐;且同一智能体的所有会话被迫共享同一模式,无法表达"这次会话只读规划、下次会话允许执行"的真实使用差异。
+- 没有"暂停等用户确认再继续"的机制:`suspended` 目前是取消后的终态(`dataagent-backend/api/routes.py` 中 `TERMINAL_TASK_STATUSES = {"finished", "error", "suspended"}`),无法支撑发布/上线这类高危操作的对话内确认。
+
+## 2. 目标与范围
+
+### In scope
+
+- 平台助手 `agent_opendataworks` 合并获得数据开发能力:生成 SQL、润色 SQL、创建任务、组装工作流、发布(deploy)、上线/下线(online/offline)、调度配置。
+- 权限模式改为**会话(topic)级**,取值与 Claude Agent SDK 对齐:`default` / `acceptEdits` / `plan` / `bypassPermissions`;删除 `da_agent_profile.permission_mode`。
+- 新增对话内权限确认流:`default` / `acceptEdits` 模式下,高危工具调用通过 SDK `can_use_tool` 回调暂停执行,等待用户在聊天界面允许/拒绝。
+- `backend-agent-api` 新增 agent 专用工作流/任务写接口;`portal-mcp` 新增对应 MCP 写工具。
+- 新增技能包 `dataagent/.claude/skills/opendataworks-data-dev`,承载数据开发方法论与工具调用契约。
+- widget 前端(`dataagent/dataagent-frontend`)支持会话权限模式选择与权限确认卡片。
+- 全链路审计:写操作落现有 `workflow_publish_record` 等审计表,operator 标记 agent 来源。
+
+### Out of scope
+
+- 不新建独立"数据开发智能体"(已决策合并进平台助手)。
+- 不改造 DolphinScheduler 本身;发布/上线仍依赖工作流已绑定 `dolphin_config_id` 的现有约束。
+- 不做用户/角色级权限映射(普通用户/开发者/管理员差异化),列为后续演进。
+- 不支持会话中途切换权限模式(与"topic 不支持中途换 agent"的既有约束一致)。
+- DataX / Dinky 等非 SQL 任务类型的开发流,本期只保证 SQL 任务(`dolphinNodeType=SQL`)路径完整,其余类型接口可用但不写入技能 playbook。
+
+## 3. 总体架构
+
+```
+widget(dataagent-frontend)
+  会话创建时选择 permission_mode + 渲染 permission_request 确认卡片
+    │
+    ▼
+dataagent-backend(FastAPI)
+  topic.permission_mode → ClaudeAgentOptions.permission_mode
+  can_use_tool 回调:高危工具 → permission_request 事件 + 等待决策(Redis)
+    │
+    ▼
+claude_agent_sdk(agent_opendataworks profile)
+  技能:opendataworks-platform-tools + opendataworks-business-knowledge
+        + 新增 opendataworks-data-dev
+    │
+    ▼
+portal-mcp(FastMCP,HTTP)
+  现有 6 个只读工具 + 新增 task/workflow 写工具
+    │
+    ▼
+backend-agent-api(/v1/ai/*,服务 token + 私网限制 + data scope)
+  新增 /v1/ai/task/*、/v1/ai/workflow/* 写接口
+    │
+    ▼
+backend 现有服务(不重写业务逻辑)
+  DataTaskService / WorkflowService / WorkflowPublishService / WorkflowScheduleService
+    │
+    ▼
+DolphinScheduler(发布与调度执行)
+```
+
+设计原则:
+
+- 复用既有三段式通道(skill → portal-mcp → backend-agent-api → backend service),写能力是对该通道的纵向扩展,不新开旁路。
+- 业务规则(版本快照、发布预览、DolphinScheduler 同步)全部留在 backend 现有服务里,agent 侧只做编排与确认。
+- 技能特定行为只进 skill 包,共享 runtime(`core/agent_runtime.py` 等)保持 skill 无关,符合仓库模块规约。
+
+## 4. 权限模式设计(核心变更)
+
+### 4.1 取值与语义
+
+权限模式与 Claude Agent SDK 对齐,四个取值,语义在数据开发场景下的映射:
+
+| 模式 | SDK 语义 | 数据开发语义 |
+| --- | --- | --- |
+| `plan` | 只读规划 | 只挂载只读工具;所有写 MCP 工具不进入 allowed_tools,调用即拒绝。助手只能生成/润色 SQL、给出任务与工作流的建议方案 |
+| `default` | 默认,未授权工具需确认 | 只读工具放行;**所有写工具**(含创建草稿)经 `can_use_tool` 对话内确认 |
+| `acceptEdits` | 自动接受编辑 | 草稿类写操作(创建/更新任务、创建/更新工作流、调度配置 upsert)自动放行;**高危操作**(publish deploy/online/offline、schedule online)仍需对话内确认 |
+| `bypassPermissions` | 全部放行 | 写工具全部自动放行;发布前 preview 与审计仍强制执行(见 4.4 与 10 节) |
+
+高危工具清单(单一来源,定义为 `dataagent-backend` 配置常量,portal-mcp 工具描述与 widget 文案从语义上保持一致):
+
+- `portal_publish_workflow`(operation 任意取值均视为高危)
+- `portal_workflow_schedule_online`
+
+### 4.2 存储迁移:profile 级 → topic 级
+
+- `da_agent_topic` 新增列 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`;任务沿用现有 snapshot 机制,`agent_snapshot_json` 之外在 `da_agent_task` 不新增列——任务执行时从所属 topic 读取(topic 在会话生命周期内模式不变,无需逐任务快照)。
+- `da_agent_profile.permission_mode` 删除:
+  - alembic 迁移:`da_agent_topic` 加列;`da_agent_profile` 删列(downgrade 恢复,默认 `inherit`)。
+  - `core/agent_profile_service.py`:移除 `_validate_permission_mode`、`PERMISSION_MODES`、内置 profile 快照中的 `permission_mode` 字段及 upsert SQL 列。
+  - admin API(`api/admin_routes.py`)与 widget 智能体设置页:移除 permission_mode 配置项;`permission_modes` 枚举元数据接口同步移除。
+- 存量数据兼容:
+  - 存量 topic 回填 `permission_mode='default'`(与现有 `inherit→default` 的实际解析结果一致,行为不变)。
+  - 存量 task 的 `agent_snapshot_json` 中残留的 `permission_mode` 字段被忽略(执行链不再读取);`_resolve_sdk_permission_mode` 改为校验 SDK 合法值并把历史值 `inherit` 归一化为 `default`。
+
+### 4.3 API 变更
+
+- `POST /api/v1/nl2sql/topics`:请求体新增可选 `permission_mode`(缺省 `default`);响应体回带。
+- `POST /api/v1/nl2sql/tasks/deliver-message`:新增可选 `permission_mode`,仅在隐式建 topic 时生效;topic 已存在时忽略并以 topic 值为准(模式会话内不可变)。
+- topic 详情 / 列表响应增加 `permission_mode` 字段(`models/schemas.py`)。
+
+### 4.4 执行链变更
+
+- `core/task_executor.py`:`permission_mode` 来源从 `agent_snapshot` 改为 `TaskExecutionInput` 携带的 topic 值;继续传给 `ClaudeAgentOptions.permission_mode`。
+- `core/agent_runtime.py`:
+  - `_resolve_sdk_permission_mode` 改为只接受 SDK 合法值(`default|acceptEdits|plan|bypassPermissions`),`inherit` 与未知值归一化为 `default`。
+  - `_build_allowed_tools` 增加按 permission_mode 的工具裁剪:`plan` 模式不挂载写 MCP 工具(写工具名单来自 4.1 的配置常量);其余模式全量挂载,确认职责交给 `can_use_tool`。
+- 防御纵深:即使模型在 `plan` 模式尝试调用写工具,SDK 层因不在 allowed_tools 而拒绝;`bypassPermissions` 下 API 层仍要求 preview 凭证(见 6 节)。
+
+## 5. 对话内权限确认流(新机制)
+
+### 5.1 流程
+
+```
+模型调用高危工具(如 portal_publish_workflow)
+  → can_use_tool 回调命中高危清单且当前模式要求确认
+  → 生成 request_id,落一条 permission_request chunk 事件
+     (含工具名、参数摘要、若有则附带最近一次 preview 结果引用)
+  → task 状态置为 waiting_permission(新增非终态)
+  → 回调 await Redis 决策键,期间任务心跳照常续租
+用户在 widget 确认卡片点击 允许 / 拒绝
+  → POST /api/v1/nl2sql/tasks/{task_id}/permission-decision
+     {request_id, decision: allow|deny, note?}
+  → 写 Redis key da:task:permission:{task_id}:{request_id} = allow|deny(带 TTL)
+  → 回调读到决策:allow → 返回允许,工具继续执行;deny → 返回拒绝,
+     模型收到拒绝结果后继续对话(说明原因/调整方案)
+  → task 状态恢复 running,落 permission_decision chunk 事件(审计)
+```
+
+### 5.2 关键决策与约束
+
+- **决策传递用 Redis 键**,复用现有取消标志模式(`da:task:cancel:{task_id}`),进程内执行与 sandbox runner(`_should_use_sandbox_runner`,`core/task_executor.py`)两条路径都可达,无需为 runner 增加反向 HTTP 通道。
+- **`waiting_permission` 是非终态**,与现有终态 `suspended`(取消)严格区分;`TERMINAL_TASK_STATUSES` 不变。topic 的 `current_task_status` 同步该状态,供前端轮询/流式展示。
+- **超时**:等待确认有独立超时(默认 600s,可配置 `task_permission_wait_seconds`),超时视为 deny 并继续执行(模型收到"用户未确认"的拒绝结果);等待期间豁免 idle/progress 超时判定,但**不豁免**总运行超时——总超时上限相应评估(等待确认时间计入总时长是可接受的,因为确认型会话本身是交互式的)。
+- **decision 端点幂等**:重复提交同一 `request_id` 返回首次决策结果;`request_id` 不匹配当前等待中的请求时返回 409。
+- **事件契约**:`permission_request` / `permission_decision` 两类 chunk 事件结构写入 `dataagent/contracts`(与现有 sdk-block-projection 契约同级),widget 与 eval 工具按契约消费。
+
+### 5.3 确认卡片内容
+
+widget 渲染 `permission_request` 事件为卡片,展示:
+
+- 操作名称与目标(如"发布工作流 #123(deploy)");
+- 参数摘要(workflow 名称、operation、版本号);
+- 若助手在请求确认前已调用 `portal_preview_publish`,卡片附带 diff/告警摘要(技能 playbook 强制要求先 preview 再请求确认,见 8 节);
+- 允许 / 拒绝按钮与可选备注输入。
+
+## 6. backend-agent-api 新增写接口
+
+新增 controller 注册在 `backend-agent-api` 模块(与 `AgentMetadataController` / `AgentQueryController` 并列),复用 `AgentApiAuthInterceptor`(`X-Agent-Service-Token` + 私网限制)与 `AgentDataScopeFilter`;实现委托 `backend` 现有服务,不复制业务逻辑。
+
+### 6.1 任务接口(委托 `DataTaskService`)
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| POST | `/v1/ai/task` | 创建任务;入参对齐 Web 端 `TaskCreateRequest`(task + inputTableIds + outputTableIds),强制要求输入/输出表 id 以维护血缘 |
+| PUT | `/v1/ai/task/{id}` | 更新任务(仅 draft 状态) |
+| GET | `/v1/ai/task/{id}` | 任务详情 |
+| GET | `/v1/ai/task/list` | 任务列表(关键字 / 类型 / 状态过滤,默认限制条数) |
+
+### 6.2 工作流接口(委托 `WorkflowService` / `WorkflowPublishService` / `WorkflowScheduleService`)
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| POST | `/v1/ai/workflow` | 创建工作流(`WorkflowDefinitionRequest` 子集) |
+| PUT | `/v1/ai/workflow/{id}` | 更新结构(任务绑定、依赖边) |
+| GET | `/v1/ai/workflow/{id}` | 详情(含任务与最近实例) |
+| GET | `/v1/ai/workflow/list` | 列表 |
+| GET | `/v1/ai/workflow/{id}/publish/preview` | 发布预览;响应在现有 `WorkflowPublishPreviewResponse` 基础上附加一次性 `previewToken`(短 TTL) |
+| POST | `/v1/ai/workflow/{id}/publish` | operation=deploy/online/offline;**deploy/online 必须携带有效 `previewToken`**,服务端校验 preview 之后工作流版本未变化 |
+| PUT | `/v1/ai/workflow/{id}/schedule` | 调度配置 upsert |
+| POST | `/v1/ai/workflow/{id}/schedule/online` | 调度上线(同样要求 previewToken) |
+| POST | `/v1/ai/workflow/{id}/schedule/offline` | 调度下线 |
+
+### 6.3 SQL 分析接口(委托 `DataQueryService`)
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| POST | `/v1/ai/sql/analyze` | SQL 解析:输入/输出表识别、操作类型、风险告警;供润色与任务血缘自动推荐 |
+
+### 6.4 鉴权与审计
+
+- `previewToken` 是 API 层防线:即使智能体侧权限模式被配置为 `bypassPermissions`,deploy/online 也必须先 preview,杜绝"未经预览直达生产调度"。
+- operator 标识:请求新增 header `X-Agent-Operator`(由 portal-mcp 透传 dataagent 会话标识,如 `agent:{topic_id}`),写入 `workflow_publish_record.operator` 与任务实体 owner/operator 字段,审计可追溯到具体会话。
+- data scope:任务/工作流涉及的数据源 database 需通过 `AgentDataScopeContext.isDatabaseNameAllowed` 校验,越权数据库直接拒绝。
+
+## 7. portal-mcp 新增 MCP 工具
+
+在 `portal_mcp/app.py` 的 `build_mcp_server` 中按现有 `@mcp.tool` 模式注册,`backend_client.py` 增加对应后端调用:
+
+| 工具名 | 后端接口 | 风险级 |
+| --- | --- | --- |
+| `portal_create_task` | POST /v1/ai/task | 草稿写 |
+| `portal_update_task` | PUT /v1/ai/task/{id} | 草稿写 |
+| `portal_list_tasks` | GET /v1/ai/task/list | 只读 |
+| `portal_get_task` | GET /v1/ai/task/{id} | 只读 |
+| `portal_create_workflow` | POST /v1/ai/workflow | 草稿写 |
+| `portal_update_workflow` | PUT /v1/ai/workflow/{id} | 草稿写 |
+| `portal_get_workflow` | GET /v1/ai/workflow/{id} | 只读 |
+| `portal_list_workflows` | GET /v1/ai/workflow/list | 只读 |
+| `portal_preview_publish` | GET /v1/ai/workflow/{id}/publish/preview | 只读 |
+| `portal_publish_workflow` | POST /v1/ai/workflow/{id}/publish | **高危** |
+| `portal_upsert_schedule` | PUT /v1/ai/workflow/{id}/schedule | 草稿写 |
+| `portal_workflow_schedule_online` | POST .../schedule/online | **高危** |
+| `portal_workflow_schedule_offline` | POST .../schedule/offline | 草稿写 |
+| `portal_analyze_sql` | POST /v1/ai/sql/analyze | 只读 |
+
+- 工具入参用 Pydantic 模型显式声明(沿用现有 `SearchTablesInput` 等风格),`portal_publish_workflow` 的 `previewToken` 为必填参数,从工具签名上强制"先 preview"。
+- 高危工具的 description 明确标注需要用户确认,辅助模型自发走 preview → 确认流程;真正的强制门控在 dataagent-backend 高危清单(4.1)与 API previewToken(6.4),工具描述只是提示层。
+
+## 8. 新技能包:`dataagent/.claude/skills/opendataworks-data-dev`
+
+```
+opendataworks-data-dev/
+├── SKILL.md            # 数据开发 playbook(单一事实来源)
+├── reference/
+│   ├── 10-task-fields.md          # DataTask 字段契约(taskType/engine/dolphinNodeType/taskSql/...)
+│   ├── 20-workflow-lifecycle.md   # draft → preview → 确认 → deploy → online 流程与状态机
+│   └── 30-tool-recipes.md         # MCP 工具调用顺序、参数契约、失败恢复
+└── assets/
+    ├── task-template.json         # SQL 任务定义模板
+    └── dev-policies.json          # 命名规范、必填校验、禁止项
+```
+
+SKILL.md playbook 核心规则:
+
+1. **SQL 生成/润色**:先用 `portal_search_tables` / `portal_get_table_ddl` 核实表结构,再生成;润色前必须 `portal_analyze_sql` 识别输入/输出表与操作类型;含写操作的 SQL(INSERT/UPDATE)只允许进任务定义,不允许通过 `portal_query_readonly` 试跑。
+2. **任务创建**:基于 analyze 结果自动推荐 inputTableIds/outputTableIds;任务一律以 draft 创建;命名遵循 dev-policies。
+3. **工作流组装**:绑定任务后必须复述 DAG 结构请用户口头确认无误,再进入发布。
+4. **发布与上线**:强制顺序 `portal_preview_publish` → 向用户展示 diff/告警 → `portal_publish_workflow(deploy, previewToken)` → 确认成功后再 `portal_publish_workflow(online, previewToken)`;preview 返回 error 级 issue 时禁止继续,转为修复建议。
+5. **失败恢复**:publish 失败读取 `workflow_publish_record` 报错信息,定位是结构问题(回到草稿修改)还是引擎问题(提示用户检查 DolphinScheduler 配置),不盲目重试。
+
+profile 更新:alembic 数据迁移将 `agent_opendataworks` 的 `skill_folders_json` 追加 `opendataworks-data-dev`,system prompt 增补数据开发职责段落(职责边界:问数为主、开发为辅,开发操作严格遵循 playbook)。
+
+技能边界(遵守仓库模块规约):路由规则、调用顺序、恢复策略只写在本 skill;`core/agent_runtime.py` 等共享模块只新增通用的"按模式裁剪工具 + 高危清单 + can_use_tool"机制,不感知任何具体业务流程。
+
+## 9. 前端改动(dataagent-frontend / widget)
+
+- 会话创建:新建会话面板增加权限模式选择(默认 `default`),四个模式配通俗文案(如"逐步确认 / 草稿自动、发布确认 / 仅规划 / 全自动");传入 `POST /topics`。
+- 确认卡片:消费 `permission_request` 事件渲染卡片(5.3),决策调用 `POST /tasks/{task_id}/permission-decision`;`waiting_permission` 状态下输入框置灰并提示"等待操作确认"。
+- 会话头部展示当前模式徽标。
+- 智能体设置页:删除 permission_mode 配置项。
+- 主应用 `frontend/` 无路由级改动(入口复用现有内嵌页与浮窗,`agentId` 不变)。
+
+## 10. 安全与审计
+
+三层防线,任何单层被绕过仍有约束:
+
+1. **SDK / 模式层**:`plan` 不挂载写工具;`default` / `acceptEdits` 高危工具经 `can_use_tool` 用户确认,决策事件全量落库。
+2. **通道层**:portal-mcp → backend-agent-api 走服务 token + 私网限制 + data scope,写接口不对公网与浏览器暴露。
+3. **API 层**:deploy/online/schedule-online 强制 `previewToken`(短 TTL、版本一致性校验);operator 透传会话标识写入 `workflow_publish_record` / 任务审计字段。
+
+另:发布产物可回滚——复用现有 `workflow_version` 快照与 rollback 能力,助手误发布后可由用户在 UI 回滚(本期不给助手回滚工具,降低能力面)。
+
+## 11. 权衡与备选
+
+- **合并 vs 独立智能体**:选择合并。入口统一、用户无需切换;能力差异收敛到会话级权限模式,避免两个助手的提示词/技能重复维护。代价是平台助手 system prompt 变长、职责变宽,通过 skill 分层(问数/开发各自 playbook)控制。
+- **会话级 vs profile 级权限模式**:选择会话级并对齐 SDK 取值。profile 级无法表达同一用户不同会话的意图差异,且 `inherit` 为自造值;会话级与 SDK `permission_mode` 一一对应,执行链零翻译。
+- **MCP 写通道三选一**:选择 backend-agent-api 新增写 API。直调 Web API 需给 dataagent 配用户级 JWT,扩大安全面;portal-mcp 直接代理 Web API 则绕过 agent 专用鉴权层、需在 portal-mcp 重复实现权限收敛。
+- **确认机制:can_use_tool vs 自定义 confirmToken 对话协议**:选择 SDK 原生 `can_use_tool`。自定义协议需要模型"自觉"走确认流程,可被提示词注入绕过;`can_use_tool` 是运行时强制拦截,模型无法跳过。
+- **决策传递:Redis 键 vs runner 反向 HTTP**:选择 Redis 键,复用 cancel-flag 既有模式,进程内与 sandbox 两条执行路径统一,不新增网络拓扑。
+
+## 12. 风险
+
+- `can_use_tool` 与 sandbox runner 的组合是新路径,需验证回调在 runner 子进程中等待 Redis 决策时心跳/租约不中断(任务租约续期 5s 周期照常运行)。
+- 等待确认期间任务占用并发槽位(`task_max_concurrency` 默认 4),长时间未确认会挤占吞吐;通过确认超时(默认 600s → deny)兜底,后续可演进为挂起释放槽位。
+- 内置 profile 的 system prompt 增补与 skill 追加通过 alembic 数据迁移下发,已被管理员自定义过的 profile 需要迁移时做"仅内置且未改名"判定,避免覆盖用户修改。

--- a/docs/design/2026-06-12-data-dev-assistant-design.md
+++ b/docs/design/2026-06-12-data-dev-assistant-design.md
@@ -2,7 +2,7 @@
 
 - 日期:2026-06-12
 - 主题:data-dev-assistant
-- 影响范围:dataagent-backend(权限模式模型 / 任务执行 / API)、portal-mcp(新增写工具)、backend-agent-api 与 backend(agent 专用工作流写接口)、dataagent 技能包(新增 skill)、dataagent-frontend(会话权限模式与确认卡片)、数据库 schema(`dataagent` 会话库)
+- 影响范围:dataagent-backend(权限模式模型 / 任务执行 / API / Chat V2 块投影)、portal-mcp(新增写工具)、backend-agent-api 与 backend(agent 专用工作流写接口)、dataagent 技能包(新增 skill)、Chat V2 共享聊天引擎(门户聊天页 + widget:权限确认通用块、会话权限模式)、数据库 schema(`dataagent` 会话库)
 - 配套计划:`docs/plans/2026-06-12-data-dev-assistant-plan.md`
 
 ## 1. 现状与问题
@@ -20,11 +20,11 @@
 ### In scope
 
 - 平台助手 `agent_opendataworks` 合并获得数据开发能力:生成 SQL、润色 SQL、创建任务、组装工作流、发布(deploy)、上线/下线(online/offline)、调度配置。
-- 权限模式改为**会话(topic)级**,取值与 Claude Agent SDK 对齐:`default` / `acceptEdits` / `plan` / `bypassPermissions`;删除 `da_agent_profile.permission_mode`。
-- 新增对话内权限确认流:`default` / `acceptEdits` 模式下,高危工具调用通过 SDK `can_use_tool` 回调暂停执行,等待用户在聊天界面允许/拒绝。
+- 权限模式改为**会话(topic)级**,取值与 Claude Agent SDK 对齐:`default` / `acceptEdits` / `plan` / `bypassPermissions`;删除 `da_agent_profile.permission_mode`。topic 只保留最新一次选择(可中途切换),用于界面展示与下一次任务执行。
+- 新增**通用**对话内权限确认能力:作为 Chat V2 通用交互块下沉到共享聊天协议,任何挂载高危工具的智能体都可复用。`default` / `acceptEdits` 模式下,高危工具调用通过 SDK `can_use_tool` 回调暂停执行,等待用户在聊天界面允许/拒绝。
 - `backend-agent-api` 新增 agent 专用工作流/任务写接口;`portal-mcp` 新增对应 MCP 写工具。
 - 新增技能包 `dataagent/.claude/skills/opendataworks-data-dev`,承载数据开发方法论与工具调用契约。
-- widget 前端(`dataagent/dataagent-frontend`)支持会话权限模式选择与权限确认卡片。
+- Chat V2 共享聊天引擎(门户聊天页 `NL2SqlChatV2.vue` 与 widget `WidgetChat.vue` 共用 `useNl2SqlChat()`)新增权限确认通用块与会话权限模式切换,两个界面自动同时生效。
 - 全链路审计:写操作落现有 `workflow_publish_record` 等审计表,operator 标记 agent 来源。
 
 ### Out of scope
@@ -32,19 +32,18 @@
 - 不新建独立"数据开发智能体"(已决策合并进平台助手)。
 - 不改造 DolphinScheduler 本身;发布/上线仍依赖工作流已绑定 `dolphin_config_id` 的现有约束。
 - 不做用户/角色级权限映射(普通用户/开发者/管理员差异化),列为后续演进。
-- 不支持会话中途切换权限模式(与"topic 不支持中途换 agent"的既有约束一致)。
 - DataX / Dinky 等非 SQL 任务类型的开发流,本期只保证 SQL 任务(`dolphinNodeType=SQL`)路径完整,其余类型接口可用但不写入技能 playbook。
 
 ## 3. 总体架构
 
 ```
-widget(dataagent-frontend)
-  会话创建时选择 permission_mode + 渲染 permission_request 确认卡片
+Chat V2 共享引擎(门户聊天页 NL2SqlChatV2.vue + widget WidgetChat.vue,共用 useNl2SqlChat())
+  composer 工具栏切换 permission_mode + 渲染 permission_request 通用块卡片
     │
     ▼
 dataagent-backend(FastAPI)
-  topic.permission_mode → ClaudeAgentOptions.permission_mode
-  can_use_tool 回调:高危工具 → permission_request 事件 + 等待决策(Redis)
+  topic.permission_mode(最新选择)→ ClaudeAgentOptions.permission_mode
+  can_use_tool 回调:高危工具 → permission_request SDK record + 等待决策(Redis)
     │
     ▼
 claude_agent_sdk(agent_opendataworks profile)
@@ -93,7 +92,7 @@ DolphinScheduler(发布与调度执行)
 
 ### 4.2 存储迁移:profile 级 → topic 级
 
-- `da_agent_topic` 新增列 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`;任务沿用现有 snapshot 机制,`agent_snapshot_json` 之外在 `da_agent_task` 不新增列——任务执行时从所属 topic 读取(topic 在会话生命周期内模式不变,无需逐任务快照)。
+- `da_agent_topic` 新增列 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`,**只存最新一次选择**,可在会话中途切换(用于界面展示与下一次任务执行)。`da_agent_task` 不新增列、不做模式快照——任务在创建时刻读取所属 topic 的当前模式作为本次执行的取值;运行中的任务不受后续切换影响(切换在下一条消息/任务生效)。与 agent profile 快照不同,模式不属于"会话可复现性"范畴,因此不冻结。
 - `da_agent_profile.permission_mode` 删除:
   - alembic 迁移:`da_agent_topic` 加列;`da_agent_profile` 删列(downgrade 恢复,默认 `inherit`)。
   - `core/agent_profile_service.py`:移除 `_validate_permission_mode`、`PERMISSION_MODES`、内置 profile 快照中的 `permission_mode` 字段及 upsert SQL 列。
@@ -105,53 +104,63 @@ DolphinScheduler(发布与调度执行)
 ### 4.3 API 变更
 
 - `POST /api/v1/nl2sql/topics`:请求体新增可选 `permission_mode`(缺省 `default`);响应体回带。
-- `POST /api/v1/nl2sql/tasks/deliver-message`:新增可选 `permission_mode`,仅在隐式建 topic 时生效;topic 已存在时忽略并以 topic 值为准(模式会话内不可变)。
+- `PUT /api/v1/nl2sql/topics/{topic_id}`:支持更新 `permission_mode`(界面切换器调用),写入 topic 最新值,下一次任务生效。
+- `POST /api/v1/nl2sql/tasks/deliver-message`:携带 `permission_mode` 时直接更新所属 topic 的最新值(无论 topic 是否新建),再以该值启动本次任务。
 - topic 详情 / 列表响应增加 `permission_mode` 字段(`models/schemas.py`)。
 
 ### 4.4 执行链变更
 
-- `core/task_executor.py`:`permission_mode` 来源从 `agent_snapshot` 改为 `TaskExecutionInput` 携带的 topic 值;继续传给 `ClaudeAgentOptions.permission_mode`。
+- `core/task_executor.py`:`permission_mode` 来源从 `agent_snapshot` 改为 `TaskExecutionInput` 携带的值,即**任务创建时刻 topic 的当前模式**;继续传给 `ClaudeAgentOptions.permission_mode`。
 - `core/agent_runtime.py`:
   - `_resolve_sdk_permission_mode` 改为只接受 SDK 合法值(`default|acceptEdits|plan|bypassPermissions`),`inherit` 与未知值归一化为 `default`。
   - `_build_allowed_tools` 增加按 permission_mode 的工具裁剪:`plan` 模式不挂载写 MCP 工具(写工具名单来自 4.1 的配置常量);其余模式全量挂载,确认职责交给 `can_use_tool`。
 - 防御纵深:即使模型在 `plan` 模式尝试调用写工具,SDK 层因不在 allowed_tools 而拒绝;`bypassPermissions` 下 API 层仍要求 preview 凭证(见 6 节)。
 
-## 5. 对话内权限确认流(新机制)
+## 5. 权限确认:Chat V2 通用交互块(新机制)
 
-### 5.1 流程
+权限确认**不是数据开发助手专属**,而是下沉为 Chat V2 聊天协议的通用交互块。任何挂载了高危工具的智能体(平台助手、本体建模助手、未来新智能体)都自动具备该能力。设计分为通用层与数据开发特定层。
+
+### 5.1 通用层:`permission_request` / `permission_decision` 块类型
+
+Chat V2 的持久化与投影管线是统一的:SDK 事件 → `core/sdk_block_writer.py` ingest → `da_agent_sdk_record`(record_type:`stream|tool_result|done|error`)→ 后端 `topic_task_store._project_sdk_records()` 与前端 `v2StreamParser.js processV2Record()` **双侧确定性投影** → 块类型(`thinking|text|tool_use`)→ 渲染。权限确认作为**新块类型**接入,与现有块同级,因此天然具备持久化、历史回放重建、门户/widget 双界面共享。
+
+- **新增两个 record_type**:`permission_request` 与 `permission_decision`,与 `tool_result` 走同一 ingest 路径落 `da_agent_sdk_record`。
+  - `permission_request.data`:`request_id`、`tool_name`、`risk_level`(`high`/`critical`)、`title`、`summary`(展示文案)、`payload_preview`(参数摘要,通用 JSON);这些字段对通用层透明,不含任何工作流语义。
+  - `permission_decision.data`:`request_id`(回链)、`decision`(`allowed`/`denied`/`timeout`)、`note`、`decided_at`。
+- **投影**:`_project_sdk_records()` 与 `processV2Record()` 各新增一个分支,产出块 `{type: 'permission_request', request_id, tool_name, risk_level, title, summary, payload_preview, decision, decided_at}`,`decision` 初始 `pending`,被对应 `permission_decision` record 合并后更新为终态。历史回放时确认请求与最终决策完整重建。
+- **契约**:`dataagent/contracts/sdk-block-projection/cases.json` 新增四态用例(请求 pending / 已允许 / 已拒绝 / 超时),后端契约测试 `tests/test_sdk_block_projection_contract.py` 与前端契约测试 `__tests__/sdkBlockProjection.contract.spec.js` 双侧校验同一组用例。
+
+### 5.2 执行流程
 
 ```
 模型调用高危工具(如 portal_publish_workflow)
   → can_use_tool 回调命中高危清单且当前模式要求确认
-  → 生成 request_id,落一条 permission_request chunk 事件
-     (含工具名、参数摘要、若有则附带最近一次 preview 结果引用)
+  → 生成 request_id,写一条 permission_request SDK record(投影为通用块)
   → task 状态置为 waiting_permission(新增非终态)
   → 回调 await Redis 决策键,期间任务心跳照常续租
-用户在 widget 确认卡片点击 允许 / 拒绝
+用户在确认卡片(门户或 widget,同一组件)点击 允许 / 拒绝
   → POST /api/v1/nl2sql/tasks/{task_id}/permission-decision
      {request_id, decision: allow|deny, note?}
-  → 写 Redis key da:task:permission:{task_id}:{request_id} = allow|deny(带 TTL)
+  → 端点双写:① Redis key da:task:permission:{task_id}:{request_id}(执行侧放行)
+              ② permission_decision SDK record(历史与投影)
   → 回调读到决策:allow → 返回允许,工具继续执行;deny → 返回拒绝,
      模型收到拒绝结果后继续对话(说明原因/调整方案)
-  → task 状态恢复 running,落 permission_decision chunk 事件(审计)
+  → task 状态恢复 running
 ```
 
-### 5.2 关键决策与约束
+### 5.3 关键决策与约束
 
-- **决策传递用 Redis 键**,复用现有取消标志模式(`da:task:cancel:{task_id}`),进程内执行与 sandbox runner(`_should_use_sandbox_runner`,`core/task_executor.py`)两条路径都可达,无需为 runner 增加反向 HTTP 通道。
+- **决策传递用 Redis 键 + SDK record 双写**:Redis 键复用现有取消标志模式(`da:task:cancel:{task_id}`),进程内执行与 sandbox runner(`_should_use_sandbox_runner`,`core/task_executor.py`)两条路径都可达,无需为 runner 增加反向 HTTP 通道;同时落 `permission_decision` record 保证历史可重建。
 - **`waiting_permission` 是非终态**,与现有终态 `suspended`(取消)严格区分;`TERMINAL_TASK_STATUSES` 不变。topic 的 `current_task_status` 同步该状态,供前端轮询/流式展示。
-- **超时**:等待确认有独立超时(默认 600s,可配置 `task_permission_wait_seconds`),超时视为 deny 并继续执行(模型收到"用户未确认"的拒绝结果);等待期间豁免 idle/progress 超时判定,但**不豁免**总运行超时——总超时上限相应评估(等待确认时间计入总时长是可接受的,因为确认型会话本身是交互式的)。
+- **超时**:等待确认有独立超时(默认 600s,可配置 `task_permission_wait_seconds`),超时视为 deny 并继续执行(模型收到"用户未确认"的拒绝结果),写入 `decision='timeout'` 的 decision record;等待期间豁免 idle/progress 超时判定,但**不豁免**总运行超时。
 - **decision 端点幂等**:重复提交同一 `request_id` 返回首次决策结果;`request_id` 不匹配当前等待中的请求时返回 409。
-- **事件契约**:`permission_request` / `permission_decision` 两类 chunk 事件结构写入 `dataagent/contracts`(与现有 sdk-block-projection 契约同级),widget 与 eval 工具按契约消费。
 
-### 5.3 确认卡片内容
+### 5.4 数据开发特定层
 
-widget 渲染 `permission_request` 事件为卡片,展示:
+通用层不感知工作流语义。数据开发只贡献两类内容:
 
-- 操作名称与目标(如"发布工作流 #123(deploy)");
-- 参数摘要(workflow 名称、operation、版本号);
-- 若助手在请求确认前已调用 `portal_preview_publish`,卡片附带 diff/告警摘要(技能 playbook 强制要求先 preview 再请求确认,见 8 节);
-- 允许 / 拒绝按钮与可选备注输入。
+- **高危工具清单条目**:在通用高危清单(§4.1 配置常量)登记 `portal_publish_workflow`、`portal_workflow_schedule_online`。
+- **卡片展示内容**:`title` / `summary` / `payload_preview` 由技能在请求确认前组织。技能 playbook 强制要求先调用 `portal_preview_publish` 得到 diff/告警摘要,再把摘要作为工具参数带入高危调用,通用层原样透出。卡片由通用组件 `PermissionConfirmationCard.vue` 渲染,展示:操作名称与目标(如"发布工作流 #123(deploy)")、参数摘要、preview diff/告警摘要、允许/拒绝按钮与可选备注。
 
 ## 6. backend-agent-api 新增写接口
 
@@ -242,11 +251,15 @@ profile 更新:alembic 数据迁移将 `agent_opendataworks` 的 `skill_folders_
 
 技能边界(遵守仓库模块规约):路由规则、调用顺序、恢复策略只写在本 skill;`core/agent_runtime.py` 等共享模块只新增通用的"按模式裁剪工具 + 高危清单 + can_use_tool"机制,不感知任何具体业务流程。
 
-## 9. 前端改动(dataagent-frontend / widget)
+## 9. 前端改动(Chat V2 共享聊天引擎,门户 + widget)
 
-- 会话创建:新建会话面板增加权限模式选择(默认 `default`),四个模式配通俗文案(如"逐步确认 / 草稿自动、发布确认 / 仅规划 / 全自动");传入 `POST /topics`。
-- 确认卡片:消费 `permission_request` 事件渲染卡片(5.3),决策调用 `POST /tasks/{task_id}/permission-decision`;`waiting_permission` 状态下输入框置灰并提示"等待操作确认"。
-- 会话头部展示当前模式徽标。
+权限确认卡片与模式切换器实现在 Chat V2 共享层,门户聊天页(`NL2SqlChatV2.vue`)与 widget(`WidgetChat.vue`)经共享引擎 `useNl2SqlChat()` 自动同时获得,无需各自实现。
+
+- **权限模式切换器**:放在**输入框底部工具栏左侧**(`NL2SqlChatV2.vue` 的 `v2-composer-toolbar-left`,现有"Enter 发送"提示旁),做成模式 pill / 小下拉,显示 topic 当前模式,四模式配通俗文案(如"逐步确认 / 草稿自动、发布确认 / 仅规划 / 全自动")。
+  - 已有 topic:切换即 `PUT /topics/{id}` 更新最新值,下一条消息生效。
+  - 新会话(未建 topic):pill 当前值作为 `POST /topics` 的初始模式。
+  - **默认 `default`**。
+- **确认卡片**:Chat V2 通用块组件 `PermissionConfirmationCard.vue`(`dataagent-frontend/src/views/intelligence/`),在 `NL2SqlChatV2.vue` 块渲染分支注册 `v-else-if="block.type === 'permission_request'"`;`v2StreamParser.js processV2Record()` 与 `chatMessage.js buildV2StateFromStoredBlocks()` 增加该块类型处理;决策走 `api/nl2sql.js` 新增 `taskApi.submitPermissionDecision()`,交互参照消息反馈 `useChatMessageActions.js`(乐观更新 + 失败回滚)。`waiting_permission` 状态下输入框置灰并提示"等待操作确认"。
 - 智能体设置页:删除 permission_mode 配置项。
 - 主应用 `frontend/` 无路由级改动(入口复用现有内嵌页与浮窗,`agentId` 不变)。
 
@@ -267,9 +280,12 @@ profile 更新:alembic 数据迁移将 `agent_opendataworks` 的 `skill_folders_
 - **MCP 写通道三选一**:选择 backend-agent-api 新增写 API。直调 Web API 需给 dataagent 配用户级 JWT,扩大安全面;portal-mcp 直接代理 Web API 则绕过 agent 专用鉴权层、需在 portal-mcp 重复实现权限收敛。
 - **确认机制:can_use_tool vs 自定义 confirmToken 对话协议**:选择 SDK 原生 `can_use_tool`。自定义协议需要模型"自觉"走确认流程,可被提示词注入绕过;`can_use_tool` 是运行时强制拦截,模型无法跳过。
 - **决策传递:Redis 键 vs runner 反向 HTTP**:选择 Redis 键,复用 cancel-flag 既有模式,进程内与 sandbox 两条执行路径统一,不新增网络拓扑。
+- **确认卡片:Chat V2 通用块 vs 数据开发专属事件**:选择通用块。Chat V2 块管线双侧投影 + 共享引擎,做成通用块后门户与 widget 自动同时支持、历史可重建,且本体建模等其他高危智能体可直接复用;专属事件会把交互能力锁死在单一功能里,且需要 widget 单独实现。
+- **权限模式存储:topic 最新值(可变)vs 逐任务/逐消息快照**:选择只存 topic 最新值。模式是用户当下意图,不属于"会话可复现性"(与 agent profile 快照不同),无需每消息冻结;任务在创建时刻读取当前值即可,简化存储与切换语义。
 
 ## 12. 风险
 
 - `can_use_tool` 与 sandbox runner 的组合是新路径,需验证回调在 runner 子进程中等待 Redis 决策时心跳/租约不中断(任务租约续期 5s 周期照常运行)。
 - 等待确认期间任务占用并发槽位(`task_max_concurrency` 默认 4),长时间未确认会挤占吞吐;通过确认超时(默认 600s → deny)兜底,后续可演进为挂起释放槽位。
 - 内置 profile 的 system prompt 增补与 skill 追加通过 alembic 数据迁移下发,已被管理员自定义过的 profile 需要迁移时做"仅内置且未改名"判定,避免覆盖用户修改。
+- `permission_request` / `permission_decision` 是 Chat V2 新块类型,后端 `_project_sdk_records()` 与前端 `processV2Record()` 必须双侧同步实现,否则历史回放不一致;以 `cases.json` 契约测试在两侧同时把关,防止投影漂移。

--- a/docs/plans/2026-06-12-data-dev-assistant-plan.md
+++ b/docs/plans/2026-06-12-data-dev-assistant-plan.md
@@ -18,10 +18,10 @@
 
 任务:
 
-1. alembic 迁移:`da_agent_topic` 新增 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`;`da_agent_profile` 删除 `permission_mode` 列;downgrade 对称恢复(profile 列默认 `inherit`)。存量 topic 回填 `default`。
-2. `models/schemas.py`:topic 创建/详情/列表模型增加 `permission_mode`;`deliver-message` 请求模型增加可选 `permission_mode`(仅隐式建 topic 生效);admin profile 模型移除 `permission_mode` 与 `permission_modes` 枚举。
-3. `api/routes.py`:`POST /topics`、`POST /tasks/deliver-message` 接收并校验模式取值(`default|acceptEdits|plan|bypassPermissions`)。
-4. `core/topic_task_store.py`:topic 读写链路携带 `permission_mode`;`TaskExecutionInput` 组装时带上 topic 模式。
+1. alembic 迁移:`da_agent_topic` 新增 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`(只存最新选择,可变);`da_agent_profile` 删除 `permission_mode` 列;downgrade 对称恢复(profile 列默认 `inherit`)。存量 topic 回填 `default`。
+2. `models/schemas.py`:topic 创建/更新/详情/列表模型增加 `permission_mode`;`deliver-message` 请求模型增加可选 `permission_mode`(携带时更新所属 topic 最新值);admin profile 模型移除 `permission_mode` 与 `permission_modes` 枚举。
+3. `api/routes.py`:`POST /topics`、`PUT /topics/{id}`(支持改模式)、`POST /tasks/deliver-message` 接收并校验模式取值(`default|acceptEdits|plan|bypassPermissions`)。
+4. `core/topic_task_store.py`:topic 读写链路携带 `permission_mode`;`PUT /topics` 更新最新值;`TaskExecutionInput` 组装时读取 topic 当前模式(任务创建时刻快照该值,不新增 task 列)。
 5. `core/agent_runtime.py`:`_resolve_sdk_permission_mode` 改为校验 SDK 合法值,`inherit`/未知值归一化 `default`;新增高危/写工具清单常量;`_build_allowed_tools` 按模式裁剪(`plan` 不挂写工具)。
 6. `core/task_executor.py`:`permission_mode` 来源改为 TaskExecutionInput(不再读 agent_snapshot)。
 7. `core/agent_profile_service.py` / `api/admin_routes.py`:删除 permission_mode 字段、校验、upsert 列与枚举接口。
@@ -30,7 +30,7 @@
 
 验证:
 
-- 更新并通过 `tests/test_agent_profile_service.py`、`tests/test_task_executor.py`(断言 `ClaudeAgentOptions.permission_mode` 来自 topic)、`tests/test_routes_contract.py`、`tests/test_admin_routes.py`。
+- 更新并通过 `tests/test_agent_profile_service.py`、`tests/test_task_executor.py`(断言 `ClaudeAgentOptions.permission_mode` 来自 topic)、`tests/test_routes_contract.py`(含中途 `PUT /topics` 切换后下一任务用新模式的用例)、`tests/test_admin_routes.py`。
 - `alembic upgrade head` + `downgrade -1` 在本地 `dataagent` 库往返成功。
 
 回退:revert 代码 + `alembic downgrade`;存量数据无损(删列在 downgrade 恢复为默认值)。
@@ -67,26 +67,29 @@
 
 回退:revert,工具未注册即不可见。
 
-## 阶段 4:can_use_tool 对话内确认流
+## 阶段 4:权限确认 Chat V2 通用块 + can_use_tool 确认流
 
 任务:
 
-1. `core/task_executor.py`:构造 `can_use_tool` 回调传入 `ClaudeAgentOptions`;命中高危清单且模式要求确认时:生成 `request_id` → 落 `permission_request` chunk → task 状态置 `waiting_permission` → 轮询 Redis 决策键(间隔 1s,总等待 `task_permission_wait_seconds` 默认 600s)→ 超时/deny 返回拒绝,allow 放行 → 状态恢复 `running`,落 `permission_decision` chunk。
-2. `core/topic_task_store.py`:`waiting_permission` 状态读写(非终态,`TERMINAL_TASK_STATUSES` 不变);topic `current_task_status` 同步。
-3. `api/routes.py`:新增 `POST /tasks/{task_id}/permission-decision`(request_id 幂等、不匹配 409),写 Redis `da:task:permission:{task_id}:{request_id}`(TTL ≈ 等待超时 + 60s)。
-4. sandbox 路径:`sandbox_runner_main.py` / `sandbox_task_main.py` 中执行 SDK 的进程同样注册回调并可访问 Redis(确认 runner 容器具备 Redis 连接配置;若 runner 无 Redis,则该阶段开始前先补通配置)。
-5. 超时模型:等待确认期间豁免 idle/progress 判定;`config.py` 新增 `task_permission_wait_seconds`。
-6. 事件契约:`dataagent/contracts/` 新增 permission 事件结构说明(与 sdk-block-projection 同级)。
+1. `core/sdk_block_writer.py`(或同路径 ingest 辅助):新增 `permission_request` / `permission_decision` 两个 record_type 的写入,与 `tool_result` 走同一持久化路径落 `da_agent_sdk_record`。
+2. `core/topic_task_store.py _project_sdk_records()`:新增两类 record 的投影分支,产出通用块 `{type: 'permission_request', request_id, tool_name, risk_level, title, summary, payload_preview, decision, decided_at}`,decision record 合并更新终态。
+3. `core/task_executor.py`:构造 `can_use_tool` 回调传入 `ClaudeAgentOptions`;命中高危清单且模式要求确认时:生成 `request_id` → 写 `permission_request` SDK record → task 状态置 `waiting_permission` → 轮询 Redis 决策键(间隔 1s,总等待 `task_permission_wait_seconds` 默认 600s)→ 超时/deny 返回拒绝,allow 放行 → 状态恢复 `running`。
+4. `core/topic_task_store.py`:`waiting_permission` 状态读写(非终态,`TERMINAL_TASK_STATUSES` 不变);topic `current_task_status` 同步。
+5. `api/routes.py`:新增 `POST /tasks/{task_id}/permission-decision`(request_id 幂等、不匹配 409),**双写** Redis `da:task:permission:{task_id}:{request_id}`(TTL ≈ 等待超时 + 60s)与 `permission_decision` SDK record。
+6. sandbox 路径:`sandbox_runner_main.py` / `sandbox_task_main.py` 中执行 SDK 的进程同样注册回调并可访问 Redis(确认 runner 容器具备 Redis 连接配置;若 runner 无 Redis,则该阶段开始前先补通配置)。
+7. 超时模型:等待确认期间豁免 idle/progress 判定;`config.py` 新增 `task_permission_wait_seconds`。
+8. 契约:`dataagent/contracts/sdk-block-projection/cases.json` 新增四态用例(pending / allowed / denied / timeout)。
 
-触达文件:`core/task_executor.py`、`core/topic_task_store.py`、`core/task_coordinator.py`(状态/租约交互确认)、`api/routes.py`、`config.py`、`sandbox_runner_main.py`、`sandbox_task_main.py`、`dataagent/contracts/`。
+触达文件:`core/sdk_block_writer.py`、`core/topic_task_store.py`、`core/task_executor.py`、`core/task_coordinator.py`(状态/租约交互确认)、`api/routes.py`、`config.py`、`sandbox_runner_main.py`、`sandbox_task_main.py`、`dataagent/contracts/sdk-block-projection/cases.json`。
 
 验证:
 
 - 单测:回调在四种模式 × 高危/草稿/只读工具矩阵下的放行/确认/拒绝行为;decision 端点幂等与 409;超时 deny。
+- 块投影契约测试:后端 `tests/test_sdk_block_projection_contract.py` 与前端 `__tests__/sdkBlockProjection.contract.spec.js` 共用 `cases.json` 四态用例双侧校验(前端见阶段 6)。
 - 契约测试:`tests/test_routes_contract.py` 增加 `waiting_permission` 状态与 decision 端点用例。
 - 租约回归:等待确认 60s+ 场景下任务租约不被回收(`tests` 中模拟心跳)。
 
-回退:`can_use_tool` 不注册即回到无确认行为;新端点/状态向后兼容。
+回退:`can_use_tool` 不注册即回到无确认行为;新块类型/端点/状态向后兼容(旧记录无该 record_type,投影不产出块)。
 
 ## 阶段 5:技能包 + profile 更新
 
@@ -100,15 +103,19 @@
 
 回退:迁移 downgrade 移除 skill 引用;技能目录删除即不可被挂载。
 
-## 阶段 6:widget 前端(dataagent-frontend)
+## 阶段 6:Chat V2 前端(门户 + widget 共享)
+
+实现在 Chat V2 共享层,门户聊天页 `NL2SqlChatV2.vue` 与 widget `WidgetChat.vue` 经 `useNl2SqlChat()` 自动同时生效。
 
 任务:
 
-1. 新建会话面板:权限模式选择(默认 `default`,四模式通俗文案),随 `POST /topics` 提交;会话头部模式徽标。
-2. `permission_request` 事件 → 确认卡片(操作/参数摘要/preview 摘要/允许/拒绝/备注);决策调用 decision 端点;`waiting_permission` 状态输入框置灰提示。
+1. 模式切换器:放在 composer 底部工具栏左侧(`NL2SqlChatV2.vue` 的 `v2-composer-toolbar-left`),模式 pill / 小下拉,默认 `default`,四模式通俗文案。已有 topic 切换调 `PUT /topics/{id}`;新会话用 pill 值作为 `POST /topics` 初始模式。
+2. 通用确认卡片块:新建 `PermissionConfirmationCard.vue`(`src/views/intelligence/`),在 `NL2SqlChatV2.vue` 注册 `v-else-if="block.type === 'permission_request'"`;`v2StreamParser.js processV2Record()` 与 `chatMessage.js buildV2StateFromStoredBlocks()` 增加块解析;决策走 `api/nl2sql.js` 新增 `taskApi.submitPermissionDecision()`,交互参照 `useChatMessageActions.js`(乐观更新 + 回滚);`waiting_permission` 状态输入框置灰提示。
 3. 智能体设置页移除 permission_mode 配置项。
 
-验证:`nvm use` 后 widget 构建通过 + 既有前端测试;事件渲染按 `dataagent/contracts` 契约写组件测试。
+触达文件:`v2StreamParser.js`、`chatMessage.js`、`NL2SqlChatV2.vue`、新建 `PermissionConfirmationCard.vue`、`api/nl2sql.js`、设置页组件。
+
+验证:`nvm use` 后前端构建通过 + 既有前端测试;`__tests__/sdkBlockProjection.contract.spec.js` 新增四态块解析用例(与后端共用 `cases.json`);`PermissionConfirmationCard.vue` 组件测试。
 
 回退:UI revert;后端缺省 `default` 模式行为与现状等价(高危工具确认,但本阶段前写工具尚未对模型开放使用场景)。
 
@@ -122,7 +129,7 @@
 全链路 smoke(按 AGENTS.md 智能问数验证规约):
 
 - 环境:本地 Docker MySQL `127.0.0.1:3316`(schema `opendataworks` + `dataagent`)、Redis `127.0.0.1:6379`、`.venv-py313`、`alembic upgrade head`、真实 provider 凭证。
-- 场景 A(default 模式主路径):创建 topic(`permission_mode=default`)→ 请求"为 XX 表写一个聚合 SQL 并创建任务加入工作流发布上线" → 验证:写工具触发 `permission_request` 事件 → decision 端点 allow → 任务/工作流创建成功 → preview → deploy → online,`workflow_publish_record` operator 含会话标识。
+- 场景 A(default 模式主路径):创建 topic(`permission_mode=default`)→ 请求"为 XX 表写一个聚合 SQL 并创建任务加入工作流发布上线" → 验证:写工具触发 `permission_request` 通用块 → decision 端点 allow → 任务/工作流创建成功 → preview → deploy → online,`workflow_publish_record` operator 含会话标识。门户聊天页与 widget 两个入口各跑一次确认卡片交互,确认共享块渲染一致。
 - 场景 B(plan 模式):同样请求 → 助手只产出 SQL 与方案,写工具不可用。
 - 场景 C(拒绝路径):permission_request 后 deny → 任务恢复 running,助手解释并停止发布。
 - 场景 D(超时路径):不操作确认卡片 → 超时 deny → 任务正常收尾。

--- a/docs/plans/2026-06-12-data-dev-assistant-plan.md
+++ b/docs/plans/2026-06-12-data-dev-assistant-plan.md
@@ -1,0 +1,137 @@
+# 数据开发助手(合并入平台助手)实施计划
+
+- 日期:2026-06-12
+- 主题:data-dev-assistant
+- 配套设计:`docs/design/2026-06-12-data-dev-assistant-design.md`
+- 涉及栈:dataagent-backend(Python/FastAPI/Alembic)、portal-mcp(Python/FastMCP)、backend-agent-api + backend(Java/Spring Boot)、dataagent 技能包、dataagent-frontend(widget)、deploy
+
+## 阶段拆分与依赖
+
+```
+阶段1 权限模式迁移 ──┐
+阶段2 写 API(Java) ──┼─→ 阶段3 portal-mcp 工具 ─→ 阶段4 确认流 ─→ 阶段5 技能包+profile ─→ 阶段6 widget ─→ 阶段7 部署接线与全链路验证
+```
+
+阶段 1 与阶段 2 可并行;阶段 3 起串行。每阶段独立可合入、可回退。
+
+## 阶段 1:权限模式迁移(dataagent-backend)
+
+任务:
+
+1. alembic 迁移:`da_agent_topic` 新增 `permission_mode VARCHAR(32) NOT NULL DEFAULT 'default'`;`da_agent_profile` 删除 `permission_mode` 列;downgrade 对称恢复(profile 列默认 `inherit`)。存量 topic 回填 `default`。
+2. `models/schemas.py`:topic 创建/详情/列表模型增加 `permission_mode`;`deliver-message` 请求模型增加可选 `permission_mode`(仅隐式建 topic 生效);admin profile 模型移除 `permission_mode` 与 `permission_modes` 枚举。
+3. `api/routes.py`:`POST /topics`、`POST /tasks/deliver-message` 接收并校验模式取值(`default|acceptEdits|plan|bypassPermissions`)。
+4. `core/topic_task_store.py`:topic 读写链路携带 `permission_mode`;`TaskExecutionInput` 组装时带上 topic 模式。
+5. `core/agent_runtime.py`:`_resolve_sdk_permission_mode` 改为校验 SDK 合法值,`inherit`/未知值归一化 `default`;新增高危/写工具清单常量;`_build_allowed_tools` 按模式裁剪(`plan` 不挂写工具)。
+6. `core/task_executor.py`:`permission_mode` 来源改为 TaskExecutionInput(不再读 agent_snapshot)。
+7. `core/agent_profile_service.py` / `api/admin_routes.py`:删除 permission_mode 字段、校验、upsert 列与枚举接口。
+
+触达文件:`alembic/versions/`(新迁移)、`models/schemas.py`、`api/routes.py`、`api/admin_routes.py`、`core/topic_task_store.py`、`core/agent_runtime.py`、`core/task_executor.py`、`core/agent_profile_service.py`。
+
+验证:
+
+- 更新并通过 `tests/test_agent_profile_service.py`、`tests/test_task_executor.py`(断言 `ClaudeAgentOptions.permission_mode` 来自 topic)、`tests/test_routes_contract.py`、`tests/test_admin_routes.py`。
+- `alembic upgrade head` + `downgrade -1` 在本地 `dataagent` 库往返成功。
+
+回退:revert 代码 + `alembic downgrade`;存量数据无损(删列在 downgrade 恢复为默认值)。
+
+## 阶段 2:backend-agent-api 写接口(Java)
+
+任务:
+
+1. `backend-agent-api` 新增 `AgentTaskController`、`AgentWorkflowController`、`AgentSqlController` 与请求/响应 DTO(对齐设计 6 节接口表)。
+2. `backend` 新增对应 `BackendAgentTaskService` / `BackendAgentWorkflowService`(与现有 `BackendAgentMetadataService` 同模式),委托 `DataTaskService` / `WorkflowService` / `WorkflowPublishService` / `WorkflowScheduleService` / `DataQueryService`。
+3. previewToken 机制:preview 响应生成一次性 token(含 workflowId + 当前版本号 + 过期时间,HMAC 签名或服务端缓存);publish(deploy/online)与 schedule/online 校验 token 有效且版本未变。
+4. `X-Agent-Operator` header 解析,写入 operator/owner 审计字段;data scope 校验任务/工作流涉及的 database。
+
+触达文件:`backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/`(新 controller)、`backend/src/main/java/com/onedata/portal/agentapi/service/`(新 service)、相关 DTO 包。
+
+验证:
+
+- 新增单测:controller 参数校验、previewToken 过期/版本漂移拒绝、data scope 越权拒绝、鉴权拦截(无 token 401)。
+- `mvn -pl backend-agent-api,backend test`(或仓库等效最小命令)通过。
+
+回退:新增类整体 revert,无 schema 变更。
+
+## 阶段 3:portal-mcp 写工具
+
+任务:
+
+1. `portal_mcp/backend_client.py` 增加 task/workflow/sql-analyze 后端调用方法。
+2. `portal_mcp/app.py` 按 `@mcp.tool` 模式注册设计 7 节的 14 个工具,Pydantic 入参模型;`portal_publish_workflow` 的 `previewToken` 必填;高危工具 description 标注需用户确认。
+3. 透传 `X-Agent-Operator`(从 MCP 请求上下文/header 获取,沿用 data scope 的 contextvar 模式 `scope_context.py`)。
+
+触达文件:`dataagent/portal-mcp/portal_mcp/app.py`、`backend_client.py`、`config.py`、`tests/`。
+
+验证:portal-mcp 现有测试风格下新增工具契约测试(mock backend client),`pytest dataagent/portal-mcp/tests` 通过。
+
+回退:revert,工具未注册即不可见。
+
+## 阶段 4:can_use_tool 对话内确认流
+
+任务:
+
+1. `core/task_executor.py`:构造 `can_use_tool` 回调传入 `ClaudeAgentOptions`;命中高危清单且模式要求确认时:生成 `request_id` → 落 `permission_request` chunk → task 状态置 `waiting_permission` → 轮询 Redis 决策键(间隔 1s,总等待 `task_permission_wait_seconds` 默认 600s)→ 超时/deny 返回拒绝,allow 放行 → 状态恢复 `running`,落 `permission_decision` chunk。
+2. `core/topic_task_store.py`:`waiting_permission` 状态读写(非终态,`TERMINAL_TASK_STATUSES` 不变);topic `current_task_status` 同步。
+3. `api/routes.py`:新增 `POST /tasks/{task_id}/permission-decision`(request_id 幂等、不匹配 409),写 Redis `da:task:permission:{task_id}:{request_id}`(TTL ≈ 等待超时 + 60s)。
+4. sandbox 路径:`sandbox_runner_main.py` / `sandbox_task_main.py` 中执行 SDK 的进程同样注册回调并可访问 Redis(确认 runner 容器具备 Redis 连接配置;若 runner 无 Redis,则该阶段开始前先补通配置)。
+5. 超时模型:等待确认期间豁免 idle/progress 判定;`config.py` 新增 `task_permission_wait_seconds`。
+6. 事件契约:`dataagent/contracts/` 新增 permission 事件结构说明(与 sdk-block-projection 同级)。
+
+触达文件:`core/task_executor.py`、`core/topic_task_store.py`、`core/task_coordinator.py`(状态/租约交互确认)、`api/routes.py`、`config.py`、`sandbox_runner_main.py`、`sandbox_task_main.py`、`dataagent/contracts/`。
+
+验证:
+
+- 单测:回调在四种模式 × 高危/草稿/只读工具矩阵下的放行/确认/拒绝行为;decision 端点幂等与 409;超时 deny。
+- 契约测试:`tests/test_routes_contract.py` 增加 `waiting_permission` 状态与 decision 端点用例。
+- 租约回归:等待确认 60s+ 场景下任务租约不被回收(`tests` 中模拟心跳)。
+
+回退:`can_use_tool` 不注册即回到无确认行为;新端点/状态向后兼容。
+
+## 阶段 5:技能包 + profile 更新
+
+任务:
+
+1. 新建 `dataagent/.claude/skills/opendataworks-data-dev/`(SKILL.md、reference/10-task-fields.md、20-workflow-lifecycle.md、30-tool-recipes.md、assets/task-template.json、dev-policies.json),内容按设计 8 节 playbook;工具引用一律用 MCP 工具名,脚本(如需)用 `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_SKILL_ROOT}/scripts/<name>.py"` 完整形式。
+2. alembic 数据迁移:`agent_opendataworks` 内置 profile 的 `skill_folders_json` 追加 `opendataworks-data-dev`,system prompt 增补数据开发职责段(仅当 profile 仍为内置默认内容时更新,避免覆盖管理员修改)。
+3. `core/agent_runtime.py` 内置技能目录清单(builtin skill folders)登记新 skill。
+
+验证:技能文档自检(命名/目录/调用契约符合仓库规约);`reindex_documents_from_disk` 路径单测覆盖新目录;启动后 admin 技能列表可见。
+
+回退:迁移 downgrade 移除 skill 引用;技能目录删除即不可被挂载。
+
+## 阶段 6:widget 前端(dataagent-frontend)
+
+任务:
+
+1. 新建会话面板:权限模式选择(默认 `default`,四模式通俗文案),随 `POST /topics` 提交;会话头部模式徽标。
+2. `permission_request` 事件 → 确认卡片(操作/参数摘要/preview 摘要/允许/拒绝/备注);决策调用 decision 端点;`waiting_permission` 状态输入框置灰提示。
+3. 智能体设置页移除 permission_mode 配置项。
+
+验证:`nvm use` 后 widget 构建通过 + 既有前端测试;事件渲染按 `dataagent/contracts` 契约写组件测试。
+
+回退:UI revert;后端缺省 `default` 模式行为与现状等价(高危工具确认,但本阶段前写工具尚未对模型开放使用场景)。
+
+## 阶段 7:部署接线与全链路验证
+
+任务:
+
+1. 确认 `deploy/docker-compose.prod.yml` / `docker-compose.dev.yml`:portal-mcp 已有 `PORTAL_MCP_BACKEND_BASE_URL` / `PORTAL_MCP_BACKEND_SERVICE_TOKEN`,新写接口无需新增 env;sandbox runner 容器补充 Redis 连接 env(若阶段 4 确认缺失)。
+2. nginx/反代无路由变化确认(decision 端点在既有 `/api/v1/nl2sql` 前缀下)。
+
+全链路 smoke(按 AGENTS.md 智能问数验证规约):
+
+- 环境:本地 Docker MySQL `127.0.0.1:3316`(schema `opendataworks` + `dataagent`)、Redis `127.0.0.1:6379`、`.venv-py313`、`alembic upgrade head`、真实 provider 凭证。
+- 场景 A(default 模式主路径):创建 topic(`permission_mode=default`)→ 请求"为 XX 表写一个聚合 SQL 并创建任务加入工作流发布上线" → 验证:写工具触发 `permission_request` 事件 → decision 端点 allow → 任务/工作流创建成功 → preview → deploy → online,`workflow_publish_record` operator 含会话标识。
+- 场景 B(plan 模式):同样请求 → 助手只产出 SQL 与方案,写工具不可用。
+- 场景 C(拒绝路径):permission_request 后 deny → 任务恢复 running,助手解释并停止发布。
+- 场景 D(超时路径):不操作确认卡片 → 超时 deny → 任务正常收尾。
+- 既有回归:`你好,请直接回复 smoke-ok。` 与 `最近 30 天工作流发布次数趋势` 两个标准 prompt 不受影响。
+- 清理:删除 smoke 会话与 smoke 创建的任务/工作流(先 offline 再删),停止本地服务。
+- 验证记录:按规约报告 MySQL/Redis/解释器/凭证/场景通过情况,写入 `docs/reports/`。
+
+## 总回退策略
+
+- 各阶段独立 revert;DB 迁移均有 downgrade。
+- 最大风险点(阶段 4 确认流)有特性开关语义:不注册 `can_use_tool` + 高危清单置空即可退化为"写工具直通"(仅限故障应急,需同时将内置 profile 暂时移除写工具)。
+- 写能力整体下线:portal-mcp 侧注销写工具即可,无需回滚 Java 与 schema。

--- a/docs/reports/2026-06-14-data-dev-assistant-verification.md
+++ b/docs/reports/2026-06-14-data-dev-assistant-verification.md
@@ -18,26 +18,26 @@
 | 5 | opendataworks-data-dev 技能包 + 启用到平台助手 + alembic 数据迁移 | `c9e3dc4` | profile/skill-content/skill-admin 套件通过；技能目录/JSON 结构校验 |
 | 6 | 前端 Chat V2 权限卡片 + 会话模式 pill（门户 + widget 共享引擎）+ 删除 profile 权限选择器 | `12ba944` | 前端 vitest **233 passed（27 文件）**；production build 成功；双侧投影契约 13 用例两侧一致 |
 
-## 环境与未跑的端到端 smoke（如实说明）
+## Live smoke：已在真机运行的部分
 
-本环境**无法运行设计要求的 live 全链路 smoke**，原因：
+本轮在容器内启动了 docker daemon(Docker Hub CDN 被网络策略 403,无法拉镜像),改用 apt 安装 **MariaDB 10.11(MySQL 兼容)+ Redis**,完成了此前最关键的未测层——**数据库迁移与 DB 落地的 API 贯通**:
 
-- **Docker daemon 不可用**：`docker` CLI 存在但守护进程未运行，且无 podman；无法按 `deploy/docker-compose.dev.yml` 启动本地 MySQL（`127.0.0.1:3316`)与 Redis（`127.0.0.1:6379`），三个端口均 closed。
-- **无可用 DataAgent provider 凭证**：环境仅有 Claude Code 自身的 OAuth token（文件描述符形式），不可直接作为 dataagent-backend 的 provider 凭证；真实模型执行不可达。
-- 因此 `claude_agent_sdk` 真实运行路径（含 `can_use_tool` 结果类 `PermissionResultAllow/Deny` 的实际契约）未在真机执行——后端套件里该 SDK 缺包的 1 个导入测试始终失败，属环境限制。
+- **两个 alembic 迁移在真机 MySQL 兼容库上执行通过**:
+  - `20260613_000017`(权限模式迁移):`upgrade` 后 `da_agent_topic.permission_mode` 存在、默认 `'default'`、NOT NULL;`da_agent_profile.permission_mode` 已删除(列数 0)。`downgrade` 回到 000016 时:topic 列移除(0)、profile 列恢复(1);再 `upgrade head` 复原——**完整 down/up 往返通过**。
+  - `20260613_000018`(技能启用):`agent_opendataworks` 内置 profile 的 `skill_folders_json` 变为 `["opendataworks-business-knowledge","opendataworks-platform-tools","opendataworks-data-dev"]`;down/up 往返通过。
+  - 注:一个**既有**(非本次)迁移 `20260601_000014` 在 MariaDB 严格性下产出 `DEFAULT 'NULL'` 报 1067,与本改动无关;smoke 中 stamp 跳过该 comment-only 迁移后,本次两个迁移正常执行。
+- **DB 落地的 API 贯通**(dataagent-backend 连真机 MySQL+Redis,health OK,协调器启动):
+  - `POST /topics`(permission_mode=plan)→ 落库并返回 `plan`;无 mode → `default`。
+  - `PUT /topics/{id}` 切到 `bypassPermissions` → 生效;切 `junk` → 归一化 `default`;`GET` 反映最新值。
+  - `PUT /topics/{id}` 空 body → 400;`POST /tasks/{id}/permission-decision`(不存在任务)→ 404。
+  - 验证了 Stage 1 的 store SQL(create/update/get_topic + permission_mode)、归一化与 decision 端点路由,均在真实 MySQL 上。
+- 环境:MariaDB `127.0.0.1:3306`(库 `dataagent`/用户 `dataagent`)、Redis `127.0.0.1:6379`、Python venv 安装 `requirements` 子集、未配置 provider(无真实模型)。
 
-### 已验证层
+## 仍未执行（需 provider/模型 或 部署后端）
 
-- 后端 Python：单元 + 契约 + 路由（fake store）+ can_use_tool 编排（fake writer/store/wait），real-logic 覆盖。
-- 双侧投影契约：后端 `test_sdk_block_projection_contract.py` 与前端 `sdkBlockProjection.contract.spec.js` 共用 `cases.json`,四态一致。
-- Java：真实 `mvn` 编译通过 + 委托/凭证强制单测。
-- 前端：完整 vitest + 生产构建。
-
-### 尚未执行（需 live 环境）
-
-- 两个 alembic 迁移（`20260613_000017` 列增删、`20260613_000018` 技能 JSON 追加）对真实 MySQL 8 的 `upgrade head` / `downgrade`。迁移用 `_has_table`/`_has_column` 守卫且为标准 DDL，但未真机执行。
-- 真实模型驱动的确认流四场景：default 确认→deploy→online / plan 拒绝 / deny / timeout；门户与 widget 各一次。
-- portal-mcp → backend-agent-api → backend service 的真实 HTTP 贯通（含 previewToken 在真实 publish 上的校验）。
+- **无可用 DataAgent provider 凭证**:环境仅有 Claude Code 自身的 OAuth token,不可作为 dataagent provider;`claude_agent_sdk` 真实运行(含 `can_use_tool` 结果类 `PermissionResultAllow/Deny` 的实际契约、task 进入 `waiting_permission` 的 409 路径)未真机跑。
+- 真实模型驱动的确认流四场景:default 确认→deploy→online / plan 拒绝 / deny / timeout;门户与 widget 各一次。
+- portal-mcp → backend-agent-api → backend service 的真实 HTTP 贯通(需部署 Java 后端 + DolphinScheduler;previewToken 在真实 publish 上的校验)。
 
 ### 复跑建议（待环境具备时）
 

--- a/docs/reports/2026-06-14-data-dev-assistant-verification.md
+++ b/docs/reports/2026-06-14-data-dev-assistant-verification.md
@@ -1,0 +1,47 @@
+# 数据开发助手 — 实施与验证报告
+
+- 日期：2026-06-14
+- 主题：data-dev-assistant
+- 分支：`claude/data-dev-assistant-design-87a763`
+- 设计 / 计划：`docs/design/2026-06-12-data-dev-assistant-design.md`、`docs/plans/2026-06-12-data-dev-assistant-plan.md`
+
+把"数据开发助手"能力合并进 OpenDataWorks 平台助手：生成/润色 SQL、创建任务、组装工作流、发布与上线、配置调度；权限确认下沉为 Chat V2 通用交互块；权限模式与 Claude Agent SDK 对齐并迁移到会话级。
+
+## 各阶段状态与验证
+
+| 阶段 | 内容 | 提交 | 验证 |
+| --- | --- | --- | --- |
+| 1 | 权限模式迁移到 topic 级（删 profile 字段，SDK 词表，topic 加列，执行链改造） | `1803270` | 后端 targeted + 全套件 **279 passed**；alembic 链单一 head 校验通过 |
+| 2 | backend-agent-api 写接口（/v1/ai/task、/v1/ai/workflow、/v1/ai/sql/analyze）+ previewToken 二次防线 + X-Agent-Operator | `c02b2d6` | `mvn -pl backend -am compile` **BUILD SUCCESS**；新增 **9 个 Java 单测**通过（preview-token issue/verify/篡改/版本漂移/异密钥、publish 凭证强制、offline 豁免） |
+| 3 | portal-mcp 14 个写工具 + operator contextvar + publish 必填 preview_token | `ab232c0` | portal-mcp **18 测试**通过 |
+| 4 | Chat V2 通用权限确认块（record 类型 + 双侧投影 + cases.json 四态）+ permission_gate 模式策略 + decision 端点 + waiting_permission + can_use_tool 回调 | `17c6f84`,`9550b37` | 后端 **279 passed**（含 permission_gate、投影契约、decision 端点幂等/409/404、can_use_tool allow/deny/timeout/plan-deny 编排） |
+| 5 | opendataworks-data-dev 技能包 + 启用到平台助手 + alembic 数据迁移 | `c9e3dc4` | profile/skill-content/skill-admin 套件通过；技能目录/JSON 结构校验 |
+| 6 | 前端 Chat V2 权限卡片 + 会话模式 pill（门户 + widget 共享引擎）+ 删除 profile 权限选择器 | `12ba944` | 前端 vitest **233 passed（27 文件）**；production build 成功；双侧投影契约 13 用例两侧一致 |
+
+## 环境与未跑的端到端 smoke（如实说明）
+
+本环境**无法运行设计要求的 live 全链路 smoke**，原因：
+
+- **Docker daemon 不可用**：`docker` CLI 存在但守护进程未运行，且无 podman；无法按 `deploy/docker-compose.dev.yml` 启动本地 MySQL（`127.0.0.1:3316`)与 Redis（`127.0.0.1:6379`），三个端口均 closed。
+- **无可用 DataAgent provider 凭证**：环境仅有 Claude Code 自身的 OAuth token（文件描述符形式），不可直接作为 dataagent-backend 的 provider 凭证；真实模型执行不可达。
+- 因此 `claude_agent_sdk` 真实运行路径（含 `can_use_tool` 结果类 `PermissionResultAllow/Deny` 的实际契约）未在真机执行——后端套件里该 SDK 缺包的 1 个导入测试始终失败，属环境限制。
+
+### 已验证层
+
+- 后端 Python：单元 + 契约 + 路由（fake store）+ can_use_tool 编排（fake writer/store/wait），real-logic 覆盖。
+- 双侧投影契约：后端 `test_sdk_block_projection_contract.py` 与前端 `sdkBlockProjection.contract.spec.js` 共用 `cases.json`,四态一致。
+- Java：真实 `mvn` 编译通过 + 委托/凭证强制单测。
+- 前端：完整 vitest + 生产构建。
+
+### 尚未执行（需 live 环境）
+
+- 两个 alembic 迁移（`20260613_000017` 列增删、`20260613_000018` 技能 JSON 追加）对真实 MySQL 8 的 `upgrade head` / `downgrade`。迁移用 `_has_table`/`_has_column` 守卫且为标准 DDL，但未真机执行。
+- 真实模型驱动的确认流四场景：default 确认→deploy→online / plan 拒绝 / deny / timeout；门户与 widget 各一次。
+- portal-mcp → backend-agent-api → backend service 的真实 HTTP 贯通（含 previewToken 在真实 publish 上的校验）。
+
+### 复跑建议（待环境具备时）
+
+1. `docker compose -f deploy/docker-compose.dev.yml up -d mysql redis`，初始化 `dataagent` schema/用户（库 `dataagent`/用户 `dataagent`/密码 `dataagent123`）。
+2. `dataagent/dataagent-backend` 用 `.venv-py313` 安装 `requirements.txt`（含 `claude-agent-sdk`），设置本地 MySQL/Redis 环境变量，`alembic upgrade head`。
+3. `da_agent_settings` 配置有效 provider 与运行 DB；`uvicorn main:app`。
+4. 走真实 HTTP：`POST /topics`（permission_mode=default）→ "为某表写聚合 SQL 并建任务加入工作流发布上线" → 验证 `permission_request` 块 → `POST /tasks/{id}/permission-decision` allow → preview→deploy→online，`workflow_publish_record.operator` 含会话标识；再覆盖 plan/deny/timeout；门户与 widget 各一次。


### PR DESCRIPTION
## Summary

Integrates data development capabilities into the OpenDataWorks platform assistant (`agent_opendataworks`), enabling SQL generation, task/workflow creation, publishing, and scheduling. Implements session-level permission modes aligned with Claude Agent SDK, adds in-conversation permission confirmation as a reusable Chat V2 block, and introduces agent-facing write APIs for workflows and tasks.

## Key Changes

### Permission Model Migration
- **Alembic migrations** (`20260613_000017`, `20260613_000018`): Move `permission_mode` from agent profile to topic (session) level; normalize modes to SDK values (`default`, `acceptEdits`, `plan`, `bypassPermissions`)
- **Backend schema updates**: Topic model gains `permission_mode` field; profile model loses it
- **Normalization**: Legacy `inherit` and unknown values map to `default`

### Permission Gating & Confirmation
- **`core/permission_gate.py`** (new): Defines high-risk and write tool sets; provides classification logic for both bare and SDK-qualified tool names
- **`core/permission_wait.py`** (new): Async wait mechanism for user decisions via Redis, used by `can_use_tool` callback
- **`core/task_executor.py`**: Adds `_build_can_use_tool_callback()` to pause execution on high-risk tools in `default`/`acceptEdits` modes; routes through permission confirmation flow
- **`core/sdk_block_writer.py`**: New `append_permission_request()` method to emit generic permission-request blocks

### Write API Surface (Java Backend)
- **`backend-agent-api`** (new controllers & services):
  - `AgentWorkflowController`, `AgentTaskController`, `AgentSqlController`: REST endpoints for workflow/task/SQL operations
  - `BackendAgentWorkflowService`, `BackendAgentTaskService`, `BackendAgentSqlService`: Delegate to existing platform services
  - `AgentPreviewTokenSupport`: Stateless HMAC-based one-time tokens binding publish to workflow version (prevents deploy without fresh preview)
- **`backend`** (new service): `BackendAgentWorkflowService` wraps platform workflow/schedule services with agent-specific request/response DTOs

### Portal MCP Write Tools
- **`portal_mcp/app.py`**: New input models (`CreateTaskInput`, `UpdateTaskInput`, `CreateWorkflowInput`, etc.) and tool definitions
- **`portal_mcp/service.py`**: Implement `create_task()`, `update_task()`, `create_workflow()`, `update_workflow()`, `preview_publish()`, `publish_workflow()`, `schedule_upsert()`, `schedule_online()` methods
- **`portal_mcp/backend_client.py`**: Add corresponding async HTTP calls to agent API
- **`portal_mcp/scope_context.py`**: New `_operator_header` context var to track agent identity in write operations

### Data Development Skill
- **`dataagent/.claude/skills/opendataworks-data-dev/`** (new): Comprehensive skill package with:
  - `SKILL.md`: Scope, compatibility, and overview
  - `reference/10-task-fields.md`: DataTask field contract
  - `reference/20-workflow-lifecycle.md`: Workflow state machine and publish flow
  - `reference/30-tool-recipes.md`: Tool call sequences and parameter contracts
  - `assets/dev-policies.json`: Naming rules and validation policies
  - `assets/task-template.json`: SQL task creation template

### Frontend Permission Confirmation Block
- **`PermissionConfirmationCard.vue`** (new): Reusable Chat V2 block for permission requests; displays risk level, tool name, summary, and parameter preview; allows user to allow/deny
- **`NL2SqlChatV2.vue`**: Render permission-request blocks; add permission mode selector in composer toolbar; handle decision submission
- **`useNl2SqlChat.js`**: Track session `permission_mode`; expose decision submission API
- **`v2StreamParser.js`**: Parse `permission_request` records from

https://claude.ai/code/session_01BK4U2kXCxaQ7ebx75z7wHD