### PR TITLE
fix(intelligent-query): secure SQL re-execution scope context

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -841,7 +841,7 @@ async def api_list_message_schedule_logs(schedule_id: str, payload: MessageSched
 
 @query_router.post("/execute")
 async def api_execute_readonly_query(http_request: Request, request: ExecuteQueryRequest):
-    _request_context(http_request)
+    context = _request_context(http_request)
 
     sql = str(request.sql or "").strip()
     database = str(request.database or "").strip()
@@ -853,7 +853,7 @@ async def api_execute_readonly_query(http_request: Request, request: ExecuteQuer
     data_scope_header: str | None = None
     topic_id = str(request.topic_id or "").strip()
     if topic_id:
-        data_scope_header = _resolve_topic_data_scope_header(topic_id)
+        data_scope_header = _resolve_topic_data_scope_header(topic_id, context=context)
 
     try:
         return await execute_readonly_query(
@@ -870,13 +870,13 @@ async def api_execute_readonly_query(http_request: Request, request: ExecuteQuer
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
-def _resolve_topic_data_scope_header(topic_id: str) -> str:
+def _resolve_topic_data_scope_header(topic_id: str, *, context: dict[str, str]) -> str:
     from core.data_scope import encode_scope_header, normalize_data_scope
 
     store = _get_store()
-    topic = store.get_topic(topic_id)
+    topic = store.get_topic(topic_id, context=context)
     if not topic:
-        return ""
+        raise HTTPException(status_code=404, detail="Topic not found")
     snapshot = topic.get("agent_snapshot") or {}
     scope = normalize_data_scope(snapshot.get("data_scope") or {})
     if not scope.get("allowed_scopes"):

--- a/dataagent/dataagent-backend/core/readonly_query_proxy.py
+++ b/dataagent/dataagent-backend/core/readonly_query_proxy.py
@@ -136,7 +136,7 @@ async def execute_readonly_query(
     clamped_timeout = clamp_timeout_seconds(timeout_seconds)
 
     headers = {_service_token_header_name(): token}
-    data_scope = data_scope_header or runtime_data_scope_header()
+    data_scope = runtime_data_scope_header() if data_scope_header is None else str(data_scope_header).strip()
     if data_scope:
         headers[DATA_SCOPE_HEADER_NAME] = data_scope
 

--- a/dataagent/dataagent-backend/tests/test_readonly_query_proxy.py
+++ b/dataagent/dataagent-backend/tests/test_readonly_query_proxy.py
@@ -224,6 +224,22 @@ class TestExecuteReadonlyQuery:
         assert captured["scope_header"] == explicit_scope
 
     @pytest.mark.anyio
+    async def test_explicit_empty_data_scope_header_does_not_fallback_to_env(self, monkeypatch):
+        configure_proxy_env(monkeypatch, env={
+            **PROXY_ENV,
+            "DATAAGENT_DATA_SCOPE_JSON": json.dumps({"allowed_scopes": [{"database": "env_db", "source_type": "MYSQL", "cluster_id": 1}]}),
+        })
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["scope_header"] = request.headers.get("X-Agent-Data-Scope")
+            return httpx.Response(200, json={"rows": [{"x": 1}], "row_count": 1, "has_more": False})
+
+        install_upstream(monkeypatch, handler)
+        await execute_readonly_query("SELECT 1", "demo", data_scope_header="")
+        assert captured["scope_header"] is None
+
+    @pytest.mark.anyio
     async def test_missing_config_raises(self, monkeypatch):
         configure_proxy_env(monkeypatch, env={})
         with pytest.raises(QueryProxyConfigError):
@@ -312,6 +328,7 @@ class TestExecuteQueryRoute:
     def test_execute_route_passes_topic_scope(self, monkeypatch):
         configure_proxy_env(monkeypatch)
         captured = {}
+        contexts = []
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured["scope_header"] = request.headers.get("X-Agent-Data-Scope", "")
@@ -329,12 +346,10 @@ class TestExecuteQueryRoute:
             "agent_snapshot": {"data_scope": fake_scope},
         }
 
-        from api.routes import _get_store
-        original_get_store = _get_store
-
         class FakeStore:
             def get_topic(self, topic_id, context=None):
-                if topic_id == "t-123":
+                contexts.append(context)
+                if topic_id == "t-123" and context and context.get("source") == "portal":
                     return fake_topic
                 return None
 
@@ -351,6 +366,52 @@ class TestExecuteQueryRoute:
         decoded = base64.urlsafe_b64decode(captured["scope_header"] + "==").decode()
         scope = json.loads(decoded)
         assert scope["allowed_scopes"][0]["database"] == "scoped_db"
+        assert contexts == [{
+            "source": "portal",
+            "website_id": "",
+            "external_user_id": "",
+            "visitor_id": "",
+        }]
+
+    def test_execute_route_rejects_topic_outside_request_context(self, monkeypatch):
+        configure_proxy_env(monkeypatch)
+        upstream_called = False
+        contexts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal upstream_called
+            upstream_called = True
+            return httpx.Response(200, json={"rows": [{"x": 1}], "row_count": 1, "has_more": False})
+
+        install_upstream(monkeypatch, handler)
+
+        class FakeStore:
+            def get_topic(self, topic_id, context=None):
+                contexts.append(context)
+                return None
+
+        import api.routes as routes_mod
+        monkeypatch.setattr(routes_mod, "_get_store", lambda: FakeStore())
+        monkeypatch.setattr(routes_mod, "_allowed_widget_sites", lambda: [{"website_id": "site-a"}])
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/nl2sql/query/execute",
+            headers={
+                "X-ODW-Client": "widget",
+                "X-ODW-Website-Id": "site-a",
+                "X-ODW-User-Id": "user-a",
+            },
+            json={"sql": "SELECT 1", "database": "demo", "topic_id": "t-other"},
+        )
+        assert response.status_code == 404
+        assert not upstream_called
+        assert contexts == [{
+            "source": "widget",
+            "website_id": "site-a",
+            "external_user_id": "user-a",
+            "visitor_id": "",
+        }]
 
     def test_execute_route_upstream_failure_maps_status(self, monkeypatch):
         configure_proxy_env(monkeypatch)

--- a/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -153,14 +153,16 @@ describe('createNl2SqlApiClient', () => {
       database: 'demo',
       engine: 'mysql',
       limit: 500,
-      timeoutSeconds: 30
+      timeoutSeconds: 30,
+      topicId: 'topic-1'
     })
     expect(clients[0].post).toHaveBeenLastCalledWith('/query/execute', {
       sql: 'select 1',
       database: 'demo',
       engine: 'mysql',
       limit: 500,
-      timeout_seconds: 30
+      timeout_seconds: 30,
+      topic_id: 'topic-1'
     })
   })
 })

