### PR TITLE
feat(dataagent): empty completion auto-recovery for nl2sql format drift

### DIFF
--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -68,15 +68,42 @@ class TaskCoordinator:
     async def submit_task(self, task_id: str) -> dict[str, Any] | None:
         task = self.store.get_task(task_id)
         if not task:
+            logger.warning("task.queue.missing task_id=%s", task_id)
             return None
         if str(task.get("task_status") or "") != "waiting":
+            logger.info(
+                "task.queue.skip_status task_id=%s topic_id=%s task_status=%s",
+                task_id,
+                str(task.get("topic_id") or ""),
+                str(task.get("task_status") or ""),
+            )
             return task
         if task_id in self._queued_task_ids or task_id in self._active_tasks:
+            logger.info(
+                "task.queue.skip_duplicate task_id=%s topic_id=%s queued=%s active=%s",
+                task_id,
+                str(task.get("topic_id") or ""),
+                task_id in self._queued_task_ids,
+                task_id in self._active_tasks,
+            )
             return task
         if not await self._acquire_lease(task_id):
+            logger.warning(
+                "task.queue.lease_unavailable task_id=%s topic_id=%s",
+                task_id,
+                str(task.get("topic_id") or ""),
+            )
             return task
         self._queued_task_ids.add(task_id)
         await self._queue.put(task_id)
+        logger.info(
+            "task.queue.enqueued task_id=%s topic_id=%s provider=%s model=%s agent_id=%s",
+            task_id,
+            str(task.get("topic_id") or ""),
+            str(task.get("provider_id") or ""),
+            str(task.get("model") or ""),
+            str(task.get("agent_id") or ""),
+        )
         return self.store.get_task(task_id) or task
 
     async def request_cancel(self, task_id: str) -> None:
@@ -141,16 +168,39 @@ class TaskCoordinator:
             async with self._semaphore:
                 task = self.store.get_task(task_id)
                 if not task:
+                    logger.warning("task.run.skip_missing task_id=%s", task_id)
                     return
                 if str(task.get("task_status") or "") not in {"waiting", "running"}:
+                    logger.info(
+                        "task.run.skip_status task_id=%s topic_id=%s task_status=%s",
+                        task_id,
+                        str(task.get("topic_id") or ""),
+                        str(task.get("task_status") or ""),
+                    )
                     return
                 if lease_lost.is_set():
                     # Lease was lost while queued; let the recovery loop re-pick the
                     # task up instead of running without a valid lease.
+                    logger.warning(
+                        "task.run.skip_lease_lost task_id=%s topic_id=%s",
+                        task_id,
+                        str(task.get("topic_id") or ""),
+                    )
                     return
 
                 topic_id = str(task.get("topic_id") or "")
                 resume_session_id = self.store.get_resumable_conversation_id(topic_id)
+                logger.info(
+                    "task.run.start task_id=%s topic_id=%s provider=%s model=%s agent_id=%s resume_session=%s timeout=%s sql_read_timeout=%s",
+                    task_id,
+                    topic_id,
+                    str(task.get("provider_id") or ""),
+                    str(task.get("model") or ""),
+                    str(task.get("agent_id") or ""),
+                    bool(resume_session_id),
+                    int(task.get("timeout_seconds") or 0),
+                    int(task.get("sql_read_timeout_seconds") or 0),
+                )
                 self.store.mark_task_running(task_id)
                 running.set()
                 self.store.ensure_assistant_message(topic_id=topic_id, task_id=task_id, status="running")
@@ -181,6 +231,17 @@ class TaskCoordinator:
                     ),
                     is_cancel_requested=lambda: self._should_stop_task(task_id, lease_lost),
                 )
+                logger.info(
+                    "task.run.result task_id=%s topic_id=%s task_status=%s error_code=%s content_len=%s session_id_set=%s usage_set=%s",
+                    task_id,
+                    topic_id,
+                    result.task_status,
+                    str((result.error or {}).get("code") or ""),
+                    len(str(result.content or "")),
+                    bool(result.session_id),
+                    bool(result.usage),
+                )
+                attachments = self._collect_generated_files(topic_id, task_id, workspace_before)
                 self.store.update_assistant_message(
                     topic_id=topic_id,
                     task_id=task_id,
@@ -188,11 +249,33 @@ class TaskCoordinator:
                     content=result.content,
                     usage=result.usage,
                     error=result.error,
-                    attachments=self._collect_generated_files(topic_id, task_id, workspace_before),
+                    attachments=attachments,
+                )
+                logger.info(
+                    "task.run.message_updated task_id=%s topic_id=%s status=%s content_len=%s attachments=%s error_code=%s",
+                    task_id,
+                    topic_id,
+                    result.task_status,
+                    len(str(result.content or "")),
+                    len(attachments),
+                    str((result.error or {}).get("code") or ""),
                 )
                 if result.session_id:
                     self.store.update_topic_conversation_id(topic_id, conversation_id=result.session_id)
+                    logger.info(
+                        "task.run.conversation_updated task_id=%s topic_id=%s session_id_set=%s",
+                        task_id,
+                        topic_id,
+                        True,
+                    )
                 self.store.finish_task(task_id=task_id, task_status=result.task_status, error=result.error)
+                logger.info(
+                    "task.run.finished task_id=%s topic_id=%s task_status=%s error_code=%s",
+                    task_id,
+                    topic_id,
+                    result.task_status,
+                    str((result.error or {}).get("code") or ""),
+                )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -207,7 +290,19 @@ class TaskCoordinator:
                     usage=None,
                     error=error,
                 )
+                logger.info(
+                    "task.run.crash_message_updated task_id=%s topic_id=%s error_code=%s",
+                    task_id,
+                    topic_id,
+                    error["code"],
+                )
             self.store.finish_task(task_id=task_id, task_status="error", error=error)
+            logger.info(
+                "task.run.crash_finished task_id=%s topic_id=%s task_status=error error_code=%s",
+                task_id,
+                topic_id,
+                error["code"],
+            )
         finally:
             stop_heartbeat.set()
             heartbeat_task.cancel()
@@ -329,6 +424,12 @@ class TaskCoordinator:
 
     async def _recover_waiting_tasks(self, *, batch_size: int) -> None:
         for task in self.store.list_waiting_tasks(limit=batch_size):
