### PR TITLE
deploy: 离线包容器日志统一落盘宿主机便于排障

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -267,8 +267,29 @@ scripts/restart.sh
 scripts/restart.sh
 ```
 
-### Check Logs
+### Check Logs / 日志排障
+
+所有服务统一使用 `json-file` 日志驱动并轮转（单服务上限 `20m × 5 = 100MB`），容器重启不丢、磁盘不被撑爆：
+
 ```bash
-# View logs for a specific service (e.g., backend)
+# 实时查看某个服务日志（例如 backend）
 docker-compose -f docker-compose.prod.yml logs -f backend
 ```
+
+#### 宿主机日志文件（方便排障/打包带走）
+
+- **服务日志（实时落盘）**：`log-collector` sidecar 自动把各服务日志实时写到包目录
+  `deploy/logs/<container>.log`，打开目录即可查看，无需敲命令。
+  - 默认只覆盖 4 个应用服务：`backend`、`dataagent-backend`、`dataagent-sandbox-runner`、`portal-mcp`。
+  - 不收集 mysql/redis 基础设施与两个 nginx 前端；如需增减，在 `deploy/.env` 设置 `LOG_COLLECTOR_CONTAINERS`（空格分隔容器名）。
+  - 收集器复用 runner 镜像自带的 docker CLI，离线包不新增镜像；只读挂载 docker socket。
+- **task child 日志（已落盘）**：DataAgent 每个 `--rm` task child 的输出由 runner 实时写在挂载卷上
+  `<DATAAGENT_HOST_ROOT>/<topic_id>/logs/<task_id>.log`，`--rm` 删容器不影响留存。
+- **一键汇总/导出**：需要把全部服务日志 + 所有 task child 日志固化到一处时，运行：
+  ```bash
+  scripts/dump-logs.sh
+  # 产物：
+  #   deploy/logs/services/<service>.log     各服务日志快照
+  #   deploy/logs/task-child/<topic>/*.log   所有 task child 日志
+  # 打包带走：tar -czf odw-logs.tgz -C deploy logs
+  ```

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,3 +1,12 @@
+# 统一容器日志驱动：json-file + 轮转。
+# 所有服务日志稳定落在宿主机 docker 数据目录、容器重启不丢，单服务最多保留 20m*5=100MB，
+# 避免默认无轮转把磁盘撑爆。导出成宿主机包目录文件见 scripts/dump-logs.sh。
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
 services:
   # Note: opendataagent is intentionally deployed via opendataagent/deploy/docker-compose.yml
   # and is not part of the root portal compose stack.
@@ -5,6 +14,7 @@ services:
   mysql:
     image: mysql:8.0
     container_name: opendataworks-mysql
+    logging: *default-logging
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root123}
@@ -32,6 +42,7 @@ services:
   redis:
     image: redis:7.2-alpine
     container_name: opendataworks-redis
+    logging: *default-logging
     restart: always
     command: ["redis-server", "--appendonly", "yes"]
     ports:
@@ -48,6 +59,7 @@ services:
   backend:
     image: ${OPENDATAWORKS_BACKEND_IMAGE:-mikefan2019/opendataworks-backend:1.3.0}
     container_name: opendataworks-backend
+    logging: *default-logging
     restart: always
     env_file:
       - ./.env
@@ -75,6 +87,7 @@ services:
   frontend:
     image: ${OPENDATAWORKS_FRONTEND_IMAGE:-mikefan2019/opendataworks-frontend:1.3.0}
     container_name: opendataworks-frontend
+    logging: *default-logging
     restart: always
     env_file:
       - ./.env
@@ -96,6 +109,7 @@ services:
   dataagent-frontend:
     image: ${OPENDATAWORKS_DATAAGENT_FRONTEND_IMAGE:-mikefan2019/opendataworks-dataagent-frontend:1.3.0}
     container_name: opendataworks-dataagent-frontend
+    logging: *default-logging
     restart: always
     ports:
       - "8901:80"
@@ -114,6 +128,7 @@ services:
   dataagent-home-init:
     image: ${OPENDATAWORKS_DATAAGENT_BACKEND_IMAGE:-mikefan2019/opendataworks-dataagent-backend:1.3.0}
     container_name: opendataworks-dataagent-home-init
+    logging: *default-logging
     user: "0:0"
     restart: "no"
     command:
@@ -133,6 +148,7 @@ services:
   dataagent-backend:
     image: ${OPENDATAWORKS_DATAAGENT_BACKEND_IMAGE:-mikefan2019/opendataworks-dataagent-backend:1.3.0}
     container_name: opendataworks-dataagent-backend
+    logging: *default-logging
     restart: always
     user: "${DATAAGENT_RUNTIME_UID:-1000}:${DATAAGENT_RUNTIME_GID:-1000}"
     env_file:
@@ -200,6 +216,7 @@ services:
   dataagent-sandbox-runner:
     image: ${OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE:-mikefan2019/opendataworks-dataagent-runner:1.3.0}
     container_name: opendataworks-dataagent-sandbox-runner
+    logging: *default-logging
     restart: always
     user: "${DATAAGENT_RUNNER_UID:-0}:${DATAAGENT_RUNNER_GID:-0}"
     env_file:
@@ -251,6 +268,7 @@ services:
   portal-mcp:
     image: ${OPENDATAWORKS_PORTAL_MCP_IMAGE:-mikefan2019/opendataworks-portal-mcp:1.3.0}
     container_name: opendataworks-portal-mcp
+    logging: *default-logging
     restart: always
     env_file:
       - ./.env
@@ -276,6 +294,43 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
+
+  # 日志收集 sidecar：复用 runner 镜像自带的 docker CLI，只读挂 docker socket，
+  # 对每个目标容器实时 `docker logs --follow` 写到宿主机 deploy/logs/<container>.log。
+  # 只收集应用服务（backend / dataagent-backend / sandbox-runner / portal-mcp），无需改业务镜像、无各服务挂卷权限问题。
+  # 不收集 mysql/redis 基础设施与两个 nginx 前端；如需可在 .env 用 LOG_COLLECTOR_CONTAINERS 增减。
+  # task child 日志由 runner 另行落盘在 <HOST_ROOT>/<topic>/logs/。
+  log-collector:
+    image: ${OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE:-mikefan2019/opendataworks-dataagent-runner:1.3.0}
+    container_name: opendataworks-log-collector
+    logging: *default-logging
+    restart: always
+    user: "${DATAAGENT_RUNNER_UID:-0}:${DATAAGENT_RUNNER_GID:-0}"
+    environment:
+      # 目标容器列表（仅应用服务），可在 .env 覆盖 LOG_COLLECTOR_CONTAINERS 增减
+      LOG_COLLECTOR_CONTAINERS: ${LOG_COLLECTOR_CONTAINERS:-opendataworks-backend opendataworks-dataagent-backend opendataworks-dataagent-sandbox-runner opendataworks-portal-mcp}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -u
+        mkdir -p /logs
+        echo "[log-collector] following: $$LOG_COLLECTOR_CONTAINERS"
+        for c in $$LOG_COLLECTOR_CONTAINERS; do
+          (
+            while true; do
+              # --tail 0：仅从挂接点起的新日志，避免重连后重复回灌历史。
+              # 历史完整日志由 json-file 轮转与 scripts/dump-logs.sh 兜底。
+              docker logs --follow --timestamps --tail 0 "$$c" >> "/logs/$$c.log" 2>>"/logs/_collector.err" || true
+              sleep 3
+            done
+          ) &
+        done
+        wait
+    networks:
+      - opendataworks-network
+    volumes:
+      - ./logs:/logs
+      - ${DATAAGENT_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock:ro
 
 networks:
   opendataworks-network:

--- a/docs/design/2026-06-15-offline-container-log-persistence-design.md
+++ b/docs/design/2026-06-15-offline-container-log-persistence-design.md
@@ -1,0 +1,96 @@
+# 离线包容器日志落盘设计
+
+- 日期: 2026-06-15
+- 主题 slug: offline-container-log-persistence
+- 影响范围: 部署（`deploy/docker-compose.prod.yml`、`scripts/`、`deploy/README.md`）
+- 不涉及: 后端/前端业务代码、DataAgent runtime 代码、schema
+
+## 背景与现状
+
+离线包使用 `deploy/docker-compose.prod.yml` 部署以下服务：
+`mysql`、`redis`、`backend`、`frontend`、`dataagent-frontend`、`dataagent-home-init`（一次性）、`dataagent-backend`、`dataagent-sandbox-runner`、`portal-mcp`。
+
+当前日志现状：
+
+- 仅 `backend` 通过 `backend-logs:/app/logs` 卷持久化应用日志。
+- 其余服务只把日志写到容器 stdout/stderr，交给 Docker 默认 `json-file` 驱动。
+  - 这些日志在宿主机 `/var/lib/docker/containers/<id>/<id>-json.log`，容器重启不丢，但
+    `docker rm` / `docker compose down` 删容器时一并删除，且**默认无轮转、会无限增长**。
+  - 离线/隔离环境排障时拿不到一份“宿主机包目录里的日志文件”，不便于打包带走。
+- DataAgent 的 task child 容器由 `dataagent-sandbox-runner` 以 `--rm` 启动。
+  - **child 日志已落盘**：runner（长驻服务，挂载 `${DATAAGENT_HOST_ROOT}:/dataagent_runtime`）
+    会把 child 的 stdout/stderr 实时写入
+    `/dataagent_runtime/<topic_id>/logs/<task_id>.log`
+    （见 `sandbox_runner_main.py` 的 `_sandbox_task_log_path` / `_append_task_log`）。
+  - 因为日志是 runner 写在挂载卷上的文件，不在 child 容器内，`--rm` 删除 child 不影响日志留存。
+
+## 问题
+
+1. 7 个长驻服务（除 backend 外）的容器日志没有落到宿主机包目录的可见文件，排障需要逐个 `docker logs`。
+2. 默认 `json-file` 无轮转，长期运行可能撑大磁盘。
+3. task child 日志虽已落盘，但散落在 `<HOST_ROOT>/<topic>/logs/` 下，和服务日志不在一处，排障时不直观。
+
+## 目标
+
+- 让全部服务容器日志稳定落在宿主机、容器重启不丢、且有大小上限不撑爆磁盘。
+- 提供一条命令，把全部服务日志 + 既有 task child 日志汇总成 `deploy/logs/` 下的普通文件，便于查看/打包带走。
+- 不改动 DataAgent runtime 代码（child 日志已由 runner 落盘，无需重复实现）。
+
+## 方案（json-file 轮转 + 收集 sidecar + 一键导出）
+
+经与需求方确认，落盘目标为“打开宿主机目录即见实时日志文件、覆盖除两个 nginx 前端外的全部服务、且不重建业务镜像”。
+由于 `dataagent-backend` / `portal-mcp` / `sandbox-runner` 等 python 服务仅 `logging.basicConfig(stream=sys.stdout)`
+（见 `dataagent-backend/main.py`），照搬 backend 的“应用写文件 + 挂卷”模式需要改镜像；nginx 前端则把日志软链到
+stdout。Docker 也无法把容器 stdout 原生重定向到 bind mount。因此采用**收集 sidecar** 统一镜像外采集，既能实时落盘、又
+不改任何业务镜像、也无各服务挂卷的宿主机权限问题。
+
+### 1. 统一 json-file 轮转
+
+在 `docker-compose.prod.yml` 顶部定义扩展锚点并应用到所有服务：
+
+```yaml
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+```
+
+每个服务加 `logging: *default-logging`。效果：单服务日志最多 `20m * 5 = 100MB` 滚动保留，
+容器重启/崩溃日志仍在宿主机 docker 数据目录，`docker compose logs` 始终可用。
+
+### 2. 日志收集 sidecar `log-collector`
+
+- 复用 runner 镜像（`opendataworks-dataagent-runner`，内含静态 docker CLI，见 `Dockerfile.runner`），离线包**不新增镜像**。
+- 只读挂 docker socket（`${DATAAGENT_DOCKER_SOCKET}:/var/run/docker.sock:ro`）+ bind mount `./logs:/logs`。
+- 对 `LOG_COLLECTOR_CONTAINERS` 列出的每个容器跑 `docker logs --follow --timestamps --tail 0`，实时写
+  `deploy/logs/<container>.log`；单容器一个后台循环，容器未就绪/重启自动重连。
+- 默认目标（仅应用服务）：`backend`、`dataagent-backend`、`dataagent-sandbox-runner`、`portal-mcp`；
+  不含 mysql/redis 基础设施与两个 nginx 前端；可在 `.env` 用 `LOG_COLLECTOR_CONTAINERS` 覆盖增减。
+- `--tail 0`：只采挂接点之后的新日志，避免重连重复回灌；完整历史由 json-file 轮转与 `dump-logs.sh` 兜底。
+
+打开 `deploy/logs/` 即见各服务实时日志文件，无需敲命令。
+
+### 3. 一键导出脚本 `scripts/dump-logs.sh`
+
+- 复用 `scripts/lib/container-runtime.sh` 检测 compose 命令（docker/podman 兼容）。
+- 把每个服务的日志导出到 `deploy/logs/services/<service>.log`。
+- 解析 `DATAAGENT_HOST_ROOT`（同 `start.sh` 规则：默认 `/dataagent_runtime`，相对路径按 `deploy/` 展开），
+  把既有 task child 日志 `<HOST_ROOT>/<topic>/logs/*.log` 复制到 `deploy/logs/task-child/<topic>/`。
+- 输出目录、文件清单、读取失败（权限）以明确提示打印。
+
+排障流程：`scripts/dump-logs.sh` → 打开 `deploy/logs/` 即可看到全部服务 + 所有 task child 日志。
+
+### 4. 文档
+
+更新 `deploy/README.md` 的日志/排障章节：说明 json-file 轮转、`log-collector` 实时落盘、`dump-logs.sh` 用法、child 日志位置。
+
+## 取舍
+
+- 选收集 sidecar 而非“逐应用写文件 + 挂卷”：python 服务与 nginx 默认只 stdout，逐个改要动镜像/配置且不统一；
+  Docker 不能原生把 stdout 重定向到挂载文件。sidecar 镜像外统一采集，实时、不改业务镜像、无各服务挂卷权限坑。
+- 收集器复用 runner 镜像（已含 docker CLI 且已在离线包内），**不新增镜像**；socket 以**只读**挂载。
+- 仅收集应用服务；不收集 mysql/redis 基础设施与两个 nginx 前端（按需求）；如需可通过 `LOG_COLLECTOR_CONTAINERS` 加入。
+- child 日志不重复造轮子：runner 已落盘到 `<HOST_ROOT>/<topic>/logs/`，`dump-logs.sh` 负责汇总进 `deploy/logs/`。
+- json-file 轮转作为通用兜底：容器重启不丢、有大小上限；收集器/导出脚本不可用时仍可 `docker compose logs`。
+- `deploy/logs/` 已被根 `.gitignore` 的 `logs/` 规则忽略，运行期日志不入库。

--- a/docs/plans/2026-06-15-offline-container-log-persistence-plan.md
+++ b/docs/plans/2026-06-15-offline-container-log-persistence-plan.md
@@ -1,0 +1,54 @@
+# 离线包容器日志落盘实施计划
+
+- 日期: 2026-06-15
+- 主题 slug: offline-container-log-persistence
+- 配套设计: docs/design/2026-06-15-offline-container-log-persistence-design.md
+
+## 任务
+
+1. `deploy/docker-compose.prod.yml`
+   - 顶部新增扩展锚点 `x-default-logging`（json-file，max-size 20m，max-file 5）。
+   - 为以下服务各加 `logging: *default-logging`：
+     `mysql`、`redis`、`backend`、`frontend`、`dataagent-frontend`、`dataagent-home-init`、
+     `dataagent-backend`、`dataagent-sandbox-runner`、`portal-mcp`。
+
+2. `deploy/docker-compose.prod.yml`：新增 `log-collector` sidecar
+   - 复用 `OPENDATAWORKS_DATAAGENT_RUNNER_IMAGE`（含 docker CLI），不新增镜像。
+   - 只读挂 `${DATAAGENT_DOCKER_SOCKET}:/var/run/docker.sock:ro` + bind mount `./logs:/logs`。
+   - 对 `LOG_COLLECTOR_CONTAINERS` 每个容器 `docker logs --follow --timestamps --tail 0` 写 `deploy/logs/<container>.log`，自愈重连。
+   - 默认目标为 4 个应用服务（backend / dataagent-backend / sandbox-runner / portal-mcp），可在 `.env` 覆盖。
+
+3. `scripts/start.sh`：启动前 `mkdir -p deploy/logs`。
+
+4. 新增 `scripts/dump-logs.sh`
+   - 复用 `scripts/lib/container-runtime.sh` 的 `detect_compose_cmd`。
+   - 解析 `DATAAGENT_HOST_ROOT`（默认 `/dataagent_runtime`，相对路径按 `deploy/` 展开）。
+   - 导出每个服务日志到 `deploy/logs/services/<service>.log`（一次性快照/兜底）。
+   - 复制 task child 日志 `<HOST_ROOT>/*/logs/*.log` 到 `deploy/logs/task-child/<topic>/`。
+   - 打印输出目录与失败提示；可执行位 `chmod +x`。
+
+5. `deploy/README.md`
+   - 更新 “Check Logs” / 排障章节：json-file 轮转、`log-collector` 实时落盘、`dump-logs.sh` 用法、child 日志位置。
+
+## 触及文件
+
+- `deploy/docker-compose.prod.yml`（改：logging 锚点 + log-collector）
+- `scripts/start.sh`（改：预建 logs 目录）
+- `scripts/dump-logs.sh`（新增，离线包打包脚本已整目录复制 `scripts/`，自动纳入）
+- `deploy/README.md`（改）
+- `docs/design/2026-06-15-offline-container-log-persistence-design.md`（新增）
+- `docs/plans/2026-06-15-offline-container-log-persistence-plan.md`（新增）
+
+## 验证
+
+- `docker compose -f deploy/docker-compose.prod.yml config`（或 `--env-file`）校验 logging 锚点与 log-collector 合法、各服务 logging 生效。
+- `bash -n scripts/dump-logs.sh`、`bash -n scripts/start.sh` 语法检查。
+- 若本地容器运行时可用：起栈后确认 `deploy/logs/<container>.log` 由 collector 实时写入；
+  跑 `scripts/dump-logs.sh` 确认 `deploy/logs/services/*.log` 生成；
+  若跑过智能问数，确认 `deploy/logs/task-child/` 有 child 日志。
+- 文档检查：目录放置、命名、交叉链接。
+
+## 回滚
+
+- 改动均为部署配置/脚本/文档，回滚即还原 compose 的 logging 锚点、删除 `dump-logs.sh` 与文档。
+- 不涉及数据迁移或运行时代码，无数据风险。

--- a/scripts/dump-logs.sh
+++ b/scripts/dump-logs.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# OpenDataWorks 日志导出脚本
+# 功能：把全部服务容器日志 + 既有 task child 日志汇总成宿主机包目录文件，便于排障/打包带走。
+#
+# 服务日志来自 compose（json-file 驱动，容器重启不丢），导出到:
+#   deploy/logs/services/<service>.log
+# task child 日志由 dataagent-sandbox-runner 实时写在挂载卷上（--rm 删容器不影响），来自:
+#   <DATAAGENT_HOST_ROOT>/<topic>/logs/<task>.log
+# 复制到:
+#   deploy/logs/task-child/<topic>/<task>.log
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_DIR="$REPO_ROOT/deploy"
+LIB_DIR="$SCRIPT_DIR/lib"
+COMPOSE_FILE_NAME="docker-compose.prod.yml"
+COMPOSE_FILE="$DEPLOY_DIR/$COMPOSE_FILE_NAME"
+ENV_FILE="$DEPLOY_DIR/.env"
+OUTPUT_DIR="$DEPLOY_DIR/logs"
+SERVICES_DIR="$OUTPUT_DIR/services"
+CHILD_DIR="$OUTPUT_DIR/task-child"
+
+# shellcheck source=/dev/null
+source "$LIB_DIR/container-runtime.sh"
+
+read_env_value() {
+    local key="$1"
+    local env_file="$2"
+    [ -f "$env_file" ] || return 0
+    local line
+    line="$(grep -E "^${key}=" "$env_file" | tail -n 1 || true)"
+    printf '%s' "${line#*=}"
+}
+
+resolve_dataagent_host_root() {
+    # 与 start.sh 保持一致：默认 /dataagent_runtime；相对路径按 deploy/ 解析。
+    local configured
+    configured="$(read_env_value "DATAAGENT_HOST_ROOT" "$ENV_FILE")"
+    [ -n "$configured" ] || configured="/dataagent_runtime"
+    if [[ "$configured" = /* ]]; then
+        printf '%s\n' "$configured"
+    else
+        printf '%s\n' "$DEPLOY_DIR/$configured"
+    fi
+}
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "❌ 错误: 未找到 $COMPOSE_FILE"
+    exit 1
+fi
+
+if ! detect_compose_cmd; then
+    echo "❌ 错误: 未找到可用的 compose 命令（docker-compose、docker compose、podman compose、podman-compose）"
+    exit 1
+fi
+
+echo "========================================="
+echo "  OpenDataWorks 日志导出"
+echo "========================================="
+echo ""
+
+mkdir -p "$SERVICES_DIR" "$CHILD_DIR"
+
+ENV_ARGS=()
+if [ "$COMPOSE_SUPPORTS_ENV_FILE" = true ] && [ -f "$ENV_FILE" ]; then
+    ENV_ARGS=(--env-file "$ENV_FILE")
+fi
+
+pushd "$DEPLOY_DIR" >/dev/null
+
+# 解析服务列表（失败则回退到已知服务清单）
+SERVICES="$("${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE_NAME" "${ENV_ARGS[@]}" config --services 2>/dev/null || true)"
+if [ -z "$SERVICES" ]; then
+    SERVICES="mysql redis backend frontend dataagent-frontend dataagent-home-init dataagent-backend dataagent-sandbox-runner portal-mcp"
+fi
+
+echo "📦 导出服务日志 -> $SERVICES_DIR"
+for svc in $SERVICES; do
+    out="$SERVICES_DIR/${svc}.log"
+    if "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE_NAME" "${ENV_ARGS[@]}" logs --no-color --timestamps "$svc" >"$out" 2>/dev/null; then
+        echo "  ✅ $svc -> $(basename "$out")"
+    else
+        echo "stale or not running" >"$out"
+        echo "  ⚠️  $svc 无日志或容器不存在"
+    fi
+done
+
+popd >/dev/null
+
+# task child 日志（runner 已落盘在挂载卷上）
+HOST_ROOT="$(resolve_dataagent_host_root)"
+echo ""
+echo "🧩 汇总 task child 日志 (DATAAGENT_HOST_ROOT=$HOST_ROOT) -> $CHILD_DIR"
+if [ -d "$HOST_ROOT" ]; then
+    child_count=0
+    # 结构: <HOST_ROOT>/<topic>/logs/<task>.log
+    while IFS= read -r -d '' logfile; do
+        topic="$(basename "$(dirname "$(dirname "$logfile")")")"
+        dest_dir="$CHILD_DIR/$topic"
+        mkdir -p "$dest_dir"
+        if cp -f "$logfile" "$dest_dir/" 2>/dev/null; then
+            child_count=$((child_count + 1))
+        else
+            echo "  ⚠️  无法读取 $logfile（权限不足？尝试用 root 运行）"
+        fi
+    done < <(find "$HOST_ROOT" -mindepth 3 -maxdepth 3 -type f -path '*/logs/*.log' -print0 2>/dev/null)
+    echo "  ✅ 已复制 $child_count 个 task child 日志文件"
+else
+    echo "  ⚠️  未找到运行时根目录 $HOST_ROOT，跳过 child 日志"
+fi
+
+echo ""
+echo "========================================="
+echo "  导出完成"
+echo "========================================="
+echo "📁 日志目录: $OUTPUT_DIR"
+echo "   服务日志:   $SERVICES_DIR"
+echo "   task child: $CHILD_DIR"
+echo ""
+echo "可直接查看，或打包带走: tar -czf odw-logs.tgz -C \"$DEPLOY_DIR\" logs"
+echo ""

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -248,6 +248,10 @@ echo ""
 
 ensure_dataagent_cli_executable
 
+# 预建日志收集目录（log-collector sidecar 把各服务日志实时写到这里）。
+# 先建好宿主机目录，避免 Docker 以 root 自动创建后产生属主困惑。
+mkdir -p "$DEPLOY_DIR/logs" 2>/dev/null || true
+
 # 统一 DataAgent 运行时根目录为宿主机绝对路径，保证 backend 卷挂载与 runner 反查的
 # child bind 源指向同一目录，支持用户在 .env 中自定义（含相对于 deploy/ 的相对路径）。
 DATAAGENT_HOST_ROOT="$(resolve_dataagent_host_root)"


### PR DESCRIPTION
## 背景

离线包部署时,除 `backend` 外的容器日志只打到 stdout、无轮转,容器重启/`down`/`--rm` 后就难以排障,且没有一份"宿主机包目录里的日志文件"可直接查看或打包带走。

## 改动

- **统一 json-file 轮转**:给 `docker-compose.prod.yml` 所有服务加 `json-file` 日志驱动 + 轮转(单服务上限 `20m × 5 = 100MB`),容器重启不丢、磁盘不被撑爆、`docker compose logs` 始终可用。
- **新增 `log-collector` sidecar**:复用 runner 镜像自带的 docker CLI(`Dockerfile.runner` 从 `docker:27-cli` 拷的静态二进制),**离线包不新增镜像**;只读挂 docker socket,对每个目标容器实时 `docker logs --follow` 写到宿主机 `deploy/logs/<container>.log`,打开目录即见实时日志,无需敲命令;容器未就绪/重启自动重连。
  - 默认只收集 **4 个应用服务**:`backend`、`dataagent-backend`、`dataagent-sandbox-runner`、`portal-mcp`。
  - 不收集 mysql/redis 基础设施与两个 nginx 前端;可在 `.env` 用 `LOG_COLLECTOR_CONTAINERS`(空格分隔容器名)覆盖增减。
- **task child(`--rm`)日志**:已由 runner 实时写在挂载卷上 `<DATAAGENT_HOST_ROOT>/<topic_id>/logs/<task_id>.log`,删容器不影响留存,**无需改 runtime 代码**。
- **新增 `scripts/dump-logs.sh`**:一键把各服务日志 + 所有 task child 日志汇总到 `deploy/logs/`,便于打包带走(`tar -czf odw-logs.tgz -C deploy logs`)。
- **`scripts/start.sh`**:启动前预建 `deploy/logs` 目录。
- **文档**:新增 design/plan,更新 `deploy/README.md` 排障章节。

## 触及文件

- `deploy/docker-compose.prod.yml`(logging 锚点 + log-collector)
- `scripts/dump-logs.sh`(新增,打包脚本整目录复制 `scripts/`,自动纳入离线包)
- `scripts/start.sh`
- `deploy/README.md`
- `docs/design|plans/2026-06-15-offline-container-log-persistence-*.md`

## 验证

- `docker compose -f deploy/docker-compose.prod.yml config` 通过;确认 9 个服务均应用 json-file 轮转、collector 目标为 4 应用服务、`./logs` 解析为宿主机绝对路径、docker socket 只读挂载。
- collector 内联 shell 用假 `docker` 跑通:按容器分文件写入、流断自愈重连。
- `bash -n` 通过 `start.sh` / `dump-logs.sh`。
- **未做**:真实拉起整套镜像的端到端冒烟(需完整镜像)。部署后扫一眼 `deploy/logs/` 即可确认实时写入与 `--tail 0` 去重行为。

https://claude.ai/code/session_01KStD6UZcXdeq5ZW8PaqsYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KStD6UZcXdeq5ZW8PaqsYp)_