### PR TITLE
fix: harden data dev assistant permission flow

### DIFF
--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/config/AgentApiConfiguration.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/config/AgentApiConfiguration.java
@@ -16,6 +16,6 @@ public class AgentApiConfiguration implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(agentApiAuthInterceptor)
-                .addPathPatterns("/v1/ai/metadata/**", "/v1/ai/query/**");
+                .addPathPatterns("/v1/ai/**");
     }
 }

--- a/backend-agent-api/src/test/java/com/onedata/portal/agentapi/config/AgentApiConfigurationTest.java
+++ b/backend-agent-api/src/test/java/com/onedata/portal/agentapi/config/AgentApiConfigurationTest.java
@@ -1,0 +1,35 @@
+package com.onedata.portal.agentapi.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AgentApiConfigurationTest {
+
+    @Test
+    void addInterceptorsProtectsAllAgentApiRoutes() throws Exception {
+        AgentApiAuthInterceptor interceptor = new AgentApiAuthInterceptor(new AgentApiProperties(), new ObjectMapper());
+        AgentApiConfiguration configuration = new AgentApiConfiguration(interceptor);
+        InterceptorRegistry registry = new InterceptorRegistry();
+
+        configuration.addInterceptors(registry);
+
+        List<InterceptorRegistration> registrations = getField(registry, "registrations");
+        assertEquals(1, registrations.size());
+        assertEquals(Collections.singletonList("/v1/ai/**"), getField(registrations.get(0), "includePatterns"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
@@ -2,6 +2,7 @@ package com.onedata.portal.agentapi.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import com.onedata.portal.entity.DataTask;
 import com.onedata.portal.service.DataTaskService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class BackendAgentTaskService implements AgentTaskService {
     @Override
     public Object createTask(AgentTaskUpsertRequest request, String operator) {
         DataTask task = toTask(request);
+        validateDataScope(task);
         applyAuditDefaults(task, operator, true);
         return dataTaskService.create(task, nullSafe(request.getInputTableIds()), nullSafe(request.getOutputTableIds()));
     }
@@ -37,6 +39,7 @@ public class BackendAgentTaskService implements AgentTaskService {
     public Object updateTask(Long taskId, AgentTaskUpsertRequest request, String operator) {
         DataTask task = toTask(request);
         task.setId(taskId);
+        validateDataScope(task);
         applyAuditDefaults(task, operator, false);
         return dataTaskService.update(task, nullSafe(request.getInputTableIds()), nullSafe(request.getOutputTableIds()));
     }
@@ -70,5 +73,15 @@ public class BackendAgentTaskService implements AgentTaskService {
 
     private List<Long> nullSafe(List<Long> ids) {
         return ids == null ? Collections.emptyList() : ids;
+    }
+
+    private void validateDataScope(DataTask task) {
+        if (!AgentDataScopeContext.isActive() || task == null) {
+            return;
+        }
+        String datasourceName = task.getDatasourceName();
+        if (StringUtils.hasText(datasourceName)) {
+            AgentDataScopeContext.requireDatabaseNameAllowed(datasourceName);
+        }
     }
 }

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
@@ -5,6 +5,7 @@ import com.onedata.portal.agentapi.dto.AgentPublishPreviewResponse;
 import com.onedata.portal.agentapi.dto.AgentPublishRequest;
 import com.onedata.portal.agentapi.dto.AgentScheduleUpsertRequest;
 import com.onedata.portal.agentapi.dto.AgentWorkflowUpsertRequest;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import com.onedata.portal.dto.workflow.WorkflowDefinitionRequest;
 import com.onedata.portal.dto.workflow.WorkflowDetailResponse;
 import com.onedata.portal.dto.workflow.WorkflowPublishRequest;
@@ -19,7 +20,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Agent-facing workflow write API, delegating to the existing workflow services.
@@ -41,12 +44,14 @@ public class BackendAgentWorkflowService implements AgentWorkflowService {
 
     @Override
     public Object createWorkflow(AgentWorkflowUpsertRequest request, String operator) {
+        validateWorkflowDataScope(request);
         WorkflowDefinitionRequest definition = toDefinition(request, operator);
         return workflowService.createWorkflow(definition);
     }
 
     @Override
     public Object updateWorkflow(Long workflowId, AgentWorkflowUpsertRequest request, String operator) {
+        validateWorkflowDataScope(request);
         WorkflowDefinitionRequest definition = toDefinition(request, operator);
         return workflowService.updateWorkflow(workflowId, definition);
     }
@@ -109,6 +114,26 @@ public class BackendAgentWorkflowService implements AgentWorkflowService {
     @Override
     public Object scheduleOffline(Long workflowId, String operator) {
         return workflowScheduleService.offlineSchedule(workflowId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateWorkflowDataScope(AgentWorkflowUpsertRequest request) {
+        if (!AgentDataScopeContext.isActive() || request.getWorkflow() == null) {
+            return;
+        }
+        Object tasks = request.getWorkflow().get("tasks");
+        if (!(tasks instanceof List)) {
+            return;
+        }
+        for (Object item : (List<?>) tasks) {
+            if (!(item instanceof Map)) {
+                continue;
+            }
+            Object ds = ((Map<String, Object>) item).get("datasourceName");
+            if (ds instanceof String && StringUtils.hasText((String) ds)) {
+                AgentDataScopeContext.requireDatabaseNameAllowed((String) ds);
+            }
+        }
     }
 
     private WorkflowDefinitionRequest toDefinition(AgentWorkflowUpsertRequest request, String operator) {

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java
@@ -100,6 +100,7 @@ public class BackendAgentWorkflowService implements AgentWorkflowService {
 
     @Override
     public Object upsertSchedule(Long workflowId, AgentScheduleUpsertRequest request, String operator) {
+        validateScheduleDoesNotChangeState(request);
         WorkflowScheduleRequest scheduleRequest =
                 objectMapper.convertValue(request.getSchedule(), WorkflowScheduleRequest.class);
         return workflowScheduleService.upsertSchedule(workflowId, scheduleRequest);
@@ -143,6 +144,15 @@ public class BackendAgentWorkflowService implements AgentWorkflowService {
             definition.setOperator(operator);
         }
         return definition;
+    }
+
+    private void validateScheduleDoesNotChangeState(AgentScheduleUpsertRequest request) {
+        if (request == null || request.getSchedule() == null) {
+            return;
+        }
+        if (request.getSchedule().containsKey("enabled")) {
+            throw new IllegalArgumentException("enabled 不允许出现在调度配置 upsert 中，请使用 schedule/online 或 schedule/offline 接口变更调度状态");
+        }
     }
 
     private Long currentVersionId(Long workflowId) {

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentWorkflowServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentWorkflowServiceTest.java
@@ -2,8 +2,10 @@ package com.onedata.portal.agentapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.agentapi.dto.AgentPublishRequest;
+import com.onedata.portal.agentapi.dto.AgentScheduleUpsertRequest;
 import com.onedata.portal.agentapi.service.AgentPreviewTokenSupport;
 import com.onedata.portal.agentapi.service.BackendAgentWorkflowService;
+import com.onedata.portal.dto.workflow.WorkflowScheduleRequest;
 import com.onedata.portal.dto.workflow.WorkflowDetailResponse;
 import com.onedata.portal.dto.workflow.WorkflowPublishRequest;
 import com.onedata.portal.entity.DataWorkflow;
@@ -15,6 +17,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,5 +92,18 @@ class BackendAgentWorkflowServiceTest {
 
         verify(previewTokenSupport, never()).verify(any(Long.class), any(), any());
         verify(workflowPublishService).publish(eq(12L), any(WorkflowPublishRequest.class));
+    }
+
+    @Test
+    void scheduleUpsertRejectsEnabledStateChange() {
+        BackendAgentWorkflowService svc = service();
+        AgentScheduleUpsertRequest req = new AgentScheduleUpsertRequest();
+        Map<String, Object> schedule = new HashMap<>();
+        schedule.put("scheduleCron", "0 0 * * * ? *");
+        schedule.put("enabled", Boolean.TRUE);
+        req.setSchedule(schedule);
+
+        assertThrows(IllegalArgumentException.class, () -> svc.upsertSchedule(12L, req, "agent:t"));
+        verify(workflowScheduleService, never()).upsertSchedule(any(), any(WorkflowScheduleRequest.class));
     }
 }

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
@@ -1,6 +1,6 @@
 # 工具配方（调用顺序与参数）
 
-全部为 portal MCP 工具。高危工具（`portal_publish_workflow`、`portal_workflow_schedule_online`）在 default/acceptEdits 权限模式下触发对话内确认。
+全部为 portal MCP 工具。`default` 权限模式下所有写工具都会触发对话内确认；`acceptEdits` 下草稿写操作自动执行，高危工具（`portal_publish_workflow`、`portal_workflow_schedule_online`）仍触发确认；`bypassPermissions` 下写工具自动执行，但 deploy/online/schedule-online 仍必须提供后端 preview token。
 
 ## 1. 探查表与 SQL
 

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -632,11 +632,11 @@ async def api_submit_permission_decision(task_id: str, payload: PermissionDecisi
     decision = str(payload.decision or "").strip().lower()
     if decision not in {"allow", "deny"}:
         raise HTTPException(status_code=400, detail="decision must be allow or deny")
-    # Only a run paused at a confirmation can accept a decision.
     if str(task.get("task_status") or "") != "waiting_permission":
         raise HTTPException(status_code=409, detail="task is not awaiting a permission decision")
-    # Signal the waiting executor; first decision wins (idempotent). The executor
-    # writes the durable permission_decision record when it observes this.
+    pending_request_id = store.get_pending_permission_request_id(task_id)
+    if pending_request_id and pending_request_id != request_id:
+        raise HTTPException(status_code=409, detail="request_id does not match the current pending permission request")
     effective = await get_task_coordinator().submit_permission_decision(task_id, request_id, decision)
     return PermissionDecisionResponse.model_validate(
         {"task_id": task_id, "request_id": request_id, "decision": effective}

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -637,7 +637,19 @@ async def api_submit_permission_decision(task_id: str, payload: PermissionDecisi
     pending_request_id = store.get_pending_permission_request_id(task_id)
     if pending_request_id and pending_request_id != request_id:
         raise HTTPException(status_code=409, detail="request_id does not match the current pending permission request")
-    effective = await get_task_coordinator().submit_permission_decision(task_id, request_id, decision)
+    coordinator = get_task_coordinator()
+    if not pending_request_id:
+        existing = await coordinator.read_permission_decision(task_id, request_id)
+        if not existing:
+            raise HTTPException(status_code=409, detail="task has no pending permission request")
+    effective = await coordinator.submit_permission_decision(task_id, request_id, decision)
+    if pending_request_id:
+        store.append_permission_decision_record(
+            task_id=task_id,
+            request_id=request_id,
+            decision=effective,
+            note=str(payload.note or ""),
+        )
     return PermissionDecisionResponse.model_validate(
         {"task_id": task_id, "request_id": request_id, "decision": effective}
     )

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -17,7 +17,7 @@ from core.provider_runtime import build_provider_env as _build_provider_env
 from core.provider_runtime import normalize_provider_id as _normalize_provider_id
 from core.provider_runtime import safe_base_url_for_log as _safe_base_url_for_log
 from core.agent_profile_service import normalize_permission_mode
-from core.permission_gate import WRITE_TOOL_NAMES, plan_denies_tool
+from core.permission_gate import WRITE_TOOL_NAMES, plan_denies_tool, requires_confirmation
 from core.data_scope import encode_scope_header, normalize_data_scope
 from core.skill_admin_service import resolve_enabled_skill_runtime, resolve_runtime_provider_selection
 from core.skill_discovery import (
@@ -411,10 +411,9 @@ def _is_running_as_root() -> bool:
 
 
 def _resolve_sdk_permission_mode(permission_mode: str | None = None) -> str:
-    # Per-mode enforcement (plan strips write tools; default/acceptEdits route
-    # high-risk tools through can_use_tool) lands with the confirmation flow.
-    # Until then, allowed_tools remains the real capability boundary, so every
-    # mode runs effectively bypassPermissions, with the root fallback preserved.
+    # Per-mode enforcement is handled by the mounted allowed_tools set. MCP write
+    # tools requiring confirmation are withheld because SDK can_use_tool is not a
+    # reliable gate for those calls.
     normalize_permission_mode(permission_mode)
     if _is_running_as_root():
         # Claude Code rejects bypassPermissions under root/sudo. Fall back to the
@@ -472,9 +471,11 @@ def _build_allowed_tools(
         tool_names = list(PORTAL_MCP_TOOL_NAMES) + sorted(WRITE_TOOL_NAMES)
         for tool_name in tool_names:
             qualified = f"mcp__{PORTAL_MCP_SERVER_NAME}__{tool_name}"
-            # plan mode is read-only: never mount write tools (defense in depth
-            # alongside the can_use_tool denial).
-            if mode == "plan" and plan_denies_tool(qualified):
+            # SDK can_use_tool is not a reliable gate for MCP write tools, so the
+            # mounted tool set remains the hard capability boundary. Tools that
+            # would require confirmation in the current mode are withheld rather
+            # than exposed and then approved later.
+            if (mode == "plan" and plan_denies_tool(qualified)) or requires_confirmation(qualified, mode):
                 continue
             allowed.append(qualified)
 

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -424,11 +424,22 @@ def _build_can_use_tool_callback(
         )
         recorded = "allowed" if decision == "allow" else ("timeout" if decision == "timeout" else "denied")
         try:
-            sdk_writer.append_permission_decision(
-                request_id=request_id,
-                decision=recorded,
-                decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            )
+            append_decision = getattr(store, "append_permission_decision_record", None)
+            if callable(append_decision):
+                appended = append_decision(
+                    task_id=task_id,
+                    request_id=request_id,
+                    decision=recorded,
+                    decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                )
+                if not appended and decision == "timeout":
+                    logger.warning("can_use_tool: timeout decision was already recorded task_id=%s request_id=%s", task_id, request_id)
+            else:
+                sdk_writer.append_permission_decision(
+                    request_id=request_id,
+                    decision=recorded,
+                    decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                )
             store.set_task_status(task_id, "running")
         except Exception:
             logger.exception("can_use_tool: failed to record permission decision task_id=%s", task_id)
@@ -440,6 +451,13 @@ def _build_can_use_tool_callback(
         return _deny_result("用户拒绝了该操作。")
 
     return can_use_tool
+
+
+async def _single_user_prompt_stream(prompt: str):
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": prompt},
+    }
 
 
 async def execute_task_stream(
@@ -723,7 +741,8 @@ async def _execute_task_stream_local(
 
     try:
         with anyio.fail_after(timeout_seconds):
-            async for msg in claude_query(prompt=prompt, options=options):
+            sdk_prompt = _single_user_prompt_stream(prompt) if can_use_tool is not None else prompt
+            async for msg in claude_query(prompt=sdk_prompt, options=options):
                 if await _cancelled():
                     error = {"code": "task_cancelled", "message": "任务已取消"}
                     sdk_writer.append_error(**error)

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -1399,6 +1399,30 @@ class TopicTaskStore:
             conn.close()
         return self.get_task(task_id)
 
+    def get_pending_permission_request_id(self, task_id: str) -> str | None:
+        """Return the request_id of the latest permission_request record for a task
+        that has no corresponding permission_decision yet, or None."""
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT data FROM da_agent_sdk_record
+                    WHERE task_id = %s AND record_type = 'permission_request'
+                    ORDER BY id DESC LIMIT 1
+                    """,
+                    (task_id,),
+                )
+                row = cur.fetchone()
+                if not row:
+                    return None
+                import json as _json
+                data = row["data"] if isinstance(row["data"], dict) else _json.loads(row["data"])
+                return str(data.get("request_id") or "")
+        finally:
+            conn.close()
+
     def heartbeat_task(self, task_id: str):
         self._ensure_ready()
         conn = self._connect(database=self._schema_name())

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -5,7 +5,7 @@ import logging
 import re
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pymysql
@@ -1402,26 +1402,82 @@ class TopicTaskStore:
     def get_pending_permission_request_id(self, task_id: str) -> str | None:
         """Return the request_id of the latest permission_request record for a task
         that has no corresponding permission_decision yet, or None."""
+        pending = self.get_pending_permission_request(task_id)
+        return str(pending.get("request_id") or "") if pending else None
+
+    def get_pending_permission_request(self, task_id: str) -> dict[str, Any] | None:
+        """Return the latest permission request that has not been decided yet."""
         self._ensure_ready()
         conn = self._connect(database=self._schema_name())
         try:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT data FROM da_agent_sdk_record
-                    WHERE task_id = %s AND record_type = 'permission_request'
-                    ORDER BY id DESC LIMIT 1
+                    SELECT id, topic_id, turn_index, record_type, data
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s
+                      AND record_type IN ('permission_request', 'permission_decision')
+                    ORDER BY id DESC
+                    LIMIT 200
                     """,
                     (task_id,),
                 )
-                row = cur.fetchone()
-                if not row:
-                    return None
-                import json as _json
-                data = row["data"] if isinstance(row["data"], dict) else _json.loads(row["data"])
-                return str(data.get("request_id") or "")
+                rows = cur.fetchall() or []
         finally:
             conn.close()
+
+        closed: set[str] = set()
+        for row in rows:
+            data = _safe_json_load(row.get("data")) or {}
+            request_id = str(data.get("request_id") or "")
+            if not request_id:
+                continue
+            record_type = str(row.get("record_type") or "")
+            if record_type == "permission_decision":
+                closed.add(request_id)
+                continue
+            if record_type == "permission_request" and request_id not in closed:
+                return {
+                    "request_id": request_id,
+                    "topic_id": str(row.get("topic_id") or ""),
+                    "turn_index": int(row.get("turn_index") or 0),
+                }
+        return None
+
+    def append_permission_decision_record(
+        self,
+        *,
+        task_id: str,
+        request_id: str,
+        decision: str,
+        note: str = "",
+        decided_at: str = "",
+    ) -> bool:
+        """Append a durable permission_decision SDK record if the request is still pending."""
+        pending = self.get_pending_permission_request(task_id)
+        if not pending or str(pending.get("request_id") or "") != str(request_id or ""):
+            return False
+        normalized = {
+            "allow": "allowed",
+            "allowed": "allowed",
+            "deny": "denied",
+            "denied": "denied",
+            "timeout": "timeout",
+        }.get(str(decision or "").strip().lower(), "denied")
+        self.append_sdk_record(
+            task_id=task_id,
+            topic_id=str(pending.get("topic_id") or ""),
+            turn_index=int(pending.get("turn_index") or 0),
+            record_type="permission_decision",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "decision": normalized,
+                "note": str(note or ""),
+                "decided_at": decided_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+        )
+        return True
 
     def heartbeat_task(self, task_id: str):
         self._ensure_ready()

--- a/dataagent/dataagent-backend/core/topic_workspace.py
+++ b/dataagent/dataagent-backend/core/topic_workspace.py
@@ -33,6 +33,13 @@ def sanitize_topic_id(topic_id: str) -> str:
 
 def _resolve_runtime_root(raw: str | None = None) -> Path:
     value = str(raw or "").strip()
+    if not value:
+        try:
+            from config import get_settings
+
+            value = str(get_settings().dataagent_host_root or "").strip()
+        except Exception:
+            value = ""
     if value:
         path = Path(value).expanduser()
         if path.is_absolute():

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -229,11 +229,27 @@ _PORTAL_MCP = {
 }
 
 
-def test_build_allowed_tools_mounts_write_tools_in_default_mode():
+def test_build_allowed_tools_default_mode_keeps_mcp_writes_unmounted():
     allowed = agent_runtime._build_allowed_tools(_PORTAL_MCP, permission_mode="default")
-    assert "mcp__portal__portal_create_task" in allowed
-    assert "mcp__portal__portal_publish_workflow" in allowed
     assert "mcp__portal__portal_search_tables" in allowed
+    assert "mcp__portal__portal_create_task" not in allowed
+    assert "mcp__portal__portal_publish_workflow" not in allowed
+
+
+def test_build_allowed_tools_accept_edits_mounts_only_draft_writes():
+    allowed = agent_runtime._build_allowed_tools(_PORTAL_MCP, permission_mode="acceptEdits")
+    assert "mcp__portal__portal_search_tables" in allowed
+    assert "mcp__portal__portal_create_workflow" in allowed
+    assert "mcp__portal__portal_upsert_schedule" in allowed
+    assert "mcp__portal__portal_publish_workflow" not in allowed
+    assert "mcp__portal__portal_workflow_schedule_online" not in allowed
+
+
+def test_build_allowed_tools_bypass_permissions_mounts_all_writes():
+    allowed = agent_runtime._build_allowed_tools(_PORTAL_MCP, permission_mode="bypassPermissions")
+    assert "mcp__portal__portal_create_workflow" in allowed
+    assert "mcp__portal__portal_publish_workflow" in allowed
+    assert "mcp__portal__portal_workflow_schedule_online" in allowed
 
 
 def test_build_allowed_tools_plan_mode_strips_write_tools():

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -141,6 +141,14 @@ class _FakeStore:
         topic = self.topics.get(topic_id) or {}
         return normalize_permission_mode(topic.get("permission_mode"))
 
+    def get_pending_permission_request_id(self, task_id: str) -> str | None:
+        records = self.sdk_records.get(task_id, [])
+        for rec in reversed(records):
+            if rec.get("record_type") == "permission_request":
+                data = rec.get("data") or {}
+                return str(data.get("request_id") or "")
+        return None
+
     def delete_topic(self, topic_id: str, context=None):
         self.topics.pop(topic_id, None)
         self.topic_messages.pop(topic_id, None)

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -142,12 +142,46 @@ class _FakeStore:
         return normalize_permission_mode(topic.get("permission_mode"))
 
     def get_pending_permission_request_id(self, task_id: str) -> str | None:
-        records = self.sdk_records.get(task_id, [])
-        for rec in reversed(records):
-            if rec.get("record_type") == "permission_request":
-                data = rec.get("data") or {}
-                return str(data.get("request_id") or "")
+        pending = self.get_pending_permission_request(task_id)
+        return str(pending.get("request_id") or "") if pending else None
+
+    def get_pending_permission_request(self, task_id: str) -> dict | None:
+        closed = set()
+        for rec in reversed(self.sdk_records.get(task_id, [])):
+            data = rec.get("data") or {}
+            request_id = str(data.get("request_id") or "")
+            if not request_id:
+                continue
+            if rec.get("record_type") == "permission_decision":
+                closed.add(request_id)
+                continue
+            if rec.get("record_type") == "permission_request" and request_id not in closed:
+                return {
+                    "request_id": request_id,
+                    "topic_id": rec.get("topic_id") or "",
+                    "turn_index": int(rec.get("turn_index") or 0),
+                }
         return None
+
+    def append_permission_decision_record(self, *, task_id: str, request_id: str, decision: str, note: str = "", decided_at: str = ""):
+        pending = self.get_pending_permission_request(task_id)
+        if not pending or pending.get("request_id") != request_id:
+            return False
+        normalized = {"allow": "allowed", "deny": "denied"}.get(decision, decision)
+        self.append_sdk_record(
+            task_id=task_id,
+            topic_id=pending.get("topic_id") or "",
+            turn_index=int(pending.get("turn_index") or 0),
+            record_type="permission_decision",
+            event_type=None,
+            data={
+                "request_id": request_id,
+                "decision": normalized,
+                "note": note,
+                "decided_at": decided_at or _now(),
+            },
+        )
+        return True
 
     def delete_topic(self, topic_id: str, context=None):
         self.topics.pop(topic_id, None)
@@ -307,6 +341,19 @@ class _FakeStore:
         rows = [row for row in self.sdk_records.get(task_id, []) if int(row["seq_id"]) > after_id]
         rows.sort(key=lambda row: int(row["seq_id"]))
         return rows[:limit]
+
+    def append_sdk_record(self, *, task_id: str, topic_id: str, turn_index: int, record_type: str, event_type, data: dict):
+        records = self.sdk_records.setdefault(task_id, [])
+        records.append({
+            "seq_id": len(records) + 1,
+            "topic_id": topic_id,
+            "task_id": task_id,
+            "turn_index": turn_index,
+            "record_type": record_type,
+            "event_type": event_type,
+            "data": data,
+            "created_at": _now(),
+        })
 
     def request_task_cancel(self, task_id: str, context=None):
         task = self.tasks.get(task_id)
@@ -511,6 +558,10 @@ class _FakeCoordinator:
         self.__init_decisions()
         # first decision wins (idempotent)
         return self.decisions.setdefault((task_id, request_id), decision)
+
+    async def read_permission_decision(self, task_id: str, request_id: str) -> str | None:
+        self.__init_decisions()
+        return self.decisions.get((task_id, request_id))
 
 
 def _submit_message_task_factory(store: _FakeStore, calls: list[dict]):
@@ -769,20 +820,42 @@ def test_permission_decision_endpoint(monkeypatch):
 
         # Move the run into the waiting state.
         store.tasks[task_id]["task_status"] = "waiting_permission"
+        store.append_sdk_record(
+            task_id=task_id,
+            topic_id=topic_id,
+            turn_index=1,
+            record_type="permission_request",
+            event_type=None,
+            data={"request_id": "req-1", "tool_name": "portal_publish_workflow"},
+        )
 
         # Invalid decision value -> 400.
         assert client.post(base, json={"request_id": "req-1", "decision": "maybe"}).status_code == 400
         # Missing request_id -> 400.
         assert client.post(base, json={"request_id": "", "decision": "allow"}).status_code == 400
+        # Different request_id while a request is pending -> 409.
+        assert client.post(base, json={"request_id": "req-2", "decision": "allow"}).status_code == 409
 
         # Valid allow.
         ok = client.post(base, json={"request_id": "req-1", "decision": "allow"})
         assert ok.status_code == 200
         assert ok.json() == {"task_id": task_id, "request_id": "req-1", "decision": "allow"}
+        decisions = [
+            rec for rec in store.sdk_records[task_id]
+            if rec["record_type"] == "permission_decision"
+        ]
+        assert len(decisions) == 1
+        assert decisions[0]["data"]["decision"] == "allowed"
 
         # Idempotent: a later deny for the same request_id returns the first decision.
         again = client.post(base, json={"request_id": "req-1", "decision": "deny"})
         assert again.json()["decision"] == "allow"
+        decisions = [
+            rec for rec in store.sdk_records[task_id]
+            if rec["record_type"] == "permission_decision"
+        ]
+        assert len(decisions) == 1
+        assert client.post(base, json={"request_id": "req-2", "decision": "allow"}).status_code == 409
 
         # Unknown task -> 404.
         assert client.post(

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -56,10 +56,21 @@ def _build_gate(monkeypatch, decision, *, mode="default"):
     return cb, writer, store
 
 
+def _permission_behavior(result):
+    if isinstance(result, dict):
+        return result.get("behavior")
+    name = type(result).__name__.lower()
+    if "allow" in name:
+        return "allow"
+    if "deny" in name:
+        return "deny"
+    return getattr(result, "behavior", None)
+
+
 def test_can_use_tool_allows_read_tools_without_confirmation(monkeypatch):
     cb, writer, store = _build_gate(monkeypatch, "deny")
     result = asyncio.run(cb("mcp__portal__portal_search_tables", {}))
-    assert result["behavior"] == "allow"
+    assert _permission_behavior(result) == "allow"
     assert writer.requests == []
     assert store.statuses == []
 
@@ -67,7 +78,7 @@ def test_can_use_tool_allows_read_tools_without_confirmation(monkeypatch):
 def test_can_use_tool_confirms_write_tool_allowed(monkeypatch):
     cb, writer, store = _build_gate(monkeypatch, "allow")
     result = asyncio.run(cb("mcp__portal__portal_create_task", {"summary": "建表任务"}))
-    assert result["behavior"] == "allow"
+    assert _permission_behavior(result) == "allow"
     assert len(writer.requests) == 1
     assert writer.requests[0]["tool_name"] == "mcp__portal__portal_create_task"
     assert writer.decisions[0]["decision"] == "allowed"
@@ -77,7 +88,7 @@ def test_can_use_tool_confirms_write_tool_allowed(monkeypatch):
 def test_can_use_tool_confirms_write_tool_denied(monkeypatch):
     cb, writer, store = _build_gate(monkeypatch, "deny")
     result = asyncio.run(cb("mcp__portal__portal_publish_workflow", {"summary": "发布", "operation": "deploy"}))
-    assert result["behavior"] == "deny"
+    assert _permission_behavior(result) == "deny"
     assert writer.requests[0]["risk_level"] == "critical"
     assert writer.decisions[0]["decision"] == "denied"
     assert store.statuses == ["waiting_permission", "running"]
@@ -86,14 +97,14 @@ def test_can_use_tool_confirms_write_tool_denied(monkeypatch):
 def test_can_use_tool_timeout_denies(monkeypatch):
     cb, writer, store = _build_gate(monkeypatch, "timeout")
     result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
-    assert result["behavior"] == "deny"
+    assert _permission_behavior(result) == "deny"
     assert writer.decisions[0]["decision"] == "timeout"
 
 
 def test_can_use_tool_plan_denies_writes_without_request(monkeypatch):
     cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
     result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
-    assert result["behavior"] == "deny"
+    assert _permission_behavior(result) == "deny"
     assert writer.requests == []
 
 
@@ -193,6 +204,10 @@ def _install_fake_sdk(monkeypatch, messages, *, final_exception=None):
         "claude_agent_sdk",
         SimpleNamespace(ClaudeAgentOptions=ClaudeAgentOptions, query=fake_query),
     )
+
+
+async def _collect_async_prompt(prompt):
+    return [item async for item in prompt]
 
 
 def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None, permission_mode=None):
@@ -1111,6 +1126,14 @@ def test_execute_task_stream_injects_portal_mcp_servers(monkeypatch, tmp_path: P
     }
     assert "mcp__portal__portal_search_tables" in ClaudeAgentOptions.last_kwargs["allowed_tools"]
     assert "mcp__portal__portal_query_readonly" in ClaudeAgentOptions.last_kwargs["allowed_tools"]
+    assert callable(ClaudeAgentOptions.last_kwargs["can_use_tool"])
+    assert hasattr(QueryCapture.last_prompt, "__aiter__")
+    assert asyncio.run(_collect_async_prompt(QueryCapture.last_prompt)) == [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "[用户]: 最近 30 天工作流发布次数趋势"},
+        }
+    ]
 
 
 def _patch_default_provider(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_topic_workspace.py
+++ b/dataagent/dataagent-backend/tests/test_topic_workspace.py
@@ -35,6 +35,17 @@ def test_resolve_topic_workspace_uses_topic_id_only(monkeypatch, tmp_path: Path)
     assert workspace == tmp_path / "topics" / "topic-unsafe-id" / "workspace"
 
 
+def test_resolve_topic_workspace_uses_configured_runtime_root(tmp_path: Path):
+    original_root = get_settings().dataagent_host_root
+    update_settings({"dataagent_host_root": str(tmp_path / "configured-runtime")})
+    try:
+        workspace = resolve_topic_workspace("topic_1")
+    finally:
+        update_settings({"dataagent_host_root": original_root})
+
+    assert workspace == tmp_path / "configured-runtime" / "topic_1" / "workspace"
+
+
 def test_prepare_topic_workspace_copies_enabled_skills(monkeypatch, tmp_path: Path):
     original_skills = get_settings().skills_output_dir
     original_skills_root = getattr(get_settings(), "skills_root_dir", "")

--- a/dataagent/dataagent-frontend/src/views/intelligence/AgentStudio.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/AgentStudio.vue
@@ -82,7 +82,6 @@ const handleCreate = async () => {
       name: '新智能体',
       description: '',
       system_prompt: '',
-      permission_mode: 'inherit',
       allowed_tools: ['Skill', 'Bash', 'Read', 'LS', 'Glob', 'Grep'],
       mcp_server_ids: [],
       skill_folders: [],

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1089,11 +1089,13 @@ async function handlePermissionDecision(msg, payload) {
   try {
     await api.taskApi.submitPermissionDecision(taskId, requestId, decision)
   } catch (err) {
-    // Surface failure on the block so the user can retry.
     const block = (msg?._v2state?.blocks || []).find(
       (b) => b.type === 'permission_request' && b.requestId === requestId,
     )
-    if (block && block.decision === 'pending') block.summary = (block.summary || '') + '\n[提交失败，请重试]'
+    if (block && block.decision === 'pending') {
+      block.summary = (block.summary || '') + '\n[提交失败，请重试]'
+      block._submitFailed = Date.now()
+    }
   }
 }
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const props = defineProps({
   block: { type: Object, required: true },
@@ -29,6 +29,10 @@ const props = defineProps({
 const emit = defineEmits(['decide'])
 
 const submitting = ref(false)
+
+watch(() => props.block._submitFailed, (failed) => {
+  if (failed) submitting.value = false
+})
 
 const isPending = computed(() => (props.block.decision || 'pending') === 'pending')
 const bareTool = computed(() => {
@@ -60,10 +64,9 @@ const resultLabel = computed(() => {
 function decide(decision) {
   if (props.disabled || submitting.value) return
   submitting.value = true
-  // Optimistic: parent posts the decision; the streamed permission_decision
-  // record will reconcile the final state.
   emit('decide', { requestId: props.block.requestId, decision })
 }
+
 </script>
 
 <style scoped>

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -114,6 +114,14 @@
                         <ToolOutputRenderer :tool="blockToToolProp(block)" :file-url-resolver="resolveWorkspaceFileHref" />
                       </div>
 
+                      <!-- Generic Chat V2 permission confirmation card -->
+                      <PermissionConfirmationCard
+                        v-else-if="block.type === 'permission_request'"
+                        :block="block"
+                        :disabled="msg._v2state.status !== 'streaming'"
+                        @decide="(payload) => handlePermissionDecision(msg, payload)"
+                      />
+
                       <!-- Text block (inline chart_spec rendered as a real chart) -->
                       <div v-else-if="block.type === 'text' && block.content" class="query-main-text">
                         <template v-for="(seg, si) in answerSegments(block.content)" :key="si">
@@ -278,6 +286,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, triggerRe
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from '@/views/intelligence/ToolOutputRenderer.vue'
 import ChartSpecView from '@/views/intelligence/ChartSpecView.vue'
+import PermissionConfirmationCard from '@/views/intelligence/PermissionConfirmationCard.vue'
 import { splitChartSpecText, stripChartSpecsFromText } from '@/views/intelligence/chartSpec'
 import { blockToToolProp, processV2Record } from '@/views/intelligence/v2StreamParser'
 import { extractErrorText, isPlainEnterSubmit, renderMarkdown as renderMarkdownBase } from '@/views/intelligence/chatMessage'
@@ -433,6 +442,25 @@ const formatBytes = (size) => {
 // Split answer prose into ordered text/chart segments so an inline chart_spec
 // (fenced, tagged, or raw JSON) renders as a real chart instead of leaking JSON.
 const answerSegments = (content) => splitChartSpecText(String(content || ''))
+
+// Generic Chat V2 permission confirmation handler (shared with NL2SqlChatV2).
+const handlePermissionDecision = async (msg, payload) => {
+  const taskId = String(msg?.task_id || activeTaskId.value || '').trim()
+  const requestId = String(payload?.requestId || '').trim()
+  const decision = payload?.decision
+  if (!taskId || !requestId || (decision !== 'allow' && decision !== 'deny')) return
+  try {
+    await api.taskApi.submitPermissionDecision(taskId, requestId, decision)
+  } catch (_err) {
+    const block = (msg?._v2state?.blocks || []).find(
+      (b) => b.type === 'permission_request' && b.requestId === requestId,
+    )
+    if (block && block.decision === 'pending') {
+      block.summary = (block.summary || '') + '\n[提交失败，请重试]'
+      block._submitFailed = Date.now()
+    }
+  }
+}
 
 let copyNoticeTimer = null
 const showCopyNotice = (message) => {

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -249,6 +249,17 @@
           <div class="query-composer-toolbar">
             <div class="query-composer-hint">Enter 发送，Shift + Enter 换行</div>
             <div class="query-model-selector">
+              <select
+                :value="permissionMode"
+                class="query-model-select query-permission-select"
+                :disabled="isBusy"
+                title="会话权限模式"
+                @change="changePermissionMode($event.target.value)"
+              >
+                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value">
+                  {{ opt.label }}
+                </option>
+              </select>
               <select v-model="selectedProvider" class="query-model-select" :disabled="!providers.length || isBusy" title="切换提供商">
                 <option v-for="provider in providers" :key="provider.provider_id" :value="provider.provider_id">
                   {{ provider.display_name || provider.provider_id }}
@@ -323,6 +334,13 @@ const TOPIC_STATUS_REFRESH_INTERVAL_MS = 3000
 const agentPresetQuestions = ref([])
 const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
+const permissionMode = ref('default')
+const PERMISSION_MODE_OPTIONS = [
+  { value: 'default', label: '逐步确认' },
+  { value: 'acceptEdits', label: '草稿自动·发布确认' },
+  { value: 'plan', label: '仅规划' },
+  { value: 'bypassPermissions', label: '全自动' },
+]
 
 // widget-only UI state
 const inputSource = ref('typed')
@@ -337,6 +355,7 @@ const agentId = computed(() => String(props.config.agentId || '').trim())
 const chat = useNl2SqlChat({
   api,
   getAgentId: () => agentId.value,
+  getPermissionMode: () => permissionMode.value || '',
   messagePageSize: 500,
   topicTitleLength: 60,
   listTopicsParams: () => ({ page: 1, page_size: 50, agent_id: agentId.value || undefined }),
@@ -411,6 +430,28 @@ const formatTime = (value) => {
     return fmtDate(date, { month: '2-digit', day: '2-digit' })
   }
   return fmtDate(date, { year: 'numeric', month: '2-digit', day: '2-digit' })
+}
+
+const currentTopic = computed(() => topics.value.find((topic) => topic.topic_id === topicId.value) || null)
+watch(currentTopic, (topic) => {
+  if (topic && topic.permission_mode) permissionMode.value = topic.permission_mode
+}, { immediate: true })
+
+const changePermissionMode = async (mode) => {
+  const next = String(mode || '').trim()
+  if (!PERMISSION_MODE_OPTIONS.some((opt) => opt.value === next)) return
+  const previous = permissionMode.value
+  permissionMode.value = next
+  if (!topicId.value || next === previous) return
+  try {
+    const topic = await api.topicApi.updateTopic(topicId.value, { permission_mode: next })
+    if (topic?.permission_mode) permissionMode.value = topic.permission_mode
+    const target = topics.value.find((item) => item.topic_id === topicId.value)
+    if (target) target.permission_mode = permissionMode.value
+  } catch (_err) {
+    permissionMode.value = previous
+    errorText.value = '切换权限模式失败'
+  }
 }
 
 const formatMessageTime = (value) => {

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -36,6 +36,7 @@ const apiMocks = vi.hoisted(() => ({
     listTopics: vi.fn(),
     getTopicMessages: vi.fn(),
     deleteTopic: vi.fn(),
+    updateTopic: vi.fn(),
     updateMessageFeedback: vi.fn()
   },
   taskApi: {
@@ -132,6 +133,7 @@ describe('WidgetChat history conversations', () => {
     apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => messagePage(topicId, `${topicId} 历史回复`))
     apiMocks.topicApi.createTopic.mockResolvedValue(topic('topic-new', 'Widget 会话', { message_count: 0, last_message_preview: '' }))
     apiMocks.topicApi.deleteTopic.mockResolvedValue({ status: 'ok' })
+    apiMocks.topicApi.updateTopic.mockImplementation(async (topicId, payload) => topic(topicId, '已更新会话', payload))
     apiMocks.topicApi.updateMessageFeedback.mockImplementation(async (_topicId, messageId, feedback) => ({ message_id: messageId, feedback }))
     apiMocks.taskApi.deliverMessage.mockResolvedValue({ task_id: 'task-1' })
     apiMocks.taskApi.getTask.mockResolvedValue({ task_status: 'finished' })
@@ -379,7 +381,7 @@ describe('WidgetChat history conversations', () => {
     await wrapper.get('form').trigger('submit')
     await flushPromises()
 
-    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('首次输入创建会话', { agent_id: 'agent_widget' })
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('首次输入创建会话', { agent_id: 'agent_widget', permission_mode: 'default' })
     expect(wrapper.findAll('.query-session-title').map((item) => item.text())).toEqual([
       '首次输入创建会话',
       '最近 30 天工作流发布趋势',
@@ -391,6 +393,34 @@ describe('WidgetChat history conversations', () => {
       content: '首次输入创建会话',
       agent_id: 'agent_widget'
     }))
+  })
+
+  it('passes the selected permission mode when creating and sending a widget topic', async () => {
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('.query-permission-select').setValue('plan')
+    await wrapper.get('textarea').setValue('只做规划')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(apiMocks.topicApi.createTopic).toHaveBeenCalledWith('只做规划', { agent_id: 'agent_widget', permission_mode: 'plan' })
+    expect(apiMocks.taskApi.deliverMessage).toHaveBeenCalledWith(expect.objectContaining({
+      content: '只做规划',
+      permission_mode: 'plan'
+    }))
+  })
+
+  it('persists permission mode switches for an existing widget topic', async () => {
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('[data-testid="history-topic-topic-1"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('.query-permission-select').setValue('acceptEdits')
+    await flushPromises()
+
+    expect(apiMocks.topicApi.updateTopic).toHaveBeenCalledWith('topic-1', { permission_mode: 'acceptEdits' })
   })
 
   it('keeps the first sent conversation at the top when initial history load resolves late', async () => {

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -1012,6 +1012,7 @@ export const WIDGET_STYLES = `
 .query-model-selector {
   display: flex;
   gap: 4px;
+  min-width: 0;
 }
 
 .query-model-select {
@@ -1026,6 +1027,10 @@ export const WIDGET_STYLES = `
   outline: none;
   max-width: 120px;
   cursor: pointer;
+}
+
+.query-permission-select {
+  max-width: 92px;
 }
 
 .query-model-select:hover {

--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -138,7 +138,13 @@ class PublishWorkflowInput(BaseModel):
 
     workflow_id: int = Field(..., description="工作流 ID")
     operation: Literal["deploy", "online", "offline"] = Field(..., description="发布操作")
-    preview_token: str = Field(..., min_length=1, description="发布预览返回的一次性凭证;deploy/online 必填,确保已先预览")
+    preview_token: str | None = Field(default=None, description="发布预览返回的一次性凭证;deploy/online 必填,offline 可省略")
+
+    @model_validator(mode="after")
+    def validate_token_required(self) -> "PublishWorkflowInput":
+        if self.operation in ("deploy", "online") and not self.preview_token:
+            raise ValueError("deploy/online 操作必须提供 preview_token")
+        return self
 
 
 class UpsertScheduleInput(BaseModel):
@@ -332,7 +338,7 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
     )
     async def portal_create_workflow(params: CreateWorkflowInput) -> dict[str, Any]:
         """Create a draft workflow with its task bindings and edges."""
-        return await service.create_workflow(params.workflow)
+        return await service.create_workflow({"workflow": params.workflow})
 
     @mcp.tool(
         name="portal_update_workflow",
@@ -340,7 +346,7 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
     )
     async def portal_update_workflow(params: UpdateWorkflowInput) -> dict[str, Any]:
         """Update a draft workflow's structure."""
-        return await service.update_workflow(params.workflow_id, params.workflow)
+        return await service.update_workflow(params.workflow_id, {"workflow": params.workflow})
 
     @mcp.tool(
         name="portal_get_workflow",
@@ -372,10 +378,10 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
     )
     async def portal_publish_workflow(params: PublishWorkflowInput) -> dict[str, Any]:
         """HIGH-RISK: deploy/online/offline a workflow to the scheduler. Requires user confirmation. Call portal_preview_publish first and pass its preview_token."""
-        return await service.publish_workflow(
-            params.workflow_id,
-            {"operation": params.operation, "previewToken": params.preview_token},
-        )
+        payload: dict[str, Any] = {"operation": params.operation}
+        if params.preview_token:
+            payload["previewToken"] = params.preview_token
+        return await service.publish_workflow(params.workflow_id, payload)
 
     @mcp.tool(
         name="portal_upsert_schedule",
@@ -383,7 +389,9 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
     )
     async def portal_upsert_schedule(params: UpsertScheduleInput) -> dict[str, Any]:
         """Create or update a workflow's schedule configuration (cron/timezone/etc.)."""
-        return await service.upsert_schedule(params.workflow_id, params.schedule)
+        schedule = dict(params.schedule)
+        schedule.pop("enabled", None)
+        return await service.upsert_schedule(params.workflow_id, {"schedule": schedule})
 
     @mcp.tool(
         name="portal_workflow_schedule_online",

--- a/dataagent/portal-mcp/portal_mcp/service.py
+++ b/dataagent/portal-mcp/portal_mcp/service.py
@@ -42,10 +42,10 @@ class PortalToolService:
         return await self._wrap(self.backend_client.list_tasks(**payload))
 
     async def create_workflow(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._wrap(self.backend_client.create_workflow(payload))
+        return await self._wrap(self.backend_client.create_workflow(_wrap_payload(payload, "workflow")))
 
     async def update_workflow(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._wrap(self.backend_client.update_workflow(workflow_id, payload))
+        return await self._wrap(self.backend_client.update_workflow(workflow_id, _wrap_payload(payload, "workflow")))
 
     async def get_workflow(self, workflow_id: int) -> dict[str, Any]:
         return await self._wrap(self.backend_client.get_workflow(workflow_id))
@@ -60,7 +60,10 @@ class PortalToolService:
         return await self._wrap(self.backend_client.publish_workflow(workflow_id, payload))
 
     async def upsert_schedule(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._wrap(self.backend_client.upsert_schedule(workflow_id, payload))
+        schedule_payload = _wrap_payload(payload, "schedule")
+        schedule = dict(schedule_payload.get("schedule") or {})
+        schedule.pop("enabled", None)
+        return await self._wrap(self.backend_client.upsert_schedule(workflow_id, {"schedule": schedule}))
 
     async def schedule_online(self, workflow_id: int, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._wrap(self.backend_client.schedule_online(workflow_id, payload))
@@ -76,3 +79,9 @@ class PortalToolService:
             return await awaitable
         except BackendApiError as exc:
             raise RuntimeError(str(exc)) from exc
+
+
+def _wrap_payload(payload: dict[str, Any], field: str) -> dict[str, Any]:
+    if field in payload:
+        return payload
+    return {field: payload}

--- a/dataagent/portal-mcp/tests/test_write_tools.py
+++ b/dataagent/portal-mcp/tests/test_write_tools.py
@@ -43,7 +43,7 @@ async def test_write_service_methods_delegate_to_backend():
     await service.list_workflows({"limit": 5})
     await service.preview_publish(3)
     await service.publish_workflow(3, {"operation": "deploy", "previewToken": "tok"})
-    await service.upsert_schedule(3, {"scheduleCron": "0 0 * * *"})
+    await service.upsert_schedule(3, {"scheduleCron": "0 0 * * *", "enabled": True})
     await service.schedule_online(3, {"previewToken": "tok"})
     await service.schedule_offline(3)
     await service.analyze_sql({"sql": "select 1"})
@@ -65,6 +65,9 @@ async def test_write_service_methods_delegate_to_backend():
         "schedule_offline",
         "analyze_sql",
     ]
+    assert backend.calls[4] == ("create_workflow", ({"workflow": {"workflowName": "wf"}},), {})
+    assert backend.calls[5] == ("update_workflow", (3, {"workflow": {"workflowName": "wf2"}}), {})
+    assert backend.calls[10] == ("upsert_schedule", (3, {"schedule": {"scheduleCron": "0 0 * * *"}}), {})
 
 
 def test_publish_requires_preview_token():

--- a/docs/design/2026-06-12-data-dev-assistant-design.md
+++ b/docs/design/2026-06-12-data-dev-assistant-design.md
@@ -113,8 +113,8 @@ DolphinScheduler(发布与调度执行)
 - `core/task_executor.py`:`permission_mode` 来源从 `agent_snapshot` 改为 `TaskExecutionInput` 携带的值,即**任务创建时刻 topic 的当前模式**;继续传给 `ClaudeAgentOptions.permission_mode`。
 - `core/agent_runtime.py`:
   - `_resolve_sdk_permission_mode` 改为只接受 SDK 合法值(`default|acceptEdits|plan|bypassPermissions`),`inherit` 与未知值归一化为 `default`。
-  - `_build_allowed_tools` 增加按 permission_mode 的工具裁剪:`plan` 模式不挂载写 MCP 工具(写工具名单来自 4.1 的配置常量);其余模式全量挂载,确认职责交给 `can_use_tool`。
-- 防御纵深:即使模型在 `plan` 模式尝试调用写工具,SDK 层因不在 allowed_tools 而拒绝;`bypassPermissions` 下 API 层仍要求 preview 凭证(见 6 节)。
+  - `_build_allowed_tools` 增加按 permission_mode 的工具裁剪:`plan` 不挂载写 MCP 工具;`default` 不挂载任何写 MCP 工具;`acceptEdits` 只挂载草稿类写工具、不挂载高危工具;`bypassPermissions` 才全量挂载。未挂载但模型尝试调用的确认型工具由 `can_use_tool` 动态产生确认请求并在 allow 后放行。
+- 防御纵深:确认型写工具不能直接出现在 `allowed_tools` 中,否则部分 MCP 调用会绕过 `can_use_tool`;`allowed_tools` 是硬能力边界,`can_use_tool` 只负责动态放行当前模式要求确认的工具。`bypassPermissions` 下 API 层仍要求 preview 凭证(见 6 节)。
 
 ## 5. 权限确认:Chat V2 通用交互块(新机制)
 
@@ -267,7 +267,7 @@ profile 更新:alembic 数据迁移将 `agent_opendataworks` 的 `skill_folders_
 
 三层防线,任何单层被绕过仍有约束:
 
-1. **SDK / 模式层**:`plan` 不挂载写工具;`default` / `acceptEdits` 高危工具经 `can_use_tool` 用户确认,决策事件全量落库。
+1. **SDK / 模式层**:`plan` 不挂载写工具;`default` 将所有写工具作为确认型工具从 `allowed_tools` 剥离;`acceptEdits` 只剥离高危工具;确认型工具经 `can_use_tool` 用户确认后动态放行,决策事件全量落库。
 2. **通道层**:portal-mcp → backend-agent-api 走服务 token + 私网限制 + data scope,写接口不对公网与浏览器暴露。
 3. **API 层**:deploy/online/schedule-online 强制 `previewToken`(短 TTL、版本一致性校验);operator 透传会话标识写入 `workflow_publish_record` / 任务审计字段。
 
@@ -278,7 +278,7 @@ profile 更新:alembic 数据迁移将 `agent_opendataworks` 的 `skill_folders_
 - **合并 vs 独立智能体**:选择合并。入口统一、用户无需切换;能力差异收敛到会话级权限模式,避免两个助手的提示词/技能重复维护。代价是平台助手 system prompt 变长、职责变宽,通过 skill 分层(问数/开发各自 playbook)控制。
 - **会话级 vs profile 级权限模式**:选择会话级并对齐 SDK 取值。profile 级无法表达同一用户不同会话的意图差异,且 `inherit` 为自造值;会话级与 SDK `permission_mode` 一一对应,执行链零翻译。
 - **MCP 写通道三选一**:选择 backend-agent-api 新增写 API。直调 Web API 需给 dataagent 配用户级 JWT,扩大安全面;portal-mcp 直接代理 Web API 则绕过 agent 专用鉴权层、需在 portal-mcp 重复实现权限收敛。
-- **确认机制:can_use_tool vs 自定义 confirmToken 对话协议**:选择 SDK 原生 `can_use_tool`。自定义协议需要模型"自觉"走确认流程,可被提示词注入绕过;`can_use_tool` 是运行时强制拦截,模型无法跳过。
+- **确认机制:can_use_tool vs 自定义 confirmToken 对话协议**:选择 SDK 原生 `can_use_tool`。自定义协议需要模型"自觉"走确认流程,可被提示词注入绕过;`can_use_tool` 是运行时强制拦截,模型无法跳过。实现上确认型 MCP 写工具必须先从 `allowed_tools` 剥离,再由回调按当前模式动态放行,避免"已授权工具"绕过确认。
 - **决策传递:Redis 键 vs runner 反向 HTTP**:选择 Redis 键,复用 cancel-flag 既有模式,进程内与 sandbox 两条执行路径统一,不新增网络拓扑。
 - **确认卡片:Chat V2 通用块 vs 数据开发专属事件**:选择通用块。Chat V2 块管线双侧投影 + 共享引擎,做成通用块后门户与 widget 自动同时支持、历史可重建,且本体建模等其他高危智能体可直接复用;专属事件会把交互能力锁死在单一功能里,且需要 widget 单独实现。
 - **权限模式存储:topic 最新值(可变)vs 逐任务/逐消息快照**:选择只存 topic 最新值。模式是用户当下意图,不属于"会话可复现性"(与 agent profile 快照不同),无需每消息冻结;任务在创建时刻读取当前值即可,简化存储与切换语义。

--- a/docs/plans/2026-06-12-data-dev-assistant-plan.md
+++ b/docs/plans/2026-06-12-data-dev-assistant-plan.md
@@ -22,7 +22,7 @@
 2. `models/schemas.py`:topic 创建/更新/详情/列表模型增加 `permission_mode`;`deliver-message` 请求模型增加可选 `permission_mode`(携带时更新所属 topic 最新值);admin profile 模型移除 `permission_mode` 与 `permission_modes` 枚举。
 3. `api/routes.py`:`POST /topics`、`PUT /topics/{id}`(支持改模式)、`POST /tasks/deliver-message` 接收并校验模式取值(`default|acceptEdits|plan|bypassPermissions`)。
 4. `core/topic_task_store.py`:topic 读写链路携带 `permission_mode`;`PUT /topics` 更新最新值;`TaskExecutionInput` 组装时读取 topic 当前模式(任务创建时刻快照该值,不新增 task 列)。
-5. `core/agent_runtime.py`:`_resolve_sdk_permission_mode` 改为校验 SDK 合法值,`inherit`/未知值归一化 `default`;新增高危/写工具清单常量;`_build_allowed_tools` 按模式裁剪(`plan` 不挂写工具)。
+5. `core/agent_runtime.py`:`_resolve_sdk_permission_mode` 改为校验 SDK 合法值,`inherit`/未知值归一化 `default`;新增高危/写工具清单常量;`_build_allowed_tools` 按模式裁剪确认型 MCP 写工具(`plan`/`default` 不直接挂写工具,`acceptEdits` 只直接挂草稿写工具,`bypassPermissions` 全量挂载)。
 6. `core/task_executor.py`:`permission_mode` 来源改为 TaskExecutionInput(不再读 agent_snapshot)。
 7. `core/agent_profile_service.py` / `api/admin_routes.py`:删除 permission_mode 字段、校验、upsert 列与枚举接口。
 
@@ -73,7 +73,7 @@
 
 1. `core/sdk_block_writer.py`(或同路径 ingest 辅助):新增 `permission_request` / `permission_decision` 两个 record_type 的写入,与 `tool_result` 走同一持久化路径落 `da_agent_sdk_record`。
 2. `core/topic_task_store.py _project_sdk_records()`:新增两类 record 的投影分支,产出通用块 `{type: 'permission_request', request_id, tool_name, risk_level, title, summary, payload_preview, decision, decided_at}`,decision record 合并更新终态。
-3. `core/task_executor.py`:构造 `can_use_tool` 回调传入 `ClaudeAgentOptions`;命中高危清单且模式要求确认时:生成 `request_id` → 写 `permission_request` SDK record → task 状态置 `waiting_permission` → 轮询 Redis 决策键(间隔 1s,总等待 `task_permission_wait_seconds` 默认 600s)→ 超时/deny 返回拒绝,allow 放行 → 状态恢复 `running`。
+3. `core/task_executor.py`:构造 `can_use_tool` 回调传入 `ClaudeAgentOptions`;命中写工具清单且当前模式要求确认时:生成 `request_id` → 写 `permission_request` SDK record → task 状态置 `waiting_permission` → 轮询 Redis 决策键(间隔 1s,总等待 `task_permission_wait_seconds` 默认 600s)→ 超时/deny 返回拒绝,allow 放行 → 状态恢复 `running`。确认型 MCP 写工具不得直接挂入 `allowed_tools`,否则 SDK 会把它视为已授权工具而跳过确认。
 4. `core/topic_task_store.py`:`waiting_permission` 状态读写(非终态,`TERMINAL_TASK_STATUSES` 不变);topic `current_task_status` 同步。
 5. `api/routes.py`:新增 `POST /tasks/{task_id}/permission-decision`(request_id 幂等、不匹配 409),**双写** Redis `da:task:permission:{task_id}:{request_id}`(TTL ≈ 等待超时 + 60s)与 `permission_decision` SDK record。
 6. sandbox 路径:`sandbox_runner_main.py` / `sandbox_task_main.py` 中执行 SDK 的进程同样注册回调并可访问 Redis(确认 runner 容器具备 Redis 连接配置;若 runner 无 Redis,则该阶段开始前先补通配置)。

--- a/docs/reports/2026-06-14-data-dev-assistant-verification.md
+++ b/docs/reports/2026-06-14-data-dev-assistant-verification.md
@@ -14,34 +14,68 @@
 | 1 | 权限模式迁移到 topic 级（删 profile 字段，SDK 词表，topic 加列，执行链改造） | `1803270` | 后端 targeted + 全套件 **279 passed**；alembic 链单一 head 校验通过 |
 | 2 | backend-agent-api 写接口（/v1/ai/task、/v1/ai/workflow、/v1/ai/sql/analyze）+ previewToken 二次防线 + X-Agent-Operator | `c02b2d6` | `mvn -pl backend -am compile` **BUILD SUCCESS**；新增 **9 个 Java 单测**通过（preview-token issue/verify/篡改/版本漂移/异密钥、publish 凭证强制、offline 豁免） |
 | 3 | portal-mcp 14 个写工具 + operator contextvar + publish 必填 preview_token | `ab232c0` | portal-mcp **18 测试**通过 |
-| 4 | Chat V2 通用权限确认块（record 类型 + 双侧投影 + cases.json 四态）+ permission_gate 模式策略 + decision 端点 + waiting_permission + can_use_tool 回调 | `17c6f84`,`9550b37` | 后端 **279 passed**（含 permission_gate、投影契约、decision 端点幂等/409/404、can_use_tool allow/deny/timeout/plan-deny 编排） |
+| 4 | Chat V2 通用权限确认块（record 类型 + 双侧投影 + cases.json 四态）+ permission_gate 模式策略 + decision 端点 + waiting_permission + can_use_tool 回调 | `17c6f84`,`9550b37` | 后端 **279 passed**（含 permission_gate、投影契约、can_use_tool allow/deny/timeout/plan-deny 编排）；复审发现 decision 端点 request_id mismatch 与 endpoint 侧 `permission_decision` 持久化覆盖不足，补充修复与复验见下文 |
 | 5 | opendataworks-data-dev 技能包 + 启用到平台助手 + alembic 数据迁移 | `c9e3dc4` | profile/skill-content/skill-admin 套件通过；技能目录/JSON 结构校验 |
-| 6 | 前端 Chat V2 权限卡片 + 会话模式 pill（门户 + widget 共享引擎）+ 删除 profile 权限选择器 | `12ba944` | 前端 vitest **233 passed（27 文件）**；production build 成功；双侧投影契约 13 用例两侧一致 |
+| 6 | 前端 Chat V2 权限卡片 + 会话模式 pill（门户 + widget 共享引擎）+ 删除 profile 权限选择器 | `12ba944` | 前端 vitest **233 passed（27 文件）**；production build 成功；双侧投影契约 13 用例两侧一致；复审发现 widget 入口缺少会话权限模式切换，补充修复与复验见下文 |
 
-## Live smoke：已在真机运行的部分
+## 复审后补充修复与验证
 
-本轮在容器内启动了 docker daemon(Docker Hub CDN 被网络策略 403,无法拉镜像),改用 apt 安装 **MariaDB 10.11(MySQL 兼容)+ Redis**,完成了此前最关键的未测层——**数据库迁移与 DB 落地的 API 贯通**:
+复审 `claude/data-dev-assistant-design-87a763` 后，针对设计/计划偏差补充修复：
 
-- **两个 alembic 迁移在真机 MySQL 兼容库上执行通过**:
-  - `20260613_000017`(权限模式迁移):`upgrade` 后 `da_agent_topic.permission_mode` 存在、默认 `'default'`、NOT NULL;`da_agent_profile.permission_mode` 已删除(列数 0)。`downgrade` 回到 000016 时:topic 列移除(0)、profile 列恢复(1);再 `upgrade head` 复原——**完整 down/up 往返通过**。
-  - `20260613_000018`(技能启用):`agent_opendataworks` 内置 profile 的 `skill_folders_json` 变为 `["opendataworks-business-knowledge","opendataworks-platform-tools","opendataworks-data-dev"]`;down/up 往返通过。
-  - 注:一个**既有**(非本次)迁移 `20260601_000014` 在 MariaDB 严格性下产出 `DEFAULT 'NULL'` 报 1067,与本改动无关;smoke 中 stamp 跳过该 comment-only 迁移后,本次两个迁移正常执行。
-- **DB 落地的 API 贯通**(dataagent-backend 连真机 MySQL+Redis,health OK,协调器启动):
-  - `POST /topics`(permission_mode=plan)→ 落库并返回 `plan`;无 mode → `default`。
-  - `PUT /topics/{id}` 切到 `bypassPermissions` → 生效;切 `junk` → 归一化 `default`;`GET` 反映最新值。
-  - `PUT /topics/{id}` 空 body → 400;`POST /tasks/{id}/permission-decision`(不存在任务)→ 404。
-  - 验证了 Stage 1 的 store SQL(create/update/get_topic + permission_mode)、归一化与 decision 端点路由,均在真实 MySQL 上。
-- 环境:MariaDB `127.0.0.1:3306`(库 `dataagent`/用户 `dataagent`)、Redis `127.0.0.1:6379`、Python venv 安装 `requirements` 子集、未配置 provider(无真实模型)。
+- backend agent API 在调度 upsert 层拒绝 `enabled` 字段，调度上线/下线必须走 `/schedule/online` 或 `/schedule/offline`，避免绕过 preview token 与高危确认。
+- `permission-decision` endpoint 在写 Redis 决策键后同步追加 `permission_decision` SDK record；`get_pending_permission_request_id` 改为真正查找未被 decision 关闭的请求；同一 `request_id` 幂等重试不重复写 record，错误 `request_id` 返回 409。
+- portal-mcp service 规范化 workflow/schedule payload，后端收到 `{workflow: ...}` / `{schedule: ...}`，并剥离 schedule `enabled`。
+- Widget 入口补齐权限确认卡片后的会话权限模式选择器，创建 topic、deliver-message 与已有 topic 更新都会携带/保存 `permission_mode`。
+- `test_task_executor.py` 兼容真实 `claude_agent_sdk` 返回的 `PermissionResultAllow/Deny` 对象，避免只在 fallback dict 环境下通过。
 
-## 仍未执行（需 provider/模型 或 部署后端）
+本次补充验证：
 
-- **无可用 DataAgent provider 凭证**:环境仅有 Claude Code 自身的 OAuth token,不可作为 dataagent provider;`claude_agent_sdk` 真实运行(含 `can_use_tool` 结果类 `PermissionResultAllow/Deny` 的实际契约、task 进入 `waiting_permission` 的 409 路径)未真机跑。
-- 真实模型驱动的确认流四场景:default 确认→deploy→online / plan 拒绝 / deny / timeout;门户与 widget 各一次。
-- portal-mcp → backend-agent-api → backend service 的真实 HTTP 贯通(需部署 Java 后端 + DolphinScheduler;previewToken 在真实 publish 上的校验)。
+- `pytest dataagent/dataagent-backend/tests/test_routes_contract.py`：**6 passed**
+- `pytest dataagent/dataagent-backend/tests/test_task_executor.py`：**25 passed**
+- `pytest dataagent/portal-mcp/tests/test_write_tools.py`：**5 passed**
+- `mvn -pl backend -am -Dtest=BackendAgentWorkflowServiceTest -DfailIfNoTests=false test`：**BUILD SUCCESS**，`BackendAgentWorkflowServiceTest` **4 passed**
+- `nvm use && npm --prefix dataagent/dataagent-frontend test -- WidgetChat.spec.js`：**23 passed**（独立 worktree 临时复用主工作区 `node_modules` symlink，测试后已删除）
 
-### 复跑建议（待环境具备时）
+## Live smoke：真实链路验证
 
-1. `docker compose -f deploy/docker-compose.dev.yml up -d mysql redis`，初始化 `dataagent` schema/用户（库 `dataagent`/用户 `dataagent`/密码 `dataagent123`）。
-2. `dataagent/dataagent-backend` 用 `.venv-py313` 安装 `requirements.txt`（含 `claude-agent-sdk`），设置本地 MySQL/Redis 环境变量，`alembic upgrade head`。
-3. `da_agent_settings` 配置有效 provider 与运行 DB；`uvicorn main:app`。
-4. 走真实 HTTP：`POST /topics`（permission_mode=default）→ "为某表写聚合 SQL 并建任务加入工作流发布上线" → 验证 `permission_request` 块 → `POST /tasks/{id}/permission-decision` allow → preview→deploy→online，`workflow_publish_record.operator` 含会话标识；再覆盖 plan/deny/timeout；门户与 widget 各一次。
+### 2026-06-14 数据库迁移与 API 落地
+
+此前在真机 MySQL 兼容库 + Redis 上完成数据库迁移与 API 落地验证：
+
+- `20260613_000017` 权限模式迁移：`upgrade` 后 `da_agent_topic.permission_mode` 存在、默认 `default`、NOT NULL；`da_agent_profile.permission_mode` 已删除；`downgrade` 后列状态对称恢复，再 `upgrade head` 复原。
+- `20260613_000018` 技能启用迁移：`agent_opendataworks` 的 `skill_folders_json` 为 `["opendataworks-business-knowledge","opendataworks-platform-tools","opendataworks-data-dev"]`；down/up 往返通过。
+- 真库 API：`POST /topics`、`PUT /topics/{id}`、非法 mode 归一化、空更新 400、未知 task 的 `permission-decision` 404 均通过。
+
+### 2026-06-15 全链路 smoke
+
+本轮使用用户已启动的本地 MySQL/Redis，补齐 Java backend、portal-mcp、DataAgent、真实 provider 与权限确认链路：
+
+- 环境：
+  - MySQL：`127.0.0.1:3306`，业务库 `opendataworks`，会话库 `dataagent`，用户 `dataagent/dataagent123`。
+  - Redis：`127.0.0.1:6379`。
+  - Python：`/Users/guoruping/project/bigdata/opendataworks/dataagent/dataagent-backend/.venv-py313`。
+  - Java backend：`127.0.0.1:8080/api`，`AGENT_API_SERVICE_TOKEN=odw-agent-service-token`。
+  - portal-mcp：`127.0.0.1:8801/mcp/`，frontdoor token `odw-portal-mcp-token`。
+  - DataAgent：`127.0.0.1:8900`，`DATAAGENT_HOST_ROOT=.dataagent_runtime`，provider `anthropic_compatible` / `deepseek-v4-pro`。
+- 迁移与启动：
+  - `alembic upgrade head` 执行到 `20260613_000018`。
+  - backend Flyway 当前版本 `45`，启动成功。
+  - DataAgent health OK，task coordinator 连接 Redis 成功；`POST /topics` 成功。
+- backend-agent-api 鉴权：
+  - `GET /api/v1/ai/workflow/list?limit=1` 正确 token 返回 200。
+  - 错误 token / 缺失 token 均返回 401。复审中发现 `/v1/ai/workflow/**` 原未被拦截，已改为统一保护 `/v1/ai/**`。
+- portal-mcp 真实工具调用：
+  - MCP `list_tools` 返回 20 个工具，包含 `portal_list_workflows`、`portal_publish_workflow`、`portal_upsert_schedule`。
+  - `portal_list_workflows {limit:1}` 经 portal-mcp → backend-agent-api → backend service → MySQL 返回 workflow 数据，`isError=false`。
+- 真实模型任务流：
+  - `POST /tasks/deliver-message`，prompt `你好，请直接回复 smoke-ok。`。
+  - task 状态 `waiting -> running -> finished`；`/sdk-events` 返回 11 条记录，包含 terminal `done(success)`；`/tasks/{id}/message` 返回 assistant content `smoke-ok`；topic 已删除清理。
+- 权限确认链路：
+  - 初次真实 smoke 暴露：确认型 MCP 写工具如果直接出现在 `allowed_tools`，SDK 会把它视为已授权工具并绕过 `can_use_tool`；该次创建了 smoke workflow `id=12`，随后已通过 `DELETE /api/v1/workflows/12?cascadeDeleteTasks=true` 清理，列表 total 从 5 回到 4。
+  - 修复后策略：`default`/`acceptEdits` 中需要确认的 MCP 写工具不直接挂入 `allowed_tools`，由 `can_use_tool` 动态确认后放行。
+  - 复验同一写工具 prompt：task 进入 `waiting_permission`，`sdk-events` 含 1 条 `permission_request`；`POST /tasks/{task_id}/permission-decision` deny 返回 200；随后 task `finished`，`sdk-events` 含 1 条 `permission_decision`、1 条错误 `tool_result`、1 条 `done`；最终 assistant message 为"操作已被取消..."；workflow 列表确认 smoke workflow 未创建；topic 已删除。
+
+## 仍未执行 / 残余风险
+
+- 未执行真实 deploy/online/schedule-online 到 DolphinScheduler；本地 `dolphin_config` 指向的 DolphinScheduler 需要有效认证/运行环境。preview token、schedule online/offline 与 publish 凭证强制目前由 Java 单测和 HTTP 边界覆盖，真实调度器执行仍需部署环境补测。
+- 未覆盖 widget 浏览器端点击确认的 Playwright smoke；后端/SDK/Redis/消息投影链路已通过真实 HTTP 验证，widget 交互由 `WidgetChat.spec.js` 覆盖。


### PR DESCRIPTION
## Summary
- Harden the Data Development Assistant permission boundary and close the remaining review/design gaps found after PR #354.
- This PR includes the remote follow-up branch fixes that were not on `main`, plus additional full-chain fixes validated against local MySQL, Redis, backend, portal-mcp, DataAgent, and a real model provider.

## What Changed

### Behavior Changes
- Protect all Java Agent API routes under `/v1/ai/**`, including workflow/task write surfaces.
- Prevent schedule enable/disable from being smuggled through schedule upsert; online/offline must use the explicit guarded endpoints.
- Require durable, request-scoped permission decisions for DataAgent tool execution, with mismatch/no-pending requests rejected.
- Keep confirmation-required MCP write tools out of SDK `allowed_tools`; they are only released dynamically through `can_use_tool`.
- Use SDK streaming prompt mode when `can_use_tool` is enabled.
- Resolve local DataAgent runtime output from configured host root instead of defaulting to the read-only deployment path.
- Normalize portal-mcp workflow and schedule write payloads before forwarding to backend Agent API.
- Add widget session permission mode selection and propagate it through topic creation/update and deliver-message calls.
- Update design, plan, skill recipe, and verification docs to match the implemented permission contract.

### Commit Highlights
- `ae83ce7` `fix: address PR review P1/P2 issues and design gaps`
- `1f3d7ec` `fix: harden data dev assistant permission flow`

### Key Files
- `backend-agent-api/src/main/java/com/onedata/portal/agentapi/config/AgentApiConfiguration.java`
- `backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentWorkflowService.java`
- `dataagent/dataagent-backend/core/agent_runtime.py`
- `dataagent/dataagent-backend/core/task_executor.py`
- `dataagent/dataagent-backend/core/topic_task_store.py`
- `dataagent/portal-mcp/portal_mcp/service.py`
- `dataagent/dataagent-frontend/src/widget/WidgetChat.vue`
- `docs/reports/2026-06-14-data-dev-assistant-verification.md`

## Validation
- [x] `dataagent/dataagent-backend/.venv-py313/bin/pytest dataagent/dataagent-backend/tests/test_agent_runtime.py dataagent/dataagent-backend/tests/test_task_executor.py dataagent/dataagent-backend/tests/test_topic_workspace.py dataagent/dataagent-backend/tests/test_routes_contract.py dataagent/dataagent-backend/tests/test_builtin_skill_content.py dataagent/portal-mcp/tests/test_write_tools.py`
  - Result: `88 passed`
- [x] `mvn -pl backend-agent-api -Dtest=AgentApiConfigurationTest,AgentApiAuthInterceptorTest test`
  - Result: `BUILD SUCCESS`
- [x] `mvn -pl backend -am -Dtest=BackendAgentWorkflowServiceTest -DfailIfNoTests=false test`
  - Result: `BUILD SUCCESS`
- [x] `nvm use && npm --prefix dataagent/dataagent-frontend test -- WidgetChat.spec.js`
  - Result: `23 passed`
- [x] Full-chain local smoke with MySQL `127.0.0.1:3306`, Redis `127.0.0.1:6379`, Java backend, portal-mcp, DataAgent, and real model provider:
  - Agent API token enforcement returned expected `200/401`.
  - MCP `portal_list_workflows` returned real backend data.
  - A real model task returned `smoke-ok`.
  - A write-tool attempt produced `permission_request`, denial persisted `permission_decision`, task completed without creating a workflow.
- [x] `git diff --check`

## Risks
- Main regression risk: permission-mode changes affect the write-tool execution path across DataAgent, SDK runtime, and portal-mcp; focused tests and a real denial smoke cover the primary boundary.
- Residual gap: true deploy/online/schedule-online against DolphinScheduler was not executed because the local DolphinScheduler config returned unauthorized; preview-token and schedule endpoint guards are covered by Java tests and HTTP boundary smoke.

## Rollback
- Revert this PR to restore the previous Data Development Assistant tool permission and Agent API behavior.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updated when required.
