### PR TITLE
Refactor chat composer layout and update permission mode labels

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -340,15 +340,6 @@
               class="v2-file-input"
               @change="handleFilesSelected"
             />
-            <button
-              type="button"
-              class="v2-attach-btn"
-              :disabled="isStreaming"
-              title="上传文件"
-              @click="triggerFilePicker"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 12.5 12.5 21a4 4 0 0 1-5.66-5.66l8.49-8.49a2.5 2.5 0 0 1 3.54 3.54l-8.49 8.49a1 1 0 0 1-1.41-1.41l7.78-7.78" /></svg>
-            </button>
             <textarea
               ref="textareaRef"
               v-model="inputText"
@@ -359,16 +350,19 @@
               @keydown.enter="onEnterKey"
               @input="autoResize"
             />
-            <button
-              type="button"
-              class="v2-send-btn"
-              :class="{ 'v2-cancel-btn': activeTaskId }"
-              :disabled="activeTaskId ? false : !canSendV2"
-              @click="activeTaskId ? handleCancel() : handleSend()"
-            >
-              <svg v-if="activeTaskId" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><rect x="8" y="8" width="8" height="8" rx="1.5" /></svg>
-              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" /></svg>
-            </button>
+            <div class="v2-composer-inline">
+              <span class="v2-composer-hint">Enter 发送，Shift + Enter 换行</span>
+              <button
+                type="button"
+                class="v2-send-btn"
+                :class="{ 'v2-cancel-btn': activeTaskId }"
+                :disabled="activeTaskId ? false : !canSendV2"
+                @click="activeTaskId ? handleCancel() : handleSend()"
+              >
+                <svg v-if="activeTaskId" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><rect x="8" y="8" width="8" height="8" rx="1.5" /></svg>
+                <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15"><line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" /></svg>
+              </button>
+            </div>
           </div>
           <!-- Bottom toolbar -->
           <div class="v2-composer-toolbar">
@@ -389,7 +383,15 @@
                   </el-dropdown-menu>
                 </template>
               </el-dropdown>
-              <span class="v2-composer-hint">Enter 发送，Shift + Enter 换行</span>
+              <button
+                type="button"
+                class="v2-attach-btn"
+                :disabled="isStreaming"
+                title="上传文件"
+                @click="triggerFilePicker"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
+              </button>
             </div>
             <div class="v2-composer-toolbar-right">
               <el-dropdown trigger="click" @command="handleModelCommand">
@@ -541,10 +543,10 @@ const agentSelectValue = ref('')
 // Session permission mode (latest selection). Default per design: 'default'.
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: '逐步确认' },
-  { value: 'acceptEdits', label: '草稿自动·发布确认' },
-  { value: 'plan', label: '仅规划' },
-  { value: 'bypassPermissions', label: '全自动' },
+  { value: 'default', label: 'Default' },
+  { value: 'acceptEdits', label: 'Accept edits' },
+  { value: 'plan', label: 'Plan mode' },
+  { value: 'bypassPermissions', label: 'Bypass permissions' },
 ]
 const searchKeyword = ref('')
 const autoScroll = ref(true)
