### PR TITLE
refactor(dataagent): remove pseudo tool-call drift detection and restore ask-user toggle

### DIFF
--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -86,6 +86,13 @@ class Settings(BaseSettings):
     dataagent_portal_mcp_token: str = ""
     dataagent_portal_mcp_token_header_name: str = "X-Portal-MCP-Token"
 
+    # ---- Agent 交互能力 ----
+    # AskUserQuestion 让 agent 通过选择卡片向用户提问。开启时会为每次运行安装
+    # can_use_tool 回调，并以流式输入形态投递 prompt。置 false 后：AskUserQuestion 不再
+    # 加入 allowed_tools，且在无写工具门控的会话中 can_use_tool 回到 None、prompt 回到
+    # 纯字符串形态（更接近 v1.3.0 的调用形态）。写工具确认门控不受本开关影响。
+    dataagent_ask_user_question_enabled: bool = True
+
     # ---- Topic runtime root / sandbox ----
     # Host-visible persistent root used by the sandbox runner when asking the
     # host Docker/Podman daemon to bind-mount topic subdirectories into child

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -542,50 +542,12 @@ def _block_has_tool_output(block: dict[str, Any]) -> bool:
     return False
 
 
-# Pseudo tool-call tag fragments the model sometimes leaks as plain text instead
-# of emitting a real tool_use block. When these appear the model turn ends
-# "normally" but no tool was actually invoked, so the run drifts to a dead-end
-# answer. Matched case-insensitively as substrings.
-_PSEUDO_TOOL_CALL_MARKERS: tuple[str, ...] = (
-    "<tool_call",
-    "</tool_call>",
-    "<function",
-    "</function>",
-    "<parameter",
-    "</parameter>",
-    "<invoke",
-    "</invoke>",
-    "</antml",
-)
-
-_PSEUDO_TOOL_CALL_TAG_RE = re.compile(
-    r"</?(?:tool_call|function|parameter|invoke|antml[^>\s]*)[^>]*>",
-    re.IGNORECASE,
-)
-
-
-def _contains_pseudo_tool_call(text: str) -> bool:
-    lowered = str(text or "").lower()
-    if not lowered:
-        return False
-    return any(marker in lowered for marker in _PSEUDO_TOOL_CALL_MARKERS)
-
-
-def _strip_pseudo_tool_call_tags(text: str) -> str:
-    raw = str(text or "")
-    if not raw:
-        return ""
-    return _PSEUDO_TOOL_CALL_TAG_RE.sub("", raw)
-
-
 def _partial_completion_note(reason: str) -> str:
     text = str(reason or "").strip()
     if "最大轮次" in text:
         return "注：本次推理达到轮次上限，已返回当前可用结果。"
     if "超时" in text:
         return "注：本次执行耗时较长，已返回当前可用结果。"
