### PR TITLE
Handle empty completions without tool use as retryable errors

### DIFF
--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -293,12 +293,17 @@ class SdkResultAccumulator:
         if self._saw_pseudo_tool_call:
             return self._build_format_drift_result(content)
 
-        if not content:
+        # A clean run with no visible answer and no tool call is a thinking-only
+        # dead-end — surface it as a retryable error so the chat does not end
+        # silently on an empty answer. When a real tool ran, keep the prior
+        # finished behavior: re-running could repeat a write, so only the no-tool
+        # case is converted here.
+        if not content and not self._saw_tool_use:
             return self._build_empty_completion_result()
 
         return TaskExecutionResult(
             task_status="finished",
-            content=content,
+            content=content or "已完成。",
             usage=self.usage or None,
             provider_id=self.provider_id,
             model=self.model,
@@ -355,14 +360,15 @@ class SdkResultAccumulator:
         )
 
     def _build_empty_completion_result(self) -> TaskExecutionResult:
-        """Close out a clean run that ended with no visible answer at all.
+        """Close out a clean run that ended with no visible answer and no tool.
 
-        The turn ended without an SDK error and without leaking pseudo tool-call
-        tags, yet produced no final text — usually a thinking-only turn that
-        stopped early. This previously fell back to a silent ``finished`` with
-        "已完成。", so the chat ended on an empty answer with no way to retry.
-        Routing it through the shared error closeout makes the existing error
-        card and retry button surface instead.
+        A thinking-only turn that stopped early: no SDK error, no leaked pseudo
+        tool-call tag, no ``tool_use``, and no final text. This previously fell
+        back to a silent ``finished`` with "已完成。", so the chat ended on an
+        empty answer with no way to retry. Routing it through the shared error
+        closeout makes the existing error card and retry button surface instead.
+        Runs that did invoke a tool keep the prior finished behavior — see the
+        ``_saw_tool_use`` guard in ``build_result``.
         """
         return self._build_incomplete_run_result(
             content="",

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -293,46 +293,83 @@ class SdkResultAccumulator:
         if self._saw_pseudo_tool_call:
             return self._build_format_drift_result(content)
 
+        if not content:
+            return self._build_empty_completion_result()
+
         return TaskExecutionResult(
             task_status="finished",
-            content=content or "已完成。",
+            content=content,
             usage=self.usage or None,
+            provider_id=self.provider_id,
+            model=self.model,
+            session_id=self.session_id,
+        )
+
+    def _build_incomplete_run_result(
+        self,
+        *,
+        content: str,
+        reason: str,
+        error_code: str,
+        message: str,
+        fallback: str,
+    ) -> TaskExecutionResult:
+        """Terminate a non-error run that produced no trustworthy final answer.
+
+        Shared closeout for the two ways a clean (success-subtype) run can still
+        dead-end: it leaked pseudo tool-call tags instead of a real call, or it
+        ended with no visible answer at all (typically a thinking-only turn that
+        stopped early). Both must surface as a task error — the live stream only
+        carries the raw blocks, so without a terminal error record the chat UI
+        ends the conversation silently with no way to notice the failure or
+        retry. Salvaged clean text / tool-output note is kept in the content for
+        history; the error itself carries the user-facing retry message.
+        """
+        synthetic_blocks: dict[str, dict[str, Any]] = (
+            {"tool": {"type": "tool_result", "output": "1"}} if self._saw_tool_use else {}
+        )
+        recovered = _recover_partial_content(
+            question=self.params.question,
+            main_text=content,
+            blocks=synthetic_blocks,
+            reason=reason,
+        )
+        return TaskExecutionResult(
+            task_status="error",
+            content=recovered or fallback,
+            usage=self.usage or None,
+            error={"code": error_code, "message": message, "detail": reason},
             provider_id=self.provider_id,
             model=self.model,
             session_id=self.session_id,
         )
 
     def _build_format_drift_result(self, content: str) -> TaskExecutionResult:
-        """Close out a run that leaked pseudo tool-call tags instead of a real call.
+        """Close out a run that leaked pseudo tool-call tags instead of a real call."""
+        return self._build_incomplete_run_result(
+            content=_strip_pseudo_tool_call_tags(content).strip(),
+            reason="模型工具调用格式异常未正常收口",
+            error_code="tool_call_format_drift",
+            message="模型输出了伪工具调用标签，本次回答未正常完成，请重试",
+            fallback="模型本次回答因工具调用格式异常未能正常生成，请重试。",
+        )
 