@@ -1501,8 +1503,9 @@ onBeforeUnmount(() => {
 .v2-file-input { display: none; }
 .v2-attach-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 30px; height: 30px; flex: none; border: none; border-radius: 8px;
-  background: transparent; color: #6B7280; cursor: pointer;
+  width: 26px; height: 26px; flex: none; border: 1px solid #dbe3ef; border-radius: 9px;
+  background: #f4f7fb; color: #4a5568; cursor: pointer;
+  transition: background var(--odw-transition), color var(--odw-transition);
 }
 .v2-attach-btn:hover:not(:disabled) { background: #EEF1F5; color: #111827; }
 .v2-attach-btn:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -2138,14 +2141,22 @@ onBeforeUnmount(() => {
 
 .v2-composer {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 10px 10px 18px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 12px 14px 10px 16px;
   border: 1px solid #dde2ea;
   border-radius: 16px;
   background: #ffffff;
   transition: border-color var(--odw-transition), box-shadow var(--odw-transition);
   box-shadow: 0 1px 4px rgba(15, 23, 42, 0.04);
+}
+
+.v2-composer-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .v2-composer:focus-within {
@@ -2154,8 +2165,10 @@ onBeforeUnmount(() => {
 }
 
 .v2-textarea {
-  flex: 1;
+  flex: none;
+  width: 100%;
   min-width: 0;
+  box-sizing: border-box;
   border: none;
   outline: none;
   background: transparent;

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -229,26 +229,28 @@
               @keydown.enter="onEnterKey"
               @input="autoResizeTextarea"
             />
-            <button
-              type="button"
-              class="query-send-btn"
-              :class="{ 'query-cancel-btn': activeTaskId }"
-              :disabled="activeTaskId ? false : !canSend"
-              :aria-label="activeTaskId ? '取消当前任务' : '发送消息'"
-              @click="activeTaskId ? cancel() : send()"
-            >
-              <svg v-if="activeTaskId" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15">
-                <rect x="8" y="8" width="8" height="8" rx="1.5" />
-              </svg>
-              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15">
-                <line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" />
-              </svg>
-            </button>
+            <div class="query-composer-actions">
+              <div class="query-composer-hint">Enter 发送，Shift + Enter 换行</div>
+              <button
+                type="button"
+                class="query-send-btn"
+                :class="{ 'query-cancel-btn': activeTaskId }"
+                :disabled="activeTaskId ? false : !canSend"
+                :aria-label="activeTaskId ? '取消当前任务' : '发送消息'"
+                @click="activeTaskId ? cancel() : send()"
+              >
+                <svg v-if="activeTaskId" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15">
+                  <rect x="8" y="8" width="8" height="8" rx="1.5" />
+                </svg>
+                <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="15" height="15">
+                  <line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" />
+                </svg>
+              </button>
+            </div>
           </div>
           <!-- Toolbar row -->
           <div class="query-composer-toolbar">
-            <div class="query-composer-hint">Enter 发送，Shift + Enter 换行</div>
-            <div class="query-model-selector">
+            <div class="query-composer-toolbar-left">
               <select
                 :value="permissionMode"
                 class="query-model-select query-permission-select"
@@ -260,6 +262,8 @@
                   {{ opt.label }}
                 </option>
               </select>
+            </div>
+            <div class="query-model-selector">
               <select v-model="selectedProvider" class="query-model-select" :disabled="!providers.length || isBusy" title="切换提供商">
                 <option v-for="provider in providers" :key="provider.provider_id" :value="provider.provider_id">
                   {{ provider.display_name || provider.provider_id }}
@@ -336,10 +340,10 @@ const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: '逐步确认' },
-  { value: 'acceptEdits', label: '草稿自动·发布确认' },
-  { value: 'plan', label: '仅规划' },
-  { value: 'bypassPermissions', label: '全自动' },
+  { value: 'default', label: 'Default' },
+  { value: 'acceptEdits', label: 'Accept edits' },
+  { value: 'plan', label: 'Plan mode' },
+  { value: 'bypassPermissions', label: 'Bypass permissions' },
 ]
 
 // widget-only UI state

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -946,9 +946,10 @@ export const WIDGET_STYLES = `
 
 .query-composer {
   display: flex;
-  align-items: flex-end;
-  gap: 8px;
-  padding: 8px 10px 8px 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 10px 12px 8px 16px;
   border: 1px solid #dde2ea;
   border-radius: 16px;
   background: #fff;
@@ -962,7 +963,8 @@ export const WIDGET_STYLES = `
 }
 
 .query-textarea {
-  flex: 1;
+  flex: none;
+  width: 100%;
   min-width: 0;
   min-height: 22px;
   max-height: 160px;
@@ -988,8 +990,8 @@ export const WIDGET_STYLES = `
 .query-composer-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .query-composer-toolbar {
@@ -1001,12 +1003,22 @@ export const WIDGET_STYLES = `
   padding-inline: 4px;
 }
 
+.query-composer-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .query-composer-hint {
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
   color: #9aa5b1;
   font-size: 11px;
   line-height: 1.4;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .query-model-selector {
@@ -1043,7 +1055,7 @@ export const WIDGET_STYLES = `
   cursor: not-allowed;
 }
 
-.query-workbench.is-floating .query-model-selector {
+.query-workbench.is-floating .query-composer-toolbar {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
Restructured the NL2SqlChatV2 chat input composer to improve layout organization and updated permission mode labels to English.

## Key Changes
- **Layout restructuring**: Converted the composer from a horizontal flex layout to a vertical flex layout with a new `.v2-composer-inline` wrapper for the textarea and send button
- **Component repositioning**: Moved the file attachment button from the input area to the bottom toolbar, and relocated the keyboard hint text accordingly
- **Styling updates**: 
  - Updated `.v2-attach-btn` styling with new dimensions (26x26px), border, and background color
  - Adjusted `.v2-composer` padding and gap values for the new vertical layout
  - Modified `.v2-textarea` to use full width with proper box-sizing
- **Internationalization**: Changed permission mode labels from Chinese to English:
  - '逐步确认' → 'Default'
  - '草稿自动·发布确认' → 'Accept edits'
  - '仅规划' → 'Plan mode'
  - '全自动' → 'Bypass permissions'
- **SVG icon update**: Changed the attachment button icon from a paperclip to a plus sign

## Implementation Details
The new layout separates the textarea input from the action buttons, with the send button and keyboard hint displayed inline below the textarea. The file attachment button is now part of the bottom toolbar alongside other utility options, creating a cleaner and more organized interface.

https://claude.ai/code/session_01Y9wC7BSKyp1JrzPBNnMWtt