-    if "工具调用格式" in text:
-        return "注：模型本次工具调用格式异常，已返回当前可用结果。"
     return "注：本次执行未完整结束，已返回当前可用结果。"
 
 

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -40,7 +40,6 @@ from core.agent_runtime import (
     _build_system_prompt,
     _build_workspace_boundary_hooks,
     _clip_text,
-    _contains_pseudo_tool_call,
     _default_model_for_provider,
     _extract_block,
     _format_exception_reason,
@@ -52,7 +51,6 @@ from core.agent_runtime import (
     _result_subtype_to_reason,
     _safe_base_url,
     _safe_stringify,
-    _strip_pseudo_tool_call_tags,
     resolve_agent_skill_runtime,
     resolve_enabled_skill_runtime,
     resolve_runtime_provider_selection,
@@ -115,16 +113,11 @@ class SdkResultAccumulator:
         self.result_is_error = False
         self.provider_error_message = ""
         self._saw_stream_event = False
-        self._saw_pseudo_tool_call = False
         self._saw_tool_use = False
         self._text_order: list[int] = []
         self._text_by_index: dict[int, str] = {}
         self._block_context: dict[int, dict[str, Any]] = {}
         self._next_message_block_index = 10_000
-
-    def _note_pseudo_tool_call(self, text: str) -> None:
-        if not self._saw_pseudo_tool_call and _contains_pseudo_tool_call(text):
-            self._saw_pseudo_tool_call = True
 
     def _remember_provider_error(self, message: Any) -> None:
         text = str(message or "").strip()
@@ -233,10 +226,8 @@ class SdkResultAccumulator:
             lower_type = block_type.lower()
             if "tool_use" in lower_type:
                 self._saw_tool_use = True
-            if block_text:
-                self._note_pseudo_tool_call(block_text)
-                if "text" in lower_type or lower_type in {"textblock", "text"}:
-                    self._append_message_text(block_text)
+            if block_text and ("text" in lower_type or lower_type in {"textblock", "text"}):
+                self._append_message_text(block_text)
 
     def _ingest_stream_event(self, raw_event: dict[str, Any]) -> None:
         event_type = str(raw_event.get("type") or "").strip()
@@ -273,14 +264,6 @@ class SdkResultAccumulator:
             block_payload = self._block_context.get(block_index) or {}
             delta_payload = raw_event.get("delta") if isinstance(raw_event.get("delta"), dict) else {}
             delta_type = str(delta_payload.get("type") or "")
-            # Detect leaked pseudo tool-call tags in any block, including thinking,
-            # so a drifted run is not silently reported as a clean answer. Thinking
-            # deltas carry text under "thinking"; text deltas under "text". Thinking
-            # text is still kept out of the visible answer below.
-            if delta_type == "thinking_delta":
-                self._note_pseudo_tool_call(str(delta_payload.get("thinking") or ""))
-            elif delta_type == "text_delta":
-                self._note_pseudo_tool_call(str(delta_payload.get("text") or ""))
             if str(block_payload.get("type") or "") != "text":
                 return
             if delta_type == "text_delta":
@@ -358,18 +341,6 @@ class SdkResultAccumulator:
                 session_id=self.session_id,
             )
 
-        if self._saw_pseudo_tool_call:
-            logger.warning(
-                "task.result.format_drift task_id=%s topic_id=%s provider=%s model=%s saw_tool_use=%s content_len=%s",
-                self.params.task_id,
-                self.params.topic_id,
-                self.provider_id,
-                self.model,
-                self._saw_tool_use,
-                len(content),
-            )
-            return self._build_format_drift_result(content)
-
         # A clean run with no visible answer is still an incomplete run. The
         # no-tool case can be retried once by the caller below; a tool-backed
         # empty closeout is marked explicitly without an automatic retry because
@@ -430,11 +401,10 @@ class SdkResultAccumulator:
         """Terminate a non-error run that produced no trustworthy final answer.
 
         Shared closeout for the ways a clean (success-subtype) run can still
-        dead-end: it leaked pseudo tool-call tags instead of a real call, ended
-        thinking-only with no answer, or invoked tools but never wrote the final
-        response. These must surface as task errors — the live stream only
-        carries the raw blocks, so without a terminal error record the chat UI
-        cannot distinguish success from an incomplete answer.
+        dead-end: it ended thinking-only with no answer, or invoked tools but
+        never wrote the final response. These must surface as task errors — the
+        live stream only carries the raw blocks, so without a terminal error
+        record the chat UI cannot distinguish success from an incomplete answer.
         """
         synthetic_blocks: dict[str, dict[str, Any]] = (
             {"tool": {"type": "tool_result", "output": "1"}} if self._saw_tool_use else {}
@@ -455,16 +425,6 @@ class SdkResultAccumulator:
             session_id=self.session_id,
         )
 
-    def _build_format_drift_result(self, content: str) -> TaskExecutionResult:
-        """Close out a run that leaked pseudo tool-call tags instead of a real call."""
-        return self._build_incomplete_run_result(
-            content=_strip_pseudo_tool_call_tags(content).strip(),
-            reason="模型工具调用格式异常未正常收口",
-            error_code="tool_call_format_drift",
-            message="模型输出了伪工具调用标签，本次回答未正常完成，请重试",
-            fallback="模型本次回答因工具调用格式异常未能正常生成，请重试。",
-        )
-
     def _build_incomplete_answer_result(self) -> TaskExecutionResult:
         """Close out a tool-backed run that never produced final visible text."""
         return self._build_incomplete_run_result(
@@ -478,11 +438,11 @@ class SdkResultAccumulator:
     def _build_empty_completion_result(self) -> TaskExecutionResult:
         """Close out a clean run that ended with no visible answer and no tool.
 
-        A thinking-only turn that stopped early: no SDK error, no leaked pseudo
-        tool-call tag, no ``tool_use``, and no final text. This previously fell
-        back to a silent ``finished`` with "已完成。", so the chat ended on an
-        empty answer with no way to retry. Routing it through the shared error
-        closeout makes the existing error card and retry button surface instead.
+        A thinking-only turn that stopped early: no SDK error, no ``tool_use``,
+        and no final text. This previously fell back to a silent ``finished``
+        with "已完成。", so the chat ended on an empty answer with no way to
+        retry. Routing it through the shared error closeout makes the existing
+        error card and retry button surface instead.
         """
         return self._build_incomplete_run_result(
             content="",

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -512,25 +512,3 @@ def test_build_system_prompt_omits_generic_model_known_methodology():
 
 def test_legacy_lf_system_prompt_template_is_removed():
     assert not (BACKEND_ROOT / "prompts" / "system_prompt.py").exists()
-
-
-def test_contains_pseudo_tool_call_detects_leaked_tags():
-    assert agent_runtime._contains_pseudo_tool_call("Now let me check </parameter></function></tool_call>")
-    assert agent_runtime._contains_pseudo_tool_call("<tool_call>{...}")
-    assert agent_runtime._contains_pseudo_tool_call("</invoke>")
-    assert not agent_runtime._contains_pseudo_tool_call("最近 30 天工作流发布次数为 3 次。")
-    assert not agent_runtime._contains_pseudo_tool_call("使用 a < b 与 c > d 的比较条件")
-
-
-def test_strip_pseudo_tool_call_tags_removes_only_tags():
-    raw = "结论：发布 174 次 </parameter></function></tool_call>"
-    cleaned = agent_runtime._strip_pseudo_tool_call_tags(raw)
-    assert "结论：发布 174 次" in cleaned
-    assert "</tool_call>" not in cleaned
-    assert "</parameter>" not in cleaned
-    assert "</function>" not in cleaned
-
-
-def test_partial_completion_note_for_tool_call_format_drift():
-    note = agent_runtime._partial_completion_note("模型工具调用格式异常未正常收口")
-    assert "工具调用格式异常" in note

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -1341,84 +1341,27 @@ def _patch_default_provider(monkeypatch):
     )
 
 
-def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_with_partial_text(monkeypatch, tmp_path: Path):
-    # The model leaks pseudo tool-call tags in a thinking block instead of making
-    # a real tool call, then ends the turn. The run must terminate as a task
-    # error so the stream carries a terminal error record the chat UI can render
-    # (error card + retry); the salvaged partial text stays in the content.
+def test_execute_task_stream_keeps_leaked_pseudo_tag_in_thinking_as_finish(monkeypatch, tmp_path: Path):
+    # Pseudo tool-call format-drift detection was removed: a leaked tool-call tag
+    # in a thinking block is no longer reclassified as an error. With a real
+    # visible answer present, the run finishes normally and the thinking-only
+    # tags never reach the visible content.
     _install_fake_sdk(
         monkeypatch,
         [
             StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
-            StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "正在检查 issue_status"}}),
+            StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "最近 30 天发布 174 次。"}}),
             StreamEvent({"type": "content_block_stop", "index": 0}),