-        The model turn ended without an SDK error, but it emitted XML-style
-        tool-call markup as text and never produced a trustworthy final answer.
-        A drifted run must always terminate as a task error: the live stream only
-        carries the raw blocks (leaked tags included), so without a terminal
-        error record the chat UI ends the conversation silently with no way to
-        notice the failure or retry. Salvaged clean text is kept in the content
-        for history; the error itself carries the user-facing retry message.
+    def _build_empty_completion_result(self) -> TaskExecutionResult:
+        """Close out a clean run that ended with no visible answer at all.
+
+        The turn ended without an SDK error and without leaking pseudo tool-call
+        tags, yet produced no final text — usually a thinking-only turn that
+        stopped early. This previously fell back to a silent ``finished`` with
+        "已完成。", so the chat ended on an empty answer with no way to retry.
+        Routing it through the shared error closeout makes the existing error
+        card and retry button surface instead.
         """
-        reason = "模型工具调用格式异常未正常收口"
-        cleaned = _strip_pseudo_tool_call_tags(content).strip()
-        synthetic_blocks: dict[str, dict[str, Any]] = (
-            {"tool": {"type": "tool_result", "output": "1"}} if self._saw_tool_use else {}
-        )
-        recovered = _recover_partial_content(
-            question=self.params.question,
-            main_text=cleaned,
-            blocks=synthetic_blocks,
-            reason=reason,
-        )
-        message = "模型输出了伪工具调用标签，本次回答未正常完成，请重试"
-        return TaskExecutionResult(
-            task_status="error",
-            content=recovered or "模型本次回答因工具调用格式异常未能正常生成，请重试。",
-            usage=self.usage or None,
-            error={"code": "tool_call_format_drift", "message": message, "detail": reason},
-            provider_id=self.provider_id,
-            model=self.model,
-            session_id=self.session_id,
+        return self._build_incomplete_run_result(
+            content="",
+            reason="模型本次未产出可见回答",
+            error_code="empty_completion",
+            message="模型本次没有给出回答，请重试",
+            fallback="模型本次没有返回任何回答，请重试。",
         )
 
 

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -1313,10 +1313,11 @@ def test_execute_task_stream_marks_thinking_only_empty_finish_as_error(monkeypat
     assert result.content != "已完成。"
 
 
-def test_execute_task_stream_marks_empty_finish_with_tool_output_as_error(monkeypatch, tmp_path: Path):
-    # Tools ran and returned output, but the model ended the turn with no final
-    # text and no leaked tag. The run must terminate as a retryable error whose
-    # salvaged content points at the gathered tool output, not "已完成。".
+def test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished(monkeypatch, tmp_path: Path):
+    # Tools ran but the model ended the turn with no final text and no leaked
+    # tag. Only the no-tool thinking-only case is converted to an error; a run
+    # that actually invoked a tool keeps the prior finished behavior, because
+    # retrying it could repeat a write. So this stays finished, not empty_completion.
     _install_fake_sdk(
         monkeypatch,
         [
@@ -1349,8 +1350,6 @@ def test_execute_task_stream_marks_empty_finish_with_tool_output_as_error(monkey
 
     result = asyncio.run(_run())
 
-    assert result.task_status == "error"
-    assert result.error is not None
-    assert result.error["code"] == "empty_completion"
-    assert "工具输出" in result.content
-    assert result.content != "已完成。"
+    assert result.task_status == "finished"
+    assert result.error is None
+    assert result.content == "已完成。"

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -333,7 +333,7 @@ def test_execute_task_stream_logs_safe_runtime_base_url_and_preserves_env(monkey
     _install_fake_sdk(
         monkeypatch,
         [
-            ResultMessage("success", session_id="sdk-session-log"),
+            ResultMessage("success", "查询结果如下。", session_id="sdk-session-log"),
         ],
     )
     monkeypatch.setattr(
@@ -1068,7 +1068,7 @@ def test_execute_task_stream_injects_portal_mcp_servers(monkeypatch, tmp_path: P
     _install_fake_sdk(
         monkeypatch,
         [
-            ResultMessage("success", session_id="sdk-session-mcp"),
+            ResultMessage("success", "查询结果如下。", session_id="sdk-session-mcp"),
         ],
     )
     monkeypatch.setattr(
@@ -1276,3 +1276,81 @@ def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_when_nothing_
     assert result.task_status == "error"
     assert result.error is not None
     assert result.error["code"] == "tool_call_format_drift"
+
+
+def test_execute_task_stream_marks_thinking_only_empty_finish_as_error(monkeypatch, tmp_path: Path):
+    # A clean (success) run that produced only a thinking block — no visible
+    # answer, no tool_use, no leaked pseudo tag — used to fall back to a silent
+    # "finished" + "已完成。". It must instead surface as a retryable task error
+    # so the chat shows the error card / retry button instead of ending quietly.
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+            StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "Let me think about how to answer this question."},
+                }
+            ),
+            StreamEvent({"type": "content_block_stop", "index": 0}),
+            ResultMessage("success", session_id="sdk-empty-1"),
+        ],
+    )
+    _patch_default_provider(monkeypatch)
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "error"
+    assert result.error is not None
+    assert result.error["code"] == "empty_completion"
+    assert "请重试" in result.error["message"]
+    assert result.content != "已完成。"
+
+
+def test_execute_task_stream_marks_empty_finish_with_tool_output_as_error(monkeypatch, tmp_path: Path):
+    # Tools ran and returned output, but the model ended the turn with no final
+    # text and no leaked tag. The run must terminate as a retryable error whose
+    # salvaged content points at the gathered tool output, not "已完成。".
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            StreamEvent(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "tool_use", "id": "tool-bash-9", "name": "Bash", "input": {"command": "python run_sql.py"}},
+                }
+            ),
+            StreamEvent({"type": "content_block_stop", "index": 0}),
+            UserMessage([{"type": "tool_result", "tool_use_id": "tool-bash-9", "name": "Bash", "content": "2026-06-15"}]),
+            StreamEvent({"type": "content_block_start", "index": 1, "content_block": {"type": "thinking", "thinking": ""}}),
+            StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {"type": "thinking_delta", "thinking": "I now have the data and will summarize it."},
+                }
+            ),
+            StreamEvent({"type": "content_block_stop", "index": 1}),
+            ResultMessage("success", session_id="sdk-empty-2"),
+        ],
+    )
+    _patch_default_provider(monkeypatch)
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "error"
+    assert result.error is not None
+    assert result.error["code"] == "empty_completion"
+    assert "工具输出" in result.content
+    assert result.content != "已完成。"

