### PR TITLE
feat(dataagent): support recovery for empty completions and tighten eval gates

### DIFF
--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -139,8 +139,11 @@ class SdkResultAccumulator:
         return str(fallback or "").strip()
 
     def preferred_error_code(self) -> str:
-        if self.provider_error_message or self.result_is_error:
-            return str(self.result_subtype or "provider_error")
+        subtype = str(self.result_subtype or "").strip()
+        if self.provider_error_message:
+            return subtype if subtype and subtype != "success" else "provider_error"
+        if self.result_is_error:
+            return subtype if subtype and subtype != "success" else "provider_error"
         return "model_call_failed"
 
     def _append_text(self, block_index: int, piece: str) -> None:
@@ -367,11 +370,10 @@ class SdkResultAccumulator:
             )
             return self._build_format_drift_result(content)
 
-        # A clean run with no visible answer and no tool call is a thinking-only
-        # dead-end — surface it as a retryable error so the chat does not end
-        # silently on an empty answer. When a real tool ran, keep the prior
-        # finished behavior: re-running could repeat a write, so only the no-tool
-        # case is converted here.
+        # A clean run with no visible answer is still an incomplete run. The
+        # no-tool case can be retried once by the caller below; a tool-backed
+        # empty closeout is marked explicitly without an automatic retry because
+        # replaying could repeat a write.
         if not content and not self._saw_tool_use:
             logger.warning(
                 "task.result.empty_completion task_id=%s topic_id=%s provider=%s model=%s saw_stream_event=%s result_subtype=%s session_id_set=%s",
@@ -384,21 +386,32 @@ class SdkResultAccumulator:
                 bool(self.session_id),
             )
             return self._build_empty_completion_result()
+        if not content and self._saw_tool_use:
+            logger.warning(
+                "task.result.incomplete_answer task_id=%s topic_id=%s provider=%s model=%s saw_stream_event=%s result_subtype=%s session_id_set=%s",
+                self.params.task_id,
+                self.params.topic_id,
+                self.provider_id,
+                self.model,
+                self._saw_stream_event,
+                self.result_subtype,
+                bool(self.session_id),
+            )
+            return self._build_incomplete_answer_result()
 
         logger.info(
-            "task.result.finished task_id=%s topic_id=%s provider=%s model=%s content_len=%s saw_tool_use=%s fallback_content=%s session_id_set=%s",
+            "task.result.finished task_id=%s topic_id=%s provider=%s model=%s content_len=%s saw_tool_use=%s session_id_set=%s",
             self.params.task_id,
             self.params.topic_id,
             self.provider_id,
             self.model,
             len(content),
             self._saw_tool_use,
-            not bool(content),
             bool(self.session_id),
         )
         return TaskExecutionResult(
             task_status="finished",
-            content=content or "已完成。",
+            content=content,
             usage=self.usage or None,
             provider_id=self.provider_id,
             model=self.model,
@@ -416,14 +429,12 @@ class SdkResultAccumulator:
     ) -> TaskExecutionResult:
         """Terminate a non-error run that produced no trustworthy final answer.
 
-        Shared closeout for the two ways a clean (success-subtype) run can still
-        dead-end: it leaked pseudo tool-call tags instead of a real call, or it
-        ended with no visible answer at all (typically a thinking-only turn that
-        stopped early). Both must surface as a task error — the live stream only
+        Shared closeout for the ways a clean (success-subtype) run can still
+        dead-end: it leaked pseudo tool-call tags instead of a real call, ended
+        thinking-only with no answer, or invoked tools but never wrote the final
+        response. These must surface as task errors — the live stream only
         carries the raw blocks, so without a terminal error record the chat UI
-        ends the conversation silently with no way to notice the failure or
-        retry. Salvaged clean text / tool-output note is kept in the content for
-        history; the error itself carries the user-facing retry message.
+        cannot distinguish success from an incomplete answer.
         """
         synthetic_blocks: dict[str, dict[str, Any]] = (
             {"tool": {"type": "tool_result", "output": "1"}} if self._saw_tool_use else {}
@@ -454,6 +465,16 @@ class SdkResultAccumulator:
             fallback="模型本次回答因工具调用格式异常未能正常生成，请重试。",
         )
 