-            StreamEvent(
-                {
-                    "type": "content_block_start",
-                    "index": 1,
-                    "content_block": {"type": "tool_use", "id": "tool-bash-1", "name": "Bash", "input": {"command": "python run_sql.py"}},
-                }
-            ),
-            StreamEvent({"type": "content_block_stop", "index": 1}),
-            UserMessage([{ "type": "tool_result", "tool_use_id": "tool-bash-1", "name": "Bash", "content": "174"}]),
-            StreamEvent({"type": "content_block_start", "index": 2, "content_block": {"type": "thinking", "thinking": ""}}),
-            StreamEvent(
-                {
-                    "type": "content_block_delta",
-                    "index": 2,
-                    "delta": {"type": "thinking_delta", "thinking": "Now let me also get some breakdown </parameter></function></tool_call>"},
-                }
-            ),
-            StreamEvent({"type": "content_block_stop", "index": 2}),
-            ResultMessage("success", session_id="sdk-drift-1"),
-        ],
-    )
-    _patch_default_provider(monkeypatch)
-    _patch_skill_runtime(monkeypatch, tmp_path)
-
-    async def _run():
-        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
-
-    result = asyncio.run(_run())
-
-    assert result.task_status == "error"
-    assert result.error is not None
-    assert result.error["code"] == "tool_call_format_drift"
-    assert "请重试" in result.error["message"]
-    assert "正在检查 issue_status" in result.content
-    assert "工具调用格式异常" in result.content
-    assert result.content != "已完成。"
-    # Leaked pseudo tags must not survive into the visible answer.
-    assert "</tool_call>" not in result.content
-    assert "</parameter>" not in result.content
-
-
-def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_with_tool_output_only(monkeypatch, tmp_path: Path):
-    # Drift with no usable visible text but a real tool_use earlier: the run
-    # still terminates as a task error, while the content points at the gathered
-    # tool output instead of "已完成。".
-    _install_fake_sdk(
-        monkeypatch,
-        [
-            StreamEvent(
-                {
-                    "type": "content_block_start",
-                    "index": 0,
-                    "content_block": {"type": "tool_use", "id": "tool-bash-1", "name": "Bash", "input": {"command": "python run_sql.py"}},
-                }
-            ),
-            StreamEvent({"type": "content_block_stop", "index": 0}),
-            UserMessage([{ "type": "tool_result", "tool_use_id": "tool-bash-1", "name": "Bash", "content": "2026-06-09"}]),
             StreamEvent({"type": "content_block_start", "index": 1, "content_block": {"type": "thinking", "thinking": ""}}),
             StreamEvent(
                 {
                     "type": "content_block_delta",
                     "index": 1,
-                    "delta": {"type": "thinking_delta", "thinking": "Now I need to verify the enum </parameter></function></tool_call>"},
+                    "delta": {"type": "thinking_delta", "thinking": "Now let me also get some breakdown </parameter></function></tool_call>"},
                 }
             ),
             StreamEvent({"type": "content_block_stop", "index": 1}),
-            ResultMessage("success", session_id="sdk-drift-2"),
+            ResultMessage("success", session_id="sdk-no-drift-1"),
         ],
     )
     _patch_default_provider(monkeypatch)