--- a/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
+++ b/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
@@ -95,10 +95,49 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 范围说明：可发送消息的嵌入式 `WidgetChat.vue` 本次未加重试按钮（其既有错误卡片不变），
 如需可在后续迭代直接复用引擎的 `retryMessage`。
 
+## 2026-06-15 迭代：空回答（无伪标签）同样标错可重试
+
+继漂移收口后，用户复现到另一类同源现象：深度思考结束后对话直接停住，任务落库为
+`task_status=finished`、`error` 为空、`content=已完成。`，前端无报错也无法感知，只能手动
+「继续」才把答案补出来。
+
+复盘确认这是漂移收口的**残留盲区**：
+
+- `SdkResultAccumulator.build_result()` 成功兜底分支 `content or "已完成。"` 把「非错误
+  结束 + 可见回答为空」当作正常完成。`current_answer_text()` 只收集 `text` 块，`thinking`
+  内容本就不进可见答案，因此**纯思考结束、无可见文本、无 `tool_use`、且未命中伪标签**的
+  回合会落进这条静默成功分支。
+- 06-12 迭代只在命中已登记伪标签（`_saw_pseudo_tool_call`）时才标错；本类现象没有可识别
+  的伪标签（模型思考后直接 stop，常见于第三方 `anthropic_compatible` 端点的扩展思考），
+  于是绕过漂移护栏，静默成 `finished + 已完成。`。
+- 「继续就好了」是因为后续走 resume 路径（`resume_session_id`）重发同一会话，模型补出
+  上一轮跳过的回答。空回合是模型/代理侧产物，不是后端崩溃。
+
+调整：
+
+1. `build_result()` 成功分支不再使用 `content or "已完成。"` 兜底。可见回答非空时照常
+   `finished` 返回原文；**可见回答为空时一律 `task_status="error"`**，错误码
+   `empty_completion`，`error.message` 为面向用户的可重试提示。复用既有「`build_result`
+   为 error 时 `sdk_writer.append_error(...)`」通道，使实时流必然带终止 `error` 记录；前端
+   复用 06-12 已有的错误卡片与「重试」按钮（均对任意 `status=error` 生效，**前端无需改动**）。
+2. 漂移收口 `_build_format_drift_result` 与空回答收口 `_build_empty_completion_result`
+   抽取共用私有方法 `_build_incomplete_run_result(content, reason, error_code, message,
+   fallback)`，统一「合成 tool 输出标记 → `_recover_partial_content` 兜底文本 → 组装 `error`
+   结果」，避免重复 guard 分支（遵循「最小兜底、单层」）。空回答若此前有真实 `tool_use`，
+   兜底文本指向「上方思考过程中的工具输出」并保留在 `content` 供历史展示。
+
+取舍：对「有真实 `tool_use` 但无文字结论」的空回答同样标错，与漂移一致——只有 error 路径
+会把终止记录写入实时流，`finished + 兜底文本` 不进实时流会重演静默结束。写流程（data-dev）
+下空回答属模型异常静默而非操作失败，标错 + 用户手动重试比假「已完成。」更安全：现状文案会
+在模型实际异常时谎报完成、掩盖写操作是否真正生效。
+
 ## 接口与契约变化
 
 - 任务错误码 `tool_call_format_drift`：2026-06-12 起对所有伪工具调用漂移返回
   （首版仅在无可兜底内容时返回）；兜底出的部分文本保留在任务 `content` 中。