+    def _build_incomplete_answer_result(self) -> TaskExecutionResult:
+        """Close out a tool-backed run that never produced final visible text."""
+        return self._build_incomplete_run_result(
+            content="",
+            reason="模型调用工具后未生成最终回答",
+            error_code="incomplete_answer",
+            message="模型本次调用工具后没有给出最终回答，请重试",
+            fallback="模型本次调用工具后没有返回最终回答，请重试。",
+        )
+
     def _build_empty_completion_result(self) -> TaskExecutionResult:
         """Close out a clean run that ended with no visible answer and no tool.
 
@@ -462,8 +483,6 @@ class SdkResultAccumulator:
         back to a silent ``finished`` with "已完成。", so the chat ended on an
         empty answer with no way to retry. Routing it through the shared error
         closeout makes the existing error card and retry button surface instead.
-        Runs that did invoke a tool keep the prior finished behavior — see the
-        ``_saw_tool_use`` guard in ``build_result``.
         """
         return self._build_incomplete_run_result(
             content="",
@@ -1094,42 +1113,33 @@ async def _execute_task_stream_local(
     )
     if _is_empty_completion_result(result):
         recovery_session_id = str(result.session_id or accumulator.session_id or params.resume_session_id or "").strip()
-        if recovery_session_id:
-            recovery_timeout = _empty_completion_recovery_timeout(timeout_seconds)
-            logger.warning(
-                "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s timeout=%s session_id_set=%s",
-                params.task_id,
-                params.topic_id,
-                provider_id,
-                model,
-                recovery_timeout,
-                bool(recovery_session_id),
-            )
-            result = await _run_sdk_turn(
-                turn_prompt=_build_empty_completion_recovery_prompt(params.question),
-                turn_options=_make_options(recovery_session_id),
-                turn_timeout_seconds=recovery_timeout,
-                phase="empty_completion_recovery",
-            )
-            logger.info(
-                "task.empty_completion.recover_result task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s content_len=%s session_id_set=%s",
-                params.task_id,
-                params.topic_id,
-                provider_id,
-                model,
-                result.task_status,
-                str((result.error or {}).get("code") or ""),
-                len(str(result.content or "")),
-                bool(result.session_id),
-            )
-        else:
-            logger.warning(
-                "task.empty_completion.recover_skip task_id=%s topic_id=%s provider=%s model=%s reason=no_session",
-                params.task_id,
-                params.topic_id,
-                provider_id,
-                model,
-            )
+        recovery_timeout = _empty_completion_recovery_timeout(timeout_seconds)
+        logger.warning(
+            "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s timeout=%s session_id_set=%s",
+            params.task_id,
+            params.topic_id,
+            provider_id,
+            model,
+            recovery_timeout,
+            bool(recovery_session_id),
+        )
+        result = await _run_sdk_turn(
+            turn_prompt=_build_empty_completion_recovery_prompt(params.question),
+            turn_options=_make_options(recovery_session_id or None),
+            turn_timeout_seconds=recovery_timeout,
+            phase="empty_completion_recovery",
+        )
+        logger.info(
+            "task.empty_completion.recover_result task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s content_len=%s session_id_set=%s",
+            params.task_id,
+            params.topic_id,
+            provider_id,
+            model,
+            result.task_status,
+            str((result.error or {}).get("code") or ""),
+            len(str(result.content or "")),
+            bool(result.session_id),
+        )
 
     if result.task_status == "error" and not terminal_error_record_written:
         sdk_writer.append_error(

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -1174,6 +1174,44 @@ def test_execute_task_stream_surfaces_provider_error_instead_of_exit_code(monkey
     assert emitted == []
 
 
+def test_execute_task_stream_normalizes_success_subtype_provider_error(monkeypatch, tmp_path: Path):
+    provider_error = "There's an issue with the selected model (deepseek-v4-pro[1m])."
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            AssistantMessage([TextBlock(provider_error)], error=provider_error),
+            ResultMessage("success", None, is_error=False, session_id="sess-1"),
+        ],
+        final_exception=RuntimeError("Command failed with exit code 1"),
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": "anyrouter",
+            "model": "deepseek-v4-pro[1m]",
+            "api_key": "",
+            "auth_token": "token",
+            "base_url": "https://relay.example.invalid",
+            "supports_partial_messages": True,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "error"
+    assert result.content == provider_error
+    assert result.error == {
+        "code": "provider_error",
+        "message": provider_error,
+        "exception_type": "RuntimeError",
+    }
+
+
 def test_execute_task_stream_resumes_sdk_session_without_replaying_history(monkeypatch, tmp_path: Path):
     QueryCapture.last_prompt = None
     QueryCapture.last_options = None
@@ -1476,6 +1514,48 @@ def test_execute_task_stream_recovers_thinking_only_empty_finish_once(monkeypatc
     assert "最近 30 天工作流发布次数趋势" in _recovery_prompt
 
 
+def test_execute_task_stream_recovers_thinking_only_empty_finish_without_session(monkeypatch, tmp_path: Path):
+    _install_fake_sdk_runs(
+        monkeypatch,
+        [
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+                StreamEvent(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "thinking_delta", "thinking": "I should answer, but no text is emitted."},
+                    }
+                ),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success"),
+            ],
+            [
+                StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+                StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "无 session 恢复后的回答"}}),
+                StreamEvent({"type": "content_block_stop", "index": 0}),
+                ResultMessage("success", session_id="sdk-recovered-1"),
+            ],
+        ],
+    )
+    _patch_default_provider(monkeypatch)
+    _patch_skill_runtime(monkeypatch, tmp_path)
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    assert result.error is None
+    assert result.content == "无 session 恢复后的回答"
+    assert len(QueryCapture.calls) == 2
+    assert "resume" not in QueryCapture.calls[1]["options"].kwargs
+    _recovery_prompt = _prompt_text(QueryCapture.calls[1]["prompt"])
+    assert "上一轮已经以 end_turn 结束" in _recovery_prompt
+    assert "最近 30 天工作流发布次数趋势" in _recovery_prompt
+
+
 def test_execute_task_stream_marks_empty_finish_as_error_after_recovery_still_empty(monkeypatch, tmp_path: Path):
     _install_fake_sdk_runs(
         monkeypatch,
@@ -1510,11 +1590,11 @@ def test_execute_task_stream_marks_empty_finish_as_error_after_recovery_still_em
     assert len(QueryCapture.calls) == 2
 
 
-def test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished(monkeypatch, tmp_path: Path):
+def test_execute_task_stream_marks_empty_finish_with_tool_use_as_incomplete_answer(monkeypatch, tmp_path: Path):
     # Tools ran but the model ended the turn with no final text and no leaked
-    # tag. Only the no-tool thinking-only case is converted to an error; a run
-    # that actually invoked a tool keeps the prior finished behavior, because
-    # retrying it could repeat a write. So this stays finished, not empty_completion.
+    # tag. This must not be reported as a successful "已完成。" answer; it is an
+    # incomplete answer error and is not auto-retried because replaying tools
+    # could repeat writes.
     _install_fake_sdk(
         monkeypatch,
         [
@@ -1547,7 +1627,9 @@ def test_execute_task_stream_keeps_empty_finish_with_tool_use_as_finished(monkey
 
     result = asyncio.run(_run())
 
-    assert result.task_status == "finished"
-    assert result.error is None
-    assert result.content == "已完成。"
+    assert result.task_status == "error"
+    assert result.error is not None
+    assert result.error["code"] == "incomplete_answer"
+    assert "最终回答" in result.error["message"]
+    assert result.content != "已完成。"
     assert len(QueryCapture.calls) == 1

--- a/docs/design/2026-06-16-dataagent-empty-completion-eval-gates-design.md
+++ b/docs/design/2026-06-16-dataagent-empty-completion-eval-gates-design.md
@@ -1,0 +1,61 @@
+# DataAgent Empty Completion And Eval Gates Design
+
+## Current State
+
+DataAgent converts a clean model turn with no visible answer and no tool call into an `empty_completion` task error, then attempts one recovery turn when a session id is available. If a tool did run and the model ends with no visible answer, the task currently finishes with the fallback content `已完成。`.
+
+The DeepEval and builtin eval runners also collect automatic rule failures such as missing required SQL fragments, but those failures are only reported as attribution. A case can still pass when the judge score is high and no veto rule is triggered.
+
+Provider-side SDK failures may include a visible provider error message while the SDK result subtype remains `success`. In that mixed terminal state the task status is `error`, but the stored `error.code` can be misleadingly set to `success`.
+
+## Problem
+
+Recent architecture-governance evals showed two failure modes:
+
+- Thinking-only turns can end before any real tool call or visible answer. When no recoverable session is available, the recovery path is skipped.
+- Tool-backed turns can return `finished` with `已完成。`, hiding an incomplete analysis from users and evals.
+- Eval reports can show a passing case with `missing_sql_fragment` or `missing_tool` attribution, making the pass/fail contract inconsistent.
+- Provider failures can persist `task_status=error` with `error.code=success`, making terminal error records harder to diagnose.
+
+## Scope
+
+In scope:
+
+- DataAgent task result classification for empty model turns.
+- Empty-completion recovery fallback when no session id is available.
+- Builtin and DeepEval eval runner auto-rule pass/fail semantics.
+- Provider error code normalization when the SDK supplies a provider error message.
+- Unit tests for the changed contracts.
+
+Out of scope:
+
+- Model/provider tuning.
+- Full architecture-governance smoke reruns against live services.
+- Dataset rubric edits.
+
+## Solution
+
+DataAgent will keep the existing no-tool `empty_completion` behavior, but will attempt the recovery prompt even when no resume session is available. In that case the recovery turn starts without `resume`, which is safe because no tool ran in the failed initial turn.
+
+For tool-backed turns with no visible answer, DataAgent will return a task error with `code=incomplete_answer` instead of `finished` plus `已完成。`. This avoids silently accepting a partial execution. The recovery retry remains limited to no-tool empty completions to avoid repeating tool side effects.
+
+Eval runners will treat missing required SQL fragments and missing expected tool names as automatic rule failures. `case_passed` will require `auto_rule_check.passed=true` in addition to judge score and veto gates.
+
+When a provider error message is present, DataAgent will not reuse a `success` result subtype as the terminal error code. It will normalize that combination to `provider_error` while preserving explicit non-success provider subtypes such as `error_api`.
+
+## Tradeoffs
+
+Marking empty tool-backed turns as errors may surface more failures than before, but those failures already produced unusable answers. This is preferable to persisting misleading successful task states.
+
+Starting recovery without a resume session loses prior hidden reasoning, but the initial turn had no visible answer and no tool call, so there is no execution state to preserve.
+
+## Verification
+
+Targeted unit tests cover:
+
+- no-session empty completion recovery starts a second SDK turn without resume
+- empty completion remains an error if recovery is still empty
+- tool-backed empty final text returns `incomplete_answer`
+- provider error messages with `success` subtype normalize to `provider_error`
+- eval auto rules fail on missing SQL fragments or expected tools
+- eval `case_passed` respects auto-rule failure

--- a/docs/plans/2026-06-16-dataagent-empty-completion-eval-gates-plan.md
+++ b/docs/plans/2026-06-16-dataagent-empty-completion-eval-gates-plan.md
@@ -1,0 +1,35 @@
+# DataAgent Empty Completion And Eval Gates Plan
+
+## Tasks
+
+1. Update DataAgent empty result handling in `dataagent/dataagent-backend/core/task_executor.py`.
+2. Update unit tests in `dataagent/dataagent-backend/tests/test_task_executor.py`.
+3. Normalize provider-error terminal codes when a provider error is paired with a `success` SDK subtype.
+4. Update DeepEval and builtin eval runner auto-rule pass/fail semantics.
+5. Update eval runner tests in `tests/test_dataagent_deepeval_evals.py` and `tests/test_run_dataagent_evals.py`.
+6. Run targeted pytest suites for task executor and eval runners.
+
+## Touched Stacks
+
+- DataAgent backend runtime execution.
+- DataAgent eval tooling.
+
+## Verification Commands
+
+```bash
+cd dataagent/dataagent-backend
+.venv-py313/bin/python -m pytest tests/test_task_executor.py -q
+
+cd /Users/guoruping/project/bigdata/opendataworks
+dataagent/dataagent-backend/.venv-py313/bin/python -m pytest tests/test_dataagent_deepeval_evals.py tests/test_run_dataagent_evals.py -q
+```
+
+If the virtualenv is unavailable, use the repository Python baseline after verifying required imports.
+
+## Rollout
+
+This is a behavior-tightening change. Existing successful tasks with real final text are unaffected. Empty or incomplete model turns become explicit task errors and should be monitored in eval reports. Provider-denied model calls remain task errors, but their stored error code should no longer be `success`.
+
+## Backout
+
+Revert the task result classification, provider-error code normalization, and eval runner pass/fail checks if deployment reveals a caller that intentionally depends on empty `已完成。` task content or `success` error-code compatibility.

--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -171,6 +171,39 @@ def test_deepeval_apply_judges_uses_shared_results_when_metric_is_copied(monkeyp
     assert updated[0]["case_passed"] is True
 
 
+def test_deepeval_apply_judges_fails_when_auto_rule_check_fails(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    runner.DataAgentEvaluationMetric.shared_case_judges = {
+        "ODW_SAMPLE_001": {
+            "score": 9,
+            "dimension_scores": {"intent": 1},
+            "hallucination": False,
+            "veto_rules_triggered": [],
+            "failure_attribution": [],
+            "comment": "ok",
+            "judge_failed": False,
+        }
+    }
+    metric = runner.DataAgentEvaluationMetric(runner.JudgeConfig(base_url="http://judge", token="t", model="m"))
+    result = {
+        "case_id": "ODW_SAMPLE_001",
+        "task_status": "finished",
+        "errors": [],
+        "auto_rule_check": {
+            "passed": False,
+            "triggered_veto_rules": [],
+            "failure_attribution": ["missing_sql_fragment"],
+        },
+    }
+
+    updated = runner._apply_judges([result], metric)
+
+    assert updated[0]["judge"]["score"] == 9
+    assert "missing_sql_fragment" in updated[0]["judge"]["failure_attribution"]
+    assert updated[0]["case_passed"] is False
+
+
 def test_deepeval_agent_id_can_default_from_environment(monkeypatch):
     _install_fake_deepeval(monkeypatch)
     runner = _load_runner()
@@ -474,6 +507,29 @@ def test_deepeval_auto_rule_check_adds_generic_failure_attribution(monkeypatch):
     assert {"sql_only", "wrong_domain", "placeholder_leak", "empty_result"}.issubset(
         set(result["failure_attribution"])
     )
+
+
+def test_deepeval_auto_rule_check_fails_missing_sql_or_tool_requirements(monkeypatch):
+    _install_fake_deepeval(monkeypatch)
+    runner = _load_runner()
+    case = {
+        **_sample_case(),
+        "required_sql_fragments": ["public.dim_tech_env_workflow_df"],
+        "expected_tool_names": ["run_sql"],
+    }
+
+    result = runner.auto_rule_check(
+        case,
+        final_answer="当前 DEV 环境共有 10 个工作流。",
+        blocks=[],
+        sql_outputs=[],
+        tool_names=[],
+    )
+
+    assert result["passed"] is False
+    assert result["missing_sql_fragments"] == ["public.dim_tech_env_workflow_df"]
+    assert result["missing_tool_names"] == ["run_sql"]
+    assert {"missing_sql_fragment", "missing_tool"}.issubset(set(result["failure_attribution"]))
 
 
 def test_deepeval_auto_rule_check_ignores_tool_doc_text_for_user_visible_regexes(monkeypatch):

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -305,6 +305,28 @@ def test_auto_rule_check_adds_generic_failure_attribution():
     )
 
 
+def test_auto_rule_check_fails_missing_sql_or_tool_requirements():
+    runner = _load_runner()
+    case = {
+        **_sample_case(),
+        "required_sql_fragments": ["public.dim_tech_env_workflow_df"],
+        "expected_tool_names": ["run_sql"],
+    }
+
+    result = runner.auto_rule_check(
+        case,
+        final_answer="当前 DEV 环境共有 10 个工作流。",
+        blocks=[],
+        sql_outputs=[],
+        tool_names=[],
+    )
+
+    assert result["passed"] is False
+    assert result["missing_sql_fragments"] == ["public.dim_tech_env_workflow_df"]
+    assert result["missing_tool_names"] == ["run_sql"]
+    assert {"missing_sql_fragment", "missing_tool"}.issubset(set(result["failure_attribution"]))
+
+
 def test_extract_sql_outputs_ignores_reference_text_and_uses_tool_sql():
     runner = _load_runner()
     actual_sql = (
@@ -472,6 +494,59 @@ def test_run_case_submits_turns_in_order(monkeypatch):
     assert result["turns"] == case["turns"]
     assert result["case_passed"] is True
     assert result["errors"] == []
+
+
+def test_run_case_fails_when_auto_rule_check_fails(monkeypatch):
+    runner = _load_runner()
+    case = {
+        **_sample_case(),
+        "required_sql_fragments": ["public.required_table"],
+    }
+
+    def fake_http_json(method, url, payload=None, **kwargs):
+        if url.endswith("/api/v1/nl2sql/topics") and method == "POST":
+            return {"topic_id": "topic_1"}
+        if url.endswith("/api/v1/nl2sql/tasks/deliver-message"):
+            return {"task_id": "task_1", "accepted": True}
+        if url == "http://dataagent/api/v1/nl2sql/tasks/task_1":
+            return {"task_id": "task_1", "topic_id": "topic_1", "task_status": "success"}
+        if url.startswith("http://dataagent/api/v1/nl2sql/topics/topic_1/messages"):
+            return {
+                "items": [
+                    {
+                        "sender_type": "assistant",
+                        "task_id": "task_1",
+                        "content": "当前 DEV 环境共有 10 个工作流。",
+                        "blocks": _assistant_blocks("当前 DEV 环境共有 10 个工作流。"),
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected request: {method} {url}")
+
+    def fake_judge_case(judge_config, case, payload):
+        return {
+            "score": 9,
+            "dimension_scores": {"intent": 1},
+            "hallucination": False,
+            "veto_rules_triggered": [],
+            "failure_attribution": [],
+            "comment": "ok",
+            "judge_failed": False,
+        }
+
+    monkeypatch.setattr(runner, "http_json", fake_http_json)
+    monkeypatch.setattr(runner, "_judge_case", fake_judge_case)
+
+    result = runner.run_case(
+        "http://dataagent",
+        case,
+        types.SimpleNamespace(agent_id="agent_eval", provider_id="", model="", timeout_seconds=5),
+        runner.JudgeConfig(base_url="http://judge", token="t", model="m"),
+    )
+
+    assert result["auto_rule_check"]["passed"] is False
+    assert "missing_sql_fragment" in result["judge"]["failure_attribution"]
+    assert result["case_passed"] is False
 
 
 def test_judge_payload_removes_sql_style_veto_rules():

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -541,7 +541,7 @@ def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dic
         missing_tool_names=missing_tool_names,
     )
     return {
-        "passed": True,
+        "passed": not (missing_sql_fragments or missing_tool_names),
         "missing_sql_fragments": missing_sql_fragments,
         "forbidden_sql_patterns": [],
         "missing_tool_names": missing_tool_names,
@@ -975,6 +975,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
     case_passed = (
         not errors
         and str(task.get("task_status") or "").lower() in SUCCESS_STATUSES
+        and bool(rule_check.get("passed", True))
         and float(judge.get("score") or 0) >= 8
         and not bool(judge.get("judge_failed"))
         and not bool(judge.get("hallucination"))

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -574,7 +574,7 @@ def auto_rule_check(case: dict[str, Any], *, final_answer: str, blocks: list[dic
         missing_tool_names=missing_tool_names,
     )
     return {
-        "passed": not forbidden_hits,
+        "passed": not (missing_sql_fragments or forbidden_hits or missing_tool_names),
         "missing_sql_fragments": missing_sql_fragments,
         "forbidden_sql_patterns": forbidden_hits,
         "missing_tool_names": missing_tool_names,
@@ -1162,6 +1162,7 @@ def _apply_judges(results: list[dict[str, Any]], metric: DataAgentEvaluationMetr
         item["case_passed"] = (
             not item.get("errors")
             and str(item.get("task_status") or "").lower() in SUCCESS_STATUSES
+            and bool((item.get("auto_rule_check") or {}).get("passed", True))
             and float(judge.get("score") or 0) >= 8
             and not bool(judge.get("judge_failed"))
             and not bool(judge.get("hallucination"))


### PR DESCRIPTION
- Update empty completion task recovery without resume sessions
- Return incomplete_answer error for tool-backed empty model turns
- Normalize provider error codes when provider error message is present
- Require auto-rule checks to pass for eval cases to pass