### PR TITLE
fix(dataagent-frontend): clear active conversation and query params when switching assistants

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -797,7 +797,8 @@ function currentAgentFilterId() {
   return normalizeQueryValue(route.query.agent_id) || String(agentSelectValue.value || '').trim()
 }
 
-async function loadTopics() {
+async function loadTopics(options = {}) {
+  const { selectDefault = true } = options
   if (sourceMode.value === 'widget') {
     await loadWidgetTopics()
     return
@@ -811,12 +812,20 @@ async function loadTopics() {
     const requestedTopicId = routeTopicId()
     if (requestedTopicId) {
       await selectTopic(requestedTopicId, { messageId: routeMessageId() })
-    } else if (topics.value.length && !activeTopicId.value) {
+    } else if (selectDefault && topics.value.length && !activeTopicId.value) {
       await selectTopic(topics.value[0].topic_id)
     }
   } catch {
     // non-fatal
   }
+}
+
+function resetActiveConversationView() {
+  activeTopicId.value = ''
+  messages.value = []
+  targetMessageId.value = ''
+  searchKeyword.value = ''
+  closeArtifactPreview()
 }
 
 // Read-only widget session list (admin endpoint). Unlike portal topics we never
@@ -962,10 +971,7 @@ async function handleNewTopic() {
   // Leaving a running conversation detaches it (the backend task keeps running,
   // recoverable from history) instead of blocking, matching the widget.
   if (isStreaming.value) detach()
-  activeTopicId.value = ''
-  messages.value = []
-  targetMessageId.value = ''
-  searchKeyword.value = ''
+  resetActiveConversationView()
   replaceRouteTopic('')
 }
 
@@ -985,13 +991,18 @@ async function handleSelectTopic(topicId) {
 function handleAgentChange(agentId) {
   agentSelectValue.value = agentId
   const value = String(agentId || '').trim()
-  if (String(route.query.agent_id || '').trim() === value) return
+  const previousValue = String(route.query.agent_id || '').trim()
+  if (previousValue === value) return
+  if (isStreaming.value) detach()
+  resetActiveConversationView()
   const query = { ...route.query }
   if (value) {
     query.agent_id = value
   } else {
     delete query.agent_id
   }
+  delete query.topic_id
+  delete query.message_id
   const navigation = router.replace({ path: route.path, query })
   if (navigation?.catch) {
     navigation.catch(() => {})
@@ -1210,9 +1221,8 @@ onMounted(async () => {
 
 watch(() => route.query.agent_id, async () => {
   // Re-query both sources: widget mode also honors the assistant filter.
-  activeTopicId.value = ''
-  messages.value = []
-  await loadTopics()
+  resetActiveConversationView()
+  await loadTopics({ selectDefault: false })
 })
 
 watch(

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -145,13 +145,26 @@ const mountChat = () => mount(NL2SqlChatV2, {
         template: '<div class="el-scrollbar-stub"><slot /></div>'
       },
       ElSelect: {
+        inheritAttrs: false,
         props: ['modelValue', 'disabled'],
         emits: ['update:modelValue', 'change'],
-        template: '<div class="el-select-stub"><slot name="prefix" /><slot /></div>'
+        template: `
+          <label class="el-select-wrapper" :class="$attrs.class">
+            <slot name="prefix" />
+            <select
+              class="el-select-stub"
+              :disabled="disabled"
+              :value="modelValue"
+              @change="$emit('update:modelValue', $event.target.value); $emit('change', $event.target.value)"
+            >
+              <slot />
+            </select>
+          </label>
+        `
       },
       ElOption: {
         props: ['label', 'value'],
-        template: '<span class="el-option-stub" :data-value="value">{{ label }}</span>'
+        template: '<option class="el-option-stub" :data-value="value" :value="value">{{ label }}</option>'
       },
       ElDropdown: {
         template: '<div class="el-dropdown-stub"><slot /><slot name="dropdown" /></div>'
@@ -386,6 +399,47 @@ describe('NL2SqlChatV2 URL location', () => {
       query: {
         tab: 'chat-v2',
         topic_id: 'topic-2'
+      }
+    })
+  })
+
+  it('clears the active conversation and removes stale topic query when switching assistants', async () => {
+    routeState.query = {
+      tab: 'chat-v2',
+      agent_id: 'agent_default',
+      topic_id: 'topic-1',
+      message_id: 'a1'
+    }
+    apiMocks.agentApi.listAgents.mockResolvedValue([
+      {
+        agent_id: 'agent_default',
+        name: 'Default agent',
+        is_default: true
+      },
+      {
+        agent_id: 'agent_sales',
+        name: 'Sales agent',
+        is_default: false
+      }
+    ])
+
+    const wrapper = mountChat()
+
+    await flushPromises()
+    await nextTick()
+    expect(wrapper.text()).toContain('first answer')
+
+    await wrapper.find('.v2-agent-select .el-select-stub').setValue('agent_sales')
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('first answer')
+    expect(wrapper.find('.v2-session-item.active').exists()).toBe(false)
+    expect(routerReplace).toHaveBeenLastCalledWith({
+      path: '/intelligent-query',
+      query: {
+        tab: 'chat-v2',
+        agent_id: 'agent_sales'
       }
     })
   })


### PR DESCRIPTION
Clear active conversation, messages, target message ID, search keyword, and close artifact preview when switching assistants (agents). Also reset/remove the stale topic_id and message_id from the query parameters to avoid loading mismatching states.