@@ -1429,43 +1372,11 @@ def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_with_tool_out
 
     result = asyncio.run(_run())
 
-    assert result.task_status == "error"
-    assert result.error is not None
-    assert result.error["code"] == "tool_call_format_drift"
-    assert "工具调用格式异常" in result.content
-    assert "工具输出" in result.content
-    assert result.content != "已完成。"
-
-
-def test_execute_task_stream_marks_pseudo_tool_call_drift_as_error_when_nothing_usable(monkeypatch, tmp_path: Path):
-    # Drift with no visible text and no tool output: there is nothing to salvage,
-    # so the run is reported as a distinct error instead of a silent finish.
-    _install_fake_sdk(
-        monkeypatch,
-        [
-            StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
-            StreamEvent(
-                {
-                    "type": "content_block_delta",
-                    "index": 0,
-                    "delta": {"type": "thinking_delta", "thinking": "Now I have all the data I need... </parameter></function></tool_call>"},
-                }
-            ),
-            StreamEvent({"type": "content_block_stop", "index": 0}),
-            ResultMessage("success", session_id="sdk-drift-3"),
-        ],
-    )
-    _patch_default_provider(monkeypatch)
-    _patch_skill_runtime(monkeypatch, tmp_path)
-
-    async def _run():
-        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
-
-    result = asyncio.run(_run())
-
-    assert result.task_status == "error"
-    assert result.error is not None
-    assert result.error["code"] == "tool_call_format_drift"
+    assert result.task_status == "finished"
+    assert result.error is None
+    assert "最近 30 天发布 174 次。" in result.content
+    assert "</tool_call>" not in result.content
+    assert "</parameter>" not in result.content
 
 
 def test_execute_task_stream_recovers_thinking_only_empty_finish_once(monkeypatch, tmp_path: Path):

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
@@ -214,10 +214,10 @@ describe('useNl2SqlChat engine', () => {
     api.taskApi.streamSdkEvents.mockImplementation(async (_taskId, opts) => {
       streamCall += 1
       if (streamCall === 1) {
-        // First run drifts: the backend appends a terminal error record
-        // (tool_call_format_drift) after the SDK's clean done record.
+        // First run fails: the backend appends a terminal error record
+        // (e.g. empty_completion) after the SDK's clean done record.
         opts.onRecord({ record_type: 'done', data: { is_error: false } })
-        opts.onRecord({ record_type: 'error', data: { message: '模型输出了伪工具调用标签，本次回答未正常完成，请重试' } })
+        opts.onRecord({ record_type: 'error', data: { message: '模型本次没有给出回答，请重试' } })
       } else {
         opts.onRecord({ record_type: 'done', data: {} })
       }

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -440,7 +440,7 @@ export function useNl2SqlChat(options) {
     }
   }
 
-  // Recover from a failed assistant reply (e.g. tool_call_format_drift): re-ask
+  // Recover from a failed assistant reply (any status=error, e.g. empty_completion): re-ask
   // the question that produced it as a normal new turn. deliver-message persists
   // every delivery as a user message, so re-sending keeps the live view and the
   // reloaded history identical; the failed reply stays visible as the record of

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -77,6 +77,9 @@ ODW_BACKEND_BASE_URL=http://backend:8080/api/v1/ai
 ODW_BACKEND_TIMEOUT_SECONDS=30
 DATAAGENT_PORTAL_MCP_ENABLED=true
 DATAAGENT_PORTAL_MCP_BASE_URL=http://portal-mcp:8801/mcp/
+# AskUserQuestion 选择卡片开关（默认 true）。置 false 后 AskUserQuestion 不加入 allowed_tools，
+# 且无写工具门控的会话回到纯字符串 prompt 形态（更接近 v1.3.0 调用形态）。
+DATAAGENT_ASK_USER_QUESTION_ENABLED=true
 # 智能问数 Widget 允许嵌入站点白名单已迁移到「智能问数 → Widget 接入」设置页管理，
 # 持久化在 da_agent_settings，不再使用环境变量配置。
 # 生产容器默认以非 root 身份运行；compose 中的一次性 init 服务 dataagent-home-init 会以 root

--- a/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
+++ b/docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md
@@ -1,5 +1,11 @@
 # NL2SQL 伪工具调用格式漂移收口 — 设计
 
+> **2026-06-16 更新：本设计描述的「伪工具调用 / format-drift 检测与改判」已整体移除。**
+> 该检测会扫描 thinking 文本、把含工具标签子串的正常回答误判为错误，属不可控因素。
+> 详见 `docs/design/2026-06-16-nl2sql-runtime-simplification-design.md`。本文保留作历史记录。
+> `empty_completion` / `incomplete_answer` 改判与一次性自动恢复不受影响，仍然保留。
+
+
 ## 背景与问题
 
 在智能问数（NL2SQL）链路中，部分评测用例（ARCH_RISK_002 / ARCH_RISK_003 /

--- a/docs/design/2026-06-16-nl2sql-runtime-simplification-design.md
+++ b/docs/design/2026-06-16-nl2sql-runtime-simplification-design.md
@@ -1,0 +1,83 @@
+# NL2SQL 运行时收口简化 — 设计
+
+## 背景与问题
+
+对比 `v1.3.0` 与当前 main：v1.3.0 的会话链路极简、稳定，很少出现「空回复」或
+「思考后直接结束」。v1.3.0→main 之间在 `SdkResultAccumulator.build_result()` 这条
+「判定模型本轮是否算回答完」的核心路径上叠加了多层后端改判与拦截，其中部分逻辑会把
+本可正常返回的运行改判为错误，或改变了对每一次请求的 SDK 调用形态。
+
+本次只针对其中两处「v1.3.0 没有、且属于不可控/易误伤」的改动做收口简化，目标是把这条
+链路拉回更接近 v1.3.0 的可预期状态。明确不动 `empty_completion` / `incomplete_answer`
+改判与一次性自动恢复（这些在 2026-06-16 #371 刚被强化，属于刻意投入的能力）。
+
+## 现状代码
+
+1. 伪工具调用（format drift）检测：
+   - `core/agent_runtime.py`：`_PSEUDO_TOOL_CALL_MARKERS`、`_PSEUDO_TOOL_CALL_TAG_RE`、
+     `_contains_pseudo_tool_call`、`_strip_pseudo_tool_call_tags`，以及
+     `_partial_completion_note` 的 `"工具调用格式"` 分支。
+   - `core/task_executor.py`：`SdkResultAccumulator._saw_pseudo_tool_call`、
+     `_note_pseudo_tool_call`，并在整条消息文本、`text_delta`、**`thinking_delta`** 三处
+     扫描伪标签；`build_result()` 命中后走 `_build_format_drift_result` 改判为
+     `task_status="error"`、错误码 `tool_call_format_drift`。
+   - 问题：检测对 **thinking 文本**也生效，模型只要在思考里出现/复述
+     `<function>`、`<parameter>`、`</tool_call>` 等子串，即便已经产出了正常答案，整轮也被
+     改判为错误卡片。这是「本来好答案 → 变报错」的误伤来源，属不可控因素。
+
+2. AskUserQuestion / `can_use_tool` 开关缺失：
+   - `core/task_executor.py:903` 读取 `getattr(cfg, "dataagent_ask_user_question_enabled", True)`，
+     但该配置项从未在 `config.py` 中定义，因此恒为 `True`。
+   - 后果：`can_use_tool` 回调对**每一次**运行都安装；进而 prompt 恒以流式生成器
+     (`_single_user_prompt_stream`) 送入 SDK，而非 v1.3.0 的纯字符串。这条全量默认路径
+     无法通过设计文档 `2026-06-15-askuserquestion-rendering-design.md` 声称的开关关闭。
+
+## 方案
+
+### 1. 移除伪工具调用（format drift）检测
+
+完整删除上述检测与改判：标记表、正则、`_contains_pseudo_tool_call`、
+`_strip_pseudo_tool_call_tags`、`_saw_pseudo_tool_call`、`_note_pseudo_tool_call`、三处扫描
+调用、`build_result()` 的 format-drift 分支、`_build_format_drift_result`，以及
+`_partial_completion_note` 的 `"工具调用格式"` 分支。
+
+保留 `_partial_completion_note` / `_recover_partial_content` 本体——它们是 **v1.3.0 就有的**
+超时 / 最大轮次 / provider 报错的「半成品兜底」逻辑，确定性、不改判好答案，删除反而比
+v1.3.0 更激进，故只摘掉其 format-drift 专用分支。
+
+`build_result()` 简化后：provider 报错分支 → `empty_completion`（无文本无工具）→
+`incomplete_answer`（无文本有工具）→ 正常 `finished`。不再有 format-drift 这一层。
+
+### 2. 恢复 `dataagent_ask_user_question_enabled` 配置开关
+
+在 `config.py` 的 `Settings` 中新增 `dataagent_ask_user_question_enabled: bool = True`
+（默认开，保持当前行为不变），并在 `deploy/.env.example` 文档化
+`DATAAGENT_ASK_USER_QUESTION_ENABLED=true`。pydantic-settings 按字段名自动读取同名大写环境
+变量，无需额外接线。
+
+设为 `false` 时：AskUserQuestion 不再加入 `allowed_tools`，且在无写工具门控
+(`needs_gating`) 的会话中 `can_use_tool` 回到 `None`、prompt 回到 v1.3.0 的纯字符串形态——
+为运营方提供一个回到 v1.3.0 调用形态的逃生开关。写工具确认门控仍按各自模式独立生效，不受
+本开关影响。
+
+## 接口与契约变化
+
+- 任务错误码 `tool_call_format_drift`：**不再产生**。前端错误卡片/重试对任意
+  `status=error` 仍通用，无需改动；`useNl2SqlChat.js` 中引用该码的注释更新为通用措辞。
+- 新增配置 `dataagent_ask_user_question_enabled`（默认 `true`）/ 环境变量
+  `DATAAGENT_ASK_USER_QUESTION_ENABLED`。
+- `_partial_completion_note` / `_recover_partial_content` 签名不变，仅去掉 format-drift 文案分支。
+
+## 取舍
+
+- 移除检测后，若模型把工具调用 XML 当文本/思考吐出，后端不再自动标错或清洗标签——
+  这类问题交由模型与系统提示词约束处理，符合「简化、减少不可控因素，模型问题等模型修复」
+  的方向。真正的空回合仍由 `empty_completion` / `incomplete_answer` 兜住，不裸奔。
+- 配置开关默认保持 `true`，不改变现网默认行为，仅提供可关闭能力；如需默认回到 v1.3.0 调用
+  形态，由运营方显式置 `false`。
+
+## 范围外
+
+- 不改 `empty_completion` / `incomplete_answer` 改判与一次性自动恢复（#371 刚强化）。
+- 不改写工具权限门控、沙箱执行、流式投影等其它 v1.3.0→main 差异。
+- 不新增全局标签清洗器。

--- a/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
+++ b/docs/plans/2026-06-11-nl2sql-tool-call-format-drift-plan.md
@@ -1,5 +1,8 @@
 # NL2SQL 伪工具调用格式漂移收口 — 执行计划
 
+> **2026-06-16 更新：本计划交付的 format-drift 检测与改判已整体移除，**
+> 详见 `docs/plans/2026-06-16-nl2sql-runtime-simplification-plan.md`。本文保留作历史记录。
+
 配套设计：`docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md`
 
 ## 影响栈

--- a/docs/plans/2026-06-16-nl2sql-runtime-simplification-plan.md
+++ b/docs/plans/2026-06-16-nl2sql-runtime-simplification-plan.md
@@ -1,0 +1,46 @@
+# NL2SQL 运行时收口简化 — 执行计划
+
+配套设计：`docs/design/2026-06-16-nl2sql-runtime-simplification-design.md`
+
+涉及栈：DataAgent backend（`core/`、`config.py`、`tests/`）、frontend（仅注释）、
+infra（`deploy/.env.example`）。
+
+## 任务
+
+### A. 移除伪工具调用（format drift）检测
+- `core/agent_runtime.py`
+  - 删除 `_PSEUDO_TOOL_CALL_MARKERS`、`_PSEUDO_TOOL_CALL_TAG_RE`、`_contains_pseudo_tool_call`、
+    `_strip_pseudo_tool_call_tags`。
+  - `_partial_completion_note`：删除 `"工具调用格式"` 分支（回到 v1.3.0 形态）。
+  - 保留 `import re`（仍被其它正则使用）。
+- `core/task_executor.py`
+  - 删除导入 `_contains_pseudo_tool_call`、`_strip_pseudo_tool_call_tags`。
+  - 删除字段 `self._saw_pseudo_tool_call`、方法 `_note_pseudo_tool_call`。
+  - 删除 `_ingest_assistant_content` 与 `_ingest_stream_event` 中的 3 处
+    `_note_pseudo_tool_call(...)` 调用及相关注释。
+  - 删除 `build_result()` 的 `if self._saw_pseudo_tool_call:` 分支与
+    `_build_format_drift_result`。
+  - 保留 `_build_incomplete_run_result` / `_build_empty_completion_result` /
+    `_build_incomplete_answer_result`，更新其中提到伪标签的 docstring。
+- `tests/test_agent_runtime.py`：删除 3 个 pseudo/format-drift 测试。
+- `tests/test_task_executor.py`：删除 3 个 drift 测试；保留共享 `_patch_default_provider`；
+  新增 1 个回归测试：thinking 中泄漏工具标签 + 有可见答案 → `finished`、无 error。
+- `dataagent-frontend/.../useNl2SqlChat.js`：把引用 `tool_call_format_drift` 的注释改为通用措辞。
+
+### B. 恢复配置开关
+- `config.py`：`Settings` 新增 `dataagent_ask_user_question_enabled: bool = True`。
+- `deploy/.env.example`：新增 `DATAAGENT_ASK_USER_QUESTION_ENABLED=true` 并注释含义。
+
+### C. 文档
+- 在 `docs/design/2026-06-11-nl2sql-tool-call-format-drift-design.md` 与对应 plan 顶部加
+  「2026-06-16 起 format-drift 检测已移除，详见本简化设计」的注记。
+
+## 验证
+- `dataagent/dataagent-backend` 下用 `.venv-py311`：
+  - `python -m pytest tests/test_agent_runtime.py tests/test_task_executor.py -q`
+  - `python -c "import core.task_executor, core.agent_runtime, config"` 导入冒烟
+- grep 确认全仓不再有 `format_drift` / `_pseudo` 残留引用（文档历史注记除外）。
+- 前端仅注释改动，不跑重型前端构建。
+
+## 回滚
+- 单一提交，`git revert` 即可整体回退；无 schema / 迁移变更。


### PR DESCRIPTION
Simplify the NL2SQL run-result path back toward the stable v1.3.0 behavior by
removing two post-v1.3.0 sources of empty / think-then-stop replies.

- Remove the format-drift (pseudo tool-call) detection: it scanned thinking and
  text deltas for tool-call tag substrings and reclassified otherwise-good
  answers as tool_call_format_drift errors. Drop the markers/regex/helpers in
  agent_runtime, the SdkResultAccumulator flag + scan calls, the build_result
  branch, _build_format_drift_result, and the partial-completion note branch.
- Add config dataagent_ask_user_question_enabled (default true) so the
  previously always-on can_use_tool + streaming-prompt path can be disabled,
  restoring the v1.3.0 plain-string prompt for sessions without write-tool
  gating. The key was referenced but never defined, forcing the path on.
- Keep empty_completion / incomplete_answer reclassification and one-shot
  recovery unchanged; keep the v1.3.0 partial-content salvage helpers.
- Update tests (drop 6 drift tests, add 1 regression test for leaked tags now
  finishing normally), frontend comment + fixture, .env.example, and docs.

https://claude.ai/code/session_019TznamPDmb2ceNKVfhQ2FJ