+            logger.info(
+                "task.recovery.waiting_resubmit task_id=%s topic_id=%s updated_at=%s",
+                str(task.get("task_id") or ""),
+                str(task.get("topic_id") or ""),
+                str(task.get("updated_at") or ""),
+            )
             await self.submit_task(str(task.get("task_id") or ""))
 
     async def _recover_expired_tasks(self, *, batch_size: int) -> None:
@@ -338,8 +439,20 @@ class TaskCoordinator:
                 continue
             if await self._lease_exists(task_id):
                 continue
+            logger.warning(
+                "task.recovery.expired_running task_id=%s topic_id=%s heartbeat_at=%s",
+                task_id,
+                str(task.get("topic_id") or ""),
+                str(task.get("heartbeat_at") or ""),
+            )
             replacement = self.store.create_recovery_task(task_id)
             if replacement:
+                logger.info(
+                    "task.recovery.replacement_created old_task_id=%s new_task_id=%s topic_id=%s",
+                    task_id,
+                    str(replacement.get("task_id") or ""),
+                    str(replacement.get("topic_id") or ""),
+                )
                 await self.submit_task(str(replacement.get("task_id") or ""))
 
     async def _schedule_loop(self) -> None:
@@ -367,6 +480,12 @@ class TaskCoordinator:
         schedule_log = None
         queue = None
         try:
