### PR TITLE
feat(nl2sql): render AskUserQuestion tool calls as a selection card

### DIFF
--- a/dataagent/contracts/sdk-block-projection/cases.json
+++ b/dataagent/contracts/sdk-block-projection/cases.json
@@ -918,6 +918,155 @@
           "decision": "timeout"
         }
       ]
+    },
+    {
+      "name": "ask_user question pending",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "question_request",
+          "data": {
+            "request_id": "q-1",
+            "questions": [
+              {
+                "question": "你想按哪个维度统计?",
+                "header": "维度",
+                "multiSelect": false,
+                "options": [
+                  {
+                    "label": "按天",
+                    "description": "每天一个数据点"
+                  },
+                  {
+                    "label": "按周",
+                    "description": "每周一个数据点"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "question_request",
+          "request_id": "q-1",
+          "questions": [
+            {
+              "question": "你想按哪个维度统计?",
+              "header": "维度",
+              "multiSelect": false,
+              "options": [
+                {
+                  "label": "按天",
+                  "description": "每天一个数据点"
+                },
+                {
+                  "label": "按周",
+                  "description": "每周一个数据点"
+                }
+              ]
+            }
+          ],
+          "answered": false,
+          "answers": []
+        }
+      ]
+    },
+    {
+      "name": "ask_user question answered",
+      "records": [
+        {
+          "seq_id": 1,
+          "record_type": "stream",
+          "data": {
+            "type": "message_start"
+          }
+        },
+        {
+          "seq_id": 2,
+          "record_type": "question_request",
+          "data": {
+            "request_id": "q-1",
+            "questions": [
+              {
+                "question": "你想按哪个维度统计?",
+                "header": "维度",
+                "multiSelect": false,
+                "options": [
+                  {
+                    "label": "按天",
+                    "description": "每天一个数据点"
+                  },
+                  {
+                    "label": "按周",
+                    "description": "每周一个数据点"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "seq_id": 3,
+          "record_type": "question_answer",
+          "data": {
+            "request_id": "q-1",
+            "answers": [
+              {
+                "header": "维度",
+                "question": "你想按哪个维度统计?",
+                "selected": [
+                  "按天"
+                ],
+                "other": ""
+              }
+            ],
+            "answered_at": "2026-06-15T00:00:00"
+          }
+        }
+      ],
+      "expected": [
+        {
+          "kind": "question_request",
+          "request_id": "q-1",
+          "questions": [
+            {
+              "question": "你想按哪个维度统计?",
+              "header": "维度",
+              "multiSelect": false,
+              "options": [
+                {
+                  "label": "按天",
+                  "description": "每天一个数据点"
+                },
+                {
+                  "label": "按周",
+                  "description": "每周一个数据点"
+                }
+              ]
+            }
+          ],
+          "answered": true,
+          "answers": [
+            {
+              "header": "维度",
+              "question": "你想按哪个维度统计?",
+              "selected": [
+                "按天"
+              ],
+              "other": ""
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -27,6 +27,8 @@ from models.schemas import (
     CreateTaskRequest,
     PermissionDecisionRequest,
     PermissionDecisionResponse,
+    QuestionAnswerRequest,
+    QuestionAnswerResponse,
     CreateTopicRequest,
     DeliverMessageRequest,
     ExecuteQueryRequest,
@@ -652,6 +654,39 @@ async def api_submit_permission_decision(task_id: str, payload: PermissionDecisi
         )
     return PermissionDecisionResponse.model_validate(
         {"task_id": task_id, "request_id": request_id, "decision": effective}
+    )
+
+
+@task_router.post("/{task_id}/question-answer", response_model=QuestionAnswerResponse)
+async def api_submit_question_answer(task_id: str, payload: QuestionAnswerRequest, request: Request):
+    store = _get_store()
+    context = _request_context(request)
+    task = store.get_task(task_id, context=context)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    request_id = str(payload.request_id or "").strip()
+    if not request_id:
+        raise HTTPException(status_code=400, detail="request_id is required")
+    if str(task.get("task_status") or "") != "waiting_input":
+        raise HTTPException(status_code=409, detail="task is not awaiting a user answer")
+    pending_request_id = store.get_pending_question_request_id(task_id)
+    if pending_request_id and pending_request_id != request_id:
+        raise HTTPException(status_code=409, detail="request_id does not match the current pending question")
+    coordinator = get_task_coordinator()
+    if not pending_request_id:
+        existing = await coordinator.read_question_answer(task_id, request_id)
+        if not existing:
+            raise HTTPException(status_code=409, detail="task has no pending question")
+    answers = [a for a in (payload.answers or []) if isinstance(a, dict)]
+    accepted = await coordinator.submit_question_answer(task_id, request_id, answers)
+    if pending_request_id:
+        store.append_question_answer_record(
+            task_id=task_id,
+            request_id=request_id,
+            answers=answers,
+        )
+    return QuestionAnswerResponse.model_validate(
+        {"task_id": task_id, "request_id": request_id, "accepted": bool(accepted)}
     )
 
 

--- a/dataagent/dataagent-backend/core/ask_user_question.py
+++ b/dataagent/dataagent-backend/core/ask_user_question.py
@@ -1,86 +1,86 @@
 """Interactive ``AskUserQuestion`` support for the NL2SQL agent.
 
-The SDK's built-in ``AskUserQuestion`` cannot return the user's selection back
-to the model in a headless deployment (``can_use_tool`` may only allow/deny).
-So we expose our own in-process SDK MCP tool ``ask_user_question`` whose handler
-fully owns the round-trip: it records a ``question_request`` block (rendered as a
-selection card in the chat UI), parks the task in ``waiting_input``, waits on
-Redis for the user's answer, records ``question_answer``, then returns the
-selection as the tool result so the *same* run resumes with the answer.
+``AskUserQuestion`` is a *built-in* SDK tool. It always resolves through the
+``can_use_tool`` callback (``checkPermissions`` returns ``ask`` and the tool
+``requiresUserInteraction``), and the tool produces its result from the
+``answers`` carried on its (updated) input. So the host answers a question by
+returning ``PermissionResultAllow(updated_input={questions, answers, ...})``.
 
-Mirrors the permission-confirmation flow (``permission_wait`` /
-``permission_gate``) so both share the proven pause/resume infrastructure.
+This module owns the host side of that round-trip, mirroring the
+permission-confirmation flow (``permission_wait`` / ``permission_gate``): record
+a ``question_request`` block (rendered as a selection card), park the task in
+``waiting_input``, wait on Redis for the user's answer, then map the answer onto
+the SDK ``updated_input`` shape so the same run resumes with the selection.
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-import uuid
-from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from config import get_settings
 
 logger = logging.getLogger(__name__)
 
-# Server + tool identity. The SDK-qualified tool name (``mcp__<server>__<tool>``)
-# is what shows up in allowed_tools, tool_use blocks, and the frontend renderer.
-ASK_USER_MCP_SERVER_NAME = "ask_user"
-ASK_USER_TOOL_NAME = "ask_user_question"
-ASK_USER_QUALIFIED_TOOL_NAME = f"mcp__{ASK_USER_MCP_SERVER_NAME}__{ASK_USER_TOOL_NAME}"
+# The built-in tool name as it appears in tool_use blocks and allowed_tools.
+ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
 
-ASK_USER_TOOL_DESCRIPTION = (
-    "向用户提出一个或多个多选/单选问题以澄清需求、消解歧义或确认偏好,并等待用户在界面中选择后返回其选择。"
-    "当需求不明确、存在多种合理理解、或需要用户在若干口径/范围/维度间做选择时优先使用。"
-    "每个问题的 header 为不超过 12 字的简短标签;选项应互斥、简明。"
-    "不要用它询问'这样可以吗/是否继续'这类确认。"
-)
 
-ASK_USER_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "questions": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "question": {"type": "string", "description": "完整问题文本"},
-                    "header": {"type": "string", "description": "不超过12字的简短标签"},
-                    "multiSelect": {
-                        "type": "boolean",
-                        "description": "为 true 时允许多选,默认 false(单选)",
-                    },
-                    "options": {
-                        "type": "array",
-                        "minItems": 2,
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "label": {"type": "string"},
-                                "description": {"type": "string"},
-                            },
-                            "required": ["label"],
-                        },
-                    },
-                },
-                "required": ["question", "header", "options"],
-            },
-        }
-    },
-    "required": ["questions"],
-}
+def is_ask_user_question_tool(tool_name: str) -> bool:
+    return str(tool_name or "").strip() == ASK_USER_QUESTION_TOOL_NAME
 
 
 def ask_question_answer_redis_key(task_id: str, request_id: str) -> str:
-    """Redis key carrying the user's answer for a waiting ``ask_user_question``.
+    """Redis key carrying the user's answer for a waiting ``AskUserQuestion``.
 
     Single source of truth shared by the API answer endpoint (writer, via the
-    coordinator) and the tool handler's wait (reader), mirroring the permission
-    decision key pattern.
+    coordinator) and the ``can_use_tool`` wait (reader), mirroring the
+    permission-decision key pattern.
     """
     return f"da:task:answer:{task_id}:{request_id}"
+
+
+def to_sdk_answer_input(questions: list[dict[str, Any]], answers: list[dict[str, Any]]) -> dict[str, Any]:
+    """Map the UI answer payload onto the built-in tool's ``updated_input`` shape.
+
+    The tool echoes ``answers`` (``{questionText: selectedLabel}``) into its
+    result, and ``annotations[questionText].notes`` carries free-text. Returning
+    only ``questions`` (no answers) yields the tool's "did not answer" result.
+    """
+    by_question: dict[str, dict[str, Any]] = {}
+    for item in answers or []:
+        if not isinstance(item, dict):
+            continue
+        q = str(item.get("question") or "").strip()
+        if q:
+            by_question[q] = item
+
+    sdk_answers: dict[str, str] = {}
+    annotations: dict[str, dict[str, str]] = {}
+    for question in questions or []:
+        qt = str((question or {}).get("question") or "").strip()
+        if not qt:
+            continue
+        item = by_question.get(qt)
+        if not item:
+            continue
+        selected = item.get("selected")
+        if isinstance(selected, str):
+            selected = [selected]
+        picks = [str(s).strip() for s in (selected or []) if str(s).strip()]
+        if picks:
+            sdk_answers[qt] = "、".join(picks)
+        other = str(item.get("other") or "").strip()
+        if other:
+            annotations[qt] = {"notes": other}
+
+    updated: dict[str, Any] = {"questions": questions}
+    if sdk_answers:
+        updated["answers"] = sdk_answers
+    if annotations:
+        updated["annotations"] = annotations
+    return updated
 
 
 async def wait_for_answer(
@@ -152,102 +152,3 @@ def _parse_answers(value: Any) -> list[dict[str, Any]]:
     if not isinstance(parsed, list):
         return []
     return [item for item in parsed if isinstance(item, dict)]
-
-
-def summarize_answers(answers: list[dict[str, Any]]) -> str:
-    """Render the user's selection as the tool-result text fed back to the model."""
-    if not answers:
-        return "用户未作出选择(已超时或取消)。请基于已有信息继续,必要时使用合理的默认假设并说明。"
-    lines = ["用户已作答:"]
-    for item in answers:
-        header = str(item.get("header") or item.get("question") or "").strip()
-        selected = item.get("selected")
-        if isinstance(selected, str):
-            selected = [selected]
-        picks = [str(s).strip() for s in (selected or []) if str(s).strip()]
-        other = str(item.get("other") or "").strip()
-        if other:
-            picks.append(f"其他:{other}")
-        rendered = "、".join(picks) if picks else "(未选择)"
-        lines.append(f"- [{header}] → {rendered}")
-    return "\n".join(lines)
-
-
-def _sdk_tool_helpers():
-    """Return (tool, create_sdk_mcp_server) or (None, None) when SDK is absent."""
-    try:
-        from claude_agent_sdk import create_sdk_mcp_server, tool
-
-        return tool, create_sdk_mcp_server
-    except Exception:
-        return None, None
-
-
-def build_ask_user_mcp_server(
-    *,
-    sdk_writer: Any,
-    store: Any,
-    task_id: str,
-    wait_seconds: int,
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
-) -> tuple[dict[str, Any] | None, str]:
-    """Build the in-process ``ask_user`` MCP server config and its qualified tool name.
-
-    Returns ``(server_config, qualified_tool_name)``; ``server_config`` is ``None``
-    when the SDK is unavailable, in which case the caller must not advertise the
-    tool in ``allowed_tools``.
-    """
-    tool_decorator, create_server = _sdk_tool_helpers()
-    if tool_decorator is None or create_server is None:
-        return None, ASK_USER_QUALIFIED_TOOL_NAME
-
-    @tool_decorator(ASK_USER_TOOL_NAME, ASK_USER_TOOL_DESCRIPTION, ASK_USER_INPUT_SCHEMA)
-    async def _ask_user_question(args: dict[str, Any]) -> dict[str, Any]:
-        questions = args.get("questions") if isinstance(args, dict) else None
-        if not isinstance(questions, list) or not questions:
-            return {
-                "content": [{"type": "text", "text": "questions 不能为空。"}],
-                "is_error": True,
-            }
-
-        request_id = uuid.uuid4().hex
-        try:
-            sdk_writer.append_question_request(request_id=request_id, questions=questions)
-            store.set_task_status(task_id, "waiting_input")
-        except Exception:
-            logger.exception("ask_user: failed to record question request task_id=%s", task_id)
-            return {
-                "content": [{"type": "text", "text": "无法发起提问,请基于已有信息继续。"}],
-                "is_error": True,
-            }
-
-        answers = await wait_for_answer(
-            task_id,
-            request_id,
-            timeout_seconds=wait_seconds,
-            is_cancel_requested=is_cancel_requested,
-        )
-        answers = answers or []
-        try:
-            append_answer = getattr(store, "append_question_answer_record", None)
-            if callable(append_answer):
-                append_answer(
-                    task_id=task_id,
-                    request_id=request_id,
-                    answers=answers,
-                    answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                )
-            else:
-                sdk_writer.append_question_answer(
-                    request_id=request_id,
-                    answers=answers,
-                    answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                )
-            store.set_task_status(task_id, "running")
-        except Exception:
-            logger.exception("ask_user: failed to record question answer task_id=%s", task_id)
-
-        return {"content": [{"type": "text", "text": summarize_answers(answers)}]}
-
-    server = create_server(name=ASK_USER_MCP_SERVER_NAME, tools=[_ask_user_question])
-    return server, ASK_USER_QUALIFIED_TOOL_NAME

--- a/dataagent/dataagent-backend/core/ask_user_question.py
+++ b/dataagent/dataagent-backend/core/ask_user_question.py
@@ -1,0 +1,253 @@
+"""Interactive ``AskUserQuestion`` support for the NL2SQL agent.
+
+The SDK's built-in ``AskUserQuestion`` cannot return the user's selection back
+to the model in a headless deployment (``can_use_tool`` may only allow/deny).
+So we expose our own in-process SDK MCP tool ``ask_user_question`` whose handler
+fully owns the round-trip: it records a ``question_request`` block (rendered as a
+selection card in the chat UI), parks the task in ``waiting_input``, waits on
+Redis for the user's answer, records ``question_answer``, then returns the
+selection as the tool result so the *same* run resumes with the answer.
+
+Mirrors the permission-confirmation flow (``permission_wait`` /
+``permission_gate``) so both share the proven pause/resume infrastructure.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Server + tool identity. The SDK-qualified tool name (``mcp__<server>__<tool>``)
+# is what shows up in allowed_tools, tool_use blocks, and the frontend renderer.
+ASK_USER_MCP_SERVER_NAME = "ask_user"
+ASK_USER_TOOL_NAME = "ask_user_question"
+ASK_USER_QUALIFIED_TOOL_NAME = f"mcp__{ASK_USER_MCP_SERVER_NAME}__{ASK_USER_TOOL_NAME}"
+
+ASK_USER_TOOL_DESCRIPTION = (
+    "向用户提出一个或多个多选/单选问题以澄清需求、消解歧义或确认偏好,并等待用户在界面中选择后返回其选择。"
+    "当需求不明确、存在多种合理理解、或需要用户在若干口径/范围/维度间做选择时优先使用。"
+    "每个问题的 header 为不超过 12 字的简短标签;选项应互斥、简明。"
+    "不要用它询问'这样可以吗/是否继续'这类确认。"
+)
+
+ASK_USER_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "questions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string", "description": "完整问题文本"},
+                    "header": {"type": "string", "description": "不超过12字的简短标签"},
+                    "multiSelect": {
+                        "type": "boolean",
+                        "description": "为 true 时允许多选,默认 false(单选)",
+                    },
+                    "options": {
+                        "type": "array",
+                        "minItems": 2,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                            "required": ["label"],
+                        },
+                    },
+                },
+                "required": ["question", "header", "options"],
+            },
+        }
+    },
+    "required": ["questions"],
+}
+
+
+def ask_question_answer_redis_key(task_id: str, request_id: str) -> str:
+    """Redis key carrying the user's answer for a waiting ``ask_user_question``.
+
+    Single source of truth shared by the API answer endpoint (writer, via the
+    coordinator) and the tool handler's wait (reader), mirroring the permission
+    decision key pattern.
+    """
+    return f"da:task:answer:{task_id}:{request_id}"
+
+
+async def wait_for_answer(
+    task_id: str,
+    request_id: str,
+    *,
+    timeout_seconds: int,
+    poll_interval_seconds: float = 1.0,
+    is_cancel_requested: Any = None,
+) -> list[dict[str, Any]] | None:
+    """Poll Redis for the user's answer; return the answers list or ``None``.
+
+    ``None`` means the wait ended without an answer (timeout or cancellation).
+    Self-connects to Redis from settings so it works in-process and in the
+    sandbox runner subprocess, exactly like :func:`permission_wait.wait_for_decision`.
+    """
+    cfg = get_settings()
+    key = ask_question_answer_redis_key(task_id, request_id)
+    try:
+        import redis.asyncio as redis
+
+        client = redis.Redis(
+            host=cfg.redis_host,
+            port=int(cfg.redis_port or 6379),
+            password=cfg.redis_password or None,
+            db=int(cfg.redis_db or 0),
+            decode_responses=True,
+        )
+    except Exception:
+        logger.exception("ask_user wait: redis unavailable; request_id=%s", request_id)
+        return None
+
+    deadline = asyncio.get_event_loop().time() + max(1, int(timeout_seconds or 600))
+    try:
+        while True:
+            try:
+                value = await client.get(key)
+            except Exception:
+                logger.exception("ask_user wait: redis read failed; request_id=%s", request_id)
+                return None
+            if value:
+                return _parse_answers(value)
+            if is_cancel_requested is not None:
+                try:
+                    cancelled = is_cancel_requested()
+                    if asyncio.iscoroutine(cancelled):
+                        cancelled = await cancelled
+                    if cancelled:
+                        return None
+                except Exception:
+                    pass
+            if asyncio.get_event_loop().time() >= deadline:
+                return None
+            await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
+
+def _parse_answers(value: Any) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except Exception:
+        return []
+    if isinstance(parsed, dict):
+        parsed = parsed.get("answers")
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def summarize_answers(answers: list[dict[str, Any]]) -> str:
+    """Render the user's selection as the tool-result text fed back to the model."""
+    if not answers:
+        return "用户未作出选择(已超时或取消)。请基于已有信息继续,必要时使用合理的默认假设并说明。"
+    lines = ["用户已作答:"]
+    for item in answers:
+        header = str(item.get("header") or item.get("question") or "").strip()
+        selected = item.get("selected")
+        if isinstance(selected, str):
+            selected = [selected]
+        picks = [str(s).strip() for s in (selected or []) if str(s).strip()]
+        other = str(item.get("other") or "").strip()
+        if other:
+            picks.append(f"其他:{other}")
+        rendered = "、".join(picks) if picks else "(未选择)"
+        lines.append(f"- [{header}] → {rendered}")
+    return "\n".join(lines)
+
+
+def _sdk_tool_helpers():
+    """Return (tool, create_sdk_mcp_server) or (None, None) when SDK is absent."""
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+
+        return tool, create_sdk_mcp_server
+    except Exception:
+        return None, None
+
+
+def build_ask_user_mcp_server(
+    *,
+    sdk_writer: Any,
+    store: Any,
+    task_id: str,
+    wait_seconds: int,
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+) -> tuple[dict[str, Any] | None, str]:
+    """Build the in-process ``ask_user`` MCP server config and its qualified tool name.
+
+    Returns ``(server_config, qualified_tool_name)``; ``server_config`` is ``None``
+    when the SDK is unavailable, in which case the caller must not advertise the
+    tool in ``allowed_tools``.
+    """
+    tool_decorator, create_server = _sdk_tool_helpers()
+    if tool_decorator is None or create_server is None:
+        return None, ASK_USER_QUALIFIED_TOOL_NAME
+
+    @tool_decorator(ASK_USER_TOOL_NAME, ASK_USER_TOOL_DESCRIPTION, ASK_USER_INPUT_SCHEMA)
+    async def _ask_user_question(args: dict[str, Any]) -> dict[str, Any]:
+        questions = args.get("questions") if isinstance(args, dict) else None
+        if not isinstance(questions, list) or not questions:
+            return {
+                "content": [{"type": "text", "text": "questions 不能为空。"}],
+                "is_error": True,
+            }
+
+        request_id = uuid.uuid4().hex
+        try:
+            sdk_writer.append_question_request(request_id=request_id, questions=questions)
+            store.set_task_status(task_id, "waiting_input")
+        except Exception:
+            logger.exception("ask_user: failed to record question request task_id=%s", task_id)
+            return {
+                "content": [{"type": "text", "text": "无法发起提问,请基于已有信息继续。"}],
+                "is_error": True,
+            }
+
+        answers = await wait_for_answer(
+            task_id,
+            request_id,
+            timeout_seconds=wait_seconds,
+            is_cancel_requested=is_cancel_requested,
+        )
+        answers = answers or []
+        try:
+            append_answer = getattr(store, "append_question_answer_record", None)
+            if callable(append_answer):
+                append_answer(
+                    task_id=task_id,
+                    request_id=request_id,
+                    answers=answers,
+                    answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                )
+            else:
+                sdk_writer.append_question_answer(
+                    request_id=request_id,
+                    answers=answers,
+                    answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                )
+            store.set_task_status(task_id, "running")
+        except Exception:
+            logger.exception("ask_user: failed to record question answer task_id=%s", task_id)
+
+        return {"content": [{"type": "text", "text": summarize_answers(answers)}]}
+
+    server = create_server(name=ASK_USER_MCP_SERVER_NAME, tools=[_ask_user_question])
+    return server, ASK_USER_QUALIFIED_TOOL_NAME

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -238,6 +238,54 @@ class SdkBlockWriter:
             },
         )
 
+    def append_question_request(
+        self,
+        *,
+        request_id: str,
+        questions: Any,
+    ) -> None:
+        """Record an ``ask_user_question`` request block.
+
+        Skill-agnostic: ``questions`` is the opaque tool input rendered verbatim
+        as a selection card by the chat UI and widget. Projected into a
+        ``question_request`` block.
+        """
+        self._store.append_sdk_record(
+            task_id=self._task_id,
+            topic_id=self._topic_id,
+            turn_index=self._turn_index,
+            record_type="question_request",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "questions": questions if isinstance(questions, list) else [],
+            },
+        )
+
+    def append_question_answer(
+        self,
+        *,
+        request_id: str,
+        answers: Any,
+        answered_at: str = "",
+    ) -> None:
+        """Record the user's answer for a prior ``ask_user_question`` request.
+
+        Merges onto the matching ``question_request`` block during projection.
+        """
+        self._store.append_sdk_record(
+            task_id=self._task_id,
+            topic_id=self._topic_id,
+            turn_index=self._turn_index,
+            record_type="question_answer",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "answers": answers if isinstance(answers, list) else [],
+                "answered_at": str(answered_at or ""),
+            },
+        )
+
     def append_done(self, *, is_error: bool, subtype: str = "") -> None:
         self._append_terminal_record(
             record_type="done",

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import socket
@@ -11,6 +12,7 @@ from typing import Any
 import redis.asyncio as redis
 
 from config import get_settings
+from core.ask_user_question import ask_question_answer_redis_key
 from core.permission_gate import permission_decision_redis_key
 from core.task_submission_service import compute_next_run_at, current_utc_naive, submit_message_task
 from core.task_executor import TaskExecutionInput, execute_task_stream
@@ -137,6 +139,27 @@ class TaskCoordinator:
         if self._redis is None:
             return None
         value = await self._redis.get(self._permission_key(task_id, request_id))
+        return str(value) if value is not None else None
+
+    async def submit_question_answer(self, task_id: str, request_id: str, answers: list[dict[str, Any]]) -> bool:
+        """Publish the user's answer for a waiting ``ask_user_question`` run.
+
+        Idempotent: the first answer for a ``request_id`` wins. Mirrors the
+        permission-decision flow so the executor's tool handler observes it via
+        Redis. Returns whether a value is present after the call.
+        """
+        if self._redis is None:
+            return False
+        key = self._answer_key(task_id, request_id)
+        ttl = max(60, int(self.settings.task_permission_wait_seconds or 600) + 60)
+        payload = json.dumps({"answers": answers}, ensure_ascii=False)
+        await self._redis.set(key, payload, ex=ttl, nx=True)
+        return bool(await self._redis.exists(key))
+
+    async def read_question_answer(self, task_id: str, request_id: str) -> str | None:
+        if self._redis is None:
+            return None
+        value = await self._redis.get(self._answer_key(task_id, request_id))
         return str(value) if value is not None else None
 
     async def _queue_loop(self) -> None:
@@ -619,6 +642,9 @@ class TaskCoordinator:
 
     def _permission_key(self, task_id: str, request_id: str) -> str:
         return permission_decision_redis_key(task_id, request_id)
+
+    def _answer_key(self, task_id: str, request_id: str) -> str:
+        return ask_question_answer_redis_key(task_id, request_id)
 
     def _recovery_key(self) -> str:
         return "da:task:recovery:lock"

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -16,6 +16,7 @@ import httpx
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, normalize_permission_mode
+from core.ask_user_question import ASK_USER_MCP_SERVER_NAME, build_ask_user_mcp_server
 from core.permission_gate import is_high_risk_tool, plan_denies_tool, requires_confirmation
 from core.permission_wait import wait_for_decision
 from core.agent_runtime import (
@@ -810,6 +811,23 @@ async def _execute_task_stream_local(
         )
     else:
         permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
+
+    # Mount the in-process ask_user_question tool so the agent can surface a
+    # multiple-choice question card and resume the same run with the user's
+    # selection. The tool handler owns the pause/wait/resume round-trip.
+    if bool(getattr(cfg, "dataagent_ask_user_question_enabled", True)):
+        ask_server, ask_tool_name = build_ask_user_mcp_server(
+            sdk_writer=sdk_writer,
+            store=get_topic_task_store(),
+            task_id=params.task_id,
+            wait_seconds=int(getattr(cfg, "task_permission_wait_seconds", 600) or 600),
+            is_cancel_requested=is_cancel_requested,
+        )
+        if ask_server is not None:
+            mcp_servers = {**mcp_servers, ASK_USER_MCP_SERVER_NAME: ask_server}
+            if ask_tool_name not in allowed_tools:
+                allowed_tools = [*allowed_tools, ask_tool_name]
+
     options_kwargs = dict(
         system_prompt=system_prompt,
         model=model,

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -16,7 +16,12 @@ import httpx
 
 from config import get_settings
 from core.agent_profile_service import DEFAULT_AGENT_ID, normalize_agent_snapshot, normalize_permission_mode
-from core.ask_user_question import ASK_USER_MCP_SERVER_NAME, build_ask_user_mcp_server
+from core.ask_user_question import (
+    ASK_USER_QUESTION_TOOL_NAME,
+    is_ask_user_question_tool,
+    to_sdk_answer_input,
+    wait_for_answer,
+)
 from core.permission_gate import is_high_risk_tool, plan_denies_tool, requires_confirmation
 from core.permission_wait import wait_for_decision
 from core.agent_runtime import (
@@ -478,6 +483,60 @@ def _deny_result(message: str):
     return {"behavior": "deny", "message": message}
 
 
+async def _handle_ask_user_question(
+    *,
+    tool_input: dict[str, Any],
+    context: Any,
+    sdk_writer: SdkBlockWriter,
+    store: Any,
+    task_id: str,
+    wait_seconds: int,
+    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+):
+    """Resolve a built-in ``AskUserQuestion`` call against the user.
+
+    Records a question_request block (rendered as a selection card), parks the
+    task in ``waiting_input``, waits on Redis for the user's selection, records
+    question_answer, then returns ``PermissionResultAllow`` with the answer mapped
+    onto the tool's ``updated_input`` so the run resumes with the selection. With
+    no answer (timeout/cancel) the tool's own "did not answer" result is used.
+    """
+    questions = tool_input.get("questions")
+    if not isinstance(questions, list) or not questions:
+        return _allow_result(tool_input)
+
+    request_id = str(getattr(context, "tool_use_id", "") or "").strip() or uuid.uuid4().hex
+    try:
+        sdk_writer.append_question_request(request_id=request_id, questions=questions)
+        store.set_task_status(task_id, "waiting_input")
+    except Exception:
+        logger.exception("ask_user: failed to record question request task_id=%s", task_id)
+        return _allow_result(tool_input)
+
+    answers = await wait_for_answer(
+        task_id,
+        request_id,
+        timeout_seconds=wait_seconds,
+        is_cancel_requested=is_cancel_requested,
+    )
+    answers = answers or []
+    try:
+        append_answer = getattr(store, "append_question_answer_record", None)
+        if callable(append_answer):
+            append_answer(task_id=task_id, request_id=request_id, answers=answers)
+        else:
+            sdk_writer.append_question_answer(
+                request_id=request_id,
+                answers=answers,
+                answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            )
+        store.set_task_status(task_id, "running")
+    except Exception:
+        logger.exception("ask_user: failed to record question answer task_id=%s", task_id)
+
+    return _allow_result(to_sdk_answer_input(questions, answers))
+
+
 def _build_can_use_tool_callback(
     *,
     sdk_writer: SdkBlockWriter,
@@ -489,7 +548,9 @@ def _build_can_use_tool_callback(
 ):
     """Build the SDK can_use_tool callback enforcing session permission policy.
 
-    Read/analysis tools auto-allow. Write/high-risk tools (per session mode) pause
+    Read/analysis tools auto-allow. ``AskUserQuestion`` pauses the run to collect
+    a multiple-choice answer (recorded as a question_request/answer block and
+    returned via updated_input). Write/high-risk tools (per session mode) pause
     the run: a permission_request block is recorded, the task moves to
     waiting_permission, and the run waits for the user's decision (Redis) before
     recording the decision and resuming. Plan-denied tools are rejected outright.
@@ -497,6 +558,16 @@ def _build_can_use_tool_callback(
 
     async def can_use_tool(tool_name: str, tool_input: dict[str, Any] | None = None, context: Any = None):
         tool_input = dict(tool_input or {})
+        if is_ask_user_question_tool(tool_name):
+            return await _handle_ask_user_question(
+                tool_input=tool_input,
+                context=context,
+                sdk_writer=sdk_writer,
+                store=store,
+                task_id=task_id,
+                wait_seconds=wait_seconds,
+                is_cancel_requested=is_cancel_requested,
+            )
         if permission_mode == "plan" and plan_denies_tool(tool_name):
             return _deny_result("当前为规划(plan)模式，不允许执行写操作。")
         if not requires_confirmation(tool_name, permission_mode):
@@ -793,14 +864,27 @@ async def _execute_task_stream_local(
         (agent_snapshot or {}).get("allowed_tools") if agent_snapshot else None,
         permission_mode=logical_permission_mode,
     )
-    # Gating fires only when there are guardable write tools (portal MCP) and the
-    # session mode asks for confirmation. When gating, the SDK must run in
-    # "default" mode so can_use_tool is consulted; otherwise preserve the
-    # established bypassPermissions behavior (allowed_tools is the boundary).
+    # Let the agent surface multiple-choice questions via the built-in
+    # AskUserQuestion tool. It always resolves through can_use_tool, so advertise
+    # it and ensure the callback is installed below.
+    ask_user_enabled = bool(getattr(cfg, "dataagent_ask_user_question_enabled", True))
+    if ask_user_enabled and ASK_USER_QUESTION_TOOL_NAME not in allowed_tools:
+        allowed_tools = [*allowed_tools, ASK_USER_QUESTION_TOOL_NAME]
+
+    # Gating fires when there are guardable write tools (portal MCP) and the
+    # session mode asks for confirmation; only then does the SDK run in "default"
+    # mode. The SDK permission mode is otherwise preserved as-is.
     needs_gating = bool(mcp_servers) and logical_permission_mode in {"default", "acceptEdits"}
-    can_use_tool = None
     if needs_gating:
         permission_mode = "default"
+    else:
+        permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
+    # The callback is installed for gating and/or AskUserQuestion. The built-in
+    # AskUserQuestion always resolves through can_use_tool (it requires user
+    # interaction), so installing the callback is sufficient regardless of mode;
+    # non-write tools are auto-allowed, keeping allowed_tools the capability boundary.
+    can_use_tool = None
+    if needs_gating or ask_user_enabled:
         can_use_tool = _build_can_use_tool_callback(
             sdk_writer=sdk_writer,
             store=get_topic_task_store(),
@@ -809,24 +893,6 @@ async def _execute_task_stream_local(
             wait_seconds=int(getattr(cfg, "task_permission_wait_seconds", 600) or 600),
             is_cancel_requested=is_cancel_requested,
         )
-    else:
-        permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
-
-    # Mount the in-process ask_user_question tool so the agent can surface a
-    # multiple-choice question card and resume the same run with the user's
-    # selection. The tool handler owns the pause/wait/resume round-trip.
-    if bool(getattr(cfg, "dataagent_ask_user_question_enabled", True)):
-        ask_server, ask_tool_name = build_ask_user_mcp_server(
-            sdk_writer=sdk_writer,
-            store=get_topic_task_store(),
-            task_id=params.task_id,
-            wait_seconds=int(getattr(cfg, "task_permission_wait_seconds", 600) or 600),
-            is_cancel_requested=is_cancel_requested,
-        )
-        if ask_server is not None:
-            mcp_servers = {**mcp_servers, ASK_USER_MCP_SERVER_NAME: ask_server}
-            if ask_tool_name not in allowed_tools:
-                allowed_tools = [*allowed_tools, ask_tool_name]
 
     options_kwargs = dict(
         system_prompt=system_prompt,

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -206,6 +206,33 @@ def _project_sdk_records(records: list[dict[str, Any]]) -> dict[str, Any]:
                 block["note"] = str(data.get("note") or "")
                 block["decided_at"] = str(data.get("decided_at") or "")
 
+        elif record_type == "question_request":
+            request_id = str(data.get("request_id") or "")
+            questions = data.get("questions")
+            block = {
+                "type": "question_request",
+                "request_id": request_id,
+                "questions": questions if isinstance(questions, list) else [],
+                "answers": [],
+                "answered": False,
+                "answered_at": "",
+                "_idx": len(ordered_blocks),
+            }
+            ordered_blocks.append(block)
+            if current_turn_blocks is not None:
+                current_turn_blocks.append(block)
+            if request_id:
+                perm_blocks_by_request_id[request_id] = block
+
+        elif record_type == "question_answer":
+            request_id = str(data.get("request_id") or "")
+            block = perm_blocks_by_request_id.get(request_id)
+            if block is not None and block.get("type") == "question_request":
+                answers = data.get("answers")
+                block["answers"] = answers if isinstance(answers, list) else []
+                block["answered"] = True
+                block["answered_at"] = str(data.get("answered_at") or "")
+
         elif record_type == "tool_result":
             tool_use_id = str(data.get("tool_use_id") or "")
             if tool_use_id and tool_use_id in blocks_by_tool_id:
@@ -1546,6 +1573,77 @@ class TopicTaskStore:
                 "decision": normalized,
                 "note": str(note or ""),
                 "decided_at": decided_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+        )
+        return True
+
+    def get_pending_question_request_id(self, task_id: str) -> str | None:
+        """Return the request_id of the latest ``question_request`` record for a
+        task that has no corresponding ``question_answer`` yet, or None."""
+        pending = self.get_pending_question_request(task_id)
+        return str(pending.get("request_id") or "") if pending else None
+
+    def get_pending_question_request(self, task_id: str) -> dict[str, Any] | None:
+        """Return the latest ask-user question that has not been answered yet."""
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, topic_id, turn_index, record_type, data
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s
+                      AND record_type IN ('question_request', 'question_answer')
+                    ORDER BY id DESC
+                    LIMIT 200
+                    """,
+                    (task_id,),
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+
+        closed: set[str] = set()
+        for row in rows:
+            data = _safe_json_load(row.get("data")) or {}
+            request_id = str(data.get("request_id") or "")
+            if not request_id:
+                continue
+            record_type = str(row.get("record_type") or "")
+            if record_type == "question_answer":
+                closed.add(request_id)
+                continue
+            if record_type == "question_request" and request_id not in closed:
+                return {
+                    "request_id": request_id,
+                    "topic_id": str(row.get("topic_id") or ""),
+                    "turn_index": int(row.get("turn_index") or 0),
+                }
+        return None
+
+    def append_question_answer_record(
+        self,
+        *,
+        task_id: str,
+        request_id: str,
+        answers: Any,
+        answered_at: str = "",
+    ) -> bool:
+        """Append a durable ``question_answer`` SDK record if the request is still pending."""
+        pending = self.get_pending_question_request(task_id)
+        if not pending or str(pending.get("request_id") or "") != str(request_id or ""):
+            return False
+        self.append_sdk_record(
+            task_id=task_id,
+            topic_id=str(pending.get("topic_id") or ""),
+            turn_index=int(pending.get("turn_index") or 0),
+            record_type="question_answer",
+            event_type=None,
+            data={
+                "request_id": str(request_id),
+                "answers": answers if isinstance(answers, list) else [],
+                "answered_at": answered_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
             },
         )
         return True

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -82,6 +82,17 @@ class PermissionDecisionResponse(BaseModel):
     decision: str
 
 
+class QuestionAnswerRequest(BaseModel):
+    request_id: str
+    answers: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class QuestionAnswerResponse(BaseModel):
+    task_id: str
+    request_id: str
+    accepted: bool
+
+
 class CreateTaskRequest(BaseModel):
     topic_id: str
     message_type: str

--- a/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_projection_contract.py
@@ -51,6 +51,16 @@ def _to_canonical(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "decision": block.get("decision"),
                 }
             )
+        elif btype == "question_request":
+            canonical.append(
+                {
+                    "kind": "question_request",
+                    "request_id": block.get("request_id"),
+                    "questions": block.get("questions") or [],
+                    "answered": bool(block.get("answered")),
+                    "answers": block.get("answers") or [],
+                }
+            )
         else:
             kind = "text" if btype == "main_text" else str(btype or "")
             text = str(block.get("text") or "")

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -21,6 +21,8 @@ class _RecordingWriter:
     def __init__(self):
         self.requests = []
         self.decisions = []
+        self.question_requests = []
+        self.question_answers = []
 
     def append_permission_request(self, **kwargs):
         self.requests.append(kwargs)
@@ -28,13 +30,23 @@ class _RecordingWriter:
     def append_permission_decision(self, **kwargs):
         self.decisions.append(kwargs)
 
+    def append_question_request(self, **kwargs):
+        self.question_requests.append(kwargs)
+
+    def append_question_answer(self, **kwargs):
+        self.question_answers.append(kwargs)
+
 
 class _RecordingStore:
     def __init__(self):
         self.statuses = []
+        self.question_answer_records = []
 
     def set_task_status(self, task_id, status):
         self.statuses.append(status)
+
+    def append_question_answer_record(self, **kwargs):
+        self.question_answer_records.append(kwargs)
 
 
 def _build_gate(monkeypatch, decision, *, mode="default"):
@@ -99,6 +111,64 @@ def test_can_use_tool_timeout_denies(monkeypatch):
     result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
     assert _permission_behavior(result) == "deny"
     assert writer.decisions[0]["decision"] == "timeout"
+
+
+def _build_ask_gate(monkeypatch, answers, *, mode="default"):
+    writer = _RecordingWriter()
+    store = _RecordingStore()
+
+    async def fake_answer(task_id, request_id, *, timeout_seconds, is_cancel_requested=None, **kw):
+        return answers
+
+    monkeypatch.setattr(task_executor, "wait_for_answer", fake_answer)
+    cb = task_executor._build_can_use_tool_callback(
+        sdk_writer=writer,
+        store=store,
+        task_id="task-1",
+        permission_mode=mode,
+        wait_seconds=5,
+        is_cancel_requested=None,
+    )
+    return cb, writer, store
+
+
+def _updated_input(result):
+    if isinstance(result, dict):
+        return result.get("updatedInput") or result.get("updated_input")
+    return getattr(result, "updated_input", None)
+
+
+@pytest.mark.parametrize("mode", ["default", "plan", "bypassPermissions", "acceptEdits"])
+def test_can_use_tool_ask_user_question_answers_in_any_mode(monkeypatch, mode):
+    # AskUserQuestion is intercepted regardless of session mode (matching the
+    # official behavior of asking even under plan / bypassPermissions). The user's
+    # selection is mapped onto updated_input.answers so the built-in tool resumes.
+    answers = [{"question": "按哪个维度统计?", "selected": ["按天"], "other": "含节假日"}]
+    cb, writer, store = _build_ask_gate(monkeypatch, answers, mode=mode)
+    questions = [{"question": "按哪个维度统计?", "header": "维度", "options": [{"label": "按天"}]}]
+
+    result = asyncio.run(cb("AskUserQuestion", {"questions": questions}, SimpleNamespace(tool_use_id="tu-9")))
+
+    assert _permission_behavior(result) == "allow"
+    updated = _updated_input(result)
+    assert updated["answers"] == {"按哪个维度统计?": "按天"}
+    assert updated["annotations"] == {"按哪个维度统计?": {"notes": "含节假日"}}
+    assert writer.question_requests[0]["request_id"] == "tu-9"
+    assert store.question_answer_records[0]["answers"] == answers
+    assert store.statuses == ["waiting_input", "running"]
+
+
+def test_can_use_tool_ask_user_question_no_answer_returns_questions_only(monkeypatch):
+    # Timeout / cancellation yields no answers; returning only questions lets the
+    # built-in tool produce its own "did not answer" result and continue.
+    cb, writer, store = _build_ask_gate(monkeypatch, [])
+    questions = [{"question": "按哪个维度统计?", "header": "维度", "options": [{"label": "按天"}]}]
+
+    result = asyncio.run(cb("AskUserQuestion", {"questions": questions}, SimpleNamespace(tool_use_id="tu-1")))
+
+    assert _permission_behavior(result) == "allow"
+    assert _updated_input(result) == {"questions": questions}
+    assert store.statuses == ["waiting_input", "running"]
 
 
 def test_can_use_tool_plan_denies_writes_without_request(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -237,6 +237,18 @@ async def _collect_async_prompt(prompt):
     return [item async for item in prompt]
 
 
+def _prompt_text(prompt):
+    """Prompt text regardless of plain-string or streamed (can_use_tool) form.
+
+    With AskUserQuestion enabled the SDK runs in streaming-input mode, so the
+    prompt is an async generator of user-message dicts rather than a raw string.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    items = asyncio.run(_collect_async_prompt(prompt))
+    return "".join(str((item.get("message") or {}).get("content") or "") for item in items)
+
+
 def _build_input(*, history=None, resume_session_id=None, agent_snapshot=None, permission_mode=None):
     return task_executor.TaskExecutionInput(
         task_id="task-1",
@@ -452,7 +464,7 @@ def test_execute_task_stream_applies_agent_snapshot_runtime_overrides(monkeypatc
     assert captured["kwargs"]["allow_empty"] is True
     assert ClaudeAgentOptions.last_kwargs["cwd"] == str(topic_workspace)
     assert ClaudeAgentOptions.last_kwargs["skills"] == []
-    assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read"]
+    assert ClaudeAgentOptions.last_kwargs["allowed_tools"] == ["Read", "AskUserQuestion"]
     assert ClaudeAgentOptions.last_kwargs["mcp_servers"] == {}
     assert ClaudeAgentOptions.last_kwargs["max_turns"] == 7
     # Permission mode resolves through the runtime helper (root vs non-root differ);
@@ -1086,7 +1098,7 @@ def test_execute_task_stream_resumes_sdk_session_without_replaying_history(monke
 
     result = asyncio.run(_run())
 
-    assert QueryCapture.last_prompt == "最近 30 天工作流发布次数趋势"
+    assert _prompt_text(QueryCapture.last_prompt) == "最近 30 天工作流发布次数趋势"
     assert ClaudeAgentOptions.last_kwargs["resume"] == "sdk-session-continued"
     assert result.session_id == "sdk-session-continued"
 
@@ -1346,8 +1358,9 @@ def test_execute_task_stream_recovers_thinking_only_empty_finish_once(monkeypatc
     assert result.content == "恢复后的回答"
     assert len(QueryCapture.calls) == 2
     assert QueryCapture.calls[1]["options"].kwargs["resume"] == "sdk-empty-1"
-    assert "上一轮已经以 end_turn 结束" in QueryCapture.calls[1]["prompt"]
-    assert "最近 30 天工作流发布次数趋势" in QueryCapture.calls[1]["prompt"]
+    _recovery_prompt = _prompt_text(QueryCapture.calls[1]["prompt"])
+    assert "上一轮已经以 end_turn 结束" in _recovery_prompt
+    assert "最近 30 天工作流发布次数趋势" in _recovery_prompt
 
 
 def test_execute_task_stream_marks_empty_finish_as_error_after_recovery_still_empty(monkeypatch, tmp_path: Path):

--- a/dataagent/dataagent-frontend/src/api/nl2sql.js
+++ b/dataagent/dataagent-frontend/src/api/nl2sql.js
@@ -204,6 +204,12 @@ export function createNl2SqlApiClient(options = {}) {
         note,
       })
     },
+    submitQuestionAnswer(taskId, requestId, answers = []) {
+      return runtimeRequest.post(`/tasks/${taskId}/question-answer`, {
+        request_id: requestId,
+        answers,
+      })
+    },
     async streamSdkEvents(taskId, options = {}) {
       const { onRecord, signal, afterId = 0 } = options
       const response = await fetch(

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -224,6 +224,14 @@
                         @decide="(payload) => handlePermissionDecision(msg, payload)"
                       />
 
+                      <!-- AskUserQuestion selection card -->
+                      <QuestionSelectionCard
+                        v-else-if="block.type === 'question_request'"
+                        :block="block"
+                        :disabled="msg._v2state.status !== 'streaming'"
+                        @answer="(payload) => handleQuestionAnswer(msg, payload)"
+                      />
+
                       <!-- Text block (inline chart_spec rendered as a real chart) -->
                       <div v-else-if="block.type === 'text' && block.content" class="v2-text-block">
                         <template v-for="(seg, si) in answerSegments(block.content)" :key="si">
@@ -522,6 +530,7 @@ import { dataagentApi } from '@/api/dataagent'
 import ToolOutputRenderer from './ToolOutputRenderer.vue'
 import ChartSpecView from './ChartSpecView.vue'
 import PermissionConfirmationCard from './PermissionConfirmationCard.vue'
+import QuestionSelectionCard from './QuestionSelectionCard.vue'
 import { blockToToolProp } from './v2StreamParser'
 import { splitChartSpecText, stripChartSpecsFromText } from './chartSpec'
 import { topicStatusKind } from './topicStatus'
@@ -1107,6 +1116,25 @@ async function handlePermissionDecision(msg, payload) {
     )
     if (block && block.decision === 'pending') {
       block.summary = (block.summary || '') + '\n[提交失败，请重试]'
+      block._submitFailed = Date.now()
+    }
+  }
+}
+
+// AskUserQuestion: post the user's selection for a run paused in waiting_input.
+// The streamed question_answer record reconciles the card into its answered state.
+async function handleQuestionAnswer(msg, payload) {
+  const taskId = String(msg?.task_id || activeTaskId.value || '').trim()
+  const requestId = String(payload?.requestId || '').trim()
+  const answers = Array.isArray(payload?.answers) ? payload.answers : []
+  if (!taskId || !requestId) return
+  try {
+    await api.taskApi.submitQuestionAnswer(taskId, requestId, answers)
+  } catch (err) {
+    const block = (msg?._v2state?.blocks || []).find(
+      (b) => b.type === 'question_request' && b.requestId === requestId,
+    )
+    if (block && !block.answered) {
       block._submitFailed = Date.now()
     }
   }

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -86,6 +86,8 @@
               <el-radio-group v-model="filterStatus" size="small" class="v2-filter-radios">
                 <el-radio label="">全部</el-radio>
                 <el-radio label="running">进行中</el-radio>
+                <el-radio label="awaiting">待输入</el-radio>
+                <el-radio label="awaiting_permission">待确认</el-radio>
                 <el-radio label="error">失败</el-radio>
                 <el-radio label="suspended">已取消</el-radio>
                 <el-radio label="finished">完成</el-radio>
@@ -124,6 +126,7 @@
             </span>
             <span v-else class="v2-session-meta">
               <span v-if="topicBadgeKind(topic) === 'awaiting'" class="v2-session-await" title="等待你的选择">待输入</span>
+              <span v-else-if="topicBadgeKind(topic) === 'awaiting_permission'" class="v2-session-await is-permission" title="等待你的确认">待确认</span>
               <span v-else-if="topicBadgeKind(topic) === 'error'" class="v2-session-dot is-error" title="执行失败" />
               <span v-else-if="topicBadgeKind(topic) === 'suspended'" class="v2-session-dot is-suspended" title="已取消" />
               {{ formatTime(topic.updated_at || topic.created_at) }}
@@ -616,7 +619,14 @@ const targetMessageId = ref('')
 // ── Computed ─────────────────────────────────────────────────────────────────
 // Status filter values map to topicStatusKind(): '' (finished/none) is the
 // terminal-success bucket, the rest mirror the badge kinds.
-const STATUS_FILTER_KIND = { running: 'running', error: 'error', suspended: 'suspended', finished: '' }
+const STATUS_FILTER_KIND = {
+  running: 'running',
+  awaiting: 'awaiting',
+  awaiting_permission: 'awaiting_permission',
+  error: 'error',
+  suspended: 'suspended',
+  finished: '',
+}
 
 const filteredTopics = computed(() => {
   const kw = searchKeyword.value.trim().toLowerCase()
@@ -1731,6 +1741,7 @@ onBeforeUnmount(() => {
   background: #e6f0ff;
   vertical-align: middle;
 }
+.v2-session-await.is-permission { color: #b9770e; background: #fdf1dd; }
 
 .v2-session-loading {
   display: inline-flex;

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -212,7 +212,7 @@
                       </div>
 
                       <!-- Tool use block (chart-producing tools render their chart directly below the block) -->
-                      <div v-else-if="block.type === 'tool_use'" class="v2-tool-row">
+                      <div v-else-if="block.type === 'tool_use' && !isAskUserQuestionBlock(block)" class="v2-tool-row">
                         <ToolOutputRenderer :tool="blockToToolProp(block)" :file-url-resolver="resolveWorkspaceFileHref" />
                       </div>
 
@@ -1119,6 +1119,13 @@ async function handlePermissionDecision(msg, payload) {
       block._submitFailed = Date.now()
     }
   }
+}
+
+// The built-in AskUserQuestion tool_use streams as its own block, but it is
+// rendered as the QuestionSelectionCard (driven by the question_request record),
+// so the raw tool block is suppressed to avoid a duplicate.
+function isAskUserQuestionBlock(block) {
+  return String(block?.name || '') === 'AskUserQuestion'
 }
 
 // AskUserQuestion: post the user's selection for a run paused in waiting_input.

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -123,7 +123,8 @@
               </svg>
             </span>
             <span v-else class="v2-session-meta">
-              <span v-if="topicBadgeKind(topic) === 'error'" class="v2-session-dot is-error" title="执行失败" />
+              <span v-if="topicBadgeKind(topic) === 'awaiting'" class="v2-session-await" title="等待你的选择">待输入</span>
+              <span v-else-if="topicBadgeKind(topic) === 'error'" class="v2-session-dot is-error" title="执行失败" />
               <span v-else-if="topicBadgeKind(topic) === 'suspended'" class="v2-session-dot is-suspended" title="已取消" />
               {{ formatTime(topic.updated_at || topic.created_at) }}
             </span>
@@ -1719,6 +1720,17 @@ onBeforeUnmount(() => {
 .v2-session-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 5px; vertical-align: middle; }
 .v2-session-dot.is-error { background: #F56C6C; }
 .v2-session-dot.is-suspended { background: #A0AABF; }
+.v2-session-await {
+  display: inline-block;
+  margin-right: 5px;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 11px;
+  line-height: 16px;
+  color: #2f7bf0;
+  background: #e6f0ff;
+  vertical-align: middle;
+}
 
 .v2-session-loading {
   display: inline-flex;

--- a/dataagent/dataagent-frontend/src/views/intelligence/QuestionSelectionCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/QuestionSelectionCard.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="v2-q-card">
+    <div class="v2-q-head">
+      <span class="v2-q-badge">请选择</span>
+      <span class="v2-q-title">助手需要你确认以下问题</span>
+    </div>
+
+    <div v-for="(q, qi) in questions" :key="qi" class="v2-q-item">
+      <div class="v2-q-row">
+        <span v-if="q.header" class="v2-q-tag">{{ q.header }}</span>
+        <span class="v2-q-question">{{ q.question }}</span>
+        <span v-if="q.multiSelect" class="v2-q-multi">可多选</span>
+      </div>
+
+      <div class="v2-q-options">
+        <button
+          v-for="(opt, oi) in normalizedOptions(q)"
+          :key="oi"
+          type="button"
+          class="v2-q-opt"
+          :class="{ 'is-selected': isSelected(qi, opt.label) }"
+          :disabled="!editable"
+          :title="opt.description || ''"
+          @click="toggle(qi, opt.label, q.multiSelect)"
+        >
+          <span class="v2-q-opt-mark" :class="{ multi: q.multiSelect }"></span>
+          <span class="v2-q-opt-body">
+            <span class="v2-q-opt-label">{{ opt.label }}</span>
+            <span v-if="opt.description" class="v2-q-opt-desc">{{ opt.description }}</span>
+          </span>
+        </button>
+      </div>
+
+      <input
+        v-model="otherText[qi]"
+        class="v2-q-other"
+        type="text"
+        :disabled="!editable"
+        placeholder="其他(可自由填写)…"
+        @focus="editable && (otherActive[qi] = true)"
+      />
+    </div>
+
+    <div v-if="editable" class="v2-q-actions">
+      <button type="button" class="v2-q-submit" :disabled="disabled || submitting || !hasAnySelection" @click="submit">
+        提交选择
+      </button>
+    </div>
+    <div v-else class="v2-q-result">{{ resultLabel }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive, ref } from 'vue'
+
+const props = defineProps({
+  block: { type: Object, required: true },
+  disabled: { type: Boolean, default: false },
+})
+const emit = defineEmits(['answer'])
+
+const submitting = ref(false)
+const selections = reactive({}) // qi -> Set of labels
+const otherText = reactive({}) // qi -> string
+const otherActive = reactive({}) // qi -> bool
+
+const questions = computed(() => (Array.isArray(props.block.questions) ? props.block.questions : []))
+const answered = computed(() => Boolean(props.block.answered))
+const editable = computed(() => !answered.value && !props.disabled)
+
+const normalizedOptions = (q) => {
+  const opts = Array.isArray(q?.options) ? q.options : []
+  return opts
+    .map((o) => (typeof o === 'string' ? { label: o, description: '' } : { label: String(o?.label ?? ''), description: String(o?.description ?? '') }))
+    .filter((o) => o.label)
+}
+
+const selectedSet = (qi) => {
+  if (!selections[qi]) selections[qi] = new Set()
+  return selections[qi]
+}
+const isSelected = (qi, label) => selectedSet(qi).has(label)
+
+function toggle(qi, label, multiSelect) {
+  if (!editable.value) return
+  const set = selectedSet(qi)
+  if (multiSelect) {
+    if (set.has(label)) set.delete(label)
+    else set.add(label)
+  } else {
+    set.clear()
+    set.add(label)
+  }
+}
+
+const hasAnySelection = computed(() =>
+  questions.value.some((_, qi) => selectedSet(qi).size > 0 || String(otherText[qi] || '').trim())
+)
+
+function buildAnswers() {
+  return questions.value.map((q, qi) => ({
+    header: String(q?.header || ''),
+    question: String(q?.question || ''),
+    selected: Array.from(selectedSet(qi)),
+    other: String(otherText[qi] || '').trim(),
+  }))
+}
+
+function submit() {
+  if (!editable.value || submitting.value || !hasAnySelection.value) return
+  submitting.value = true
+  emit('answer', { requestId: props.block.requestId, answers: buildAnswers() })
+}
+
+const resultLabel = computed(() => {
+  const answers = Array.isArray(props.block.answers) ? props.block.answers : []
+  if (!answers.length) return answered.value ? '✓ 已提交' : ''
+  const parts = answers.map((a) => {
+    const picks = [...(Array.isArray(a.selected) ? a.selected : [])]
+    if (String(a.other || '').trim()) picks.push(`其他:${String(a.other).trim()}`)
+    return `${a.header || a.question || ''}:${picks.length ? picks.join('、') : '(未选择)'}`
+  })
+  return `✓ 已提交 — ${parts.join(' ; ')}`
+})
+</script>
+
+<style scoped>
+.v2-q-card {
+  border: 1px solid #b6d4fe;
+  border-radius: 10px;
+  background: #f5f9ff;
+  padding: 12px 14px;
+  margin: 8px 0;
+}
+.v2-q-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.v2-q-badge { font-size: 12px; font-weight: 600; color: #fff; background: #2f7bf0; border-radius: 4px; padding: 1px 8px; }
+.v2-q-title { font-weight: 600; font-size: 14px; }
+.v2-q-item { padding: 8px 0; border-top: 1px dashed #d6e4ff; }
+.v2-q-item:first-of-type { border-top: none; }
+.v2-q-row { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin-bottom: 6px; }
+.v2-q-tag { font-size: 12px; font-weight: 600; color: #2f7bf0; background: #e6f0ff; border-radius: 4px; padding: 1px 7px; }
+.v2-q-question { font-size: 13px; color: #333; }
+.v2-q-multi { font-size: 11px; color: #888; }
+.v2-q-options { display: flex; flex-direction: column; gap: 6px; }
+.v2-q-opt {
+  display: flex; align-items: flex-start; gap: 8px; text-align: left;
+  border: 1px solid #d6e4ff; border-radius: 8px; background: #fff;
+  padding: 7px 10px; cursor: pointer; font-size: 13px;
+}
+.v2-q-opt:hover:not(:disabled) { border-color: #2f7bf0; }
+.v2-q-opt.is-selected { border-color: #2f7bf0; background: #eaf2ff; }
+.v2-q-opt:disabled { cursor: default; opacity: 0.85; }
+.v2-q-opt-mark { width: 14px; height: 14px; border: 1.5px solid #9bbcf0; border-radius: 50%; margin-top: 2px; flex: 0 0 auto; }
+.v2-q-opt-mark.multi { border-radius: 4px; }
+.v2-q-opt.is-selected .v2-q-opt-mark { background: #2f7bf0; border-color: #2f7bf0; box-shadow: inset 0 0 0 2px #fff; }
+.v2-q-opt-body { display: flex; flex-direction: column; gap: 2px; }
+.v2-q-opt-label { font-weight: 500; color: #222; }
+.v2-q-opt-desc { font-size: 12px; color: #888; }
+.v2-q-other {
+  margin-top: 6px; width: 100%; box-sizing: border-box;
+  border: 1px solid #d6e4ff; border-radius: 8px; padding: 6px 10px; font-size: 13px; background: #fff;
+}
+.v2-q-other:disabled { background: #f4f7fb; }
+.v2-q-actions { display: flex; justify-content: flex-end; margin-top: 10px; }
+.v2-q-submit { border: none; border-radius: 6px; padding: 6px 18px; font-size: 13px; cursor: pointer; background: #2f7bf0; color: #fff; }
+.v2-q-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+.v2-q-result { margin-top: 8px; font-size: 13px; font-weight: 600; color: #2c9c5a; white-space: pre-wrap; }
+</style>

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/sdkBlockProjection.contract.spec.js
@@ -31,6 +31,14 @@ function toCanonical(blocks) {
         summary: block.summary ?? null,
         decision: block.decision ?? null,
       })
+    } else if (block.type === 'question_request') {
+      canonical.push({
+        kind: 'question_request',
+        request_id: block.requestId ?? null,
+        questions: block.questions ?? [],
+        answered: Boolean(block.answered),
+        answers: block.answers ?? [],
+      })
     } else {
       const text = String(block.content ?? '')
       if (!text.trim()) continue

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
@@ -7,14 +7,16 @@ describe('topicStatusKind', () => {
     expect(topicStatusKind('running')).toBe('running')
   })
 
-  it('gives waiting_input its own awaiting kind, others stay in-progress', () => {
+  it('gives waiting_input and waiting_permission their own awaiting kinds', () => {
     expect(topicStatusKind('waiting_input')).toBe('awaiting')
-    expect(topicStatusKind('waiting_permission')).toBe('running')
+    expect(topicStatusKind('waiting_permission')).toBe('awaiting_permission')
+    expect(topicStatusKind('waiting_other')).toBe('running')
   })
 
-  it('treats running and awaiting as active (keep streaming)', () => {
+  it('treats running and both awaiting kinds as active (keep streaming)', () => {
     expect(isActiveStatusKind('running')).toBe(true)
     expect(isActiveStatusKind('awaiting')).toBe(true)
+    expect(isActiveStatusKind('awaiting_permission')).toBe(true)
     expect(isActiveStatusKind('error')).toBe(false)
     expect(isActiveStatusKind('')).toBe(false)
   })

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
@@ -7,6 +7,11 @@ describe('topicStatusKind', () => {
     expect(topicStatusKind('running')).toBe('running')
   })
 
+  it('treats parked-but-active waiting_* statuses as in-progress', () => {
+    expect(topicStatusKind('waiting_permission')).toBe('running')
+    expect(topicStatusKind('waiting_input')).toBe('running')
+  })
+
   it('maps terminal failure/cancel to their own kinds', () => {
     expect(topicStatusKind('error')).toBe('error')
     expect(topicStatusKind('suspended')).toBe('suspended')

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/topicStatus.spec.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { topicStatusKind } from '../topicStatus'
+import { topicStatusKind, isActiveStatusKind } from '../topicStatus'
 
 describe('topicStatusKind', () => {
   it('maps in-progress statuses to running', () => {
@@ -7,9 +7,16 @@ describe('topicStatusKind', () => {
     expect(topicStatusKind('running')).toBe('running')
   })
 
-  it('treats parked-but-active waiting_* statuses as in-progress', () => {
+  it('gives waiting_input its own awaiting kind, others stay in-progress', () => {
+    expect(topicStatusKind('waiting_input')).toBe('awaiting')
     expect(topicStatusKind('waiting_permission')).toBe('running')
-    expect(topicStatusKind('waiting_input')).toBe('running')
+  })
+
+  it('treats running and awaiting as active (keep streaming)', () => {
+    expect(isActiveStatusKind('running')).toBe(true)
+    expect(isActiveStatusKind('awaiting')).toBe(true)
+    expect(isActiveStatusKind('error')).toBe(false)
+    expect(isActiveStatusKind('')).toBe(false)
   })
 
   it('maps terminal failure/cancel to their own kinds', () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/v2StreamParser.spec.js
@@ -183,6 +183,48 @@ describe('processV2Record — terminal records', () => {
   })
 })
 
+describe('processV2Record — ask_user_question', () => {
+  const questions = [
+    { question: '按哪个维度统计?', header: '维度', multiSelect: false, options: [{ label: '按天' }, { label: '按周' }] },
+  ]
+
+  it('question_request appends a question_request block shared with the turn', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      { record_type: 'question_request', data: { request_id: 'q1', questions } },
+    ])
+    const block = state.blocks.find((b) => b.type === 'question_request')
+    expect(block).toBeTruthy()
+    expect(block.requestId).toBe('q1')
+    expect(block.questions).toEqual(questions)
+    expect(block.answered).toBe(false)
+    expect(state.turns.at(-1).blocks).toContain(block)
+  })
+
+  it('question_answer reconciles the matching block into its answered state', () => {
+    const answers = [{ header: '维度', question: '按哪个维度统计?', selected: ['按天'], other: '' }]
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      { record_type: 'question_request', data: { request_id: 'q1', questions } },
+      { record_type: 'question_answer', data: { request_id: 'q1', answers, answered_at: '2026-06-15T00:00:00Z' } },
+    ])
+    const block = state.blocks.find((b) => b.type === 'question_request')
+    expect(block.answered).toBe(true)
+    expect(block.answers).toEqual(answers)
+    expect(block.answered_at).toBe('2026-06-15T00:00:00Z')
+  })
+
+  it('question_answer for an unknown request_id is ignored', () => {
+    const state = feed(createChatState(), [
+      stream({ type: 'message_start' }),
+      { record_type: 'question_request', data: { request_id: 'q1', questions } },
+      { record_type: 'question_answer', data: { request_id: 'other', answers: [{}] } },
+    ])
+    const block = state.blocks.find((b) => b.type === 'question_request')
+    expect(block.answered).toBe(false)
+  })
+})
+
 describe('blockToToolProp', () => {
   const baseBlock = (over) => ({
     type: 'tool_use',

--- a/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
@@ -3,17 +3,22 @@
  * mirrored from da_agent_task.task_status) to a UI badge kind for the session /
  * conversation record list.
  *
- *   waiting | running  -> 'running'    (in-progress; shown as the loading spinner)
+ *   waiting | waiting_* | running -> 'running'  (in-progress; loading spinner)
  *   error              -> 'error'      (failed; red dot)
  *   suspended          -> 'suspended'  (cancelled; grey dot)
  *   finished | (none)  -> ''           (no badge; timestamp only)
+ *
+ * The ``waiting_*`` family (``waiting_permission`` while a write awaits
+ * confirmation, ``waiting_input`` while an AskUserQuestion awaits the user's
+ * selection) is a parked-but-active run: it must read as in-progress so the
+ * spinner shows and callers keep the stream/polling alive.
  *
  * Returns '' for any unknown / terminal-success value so callers can treat the
  * empty string as "render nothing extra".
  */
 export function topicStatusKind(currentTaskStatus) {
   const status = String(currentTaskStatus || '').trim()
-  if (status === 'waiting' || status === 'running') return 'running'
+  if (status === 'running' || status === 'waiting' || status.startsWith('waiting_')) return 'running'
   if (status === 'error') return 'error'
   if (status === 'suspended') return 'suspended'
   return ''

--- a/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
@@ -3,16 +3,17 @@
  * mirrored from da_agent_task.task_status) to a UI badge kind for the session /
  * conversation record list.
  *
- *   waiting_input      -> 'awaiting'   (parked: AskUserQuestion needs the user)
- *   waiting | waiting_* | running -> 'running'  (in-progress; loading spinner)
+ *   waiting_input      -> 'awaiting'             (parked: AskUserQuestion needs the user)
+ *   waiting_permission -> 'awaiting_permission'  (parked: a write awaits confirmation)
+ *   waiting | waiting_* | running -> 'running'   (in-progress; loading spinner)
  *   error              -> 'error'      (failed; red dot)
  *   suspended          -> 'suspended'  (cancelled; grey dot)
  *   finished | (none)  -> ''           (no badge; timestamp only)
  *
- * ``waiting_input`` is a parked-but-active run blocked on the user's selection,
- * so it gets its own 'awaiting' kind (distinct "待输入" badge, not the spinner).
- * Other ``waiting_*`` states (e.g. ``waiting_permission``) read as in-progress.
- * Both still count as active so callers keep the stream/polling alive.
+ * ``waiting_input`` / ``waiting_permission`` are parked-but-active runs blocked
+ * on the user, so each gets its own kind (distinct "待输入" / "待确认" badge, not
+ * the spinner). Other ``waiting_*`` states read as in-progress. All count as
+ * active so callers keep the stream/polling alive.
  *
  * Returns '' for any unknown / terminal-success value so callers can treat the
  * empty string as "render nothing extra".
@@ -20,6 +21,7 @@
 export function topicStatusKind(currentTaskStatus) {
   const status = String(currentTaskStatus || '').trim()
   if (status === 'waiting_input') return 'awaiting'
+  if (status === 'waiting_permission') return 'awaiting_permission'
   if (status === 'running' || status === 'waiting' || status.startsWith('waiting_')) return 'running'
   if (status === 'error') return 'error'
   if (status === 'suspended') return 'suspended'
@@ -28,5 +30,5 @@ export function topicStatusKind(currentTaskStatus) {
 
 /** Kinds that represent a live run; callers keep streaming/polling for these. */
 export function isActiveStatusKind(kind) {
-  return kind === 'running' || kind === 'awaiting'
+  return kind === 'running' || kind === 'awaiting' || kind === 'awaiting_permission'
 }

--- a/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/topicStatus.js
@@ -3,23 +3,30 @@
  * mirrored from da_agent_task.task_status) to a UI badge kind for the session /
  * conversation record list.
  *
+ *   waiting_input      -> 'awaiting'   (parked: AskUserQuestion needs the user)
  *   waiting | waiting_* | running -> 'running'  (in-progress; loading spinner)
  *   error              -> 'error'      (failed; red dot)
  *   suspended          -> 'suspended'  (cancelled; grey dot)
  *   finished | (none)  -> ''           (no badge; timestamp only)
  *
- * The ``waiting_*`` family (``waiting_permission`` while a write awaits
- * confirmation, ``waiting_input`` while an AskUserQuestion awaits the user's
- * selection) is a parked-but-active run: it must read as in-progress so the
- * spinner shows and callers keep the stream/polling alive.
+ * ``waiting_input`` is a parked-but-active run blocked on the user's selection,
+ * so it gets its own 'awaiting' kind (distinct "待输入" badge, not the spinner).
+ * Other ``waiting_*`` states (e.g. ``waiting_permission``) read as in-progress.
+ * Both still count as active so callers keep the stream/polling alive.
  *
  * Returns '' for any unknown / terminal-success value so callers can treat the
  * empty string as "render nothing extra".
  */
 export function topicStatusKind(currentTaskStatus) {
   const status = String(currentTaskStatus || '').trim()
+  if (status === 'waiting_input') return 'awaiting'
   if (status === 'running' || status === 'waiting' || status.startsWith('waiting_')) return 'running'
   if (status === 'error') return 'error'
   if (status === 'suspended') return 'suspended'
   return ''
+}
+
+/** Kinds that represent a live run; callers keep streaming/polling for these. */
+export function isActiveStatusKind(kind) {
+  return kind === 'running' || kind === 'awaiting'
 }

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -12,7 +12,7 @@
 // and write the exposed `topics` ref directly.
 
 import { computed, reactive, ref, triggerRef, watch } from 'vue'
-import { topicStatusKind } from './topicStatus'
+import { topicStatusKind, isActiveStatusKind } from './topicStatus'
 import {
   compareTopicsByRecency,
   extractErrorText,
@@ -113,7 +113,9 @@ export function useNl2SqlChat(options) {
     (topic?.topic_id === topicId.value && Boolean(activeTaskId.value)) ||
     topicStatusKind(topic?.current_task_status) === 'running'
   const topicBadgeKind = (topic) => topicStatusKind(topic?.current_task_status)
-  const isTopicTaskActive = (topic) => topicStatusKind(topic?.current_task_status) === 'running'
+  // A run parked at waiting_input ('awaiting') is still live, so it counts as
+  // active — re-selecting the topic must resume its stream to deliver the answer.
+  const isTopicTaskActive = (topic) => isActiveStatusKind(topicStatusKind(topic?.current_task_status))
 
   // Reflect a task's terminal/active status onto its topic so the badge stays
   // accurate without reloading the list.

--- a/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/v2StreamParser.js
@@ -47,6 +47,10 @@ export function processV2Record(state, record) {
     _handlePermissionRequest(state, record.data || {})
   } else if (record.record_type === 'permission_decision') {
     _handlePermissionDecision(state, record.data || {})
+  } else if (record.record_type === 'question_request') {
+    _handleQuestionRequest(state, record.data || {})
+  } else if (record.record_type === 'question_answer') {
+    _handleQuestionAnswer(state, record.data || {})
   } else if (record.record_type === 'done') {
     state.status = (record.data || {}).is_error ? 'error' : 'done'
   } else if (record.record_type === 'error') {
@@ -84,6 +88,33 @@ function _handlePermissionDecision(state, data) {
   block.decision = data.decision || 'pending'
   block.note = data.note || ''
   block.decided_at = data.decided_at || ''
+}
+
+function _handleQuestionRequest(state, data) {
+  const currentTurn = state.turns.at(-1)
+  const block = {
+    turnIndex: currentTurn ? currentTurn.turnIndex : 0,
+    blockIndex: currentTurn ? currentTurn.blocks.length : state.blocks.length,
+    type: 'question_request',
+    content: '',
+    status: 'done',
+    requestId: data.request_id || '',
+    questions: Array.isArray(data.questions) ? data.questions : [],
+    answers: [],
+    answered: false,
+    answered_at: '',
+  }
+  if (currentTurn) currentTurn.blocks.push(block)
+  state.blocks.push(block)
+}
+
+function _handleQuestionAnswer(state, data) {
+  const requestId = data.request_id || ''
+  const block = state.blocks.find((b) => b.type === 'question_request' && b.requestId === requestId)
+  if (!block) return
+  block.answers = Array.isArray(data.answers) ? data.answers : []
+  block.answered = true
+  block.answered_at = data.answered_at || ''
 }
 
 function _handleStreamEvent(state, evt) {

--- a/docs/design/2026-06-15-askuserquestion-rendering-design.md
+++ b/docs/design/2026-06-15-askuserquestion-rendering-design.md
@@ -93,9 +93,9 @@
 - `NL2SqlChatV2.vue`:在 permission 分支旁挂载卡片并提交答案;抑制
   `name=AskUserQuestion` 的原始 tool_use 块,避免与卡片重复渲染。
 - `api/nl2sql.js`:`submitQuestionAnswer(taskId, requestId, answers)`。
-- `topicStatus.js`:`waiting_input` 映射为独立的 `'awaiting'` 徽标(会话列表显示
-  "待输入"),区别于"进行中"转圈;`isActiveStatusKind` 让其仍算活跃,重新进入
-  话题时继续接流。
+- `topicStatus.js`:`waiting_input → 'awaiting'`("待输入")、`waiting_permission →
+  'awaiting_permission'`("待确认"),与"进行中"转圈区分;`isActiveStatusKind` 让两者
+  仍算活跃,重新进入话题时继续接流。会话状态筛选新增"待输入""待确认"两项。
 
 ### 提问引导
 

--- a/docs/design/2026-06-15-askuserquestion-rendering-design.md
+++ b/docs/design/2026-06-15-askuserquestion-rendering-design.md
@@ -28,36 +28,43 @@
 希望 Agent 在需求不清时,能弹出多选/单选问题卡片,用户点选后把选择回填给
 模型继续推理 —— 即"渲染 AskUserQuestion 工具调用,方便用户选择"。
 
-### 为什么不能直接用 SDK 内置 AskUserQuestion
+### SDK 内置 AskUserQuestion 的工作机制
 
-经查 `claude-agent-sdk`(0.2.x):
+经查 `claude-agent-sdk`(0.2.x)随包 CLI,`AskUserQuestion` 是**内置工具**:
 
-- `can_use_tool` 回调只能返回 `PermissionResultAllow(updated_input=...)` 或
-  `PermissionResultDeny(...)`,**无法把"用户的选择"作为 tool_result 回传**。
-- 内置 `AskUserQuestion` 在无头(headless/SDK)模式下依赖 bridge / 交互终端,
-  本部署不具备,允许它执行也拿不到答案。
+- 它的 `checkPermissions` 恒返回 `behavior:"ask"`,且 `requiresUserInteraction()`
+  为真,因此**总是经过 `can_use_tool` 回调**(即使 `bypassPermissions`)。
+- 工具的结果由其**输入上的 `answers` 字段**生成:
+  `call({questions, answers})` 把 `answers` 回显进结果,
+  `mapToolResultToToolResultBlockParam` 将其格式化为 `"问题"="所选项"` 文本喂回模型。
 
-因此采用**自定义进程内 SDK MCP 工具**:由我们自己的处理函数返回用户选择作为
-tool_result,完全可控,且与现有 permission 暂停/恢复机制同构。
+所以宿主答题的正确方式是:在 `can_use_tool` 中返回
+`PermissionResultAllow(updated_input={questions, answers, annotations})`。
+不需要任何自定义工具 —— 直接复用本仓库已有的 `can_use_tool` 链路即可。
 
 ## 方案
 
-新增一个进程内 SDK MCP 工具 `ask_user_question`(限定名
-`mcp__ask_user__ask_user_question`)。模型调用它时:
+启用内置 `AskUserQuestion`(加入 `allowed_tools`),并在 `can_use_tool` 回调里
+拦截它:
 
-1. 处理函数生成 `request_id`,把问题(`questions`)写入 `question_request` SDK 记录,
-   前端据此渲染选择卡片。
-2. 任务状态置为 `waiting_input`,处理函数在 Redis 上阻塞等待用户作答
-   (复用 permission 的自连接 Redis 轮询方式,带超时与取消)。
+1. 回调以 `tool_use_id` 作为 `request_id`,把问题(`questions`)写入
+   `question_request` SDK 记录,前端据此渲染选择卡片。
+2. 任务状态置为 `waiting_input`,回调在 Redis 上等待用户作答
+   (复用 permission 的自连接 Redis 轮询,带超时与取消)。
 3. 用户在前端选择后,`POST /tasks/{task_id}/question-answer` 把答案写入 Redis。
-4. 处理函数读到答案,落 `question_answer` 记录,状态恢复 `running`,并把答案
-   文本作为 tool_result 返回给模型,**同一次运行内**继续推理。
+4. 回调读到答案,落 `question_answer` 记录,状态恢复 `running`,把答案映射为
+   `updated_input.answers` 并 `PermissionResultAllow` 返回,内置工具据此产出
+   tool_result,**同一次运行内**继续推理。
 
-这样:
+要点:
 
-- 工具调用块本身天然流式下发(`name=mcp__ask_user__ask_user_question`,
-  `input.questions`),前端可直接渲染。
+- 用 `can_use_tool` 回调答题是 SDK 的既定机制,**不引入自定义工具**。
+- 内置工具的 tool_use 块自身也会流式下发(`name=AskUserQuestion`),前端将其
+  抑制,改由 `question_request` 驱动的选择卡片渲染,避免重复。
 - 暂停/恢复语义与 permission 完全一致,复用已验证的基础设施。
+- AskUserQuestion 因 `requiresUserInteraction` 总会把 `ask` 交给 `can_use_tool`,
+  故只需在启用时**安装回调**即可,不改动 SDK 权限模式(`plan`/`bypassPermissions`
+  语义保持不变);非写工具在回调中自动放行,`allowed_tools` 仍是能力边界。
 
 ### 接口
 
@@ -83,20 +90,23 @@ tool_result,完全可控,且与现有 permission 暂停/恢复机制同构。
   生成 `type: 'question_request'` 块。
 - `QuestionSelectionCard.vue`:逐题渲染 header 标签 + 题面 + 选项(单选/多选)+
   "其他"自由文本 + 提交按钮。
-- `NL2SqlChatV2.vue`:在 permission 分支旁挂载卡片并提交答案。
+- `NL2SqlChatV2.vue`:在 permission 分支旁挂载卡片并提交答案;抑制
+  `name=AskUserQuestion` 的原始 tool_use 块,避免与卡片重复渲染。
 - `api/nl2sql.js`:`submitQuestionAnswer(taskId, requestId, answers)`。
 
-### 技能引导
+### 提问引导
 
-`dataagent/.claude/skills/dataagent-nl2sql/SKILL.md` 说明:需求歧义时优先调用
-`mcp__ask_user__ask_user_question`,问题简明、选项互斥、`header ≤ 12` 字。
-工具的启用由运行时按需挂载,保持通用 runtime 技能无关。
+不引入自定义工具,因此引导即内置 `AskUserQuestion` 的既有训练先验:需求歧义、
+存在多种合理理解、或需在若干口径/范围/维度间取舍时调用,问题简明、选项互斥、
+`header ≤ 12` 字。是否启用由 `dataagent_ask_user_question_enabled`(默认开)控制,
+保持通用 runtime 技能无关。
 
 ## 取舍
 
-- 选择"运行内阻塞 + 进程内 MCP 工具",而非"多轮 deliver-message",因为前者
-  对答案回填是确定性的,且复用 permission 机制;后者依赖模型在 tool_result 后
-  恰好停止,不确定。
+- 选择"内置 AskUserQuestion + `can_use_tool` 运行内答题",而非自定义工具或
+  "多轮 deliver-message":前者是 SDK 既定机制、对答案回填是确定性的,且复用
+  permission 暂停/恢复;自定义工具属重复造轮子;多轮方式依赖模型在 tool_result
+  后恰好停止,不确定。
 - 阻塞时长复用 `task_permission_wait_seconds` 上限,避免无界等待。
 - 不改动通用 runtime 的工具语义:工具挂载与引导都走"按需 + 技能"路径。
 

--- a/docs/design/2026-06-15-askuserquestion-rendering-design.md
+++ b/docs/design/2026-06-15-askuserquestion-rendering-design.md
@@ -1,0 +1,109 @@
+# AskUserQuestion 渲染与选择回填设计
+
+- 日期: 2026-06-15
+- 模块: 智能问数(`dataagent/dataagent-backend` + `dataagent/dataagent-frontend`)
+- 变更规模: 中(跨后端 runtime / 持久化 / API 与前端渲染)
+
+## 现状
+
+智能问数采用 Claude Agent SDK 运行,后端把原生 SDK 块事件
+(`content_block_start/delta/stop`、`tool_result`)落库到 `da_agent_sdk_record`,
+前端 `v2StreamParser.js` 重放为消息块,`ToolOutputRenderer.vue` 按工具类型渲染。
+
+仓库已有一套"运行内暂停—渲染卡片—用户操作—回填—恢复"机制,用于写工具的
+权限确认(permission):
+
+- 触发:`core/task_executor.py` 的 `can_use_tool` 回调
+- 等待:`core/permission_wait.py` 轮询 Redis
+- 回填:`POST /tasks/{task_id}/permission-decision` →
+  `task_coordinator.submit_permission_decision` 写 Redis
+- 落库:`permission_request` / `permission_decision` SDK 记录
+- 渲染:`PermissionConfirmationCard.vue`
+
+但目前没有任何让 Agent 主动向用户提问、由用户多选/单选作答的能力。
+`allowed_tools` 仅包含 `Skill/Bash/Read/LS/Glob/Grep` 与按需挂载的 portal MCP 工具。
+
+## 问题
+
+希望 Agent 在需求不清时,能弹出多选/单选问题卡片,用户点选后把选择回填给
+模型继续推理 —— 即"渲染 AskUserQuestion 工具调用,方便用户选择"。
+
+### 为什么不能直接用 SDK 内置 AskUserQuestion
+
+经查 `claude-agent-sdk`(0.2.x):
+
+- `can_use_tool` 回调只能返回 `PermissionResultAllow(updated_input=...)` 或
+  `PermissionResultDeny(...)`,**无法把"用户的选择"作为 tool_result 回传**。
+- 内置 `AskUserQuestion` 在无头(headless/SDK)模式下依赖 bridge / 交互终端,
+  本部署不具备,允许它执行也拿不到答案。
+
+因此采用**自定义进程内 SDK MCP 工具**:由我们自己的处理函数返回用户选择作为
+tool_result,完全可控,且与现有 permission 暂停/恢复机制同构。
+
+## 方案
+
+新增一个进程内 SDK MCP 工具 `ask_user_question`(限定名
+`mcp__ask_user__ask_user_question`)。模型调用它时:
+
+1. 处理函数生成 `request_id`,把问题(`questions`)写入 `question_request` SDK 记录,
+   前端据此渲染选择卡片。
+2. 任务状态置为 `waiting_input`,处理函数在 Redis 上阻塞等待用户作答
+   (复用 permission 的自连接 Redis 轮询方式,带超时与取消)。
+3. 用户在前端选择后,`POST /tasks/{task_id}/question-answer` 把答案写入 Redis。
+4. 处理函数读到答案,落 `question_answer` 记录,状态恢复 `running`,并把答案
+   文本作为 tool_result 返回给模型,**同一次运行内**继续推理。
+
+这样:
+
+- 工具调用块本身天然流式下发(`name=mcp__ask_user__ask_user_question`,
+  `input.questions`),前端可直接渲染。
+- 暂停/恢复语义与 permission 完全一致,复用已验证的基础设施。
+
+### 接口
+
+- 工具输入(模型侧):
+  ```json
+  { "questions": [
+    { "question": "...", "header": "维度(≤12字)", "multiSelect": false,
+      "options": [ { "label": "...", "description": "..." } ] } ] }
+  ```
+- 工具返回(模型侧,tool_result 文本):每个问题的用户选择摘要。
+- 新 SDK 记录:
+  - `question_request` data: `{ request_id, questions }`
+  - `question_answer` data: `{ request_id, answers, answered_at }`
+- 新 HTTP 接口:
+  `POST /api/v1/nl2sql/tasks/{task_id}/question-answer`
+  body `{ request_id, answers: [ { header, question, selected: [..], other: "" } ] }`
+- 新任务状态:`waiting_input`(非终态,沿用 `set_task_status`)。
+- Redis key:`da:task:answer:{task_id}:{request_id}`。
+
+### 前端
+
+- `v2StreamParser.js`:新增 `question_request` / `question_answer` record 处理,
+  生成 `type: 'question_request'` 块。
+- `QuestionSelectionCard.vue`:逐题渲染 header 标签 + 题面 + 选项(单选/多选)+
+  "其他"自由文本 + 提交按钮。
+- `NL2SqlChatV2.vue`:在 permission 分支旁挂载卡片并提交答案。
+- `api/nl2sql.js`:`submitQuestionAnswer(taskId, requestId, answers)`。
+
+### 技能引导
+
+`dataagent/.claude/skills/dataagent-nl2sql/SKILL.md` 说明:需求歧义时优先调用
+`mcp__ask_user__ask_user_question`,问题简明、选项互斥、`header ≤ 12` 字。
+工具的启用由运行时按需挂载,保持通用 runtime 技能无关。
+
+## 取舍
+
+- 选择"运行内阻塞 + 进程内 MCP 工具",而非"多轮 deliver-message",因为前者
+  对答案回填是确定性的,且复用 permission 机制;后者依赖模型在 tool_result 后
+  恰好停止,不确定。
+- 阻塞时长复用 `task_permission_wait_seconds` 上限,避免无界等待。
+- 不改动通用 runtime 的工具语义:工具挂载与引导都走"按需 + 技能"路径。
+
+## 验证
+
+- 前端:`QuestionSelectionCard` 渲染与提交、解析器单测、`vite build`。
+- 后端:`_project_sdk_records` 投影契约单测(纯函数,无需 DB)。
+- 端到端冒烟(需本地 Redis/MySQL/Provider):模型调用工具 → `waiting_input` →
+  前端选择 → 回填 → 运行恢复 → 最终回答落库。受环境限制时,按 AGENTS.md
+  明确说明未跑通的层。

--- a/docs/design/2026-06-15-askuserquestion-rendering-design.md
+++ b/docs/design/2026-06-15-askuserquestion-rendering-design.md
@@ -93,6 +93,9 @@
 - `NL2SqlChatV2.vue`:在 permission 分支旁挂载卡片并提交答案;抑制
   `name=AskUserQuestion` 的原始 tool_use 块,避免与卡片重复渲染。
 - `api/nl2sql.js`:`submitQuestionAnswer(taskId, requestId, answers)`。
+- `topicStatus.js`:`waiting_input` 映射为独立的 `'awaiting'` 徽标(会话列表显示
+  "待输入"),区别于"进行中"转圈;`isActiveStatusKind` 让其仍算活跃,重新进入
+  话题时继续接流。
 
 ### 提问引导
 

--- a/docs/plans/2026-06-15-askuserquestion-rendering-plan.md
+++ b/docs/plans/2026-06-15-askuserquestion-rendering-plan.md
@@ -9,16 +9,18 @@
 
 1. `core/ask_user_question.py`(新增)
    - `ask_question_answer_redis_key(task_id, request_id)`
+   - `is_ask_user_question_tool(name)` / `ASK_USER_QUESTION_TOOL_NAME`
    - `wait_for_answer(task_id, request_id, *, timeout_seconds, ...)`:自连接 Redis
-     轮询,返回答案 JSON 或 `None`(超时/取消)。
-   - `build_ask_user_mcp_server(*, sdk_writer, store, task_id, wait_seconds,
-     is_cancel_requested)`:返回 `(server, tool_qualified_name)`,工具处理函数完成
-     记录/暂停/等待/恢复/返回答案文本。
+     轮询,返回答案列表或 `None`(超时/取消)。
+   - `to_sdk_answer_input(questions, answers)`:把 UI 答案映射为内置工具的
+     `updated_input`(`answers` / `annotations`)。
 2. `core/sdk_block_writer.py`:`append_question_request` / `append_question_answer`。
 3. `core/topic_task_store.py`:投影 `question_request`/`question_answer`;
    `get_pending_question_request_id`;`append_question_answer_record`。
 4. `core/task_coordinator.py`:`submit_question_answer` / `read_question_answer`。
-5. `core/task_executor.py`:构建并挂载 ask_user MCP server,加入 `allowed_tools`。
+5. `core/task_executor.py`:`AskUserQuestion` 加入 `allowed_tools`;在
+   `can_use_tool` 回调中拦截并答题(`_handle_ask_user_question`);启用时安装回调并
+   以 `default` 模式运行。
 6. `models/schemas.py`:`QuestionAnswerRequest` / `QuestionAnswerResponse`。
 7. `api/routes.py`:`POST /{task_id}/question-answer`。
 

--- a/docs/plans/2026-06-15-askuserquestion-rendering-plan.md
+++ b/docs/plans/2026-06-15-askuserquestion-rendering-plan.md
@@ -1,0 +1,47 @@
+# AskUserQuestion 渲染与选择回填实施计划
+
+- 配套设计: `docs/design/2026-06-15-askuserquestion-rendering-design.md`
+- 分支: `claude/askuserquestion-tool-rendering-7jregf`
+
+## 任务
+
+### 后端 (`dataagent/dataagent-backend`)
+
+1. `core/ask_user_question.py`(新增)
+   - `ask_question_answer_redis_key(task_id, request_id)`
+   - `wait_for_answer(task_id, request_id, *, timeout_seconds, ...)`:自连接 Redis
+     轮询,返回答案 JSON 或 `None`(超时/取消)。
+   - `build_ask_user_mcp_server(*, sdk_writer, store, task_id, wait_seconds,
+     is_cancel_requested)`:返回 `(server, tool_qualified_name)`,工具处理函数完成
+     记录/暂停/等待/恢复/返回答案文本。
+2. `core/sdk_block_writer.py`:`append_question_request` / `append_question_answer`。
+3. `core/topic_task_store.py`:投影 `question_request`/`question_answer`;
+   `get_pending_question_request_id`;`append_question_answer_record`。
+4. `core/task_coordinator.py`:`submit_question_answer` / `read_question_answer`。
+5. `core/task_executor.py`:构建并挂载 ask_user MCP server,加入 `allowed_tools`。
+6. `models/schemas.py`:`QuestionAnswerRequest` / `QuestionAnswerResponse`。
+7. `api/routes.py`:`POST /{task_id}/question-answer`。
+
+### 前端 (`dataagent/dataagent-frontend`)
+
+8. `src/views/intelligence/v2StreamParser.js`:`question_request`/`question_answer`。
+9. `src/views/intelligence/QuestionSelectionCard.vue`(新增)。
+10. `src/views/intelligence/NL2SqlChatV2.vue`:模板分支 + `handleQuestionAnswer`。
+11. `src/api/nl2sql.js`:`submitQuestionAnswer`。
+
+### 技能
+
+12. `dataagent/.claude/skills/dataagent-nl2sql/SKILL.md`:提问引导。
+
+## 验证
+
+- `nvm use` 后 `npm --prefix dataagent/dataagent-frontend run build`(或相关单测)。
+- 后端投影契约 `pytest tests/test_sdk_block_projection_contract.py`。
+- 端到端冒烟:本地 Redis+MySQL+Provider 下走一次提问→选择→恢复;若环境不可用,
+  在报告中标明未跑通层。
+
+## 回滚
+
+- 工具默认通过运行时按需挂载;移除挂载即停用,SDK 记录向后兼容(未知 record_type
+  前端忽略)。
+- 涉及文件均为新增分支逻辑,回滚为还原本批提交。


### PR DESCRIPTION
Let the intelligent-query agent surface multiple-choice/single-choice
questions and resume the same run with the user's selection, rendered as
an interactive card in Chat V2.

The SDK built-in AskUserQuestion cannot return the user's choice headlessly
(can_use_tool only allows/denies). So expose an in-process SDK MCP tool
mcp__ask_user__ask_user_question whose handler owns the round-trip,
mirroring the existing permission-confirmation flow:

- records a question_request block (rendered as a selection card)
- parks the task in waiting_input and waits on Redis for the answer
- records question_answer, resumes, and returns the selection as the
  tool result so the run continues with the user's choice

Backend: ask_user_question module (MCP server + Redis answer wait),
sdk_block_writer/topic_task_store/task_coordinator question records,
POST /tasks/{task_id}/question-answer endpoint, and executor wiring.

Frontend: v2StreamParser question_request/question_answer handling,
QuestionSelectionCard.vue, NL2SqlChatV2 wiring, and the API client.

Tests: shared projection golden fixtures + parser regression cases on
both sides. Frontend build/test green; backend projection/routes/executor
suites green. End-to-end agent smoke (Redis+MySQL+provider) not run in
this environment.

https://claude.ai/code/session_01BgARaweBm8LdSxYrDES2Dn