--- a/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue
@@ -95,6 +95,7 @@
         <template v-if="kind === 'sql_execution'">
           <SqlCodePanel
             v-if="sqlText"
+            :key="`sql-${toolInstanceKey}-${payloadDatabase}-${payloadEngine}`"
             :sql="sqlText"
             :database="payloadDatabase"
             :engine="payloadEngine"
@@ -114,6 +115,7 @@
         <template v-else-if="kind === 'sql_export'">
           <SqlCodePanel
             v-if="sqlText"
+            :key="`sql-export-${toolInstanceKey}-${payloadDatabase}-${payloadEngine}`"
             :sql="sqlText"
             :database="payloadDatabase"
             :engine="payloadEngine"

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/SqlCodePanel.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/SqlCodePanel.spec.js
@@ -33,7 +33,7 @@ const successResult = {
   error: null
 }
 
-const mountPanel = (props = {}) => mount(SqlCodePanel, {
+const mountPanel = (props = {}, options = {}) => mount(SqlCodePanel, {
   props: {
     sql: 'SELECT COUNT(*) AS cnt FROM demo.t',
     database: 'demo',
@@ -41,6 +41,7 @@ const mountPanel = (props = {}) => mount(SqlCodePanel, {
     ...props
   },
   global: {
+    provide: options.provide || {},
     stubs: {
       ResultDataTable: {
         props: ['columns', 'rows', 'title', 'meta'],
@@ -72,9 +73,14 @@ describe('SqlCodePanel', () => {
     expect(wrapper.find('[data-action="edit"]').exists()).toBe(true)
   })
 
-  it('hides execute controls without a database', () => {
+  it('disables execute controls without a database and explains why', () => {
     const wrapper = mountPanel({ database: '' })
-    expect(wrapper.find('[data-action="execute"]').exists()).toBe(false)
+    const execute = wrapper.find('[data-action="execute"]')
+    expect(execute.exists()).toBe(true)
+    expect(execute.attributes('disabled')).toBeDefined()
+    expect(execute.attributes('title')).toBe('缺少 database，无法执行')
+    expect(wrapper.find('.sql-panel-limit').attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('缺少 database')
   })
 
   it('executes sql and renders the result table', async () => {
@@ -93,6 +99,28 @@ describe('SqlCodePanel', () => {
     expect(wrapper.find('.sql-panel-error').exists()).toBe(false)
   })
 
+  it('uses injected api client and topic id when provided', async () => {
+    const injectedExecuteSql = vi.fn().mockResolvedValue(successResult)
+    const wrapper = mountPanel({}, {
+      provide: {
+        nl2sqlApi: { queryApi: { executeSql: injectedExecuteSql } },
+        nl2sqlTopicId: { value: 'topic-42' }
+      }
+    })
+
+    await wrapper.find('[data-action="execute"]').trigger('click')
+    await flushPromises()
+
+    expect(injectedExecuteSql).toHaveBeenCalledWith({
+      sql: 'SELECT COUNT(*) AS cnt FROM demo.t',
+      database: 'demo',
+      engine: 'mysql',
+      limit: 100,
+      topicId: 'topic-42'
+    })
+    expect(apiMocks.executeSql).not.toHaveBeenCalled()
+  })
+
   it('passes the selected limit', async () => {
     apiMocks.executeSql.mockResolvedValue(successResult)
     const wrapper = mountPanel()
@@ -100,6 +128,18 @@ describe('SqlCodePanel', () => {
     await wrapper.find('[data-action="execute"]').trigger('click')
     await flushPromises()
     expect(apiMocks.executeSql.mock.calls[0][0].limit).toBe(500)
+  })
+
+  it('resets execution state when the query context changes', async () => {
+    apiMocks.executeSql.mockResolvedValue(successResult)
+    const wrapper = mountPanel()
+    await wrapper.find('[data-action="execute"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.result-table-stub').exists()).toBe(true)
+
+    await wrapper.setProps({ database: 'demo_2' })
+    await flushPromises()
+    expect(wrapper.find('.result-table-stub').exists()).toBe(false)
   })
 
   it('shows the error message when execution fails', async () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/components/SqlCodePanel.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/components/SqlCodePanel.vue
@@ -21,20 +21,20 @@
           data-action="revert"
           @click="revertSql"
         >还原</button>
-        <template v-if="executable">
-          <select v-model.number="limit" class="sql-panel-limit" aria-label="返回行数上限">
-            <option :value="100">100 行</option>
-            <option :value="500">500 行</option>
-            <option :value="1000">1000 行</option>
-          </select>
-          <button
-            type="button"
-            class="sql-panel-btn sql-panel-btn-primary"
-            data-action="execute"
-            :disabled="running || !currentSql.trim()"
-            @click="executeSql"
-          >{{ running ? '执行中…' : '执行' }}</button>
-        </template>
+        <select v-model.number="limit" class="sql-panel-limit" :disabled="!executable || running" aria-label="返回行数上限">
+          <option :value="100">100 行</option>
+          <option :value="500">500 行</option>
+          <option :value="1000">1000 行</option>
+        </select>
+        <button
+          type="button"
+          class="sql-panel-btn sql-panel-btn-primary"
+          data-action="execute"
+          :disabled="running || !currentSql.trim() || !executable"
+          :title="!executable ? '缺少 database，无法执行' : ''"
+          @click="executeSql"
+        >{{ running ? '执行中…' : '执行' }}</button>
+        <span v-if="!executable" class="sql-panel-hint">缺少 database</span>
       </div>
     </div>
 
@@ -206,8 +206,8 @@ const executeSql = async () => {
 }
 
 watch(
-  () => props.sql,
-  (value) => {
+  () => [props.sql, props.database, props.engine],
+  ([value]) => {
     if (editing.value) return
     currentSql.value = String(value || '')
     setEditorDoc(currentSql.value)
@@ -292,6 +292,17 @@ onBeforeUnmount(() => {
   font-size: 12px;
   color: #31567a;
   background: #fff;
+}
+
+.sql-panel-limit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sql-panel-hint {
+  font-size: 12px;
+  color: #8da0b3;
+  white-space: nowrap;
 }
 
 .sql-panel-editor {


### PR DESCRIPTION
## Summary

Builds on #355 to close the remaining review gaps from #353/#355:

- apply the request context when resolving `topic_id` data scope for SQL re-execution, so widget/portal requests cannot borrow another topic scope
- return 404 for topic IDs outside the caller context instead of silently executing with an empty scope
- keep an explicit empty topic scope from falling back to process-level `DATAAGENT_DATA_SCOPE_JSON`
- keep SQL execution controls visible but disabled when `database` is missing, and reset stale execution output when SQL context changes
- add backend and frontend regression coverage for the secured scope path and SQL panel behavior

## Validation

- `git diff --check`
- `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest tests/test_readonly_query_proxy.py -q` — 20 passed
- `nvm use && npm --prefix dataagent/dataagent-frontend test -- src/api/__tests__/nl2sqlClient.spec.js src/views/intelligence/__tests__/SqlCodePanel.spec.js src/views/intelligence/__tests__/ToolOutputRenderer.spec.js` — 36 passed across 3 files

## Notes

- Full local intelligent-query E2E smoke was not run in this patch pass.