+- 任务错误码 `empty_completion`：2026-06-15 起，非错误结束但无可见回答的运行返回
+  （取代原 `finished + "已完成。"` 静默兜底）；若此前有真实 `tool_use`，兜底文本指向工具输出
+  并保留在任务 `content` 中。
 - 前端共享引擎新增动作 `retryMessage(failedMessage)`。
 - `_recover_partial_content` 复用，不改签名。
 - 新增内部辅助 `_contains_pseudo_tool_call` / `_strip_pseudo_tool_call_tags`

--- a/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
+++ b/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
@@ -95,7 +95,7 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 范围说明：可发送消息的嵌入式 `WidgetChat.vue` 本次未加重试按钮（其既有错误卡片不变），
 如需可在后续迭代直接复用引擎的 `retryMessage`。
 
-## 2026-06-15 迭代：空回答（无伪标签）同样标错可重试
+## 2026-06-15 迭代：纯思考空回答（无 tool_use）标错可重试
 
 继漂移收口后，用户复现到另一类同源现象：深度思考结束后对话直接停住，任务落库为
 `task_status=finished`、`error` 为空、`content=已完成。`，前端无报错也无法感知，只能手动
@@ -115,29 +115,32 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 
 调整：
 
-1. `build_result()` 成功分支不再使用 `content or "已完成。"` 兜底。可见回答非空时照常
-   `finished` 返回原文；**可见回答为空时一律 `task_status="error"`**，错误码
+1. `build_result()` 成功分支在返回前新增**单一窄分支**:**可见回答为空且本轮无真实
+   `tool_use`（`not content and not self._saw_tool_use`）时 `task_status="error"`**，错误码
    `empty_completion`，`error.message` 为面向用户的可重试提示。复用既有「`build_result`
    为 error 时 `sdk_writer.append_error(...)`」通道，使实时流必然带终止 `error` 记录；前端
    复用 06-12 已有的错误卡片与「重试」按钮（均对任意 `status=error` 生效，**前端无需改动**）。
