### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,7 @@ docker compose -f deploy/docker-compose.dev.yml up -d
 ## 许可证
 
 本项目采用 [GNU General Public License v3.0 only](LICENSE) 开源协议。
+
+## Star 趋势
+
+[![Star History Chart](https://api.star-history.com/svg?repos=opendata-lab/opendataworks&type=Date)](https://star-history.com/#opendata-lab/opendataworks&Date)

--- a/README_en.md
+++ b/README_en.md
@@ -130,3 +130,7 @@ Contributions are welcome. Please read the [contribution guide](https://opendata
 ## License
 
 OpenDataWorks is licensed under the [GNU General Public License v3.0 only](LICENSE).
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=opendata-lab/opendataworks&type=Date)](https://star-history.com/#opendata-lab/opendataworks&Date)


### PR DESCRIPTION
Append a Star History chart section at the bottom of the Chinese and
English README files, rendered via star-history.com.