### PR TITLE
style(dataagent-frontend): borderless text-style for permission mode and add-file controls

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -1503,11 +1503,11 @@ onBeforeUnmount(() => {
 .v2-file-input { display: none; }
 .v2-attach-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 26px; height: 26px; flex: none; border: 1px solid #dbe3ef; border-radius: 9px;
-  background: #f4f7fb; color: #4a5568; cursor: pointer;
+  width: 26px; height: 26px; flex: none; border: none; border-radius: 6px;
+  background: transparent; color: #8a96a6; cursor: pointer;
   transition: background var(--odw-transition), color var(--odw-transition);
 }
-.v2-attach-btn:hover:not(:disabled) { background: #EEF1F5; color: #111827; }
+.v2-attach-btn:hover:not(:disabled) { background: #EEF1F5; color: #4a5568; }
 .v2-attach-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* ── Artifacts toggle (top bar) ──────────────────────────────────────────── */
@@ -2202,13 +2202,18 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid #dbe3ef;
-  background: #f4f7fb;
-  border-radius: 12px;
-  padding: 2px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  padding: 3px 8px;
   font-size: 12px;
-  color: #4a5568;
+  color: #8a96a6;
   cursor: pointer;
+  transition: color var(--odw-transition), background var(--odw-transition);
+}
+.v2-perm-pill:hover {
+  color: #4a5568;
+  background: #eef1f5;
 }
 .v2-perm-pill-dot {
   width: 8px;


### PR DESCRIPTION
## Summary
Follow-up to #362. Restyles the two left-side composer controls on the `NL2SqlChatV2` chat input to a borderless, **text style**, so they visually match the model selector already on the right.

## Changes (`NL2SqlChatV2.vue`)
- **`.v2-perm-pill` (permission mode)** — removed the border and filled background; now transparent text style (`#8a96a6`) with a hover-only background. The colored mode-indicator dot is kept.
- **`.v2-attach-btn` (add-file `+`)** — removed the border and filled background; transparent text style with the same hover affordance.

Result: permission mode, add-file, and the model selector now share one consistent borderless text style in the composer toolbar.

## Notes
- The widget composer was not touched here: its permission control is a native `<select>` already styled borderless/transparent, and it has no add-file button.

## Verification
- `npm run build` compiles clean.

https://claude.ai/code/session_01Y9wC7BSKyp1JrzPBNnMWtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9wC7BSKyp1JrzPBNnMWtt)_