+   其余情况保持原 `finished + content or "已完成。"` 行为不变。
 2. 漂移收口 `_build_format_drift_result` 与空回答收口 `_build_empty_completion_result`
    抽取共用私有方法 `_build_incomplete_run_result(content, reason, error_code, message,
    fallback)`，统一「合成 tool 输出标记 → `_recover_partial_content` 兜底文本 → 组装 `error`
-   结果」，避免重复 guard 分支（遵循「最小兜底、单层」）。空回答若此前有真实 `tool_use`，
-   兜底文本指向「上方思考过程中的工具输出」并保留在 `content` 供历史展示。
+   结果」，避免重复 guard 分支（遵循「最小兜底、单层」）。其中合成 tool 输出标记仅对**漂移**
+   路径有意义（漂移可发生在真实 `tool_use` 之后）；空回答路径因 `_saw_tool_use` 为假，兜底
+   恒为「无可重试内容」文案。
 
-取舍：对「有真实 `tool_use` 但无文字结论」的空回答同样标错，与漂移一致——只有 error 路径
-会把终止记录写入实时流，`finished + 兜底文本` 不进实时流会重演静默结束。写流程（data-dev）
-下空回答属模型异常静默而非操作失败，标错 + 用户手动重试比假「已完成。」更安全：现状文案会
-在模型实际异常时谎报完成、掩盖写操作是否真正生效。
+取舍（范围）：本次只收口「无真实 `tool_use` 的纯思考空回答」——这正是用户复现的场景，且
+重试安全。**有真实 `tool_use` 但无文字结论的空回答先保持原 `finished`（`content or
+"已完成。"`）不变**：这类运行已经实际执行过工具、可能含写操作，标错并引导重试有重复执行
+（如重复写）的风险，故暂不纳入本次收口。如后续需要，再单独评估更安全的收口方式（例如指向
+工具输出的非重试提示，而非走重试按钮）。
 
 ## 接口与契约变化
 
 - 任务错误码 `tool_call_format_drift`：2026-06-12 起对所有伪工具调用漂移返回
   （首版仅在无可兜底内容时返回）；兜底出的部分文本保留在任务 `content` 中。
-- 任务错误码 `empty_completion`：2026-06-15 起，非错误结束但无可见回答的运行返回
-  （取代原 `finished + "已完成。"` 静默兜底）；若此前有真实 `tool_use`，兜底文本指向工具输出
-  并保留在任务 `content` 中。
+- 任务错误码 `empty_completion`：2026-06-15 起，非错误结束、无可见回答**且无真实
+  `tool_use`**的运行返回（取代原纯思考空回答的 `finished + "已完成。"` 静默兜底）。有真实
+  `tool_use` 但无文字结论的空回答仍保持 `finished + "已完成。"`，本次不改。
 - 前端共享引擎新增动作 `retryMessage(failedMessage)`。
 - `_recover_partial_content` 复用，不改签名。
 - 新增内部辅助 `_contains_pseudo_tool_call` / `_strip_pseudo_tool_call_tags`

