### PR TITLE
fix(widget): keep a visible activity cue while the chat v2 run is still working

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -133,6 +133,14 @@
                     </template>
                   </template>
 
+                  <!-- Keep an activity cue visible whenever the run is still
+                       going but no block is currently streaming (between turns,
+                       before a new turn's first block, or after a tool/text
+                       block settled while the run continues). -->
+                  <div v-if="showTrailingActivity(msg)" class="query-typing-indicator query-typing-indicator-trailing">
+                    <span /><span /><span />
+                  </div>
+
                   <div v-if="msg._v2state.status === 'error'" class="query-error-card">
                     <span class="query-error-label">错误</span>
                     <span>{{ msg._v2state.errorText || '处理出错' }}</span>
@@ -487,6 +495,32 @@ const formatBytes = (size) => {
 // Split answer prose into ordered text/chart segments so an inline chart_spec
 // (fenced, tagged, or raw JSON) renders as a real chart instead of leaking JSON.
 const answerSegments = (content) => splitChartSpecText(String(content || ''))
+
+// A block conveys its own live progress: streaming text/thinking shows the
+// blinking cursor (or the "深度思考" badge dot), and a tool_use shows its
+// running state until its result lands. While one of these is the tail block,
+// the trailing dots would be redundant.
+const isBlockActivelyProgressing = (block) => {
+  if (!block) return false
+  if (block.type === 'text' || block.type === 'thinking') return block.status === 'streaming'
+  if (block.type === 'tool_use') return block.output == null
+  return false
+}
+
+// Show the trailing typing dots whenever the task is still running but the tail
+// block is not itself streaming — this fills the gaps the inline cursor leaves
+// (between turns, before a turn's first block, after a settled block). A pending
+// permission card means the run is waiting on the user, not working, so suppress.
+const showTrailingActivity = (msg) => {
+  if (!isActiveTask(msg)) return false
+  const state = msg._v2state
+  if (!state?.turns?.length) return false
+  if (state.status === 'done' || state.status === 'error') return false
+  const lastTurn = state.turns[state.turns.length - 1]
+  const lastBlock = lastTurn?.blocks?.[lastTurn.blocks.length - 1]
+  if (lastBlock?.type === 'permission_request' && lastBlock.decision === 'pending') return false
+  return !isBlockActivelyProgressing(lastBlock)
+}
 
 // Generic Chat V2 permission confirmation handler (shared with NL2SqlChatV2).
 const handlePermissionDecision = async (msg, payload) => {

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -755,6 +755,50 @@ describe('WidgetChat history conversations', () => {
     }))
   })
 
+  it('keeps a trailing activity cue visible between streamed blocks while the run is still working', async () => {
+    let streamControls
+    apiMocks.taskApi.streamSdkEvents.mockImplementation((taskId, options) => new Promise((resolve) => {
+      streamControls = { options, resolve }
+    }))
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    await wrapper.get('textarea').setValue('最近发布趋势')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    const { options } = streamControls
+
+    // Run started, no block yet → the initial typing indicator shows.
+    options.onRecord({ record_type: 'stream', data: { type: 'message_start', usage: {} } })
+    await flushPromises()
+    expect(wrapper.find('.query-typing-indicator').exists()).toBe(true)
+
+    // A tool settled (block stopped, result delivered) but the run keeps going:
+    // the trailing dots fill the dead air before the next block appears.
+    options.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tool-1', name: 'Bash' } } })
+    options.onRecord({ record_type: 'stream', data: { type: 'content_block_stop', index: 0 } })
+    options.onRecord({ record_type: 'tool_result', data: { tool_use_id: 'tool-1', content: 'ok' } })
+    await flushPromises()
+    expect(wrapper.find('.query-typing-indicator-trailing').exists()).toBe(true)
+
+    // While a text block streams, the inline cursor conveys progress, so the
+    // trailing dots step aside to avoid a doubled indicator.
+    options.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 1, content_block: { type: 'text' } } })
+    options.onRecord({ record_type: 'stream', data: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: '正在分析' } } })
+    await flushPromises()
+    expect(wrapper.find('.query-cursor').exists()).toBe(true)
+    expect(wrapper.find('.query-typing-indicator-trailing').exists()).toBe(false)
+
+    // Run completes → every activity cue disappears.
+    options.onRecord({ record_type: 'stream', data: { type: 'content_block_stop', index: 1 } })
+    options.onRecord({ record_type: 'done', data: {} })
+    streamControls.resolve()
+    await flushPromises()
+    expect(wrapper.find('.query-typing-indicator').exists()).toBe(false)
+  })
+
   it('renders a tool-produced chart inline below its tool-call block (no conclusion duplicate)', async () => {
     const chartSpec = JSON.stringify({
       kind: 'chart_spec',

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -881,6 +881,8 @@ export const WIDGET_STYLES = `
 .query-typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
 .query-typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
 
+.query-typing-indicator-trailing { margin-top: 2px; }
+
 @keyframes query-typing {
   0%, 60%, 100% { transform: translateY(0); opacity: 0.35; }
   30% { transform: translateY(-5px); opacity: 1; }


### PR DESCRIPTION
The widget chat only showed the three-dot typing indicator before the very
first streamed block. Once output began, the inline cursor and tool running
state left dead air between turns, before a new turn's first block, and after a
block settled while the run continued — so the conversation area no longer felt
like it was replying.

Add a trailing typing indicator that stays visible whenever the task is still
active but no block is currently streaming, suppressing it during live text
(cursor handles it), while a tool is in flight, on a pending permission card,
and once the stream reaches a terminal status.