+            logger.info(
+                "task.schedule.fire_start schedule_id=%s topic_id=%s message_type=%s",
+                schedule_id,
+                str(schedule.get("topic_id") or ""),
+                str(schedule.get("message_type") or "text"),
+            )
             next_run_at = compute_next_run_at(
                 str(schedule.get("cron_expr") or ""),
                 str(schedule.get("timezone") or "Asia/Shanghai"),
@@ -389,6 +508,13 @@ class TaskCoordinator:
                 queue_id=str(queue.get("queue_id") or ""),
                 fired_at=fired_at,
                 next_run_at=next_run_at,
+            )
+            logger.info(
+                "task.schedule.queue_created schedule_id=%s schedule_log_id=%s queue_id=%s next_run_at=%s",
+                schedule_id,
+                str(schedule_log.get("schedule_log_id") or ""),
+                str(queue.get("queue_id") or ""),
+                next_run_at,
             )
             await submit_message_task(
                 topic_id=str(schedule.get("topic_id") or ""),

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -253,6 +253,17 @@ class SdkResultAccumulator:
         content = self.current_answer_text()
         if self.result_is_error or self.provider_error_message:
             reason = self.preferred_error_message("模型会话异常结束")
+            logger.warning(
+                "task.result.provider_error task_id=%s topic_id=%s provider=%s model=%s error_code=%s subtype=%s content_len=%s provider_error=%s",
+                self.params.task_id,
+                self.params.topic_id,
+                self.provider_id,
+                self.model,
+                self.preferred_error_code(),
+                self.result_subtype,
+                len(content),
+                bool(self.provider_error_message),
+            )
             return TaskExecutionResult(
                 task_status="error",
                 content=reason,
@@ -272,6 +283,16 @@ class SdkResultAccumulator:
                 reason=reason,
             )
             if recovered_content:
+                logger.warning(
+                    "task.result.recovered_subtype task_id=%s topic_id=%s provider=%s model=%s subtype=%s reason=%s content_len=%s",
+                    self.params.task_id,
+                    self.params.topic_id,
+                    self.provider_id,
+                    self.model,
+                    self.result_subtype,
+                    reason,
+                    len(recovered_content),
+                )
                 return TaskExecutionResult(
                     task_status="finished",
                     content=recovered_content,
@@ -280,6 +301,16 @@ class SdkResultAccumulator:
                     model=self.model,
                     session_id=self.session_id,
                 )
+            logger.warning(
+                "task.result.error_subtype task_id=%s topic_id=%s provider=%s model=%s subtype=%s reason=%s content_len=%s",
+                self.params.task_id,
+                self.params.topic_id,
+                self.provider_id,
+                self.model,
+                self.result_subtype,
+                reason,
+                len(content),
+            )
             return TaskExecutionResult(
                 task_status="error",
                 content=content or reason,
@@ -291,6 +322,15 @@ class SdkResultAccumulator:
             )
 
         if self._saw_pseudo_tool_call:
+            logger.warning(
+                "task.result.format_drift task_id=%s topic_id=%s provider=%s model=%s saw_tool_use=%s content_len=%s",
+                self.params.task_id,
+                self.params.topic_id,
+                self.provider_id,
+                self.model,
+                self._saw_tool_use,
+                len(content),
+            )
             return self._build_format_drift_result(content)
 
         # A clean run with no visible answer and no tool call is a thinking-only
@@ -299,8 +339,29 @@ class SdkResultAccumulator:
         # finished behavior: re-running could repeat a write, so only the no-tool
         # case is converted here.
         if not content and not self._saw_tool_use:
+            logger.warning(
+                "task.result.empty_completion task_id=%s topic_id=%s provider=%s model=%s saw_stream_event=%s result_subtype=%s session_id_set=%s",
+                self.params.task_id,
+                self.params.topic_id,
+                self.provider_id,
+                self.model,
+                self._saw_stream_event,
+                self.result_subtype,
+                bool(self.session_id),
+            )
             return self._build_empty_completion_result()
 
+        logger.info(
+            "task.result.finished task_id=%s topic_id=%s provider=%s model=%s content_len=%s saw_tool_use=%s fallback_content=%s session_id_set=%s",
+            self.params.task_id,
+            self.params.topic_id,
+            self.provider_id,
+            self.model,
+            len(content),
+            self._saw_tool_use,
+            not bool(content),
+            bool(self.session_id),
+        )
         return TaskExecutionResult(
             task_status="finished",
             content=content or "已完成。",
@@ -501,6 +562,32 @@ async def _single_user_prompt_stream(prompt: str):
         "type": "user",
         "message": {"role": "user", "content": prompt},
     }
+
+
+def _is_empty_completion_result(result: TaskExecutionResult) -> bool:
+    return (
+        result.task_status == "error"
+        and isinstance(result.error, dict)
+        and str(result.error.get("code") or "") == "empty_completion"
+    )
+
+
+def _empty_completion_recovery_timeout(timeout_seconds: int) -> int:
+    return max(10, min(120, max(10, int(timeout_seconds or 0)) // 2))
+
+
+def _build_empty_completion_recovery_prompt(question: str) -> str:
+    original_question = _clip_text(str(question or "").strip(), 2000)
+    if not original_question:
+        original_question = "见本会话上一轮用户问题。"
+    return (
+        "系统检测到你上一轮已经以 end_turn 结束，但最终只输出了空白文本，"
+        "没有调用工具，也没有给用户可见回答。\n"
+        "请继续完成用户的原始问题。必须输出可见回答；如果需要查询真实数据，"
+        "请继续使用当前已启用的工具。\n"
+        "不要解释本条系统检测信息。\n\n"
+        f"原始用户问题：\n{original_question}"
+    )
 
 
 async def execute_task_stream(
@@ -744,8 +831,6 @@ async def _execute_task_stream_local(
             str(line or "").rstrip(),
         ),
     )
-    if params.resume_session_id:
-        options_kwargs["resume"] = params.resume_session_id
     if permission_mode:
         options_kwargs["permission_mode"] = permission_mode
     if can_use_tool is not None:
@@ -753,8 +838,14 @@ async def _execute_task_stream_local(
     cli_path = resolve_claude_cli_path(cfg)
     if cli_path:
         options_kwargs["cli_path"] = cli_path
-    options = ClaudeAgentOptions(**options_kwargs)
     timeout_seconds = max(10, int(params.timeout_seconds or cfg.agent_timeout_seconds))
+
+    def _make_options(resume_session_id: str | None = None):
+        current_options = dict(options_kwargs)
+        resume_value = str(resume_session_id or "").strip()
+        if resume_value:
+            current_options["resume"] = resume_value
+        return ClaudeAgentOptions(**current_options)
 
     logger.info(
         "task.start task_id=%s topic_id=%s provider=%s model=%s cwd=%s setting_sources=%s allowed_tools=%s mcp_servers=%s max_turns=%s partial=%s base_url=%s env_base_url=%s auth_token_set=%s api_key_set=%s",
@@ -782,75 +873,161 @@ async def _execute_task_stream_local(
             return bool(await result)
         return bool(result)
 
-    try:
-        with anyio.fail_after(timeout_seconds):
-            sdk_prompt = _single_user_prompt_stream(prompt) if can_use_tool is not None else prompt
-            async for msg in claude_query(prompt=sdk_prompt, options=options):
-                if await _cancelled():
-                    error = {"code": "task_cancelled", "message": "任务已取消"}
-                    sdk_writer.append_error(**error)
+    terminal_error_record_written = False
+
+    async def _run_sdk_turn(
+        *,
+        turn_prompt: str,
+        turn_options: Any,
+        turn_timeout_seconds: int,
+        phase: str,
+    ) -> TaskExecutionResult:
+        nonlocal terminal_error_record_written
+        try:
+            with anyio.fail_after(turn_timeout_seconds):
+                sdk_prompt = _single_user_prompt_stream(turn_prompt) if can_use_tool is not None else turn_prompt
+                async for msg in claude_query(prompt=sdk_prompt, options=turn_options):
+                    if await _cancelled():
+                        error = {"code": "task_cancelled", "message": "任务已取消"}
+                        sdk_writer.append_error(**error)
+                        terminal_error_record_written = True
+                        return TaskExecutionResult(
+                            task_status="suspended",
+                            content=accumulator.current_answer_text(),
+                            usage=accumulator.usage or None,
+                            error=error,
+                            provider_id=provider_id,
+                            model=model,
+                            session_id=accumulator.session_id,
+                        )
+                    accumulator.ingest(msg)
+                    sdk_writer.ingest(msg)
+        except Exception as exc:
+            reason = _format_exception_reason(exc)
+            partial = accumulator.current_answer_text()
+            if _is_recoverable_timeout_reason(reason):
+                recovered_content = _recover_partial_content(
+                    question=params.question,
+                    main_text=partial,
+                    blocks={},
+                    reason=reason,
+                )
+                if recovered_content:
+                    sdk_writer.append_done(is_error=False, subtype="recovered_timeout")
+                    logger.warning(
+                        "task.exception.recovered_timeout task_id=%s topic_id=%s provider=%s model=%s phase=%s reason=%s partial_len=%s recovered_len=%s session_id_set=%s",
+                        params.task_id,
+                        params.topic_id,
+                        provider_id,
+                        model,
+                        phase,
+                        reason,
+                        len(partial),
+                        len(recovered_content),
+                        bool(accumulator.session_id),
+                    )
                     return TaskExecutionResult(
-                        task_status="suspended",
-                        content=accumulator.current_answer_text(),
+                        task_status="finished",
+                        content=recovered_content,
                         usage=accumulator.usage or None,
-                        error=error,
                         provider_id=provider_id,
                         model=model,
                         session_id=accumulator.session_id,
                     )
-                accumulator.ingest(msg)
-                sdk_writer.ingest(msg)
-    except Exception as exc:
-        reason = _format_exception_reason(exc)
-        partial = accumulator.current_answer_text()
-        if _is_recoverable_timeout_reason(reason):
-            recovered_content = _recover_partial_content(
-                question=params.question,
-                main_text=partial,
-                blocks={},
-                reason=reason,
+
+            error_message = accumulator.preferred_error_message(reason)
+            error_code = accumulator.preferred_error_code()
+            error = {
+                "code": error_code,
+                "message": error_message,
+                "exception_type": exc.__class__.__name__,
+            }
+            sdk_writer.append_error(**error)
+            terminal_error_record_written = True
+            logger.warning(
+                "task.exception.error_result task_id=%s topic_id=%s provider=%s model=%s phase=%s error_code=%s reason_len=%s partial_len=%s session_id_set=%s exception_type=%s",
+                params.task_id,
+                params.topic_id,
+                provider_id,
+                model,
+                phase,
+                error_code,
+                len(error_message),
+                len(partial),
+                bool(accumulator.session_id),
+                exc.__class__.__name__,
             )
-            if recovered_content:
-                sdk_writer.append_done(is_error=False, subtype="recovered_timeout")
-                return TaskExecutionResult(
-                    task_status="finished",
-                    content=recovered_content,
-                    usage=accumulator.usage or None,
-                    provider_id=provider_id,
-                    model=model,
-                    session_id=accumulator.session_id,
-                )
+            return TaskExecutionResult(
+                task_status="error",
+                content=error_message if error_code != "model_call_failed" else (partial or error_message),
+                usage=accumulator.usage or None,
+                error=error,
+                provider_id=provider_id,
+                model=model,
+                session_id=accumulator.session_id,
+            )
 
-        error_message = accumulator.preferred_error_message(reason)
-        error_code = accumulator.preferred_error_code()
-        error = {
-            "code": error_code,
-            "message": error_message,
-            "exception_type": exc.__class__.__name__,
-        }
-        sdk_writer.append_error(**error)
-        return TaskExecutionResult(
-            task_status="error",
-            content=error_message if error_code != "model_call_failed" else (partial or error_message),
-            usage=accumulator.usage or None,
-            error=error,
-            provider_id=provider_id,
-            model=model,
-            session_id=accumulator.session_id,
-        )
+        return accumulator.build_result()
 
-    result = accumulator.build_result()
-    if result.task_status == "error":
+    result = await _run_sdk_turn(
+        turn_prompt=prompt,
+        turn_options=_make_options(params.resume_session_id),
+        turn_timeout_seconds=timeout_seconds,
+        phase="initial",
+    )
+    if _is_empty_completion_result(result):
+        recovery_session_id = str(result.session_id or accumulator.session_id or params.resume_session_id or "").strip()
+        if recovery_session_id:
+            recovery_timeout = _empty_completion_recovery_timeout(timeout_seconds)
+            logger.warning(
+                "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s timeout=%s session_id_set=%s",
+                params.task_id,
+                params.topic_id,
+                provider_id,
+                model,
+                recovery_timeout,
+                bool(recovery_session_id),
+            )
+            result = await _run_sdk_turn(
+                turn_prompt=_build_empty_completion_recovery_prompt(params.question),
+                turn_options=_make_options(recovery_session_id),
+                turn_timeout_seconds=recovery_timeout,
+                phase="empty_completion_recovery",
+            )
+            logger.info(
+                "task.empty_completion.recover_result task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s content_len=%s session_id_set=%s",
+                params.task_id,
+                params.topic_id,
+                provider_id,
+                model,
+                result.task_status,
+                str((result.error or {}).get("code") or ""),
+                len(str(result.content or "")),
+                bool(result.session_id),
+            )
+        else:
+            logger.warning(
+                "task.empty_completion.recover_skip task_id=%s topic_id=%s provider=%s model=%s reason=no_session",
+                params.task_id,
+                params.topic_id,
+                provider_id,
+                model,
+            )
+
+    if result.task_status == "error" and not terminal_error_record_written:
         sdk_writer.append_error(
             code=str((result.error or {}).get("code") or "model_error"),
             message=str((result.error or {}).get("message") or result.content or "模型会话异常结束"),
             detail=str((result.error or {}).get("detail") or ""),
         )
     logger.info(
-        "task.done task_id=%s task_status=%s provider=%s model=%s",
+        "task.done task_id=%s task_status=%s provider=%s model=%s error_code=%s content_len=%s session_id_set=%s",
         params.task_id,
         result.task_status,
         provider_id,
         model,
+        str((result.error or {}).get("code") or ""),
+        len(str(result.content or "")),
+        bool(result.session_id),
     )
     return result

--- a/dataagent/dataagent-backend/core/task_submission_service.py
+++ b/dataagent/dataagent-backend/core/task_submission_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -10,6 +11,8 @@ from croniter import croniter
 from config import get_settings
 from core.skill_admin_service import resolve_runtime_provider_selection
 from core.topic_task_store import TopicTaskStore, get_topic_task_store
+
+logger = logging.getLogger(__name__)
 
 
 def current_utc_naive() -> datetime:
@@ -109,11 +112,32 @@ async def submit_message_task(
         source_schedule_log_id=source_schedule_log_id,
     )
     task_id = str(task.get("task_id") or "")
+    logger.info(
+        "task.submit.created task_id=%s topic_id=%s agent_id=%s provider=%s model=%s mode=%s prompt_len=%s timeout=%s sql_read_timeout=%s sql_write_timeout=%s",
+        task_id,
+        topic_id,
+        str(task.get("agent_id") or ""),
+        str(runtime_target.get("provider_id") or ""),
+        str(runtime_target.get("model") or ""),
+        str(execution_mode or ""),
+        len(prompt),
+        int(timeouts["timeout_seconds"]),
+        int(timeouts["sql_read_timeout_seconds"]),
+        int(timeouts["sql_write_timeout_seconds"]),
+    )
     user_message = store.append_user_message(topic_id=topic_id, task_id=task_id, content=prompt)
     assistant_message = store.ensure_assistant_message(topic_id=topic_id, task_id=task_id, status="waiting")
     if source_queue_id:
         store.mark_message_queue_submitted(queue_id=source_queue_id, task_id=task_id)
     task = await coordinator.submit_task(task_id) or task
+    logger.info(
+        "task.submit.enqueued task_id=%s topic_id=%s task_status=%s user_message_id=%s assistant_message_id=%s",
+        task_id,
+        topic_id,
+        str(task.get("task_status") or "waiting"),
+        str(user_message.get("message_id") or ""),
+        str(assistant_message.get("message_id") or ""),
+    )
     return {
         "accepted": True,
         "topic_id": topic_id,

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -434,6 +434,7 @@ class TopicTaskStore:
         chat_topic_id = _new_id("chat_topic")
         chat_conversation_id = _new_id("chat_conv")
         conn = self._connect(database=self._schema_name())
+        affected = 0
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -820,9 +821,16 @@ class TopicTaskStore:
                     """,
                     (value, topic_id),
                 )
+                affected = cur.rowcount
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "topic.conversation_id.updated topic_id=%s affected=%s conversation_id_set=%s",
+            topic_id,
+            affected,
+            bool(value),
+        )
         return self.get_topic(topic_id)
 
     def get_resumable_conversation_id(self, topic_id: str) -> str | None:
@@ -964,6 +972,14 @@ class TopicTaskStore:
         existing = self.get_assistant_message(task_id)
         if existing:
             if status and existing.get("status") != status:
+                logger.info(
+                    "message.assistant.ensure_update task_id=%s topic_id=%s old_status=%s new_status=%s message_id=%s",
+                    task_id,
+                    topic_id,
+                    str(existing.get("status") or ""),
+                    status,
+                    str(existing.get("message_id") or ""),
+                )
                 self.update_assistant_message(
                     topic_id=topic_id,
                     task_id=task_id,
@@ -993,6 +1009,14 @@ class TopicTaskStore:
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "message.assistant.created task_id=%s topic_id=%s message_id=%s status=%s seq_id=%s",
+            task_id,
+            topic_id,
+            message_id,
+            status,
+            seq_id,
+        )
         return self.get_message(message_id) or {}
 
     def update_assistant_message(
@@ -1021,6 +1045,7 @@ class TopicTaskStore:
             params.append(attachments_json)
         params.extend([topic_id, task_id])
         conn = self._connect(database=self._schema_name())
+        affected = 0
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -1041,9 +1066,22 @@ class TopicTaskStore:
                     """,
                     params,
                 )
+                affected = cur.rowcount
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "message.assistant.updated task_id=%s topic_id=%s status=%s affected=%s content_len=%s usage_set=%s error_code=%s attachments_update=%s attachments_count=%s",
+            task_id,
+            topic_id,
+            status,
+            affected,
+            len(str(content or "")),
+            bool(usage),
+            str((error or {}).get("code") or ""),
+            set_attachments,
+            len(attachments or []) if set_attachments else 0,
+        )
         return self.get_assistant_message(task_id) or {}
 
     def get_assistant_message(self, task_id: str) -> dict[str, Any] | None:
@@ -1224,6 +1262,18 @@ class TopicTaskStore:
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "task.store.created task_id=%s topic_id=%s agent_id=%s provider=%s model=%s timeout=%s sql_read_timeout=%s source_queue_id=%s source_schedule_id=%s",
+            task_id,
+            topic_id,
+            agent_id,
+            provider_id or "",
+            model or "",
+            int(timeout_seconds or 0),
+            int(sql_read_timeout_seconds or 0),
+            bool(source_queue_id),
+            bool(source_schedule_id),
+        )
         return self.get_task(task_id) or {}
 
     def get_task(self, task_id: str, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
@@ -1332,6 +1382,8 @@ class TopicTaskStore:
     def mark_task_running(self, task_id: str) -> dict[str, Any] | None:
         self._ensure_ready()
         conn = self._connect(database=self._schema_name())
+        task_affected = 0
+        topic_affected = 0
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -1345,6 +1397,7 @@ class TopicTaskStore:
                     """,
                     (task_id,),
                 )
+                task_affected = cur.rowcount
                 cur.execute(
                     """
                     UPDATE da_agent_topic t
@@ -1356,9 +1409,16 @@ class TopicTaskStore:
                     """,
                     (task_id,),
                 )
+                topic_affected = cur.rowcount
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "task.store.running task_id=%s task_affected=%s topic_affected=%s",
+            task_id,
+            task_affected,
+            topic_affected,
+        )
         return self.get_task(task_id)
 
     def set_task_status(self, task_id: str, status: str) -> dict[str, Any] | None:
@@ -1371,6 +1431,8 @@ class TopicTaskStore:
         self._ensure_ready()
         safe_status = str(status or "running")
         conn = self._connect(database=self._schema_name())
+        task_affected = 0
+        topic_affected = 0
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -1383,6 +1445,7 @@ class TopicTaskStore:
                     """,
                     (safe_status, task_id),
                 )
+                task_affected = cur.rowcount
                 cur.execute(
                     """
                     UPDATE da_agent_topic t
@@ -1394,9 +1457,17 @@ class TopicTaskStore:
                     """,
                     (safe_status, task_id),
                 )
+                topic_affected = cur.rowcount
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "task.store.status_set task_id=%s status=%s task_affected=%s topic_affected=%s",
+            task_id,
+            safe_status,
+            task_affected,
+            topic_affected,
+        )
         return self.get_task(task_id)
 
     def get_pending_permission_request_id(self, task_id: str) -> str | None:
@@ -1503,6 +1574,11 @@ class TopicTaskStore:
         error_message = str((error or {}).get("message") or "").strip() or None
         downstream_status = "completed" if task_status == "finished" else ("suspended" if task_status == "suspended" else "failed")
         conn = self._connect(database=self._schema_name())
+        task_affected = 0
+        topic_affected = 0
+        source_queue_id = None
+        source_schedule_id = None
+        source_schedule_log_id = None
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -1517,6 +1593,7 @@ class TopicTaskStore:
                     """,
                     (task_status, error_json, task_id),
                 )
+                task_affected = cur.rowcount
                 cur.execute(
                     """
                     UPDATE da_agent_topic t
@@ -1528,6 +1605,7 @@ class TopicTaskStore:
                     """,
                     (task_status, task_id),
                 )
+                topic_affected = cur.rowcount
                 cur.execute(
                     """
                     SELECT source_queue_id, source_schedule_id, source_schedule_log_id
@@ -1583,15 +1661,31 @@ class TopicTaskStore:
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "task.store.finished task_id=%s task_status=%s error_code=%s task_affected=%s topic_affected=%s queue_link=%s schedule_link=%s schedule_log_link=%s downstream_status=%s",
+            task_id,
+            task_status,
+            str((error or {}).get("code") or ""),
+            task_affected,
+            topic_affected,
+            bool(source_queue_id),
+            bool(source_schedule_id),
+            bool(source_schedule_log_id),
+            downstream_status,
+        )
         return self.get_task(task_id)
 
     def request_task_cancel(self, task_id: str, context: dict[str, Any] | None = None) -> dict[str, Any] | None:
         self._ensure_ready()
         if not self.get_task(task_id, context=context):
+            logger.warning("task.cancel.missing task_id=%s", task_id)
             return None
         cancel_error = {"code": "task_cancelled", "message": "任务已取消"}
         cancel_error_json = json.dumps(cancel_error, ensure_ascii=False, default=_json_default)
         conn = self._connect(database=self._schema_name())
+        previous_status = ""
+        topic_id = ""
+        waiting_cancelled = False
         try:
             with conn.cursor() as cur:
                 cur.execute(
@@ -1613,6 +1707,8 @@ class TopicTaskStore:
                     (task_id,),
                 )
                 row = cur.fetchone() or {}
+                previous_status = str(row.get("task_status") or "")
+                topic_id = str(row.get("topic_id") or "")
                 if str(row.get("task_status") or "") == "waiting":
                     cur.execute(
                         """
@@ -1626,6 +1722,7 @@ class TopicTaskStore:
                         """,
                         (cancel_error_json, task_id),
                     )
+                    waiting_cancelled = True
                     cur.execute(
                         """
                         UPDATE da_agent_topic
@@ -1676,6 +1773,13 @@ class TopicTaskStore:
             conn.commit()
         finally:
             conn.close()
+        logger.info(
+            "task.cancel.requested task_id=%s topic_id=%s previous_status=%s waiting_cancelled=%s",
+            task_id,
+            topic_id,
+            previous_status,
+            waiting_cancelled,
+        )
         return self.get_task(task_id, context=context)
 
     def is_task_cancel_requested(self, task_id: str) -> bool:

--- a/dataagent/dataagent-backend/sandbox_task_main.py
+++ b/dataagent/dataagent-backend/sandbox_task_main.py
@@ -17,6 +17,13 @@ logging.basicConfig(level=logging.INFO, stream=sys.stderr)
 logger = logging.getLogger(__name__)
 
 
+def _result_error_code(result: TaskExecutionResult) -> str:
+    error = result.error
+    if isinstance(error, dict):
+        return str(error.get("code") or "")
+    return ""
+
+
 def _load_payload() -> dict[str, Any]:
     raw = str(os.environ.get("DATAAGENT_TASK_PAYLOAD_B64") or "").strip()
     if raw:
@@ -32,6 +39,20 @@ async def _execute_and_emit(params: TaskExecutionInput) -> TaskExecutionResult:
         print(json.dumps({"type": "record", "record": record}, ensure_ascii=False), flush=True)
 
     try:
+        logger.info(
+            "sandbox.task.start task_id=%s topic_id=%s provider_id=%s model=%s "
+            "execution_mode=%s resume_session=%s timeout_seconds=%s "
+            "sql_read_timeout_seconds=%s workspace=%s",
+            params.task_id,
+            params.topic_id,
+            params.provider_id,
+            params.model,
+            params.execution_mode,
+            bool(params.resume_session_id),
+            params.timeout_seconds,
+            params.sql_read_timeout_seconds,
+            Path.cwd(),
+        )
         result = await _execute_task_stream_local(
             params,
             emit=emit,
@@ -48,6 +69,16 @@ async def _execute_and_emit(params: TaskExecutionInput) -> TaskExecutionResult:
             model=params.model,
         )
 
+    logger.info(
+        "sandbox.task.result task_id=%s topic_id=%s task_status=%s error_code=%s "
+        "content_len=%s session_id_set=%s",
+        params.task_id,
+        params.topic_id,
+        result.task_status,
+        _result_error_code(result),
+        len(result.content or ""),
+        bool(result.session_id),
+    )
     print(json.dumps({"type": "result", "result": asdict(result)}, ensure_ascii=False), flush=True)
     return result
 
@@ -100,6 +131,12 @@ async def _serve_loop() -> int:
             logger.warning("sandbox child received non-json payload line; skipping")
             continue
         params = TaskExecutionInput(**payload)
+        logger.info(
+            "sandbox.child.payload_received task_id=%s topic_id=%s execution_mode=%s",
+            params.task_id,
+            params.topic_id,
+            params.execution_mode,
+        )
         await _execute_and_emit(params)
 
 

--- a/dataagent/dataagent-backend/tests/test_sandbox_task_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_task_main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -78,7 +79,7 @@ def test_serve_loop_exits_on_idle_timeout(monkeypatch, tmp_path: Path):
     assert exit_code == 0
 
 
-def test_sandbox_task_main_uses_process_cwd_as_prepared_workspace(monkeypatch, tmp_path: Path, capsys):
+def test_sandbox_task_main_uses_process_cwd_as_prepared_workspace(monkeypatch, tmp_path: Path, capsys, caplog):
     captured: dict[str, object] = {}
 
     async def fake_execute(params, *, emit, is_cancel_requested=None, prepared_workspace_dir=None):
@@ -96,6 +97,7 @@ def test_sandbox_task_main_uses_process_cwd_as_prepared_workspace(monkeypatch, t
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sandbox_task_main, "_load_payload", _payload)
     monkeypatch.setattr(sandbox_task_main, "_execute_task_stream_local", fake_execute)
+    caplog.set_level(logging.INFO, logger=sandbox_task_main.__name__)
 
     exit_code = asyncio.run(sandbox_task_main._main())
 
@@ -106,3 +108,7 @@ def test_sandbox_task_main_uses_process_cwd_as_prepared_workspace(monkeypatch, t
     assert lines[0]["type"] == "record"
     assert lines[-1]["type"] == "result"
     assert lines[-1]["result"]["content"] == "sandbox-task-ok"
+    assert "sandbox.task.start task_id=task-1" in caplog.text
+    assert "sandbox.task.result task_id=task-1" in caplog.text
+    assert "task_status=finished" in caplog.text
+    assert "content_len=15" in caplog.text

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -119,6 +119,7 @@ class ClaudeAgentOptions:
 class QueryCapture:
     last_prompt = None
     last_options = None
+    calls = []
 
 
 class StreamEvent:
@@ -191,13 +192,39 @@ def _configured_skills_root(tmp_path: Path):
 
 
 def _install_fake_sdk(monkeypatch, messages, *, final_exception=None):
+    QueryCapture.last_prompt = None
+    QueryCapture.last_options = None
+    QueryCapture.calls = []
+
     async def fake_query(*, prompt, options):
         QueryCapture.last_prompt = prompt
         QueryCapture.last_options = options
+        QueryCapture.calls.append({"prompt": prompt, "options": options})
         for message in messages:
             yield message
         if final_exception is not None:
             raise final_exception
+
+    monkeypatch.setitem(
+        sys.modules,
+        "claude_agent_sdk",
+        SimpleNamespace(ClaudeAgentOptions=ClaudeAgentOptions, query=fake_query),
+    )
+
+
+def _install_fake_sdk_runs(monkeypatch, runs):
+    QueryCapture.last_prompt = None
+    QueryCapture.last_options = None
+    QueryCapture.calls = []
+
+    async def fake_query(*, prompt, options):
+        QueryCapture.last_prompt = prompt
+        QueryCapture.last_options = options
+        QueryCapture.calls.append({"prompt": prompt, "options": options})
+        index = len(QueryCapture.calls) - 1
+        messages = runs[index] if index < len(runs) else runs[-1]
+        for message in messages:
+            yield message
 
     monkeypatch.setitem(
         sys.modules,
@@ -1028,7 +1055,7 @@ def test_execute_task_stream_resumes_sdk_session_without_replaying_history(monke
     _install_fake_sdk(
         monkeypatch,
         [
-            ResultMessage("success", session_id="sdk-session-continued"),
+            ResultMessage("success", "继续回答", session_id="sdk-session-continued"),
         ],
     )
     monkeypatch.setattr(
@@ -1278,24 +1305,67 @@ def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_when_nothing_
     assert result.error["code"] == "tool_call_format_drift"
 
 
-def test_execute_task_stream_marks_thinking_only_empty_finish_as_error(monkeypatch, tmp_path: Path):
+def test_execute_task_stream_recovers_thinking_only_empty_finish_once(monkeypatch, tmp_path: Path):
     # A clean (success) run that produced only a thinking block — no visible
-    # answer, no tool_use, no leaked pseudo tag — used to fall back to a silent
-    # "finished" + "已完成。". It must instead surface as a retryable task error
-    # so the chat shows the error card / retry button instead of ending quietly.
-    _install_fake_sdk(
+    # answer, no tool_use, no leaked pseudo tag — is safe to resume once. The
+    # recovery prompt stays inside the SDK session and should turn the same task
+    # into a normal finished answer when the model continues correctly.
+    _install_fake_sdk_runs(
         monkeypatch,
         [
-            StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
-            StreamEvent(
-                {
-                    "type": "content_block_delta",
-                    "index": 0,
-                    "delta": {"type": "thinking_delta", "thinking": "Let me think about how to answer this question."},
-                }
-            ),
-            StreamEvent({"type": "content_block_stop", "index": 0}),
-            ResultMessage("success", session_id="sdk-empty-1"),
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+                StreamEvent(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "thinking_delta", "thinking": "Let me think about how to answer this question."},
+                    }
+                ),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success", session_id="sdk-empty-1"),
+            ],
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+                StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "恢复后的回答"}}),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success", session_id="sdk-empty-1"),
+            ],
+        ],
+    )
+    _patch_default_provider(monkeypatch)
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    assert result.error is None
+    assert result.content == "恢复后的回答"
+    assert len(QueryCapture.calls) == 2
+    assert QueryCapture.calls[1]["options"].kwargs["resume"] == "sdk-empty-1"
+    assert "上一轮已经以 end_turn 结束" in QueryCapture.calls[1]["prompt"]
+    assert "最近 30 天工作流发布次数趋势" in QueryCapture.calls[1]["prompt"]
+
+
+def test_execute_task_stream_marks_empty_finish_as_error_after_recovery_still_empty(monkeypatch, tmp_path: Path):
+    _install_fake_sdk_runs(
+        monkeypatch,
+        [
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+                StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "Thinking only."}}),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success", session_id="sdk-empty-1"),
+            ],
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+                StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "\n\n"}}),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success", session_id="sdk-empty-1"),
+            ],
         ],
     )
     _patch_default_provider(monkeypatch)
@@ -1311,6 +1381,7 @@ def test_execute_task_stream_marks_thinking_only_empty_finish_as_error(monkeypat
     assert result.error["code"] == "empty_completion"
     assert "请重试" in result.error["message"]
     assert result.content != "已完成。"
+    assert len(QueryCapture.calls) == 2
 
 
 def test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished(monkeypatch, tmp_path: Path):
@@ -1353,3 +1424,4 @@ def test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished(monkey
     assert result.task_status == "finished"
     assert result.error is None
     assert result.content == "已完成。"
+    assert len(QueryCapture.calls) == 1

--- a/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
+++ b/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
@@ -113,7 +113,7 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 - 「继续就好了」是因为后续走 resume 路径（`resume_session_id`）重发同一会话，模型补出
   上一轮跳过的回答。空回合是模型/代理侧产物，不是后端崩溃。
 
-调整：
+初版调整：
 
 1. `build_result()` 成功分支在返回前新增**单一窄分支**:**可见回答为空且本轮无真实
    `tool_use`（`not content and not self._saw_tool_use`）时 `task_status="error"`**，错误码
@@ -134,12 +134,47 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 （如重复写）的风险，故暂不纳入本次收口。如后续需要，再单独评估更安全的收口方式（例如指向
 工具输出的非重试提示，而非走重试按钮）。
 
+## 2026-06-15 追加迭代：空回答自动恢复一次
+
+后续通过导出的 child 容器挂载目录复盘到更精确证据：
+
+- Claude project JSONL 中，同一 `chatcmpl` 先产生 `thinking`，随后以 `stop_reason=end_turn`
+  结束，最终 `text` 仅为两个换行。
+- Claude CLI telemetry 记录 `tengu_model_whitespace_response`，metadata 标明
+  `length=2`，证明这是模型/CLI 层可识别的 whitespace-only assistant response。
+- 同会话下一轮用户追问时，模型能够意识到上一轮中断并继续回答，说明通过同一 session
+  追加一次恢复提示有实际修复价值。
+
+因此将「直接标错」升级为「先自动恢复一次，失败再标错」：
+
+1. 仍由 `SdkResultAccumulator.build_result()` 识别 `empty_completion`，识别条件不扩大：
+   非错误结束、无可见回答、无真实 `tool_use`、未命中伪工具调用漂移。
+2. `core/task_executor.py` 在把 `empty_completion` 写成终止错误前，若存在可 resume 的
+   `session_id`，自动发起**一次**内部恢复 turn，使用同一 SDK session、同一工具/权限/技能
+   配置，并给模型一条最小诊断提示：
+   「上一轮 `end_turn` 但最终只输出空白、未调用工具、未给用户可见回答；请继续完成原始问题，
+   必须输出可见回答」。
+3. 恢复提示不持久化为平台用户消息，只存在 Claude session JSONL 中；恢复过程产生的 SDK
+   records 仍写入当前 task，使实时流和历史投影可以看到恢复后的 assistant blocks。
+4. 恢复 turn 使用独立短超时，按当前任务超时的一半推导，范围为 `10-120s`，常见 `60s`
+   任务恢复超时为 `30s`，`180s` 为 `90s`，`420s` 为 `120s`。不新增部署配置，避免再引入一层
+   timeout knob。
+5. 若恢复 turn 产生可见回答，则当前任务最终为 `finished`；若仍为空、无 session、取消、
+   或恢复异常，则按既有错误路径返回 `empty_completion` 或具体异常错误。
+
+安全边界：
+
+- 只对**无真实 `tool_use`**的空回答自动恢复，避免重复执行已经发生过的工具调用，尤其是写操作。
+- 恢复最多一次，不做循环或级联 fallback。
+- 只向模型暴露最小诊断事实，不把 runner log、路径、token 状态、工具输出等运行时日志注入模型。
+
 ## 接口与契约变化
 
 - 任务错误码 `tool_call_format_drift`：2026-06-12 起对所有伪工具调用漂移返回
   （首版仅在无可兜底内容时返回）；兜底出的部分文本保留在任务 `content` 中。
 - 任务错误码 `empty_completion`：2026-06-15 起，非错误结束、无可见回答**且无真实
-  `tool_use`**的运行返回（取代原纯思考空回答的 `finished + "已完成。"` 静默兜底）。有真实
+  `tool_use`**的运行不再静默 `finished + "已完成。"`。追加迭代后该错误码只在一次自动
+  resume 恢复仍无法产生可见回答、缺少可 resume session、或恢复被取消/失败时返回。有真实
   `tool_use` 但无文字结论的空回答仍保持 `finished + "已完成。"`，本次不改。
 - 前端共享引擎新增动作 `retryMessage(failedMessage)`。
 - `_recover_partial_content` 复用，不改签名。
@@ -148,8 +183,9 @@ ARCH_PERF_005）出现「工具/SQL 已经实际执行、却没有可用最终�
 
 ## 取舍
 
-- 不采用「自动追加一次 continuation 收口」：需要重跑模型、额外轮次/超时预算，改动更大；
-  本次按用户选择采用更小、单分支的「兜底 + 标错」。
+- 自动追加一次 continuation 收口只用于 `empty_completion`，不用于伪工具调用漂移或有真实
+  `tool_use` 的空回答；这避免重复工具副作用，同时覆盖当前已证实的 whitespace-only
+  assistant response。
 - 不新增全局标签清洗器，也不做「答案是否引用 query_result」的收口门禁——超出本次范围。
 
 ## 范围外

--- a/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
+++ b/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
@@ -127,3 +127,46 @@ python3 -m pytest tests/test_task_executor.py tests/test_agent_runtime.py -q
 `tool_call_format_drift` 仅为新增返回值，回退后不再产生。2026-06-15 迭代同理：回退
 `core/task_executor.py` 即移除 `not content and not self._saw_tool_use` 窄分支、恢复无条件
 `content or "已完成。"`，错误码 `empty_completion` 不再产生。
+
+## 2026-06-15 追加迭代任务（empty_completion 自动恢复一次）
+
+### 影响栈
+
+- DataAgent 后端（`dataagent/dataagent-backend`）：task executor 运行时收口、单测。
+- 前端无改动：恢复成功时仍是同一个 task 的 SDK records；恢复失败时继续复用既有
+  `error` 终止记录和错误卡片。
+- 部署无改动：不新增配置项、不新增 schema。
+
+### 任务与改动文件
+
+1. `docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md`
+   - 将 `empty_completion` 的处理从「直接标错」升级为「自动 resume 一次，失败再标错」。
+   - 明确只覆盖无真实 `tool_use` 的空回答，最多一次恢复，不向模型注入日志。
+2. `core/task_executor.py`
+   - 抽出单次 SDK turn 执行 helper，初次执行和恢复 turn 复用取消、异常、SDK record 写入。
+   - 新增 `_build_empty_completion_recovery_prompt(...)`：只包含最小诊断事实和原始问题。
+   - 新增 `_empty_completion_recovery_timeout(...)`：从当前 task timeout 推导短恢复超时，限制在
+     `10-120s`。
+   - 当 `build_result()` 返回 `error.code == "empty_completion"` 且 `session_id` 存在时，使用
+     同一 session 自动恢复一次；恢复成功返回 `finished`，恢复仍为空才写 `empty_completion`
+     终止错误。
+3. `tests/test_task_executor.py`
+   - 调整既有纯思考空回答测试：首次空回复后第二次 resume 返回文本，最终应 `finished`。
+   - 增加恢复仍为空的测试：最终仍为 `error: empty_completion`，且不会无限重试。
+   - 保留「有真实 `tool_use` 的空回答不自动恢复、不标错」测试。
+
+### 验证
+
+- 后端：
+  - `.venv-py313/bin/python -m py_compile core/task_executor.py`
+  - `.venv-py313/bin/python -m pytest tests/test_task_executor.py tests/test_task_coordinator.py tests/test_topic_task_store.py tests/test_sandbox_task_main.py tests/test_sandbox_runner_main.py`
+- 端到端：
+  - whitespace-only assistant response 是非确定性模型行为，自动恢复以合成 SDK 流覆盖为主。
+  - 如本地 provider/容器环境可用，再补一次真实 NL2SQL 冒烟；无法稳定复现空回复时不把该场景
+    描述为端到端已验证。
+
+### 回滚
+
+回退 `core/task_executor.py` 中自动恢复 helper 和调用逻辑即可恢复到「`empty_completion`
+直接标错」；再按上一节回退可恢复到旧的 `finished + "已完成。"` 行为。无 schema、API 或部署
+回滚步骤。


### PR DESCRIPTION
Upgrade the handling of empty completions from directly reporting errors to automatically attempting a recovery turn. When an empty completion (where the model returns no visible response and performs no tool calls) is detected, if a resumable session ID is available, the task executor will initiate a single recovery turn to prompt the model to continue its response. Added unit tests for successful recovery and continued failure scenarios.