--- a/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
+++ b/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
@@ -88,7 +88,40 @@ python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q
 - 漂移为非确定性模型行为，仍以合成流/桩测试为权威覆盖；真实端到端烟测在远程容器
   （无本地 MySQL/Redis/模型凭据）不可执行，按验证规则在交付说明中明确未覆盖层。
 
+## 2026-06-15 迭代任务（空回答无伪标签 → 标错可重试）
+
+### 影响栈
+
+- DataAgent 后端（`dataagent/dataagent-backend`）：成功收口语义、单测。
+- 前端无改动：错误卡片、重试按钮、`topicStatus`、`retryMessage` 已对任意 `status=error`
+  通用，`empty_completion` 直接复用。
+
+### 任务与改动文件
+
+1. `core/task_executor.py`
+   - `build_result()`：删除成功分支 `content or "已完成。"` 静默兜底；可见回答为空时改走
+     `_build_empty_completion_result()` 返回 `error: empty_completion`，非空时 `finished`
+     返回原文。
+   - 抽出共用 `_build_incomplete_run_result(...)`，`_build_format_drift_result` 与
+     `_build_empty_completion_result` 复用（漂移行为不变，仅去重）。
+2. `tests/test_task_executor.py`
+   - 新增两个合成流用例：纯思考空回答 → `error: empty_completion`；空回答但有真实
+     `tool_use` → `error: empty_completion` 且 `content` 指向「工具输出」。
+   - 修正两个 env/mcp 注入用例的桩：`ResultMessage("success", ...)` 补最终 `result` 文本，
+     使其代表真实成功 run（空 `result` 现属 `empty_completion` 错误，而非 `finished`）。
+
+### 验证（2026-06-15）
+
+- 后端：远程容器无 `.venv-py313`，用宿主 Python 3.11.15（满足 >=3.10）补装
+  `pytest/httpx/pymysql/cffi/anyio/pydantic-settings` 后运行
+  `python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q` →
+  62 passed（60 既有 + 2 新增）。
+- 端到端：空回答为非确定性模型行为，无法稳定触发，合成流契约测试为权威覆盖；真实
+  NL2SQL 烟测在远程容器（无本地 MySQL/Redis/模型凭据）不可执行，按验证规则在此明确未
+  覆盖真实端到端层。
+
 ## 回滚
 
 逐文件回退上述改动即可，无 schema / 部署 / 迁移变更；新增错误码
-`tool_call_format_drift` 仅为新增返回值，回退后不再产生。
+`tool_call_format_drift` 仅为新增返回值，回退后不再产生。2026-06-15 迭代同理：回退
+`core/task_executor.py` 即恢复 `content or "已完成。"`，错误码 `empty_completion` 不再产生。

--- a/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
+++ b/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
@@ -88,7 +88,7 @@ python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q
 - 漂移为非确定性模型行为，仍以合成流/桩测试为权威覆盖；真实端到端烟测在远程容器
   （无本地 MySQL/Redis/模型凭据）不可执行，按验证规则在交付说明中明确未覆盖层。
 
-## 2026-06-15 迭代任务（空回答无伪标签 → 标错可重试）
+## 2026-06-15 迭代任务（纯思考空回答无 tool_use → 标错可重试）
 
 ### 影响栈
 
@@ -99,16 +99,17 @@ python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q
 ### 任务与改动文件
 
 1. `core/task_executor.py`
-   - `build_result()`：删除成功分支 `content or "已完成。"` 静默兜底；可见回答为空时改走
-     `_build_empty_completion_result()` 返回 `error: empty_completion`，非空时 `finished`
-     返回原文。
+   - `build_result()`：成功分支新增窄判定 `not content and not self._saw_tool_use` →
+     `_build_empty_completion_result()` 返回 `error: empty_completion`；其余保持原
+     `finished + content or "已完成。"` 不变（有真实 `tool_use` 的空回答不标错，避免重试
+     重复写）。
    - 抽出共用 `_build_incomplete_run_result(...)`，`_build_format_drift_result` 与
      `_build_empty_completion_result` 复用（漂移行为不变，仅去重）。
 2. `tests/test_task_executor.py`
-   - 新增两个合成流用例：纯思考空回答 → `error: empty_completion`；空回答但有真实
-     `tool_use` → `error: empty_completion` 且 `content` 指向「工具输出」。
+   - 新增两个合成流用例：纯思考空回答（无 `tool_use`）→ `error: empty_completion`；
+     空回答但有真实 `tool_use` → 保持 `finished` 且 `content == "已完成。"`（不标错）。
    - 修正两个 env/mcp 注入用例的桩：`ResultMessage("success", ...)` 补最终 `result` 文本，
-     使其代表真实成功 run（空 `result` 现属 `empty_completion` 错误，而非 `finished`）。
+     使其代表真实成功 run（无文本、无 `tool_use` 的空 run 现属 `empty_completion` 错误）。
 
 ### 验证（2026-06-15）
 
@@ -124,4 +125,5 @@ python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q
 
 逐文件回退上述改动即可，无 schema / 部署 / 迁移变更；新增错误码
 `tool_call_format_drift` 仅为新增返回值，回退后不再产生。2026-06-15 迭代同理：回退
-`core/task_executor.py` 即恢复 `content or "已完成。"`，错误码 `empty_completion` 不再产生。
+`core/task_executor.py` 即移除 `not content and not self._saw_tool_use` 窄分支、恢复无条件
+`content or "已完成。"`，错误码 `empty_completion` 不再产生。


### PR DESCRIPTION
## Summary

Extends the task executor's error handling to surface thinking-only completions that produce no visible answer and no tool invocations as retryable errors, rather than silently marking them as finished. This prevents the chat UI from ending without feedback when a model's response consists only of internal reasoning.

## Changes

- **`core/task_executor.py`**
  - Added narrow check in `build_result()`: when a run completes successfully but produces no visible content and no tool use (`not content and not self._saw_tool_use`), route to new `_build_empty_completion_result()` to return an error with code `empty_completion`
  - Extracted shared `_build_incomplete_run_result()` helper to unify error handling for both format drift (leaked pseudo tool-call tags) and empty completions
  - Refactored `_build_format_drift_result()` to use the shared helper, eliminating code duplication
  - Preserved existing behavior for runs with actual tool invocations: empty text after tool use remains `finished` status to avoid unsafe retries of write operations

- **`tests/test_task_executor.py`**
  - Added `test_execute_task_stream_marks_thinking_only_empty_finish_as_error`: verifies that a clean run with only thinking blocks and no visible answer is marked as `error` with code `empty_completion`
  - Added `test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished`: confirms that empty text after actual tool execution remains `finished` status (not converted to error)
  - Updated two existing test fixtures (`test_execute_task_stream_logs_safe_runtime_base_url_and_preserves_env` and `test_execute_task_stream_injects_portal_mcp_servers`) to include result text in `ResultMessage` stubs, ensuring they represent successful runs with visible content

## Implementation Details

The fix targets a specific gap in the previous format-drift protection: runs that end cleanly with no leaked pseudo tool-call tags but also produce no visible answer (typically early-stopping thinking-only turns) were falling through to the silent `finished + "已完成。"` fallback. The new check catches this case before that fallback, routing it through the error card and retry button that already exist in the UI for other error types.

The guard `not self._saw_tool_use` ensures that runs which actually invoked tools keep their original behavior—retrying such runs could repeat write operations, so they remain marked finished even if no final text was produced.

https://claude.ai/code/session_01FLLCsvc1Bs79VgR3sj3swT