### PR TITLE
refactor(backend): route table DDL by datasource engine

### DIFF
--- a/backend/src/main/java/com/onedata/portal/scheduled/DataTableAutoPurgeTask.java
+++ b/backend/src/main/java/com/onedata/portal/scheduled/DataTableAutoPurgeTask.java
@@ -2,12 +2,10 @@ package com.onedata.portal.scheduled;
 
 import com.onedata.portal.entity.DataTable;
 import com.onedata.portal.service.DataTableService;
-import com.onedata.portal.service.DorisConnectionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,7 +21,6 @@ public class DataTableAutoPurgeTask {
     private static final int BATCH_SIZE = 200;
 
     private final DataTableService dataTableService;
-    private final DorisConnectionService dorisConnectionService;
 
     /**
      * 每天凌晨 03:15 清理到期废弃表
@@ -38,17 +35,7 @@ public class DataTableAutoPurgeTask {
 
         for (DataTable table : dueTables) {
             try {
-                if (dataTableService.requiresDorisPhysicalSync(table)) {
-                    String database = table.getDbName();
-                    String actualTableName = extractActualTableName(table.getTableName());
-                    if (!StringUtils.hasText(database) || !StringUtils.hasText(actualTableName)) {
-                        throw new RuntimeException("缺少数据库名或表名");
-                    }
-                    if (table.getClusterId() == null) {
-                        throw new RuntimeException("缺少 clusterId");
-                    }
-                    dorisConnectionService.dropTable(table.getClusterId(), database, actualTableName);
-                }
+                dataTableService.dropPhysicalTableIfRequired(table);
                 dataTableService.purgeTableMetadata(table.getId());
                 log.info("Auto purged deprecated table, tableId={}, db={}, table={}",
                         table.getId(), table.getDbName(), table.getTableName());
@@ -58,18 +45,5 @@ public class DataTableAutoPurgeTask {
                         table.getId(), table.getDbName(), table.getTableName(), e);
             }
         }
-    }
-
-    private String extractActualTableName(String tableName) {
-        if (!StringUtils.hasText(tableName)) {
-            return null;
-        }
-        if (tableName.contains(".")) {
-            String[] parts = tableName.split("\\.", 2);
-            if (parts.length == 2 && StringUtils.hasText(parts[1])) {
-                return parts[1];
-            }
-        }
-        return tableName;
     }
 }

--- a/backend/src/main/java/com/onedata/portal/service/DataTableService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataTableService.java
@@ -22,6 +22,8 @@ import com.onedata.portal.mapper.DataTaskMapper;
 import com.onedata.portal.mapper.DorisClusterMapper;
 import com.onedata.portal.mapper.TableTaskRelationMapper;
 import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import com.onedata.portal.service.table.TableEngineHandler;
+import com.onedata.portal.service.table.TableEngineHandlerRegistry;
 import com.onedata.portal.util.DatasourceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +54,7 @@ public class DataTableService {
     private final TaskExecutionLogMapper taskExecutionLogMapper;
     private final DataLineageMapper dataLineageMapper;
     private final DorisClusterMapper dorisClusterMapper;
-    private final DorisConnectionService dorisConnectionService;
+    private final TableEngineHandlerRegistry tableEngineHandlerRegistry;
     private final TableMetadataVersionService tableMetadataVersionService;
 
     /**
@@ -235,6 +237,7 @@ public class DataTableService {
     @Transactional
     public DataTable create(DataTable dataTable) {
         dataTable.setLayer(normalizeLayer(dataTable.getLayer(), true));
+        normalizeCreateMetadata(dataTable);
 
         // 检查表名是否已存在（在同一数据库下）
         DataTable exists = getByDbAndTableName(dataTable.getClusterId(), dataTable.getDbName(), dataTable.getTableName());
@@ -247,6 +250,31 @@ public class DataTableService {
         tableMetadataVersionService.captureVersion(dataTable.getId(),
                 TableMetadataVersionService.TRIGGER_TABLE_CREATE, null);
         return dataTable;
+    }
+
+    private void normalizeCreateMetadata(DataTable dataTable) {
+        if (dataTable == null) {
+            return;
+        }
+        Long clusterId = dataTable.getClusterId();
+        if (clusterId == null) {
+            TableEngineHandler.clearDorisPhysicalMetadata(dataTable);
+            return;
+        }
+        DorisCluster cluster = dorisClusterMapper.selectById(clusterId);
+        if (cluster == null) {
+            throw new RuntimeException("数据源不存在: " + clusterId);
+        }
+        DatasourceType sourceType = DatasourceType.from(cluster.getSourceType());
+        if (sourceType == DatasourceType.DORIS) {
+            return;
+        }
+        TableEngineHandler handler = tableEngineHandlerRegistry.find(sourceType);
+        if (handler != null) {
+            handler.prepareCreateMetadata(dataTable, null, null);
+            return;
+        }
+        TableEngineHandler.clearDorisPhysicalMetadata(dataTable);
     }
 
     /**
@@ -403,6 +431,21 @@ public class DataTableService {
     }
 
     /**
+     * 按所属数据源类型清理物理表；未同步表仅清理平台元数据。
+     */
+    public void dropPhysicalTableIfRequired(DataTable table) {
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, null);
+        if (engine == null) {
+            return;
+        }
+        TableRef tableRef = resolveTableRef(table);
+        if (tableRef == null) {
+            throw new RuntimeException("缺少数据库名或表名");
+        }
+        engine.handler.dropTable(engine.clusterId, tableRef.database, tableRef.tableName);
+    }
+
+    /**
      * 解析表的物理位置（库名 + 去前缀后的实际表名）。
      * 优先使用 dbName 字段，否则从 {@code db.table} 形式的表名解析；无法解析时抛出标准提示。
      */
@@ -448,41 +491,47 @@ public class DataTableService {
         String newActualName = extractActualTableName(tableRef != null ? tableRef.database : existing.getDbName(),
                 newTableName);
         boolean physicalTableUpdate = hasPhysicalTableUpdate(existing, dataTable, oldTableName, newActualName);
-        Long actualClusterId = resolveActualClusterId(existing, clusterId);
-        boolean syncDoris = physicalTableUpdate && requiresDorisPhysicalSync(existing, actualClusterId);
-        if (syncDoris && tableRef == null) {
+        ResolvedTableEngine engine = physicalTableUpdate ? resolveSyncedPhysicalEngine(existing, clusterId) : null;
+        if (engine != null && tableRef == null) {
             throw new RuntimeException("表未配置数据库名，请先设置 dbName 字段");
         }
-        if (syncDoris) {
+        if (engine != null) {
             try {
                 if (StringUtils.hasText(newTableName) && !Objects.equals(oldTableName, newActualName)) {
-                    dorisConnectionService.renameTable(actualClusterId, tableRef.database, oldTableName, newActualName);
+                    engine.handler.renameTable(engine.clusterId, tableRef.database, oldTableName, newActualName);
                 }
                 if (StringUtils.hasText(dataTable.getTableComment())
                         && !Objects.equals(existing.getTableComment(), dataTable.getTableComment())) {
-                    dorisConnectionService.alterTableComment(actualClusterId, tableRef.database, newActualName,
+                    engine.handler.alterTableComment(engine.clusterId, tableRef.database, newActualName,
                             dataTable.getTableComment());
                 }
                 if (dataTable.getBucketNum() != null && !Objects.equals(existing.getBucketNum(), dataTable.getBucketNum())) {
-                    if (!StringUtils.hasText(existing.getDistributionColumn())) {
-                        throw new DorisSyncRejectedException("缺少分桶字段，无法同步分桶数到 Doris");
-                    }
-                    dorisConnectionService.modifyDistribution(
-                            actualClusterId,
-                            tableRef.database,
-                            newActualName,
-                            existing.getDistributionColumn(),
+                    engine.handler.modifyDistribution(engine.clusterId, existing, tableRef.database, newActualName,
                             dataTable.getBucketNum());
                 }
                 if (dataTable.getReplicaNum() != null && !Objects.equals(existing.getReplicaNum(), dataTable.getReplicaNum())) {
-                    dorisConnectionService.setReplicationNum(actualClusterId, tableRef.database, newActualName,
+                    engine.handler.setReplicationNum(engine.clusterId, tableRef.database, newActualName,
                             dataTable.getReplicaNum());
                 }
-            } catch (DorisSyncRejectedException e) {
-                // 校验类拒绝：复刻原控制器在 rename/comment 之后直接返回的原始文案（不加同步失败前缀）
-                throw new RuntimeException(e.getMessage());
             } catch (Exception e) {
-                throw new RuntimeException("同步 Doris 失败: " + e.getMessage());
+                if ("缺少分桶字段，无法同步分桶数到 Doris".equals(e.getMessage())) {
+                    throw new RuntimeException(e.getMessage());
+                }
+                if (e.getMessage() != null && (e.getMessage().startsWith("暂不支持同步 ")
+                        || e.getMessage().startsWith("MySQL 数据源不支持"))) {
+                    throw new RuntimeException(e.getMessage());
+                }
+                String engineName = engine.handler.sourceType().name();
+                if (engine.handler.sourceType() == DatasourceType.DORIS) {
+                    engineName = "Doris";
+                }
+                throw new RuntimeException("同步 " + engineName + " 失败: " + e.getMessage());
+            }
+        } else if (physicalTableUpdate && isSyncedPhysicalTable(existing)) {
+            try {
+                resolveSyncedPhysicalEngine(existing, clusterId);
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage());
             }
         }
         dataTable.setId(id);
@@ -511,12 +560,11 @@ public class DataTableService {
         if (table == null) {
             throw new RuntimeException("表不存在");
         }
-        Long actualClusterId = resolveActualClusterId(table, clusterId);
-        boolean syncDoris = requiresDorisPhysicalSync(table, actualClusterId);
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
         try {
-            if (syncDoris) {
+            if (engine != null) {
                 TableLocation location = requireTableLocation(table);
-                dorisConnectionService.alterTableComment(actualClusterId,
+                engine.handler.alterTableComment(engine.clusterId,
                         location.getDatabase(), location.getTableName(), comment);
             }
 
@@ -540,8 +588,7 @@ public class DataTableService {
         if ("deprecated".equalsIgnoreCase(table.getStatus())) {
             throw new RuntimeException("表已处于待删除状态");
         }
-        Long actualClusterId = clusterId != null ? clusterId : table.getClusterId();
-        boolean syncDoris = requiresDorisPhysicalSync(table, actualClusterId);
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
 
         TableLocation location = requireTableLocation(table);
         String database = location.getDatabase();
@@ -556,9 +603,8 @@ public class DataTableService {
             String timestamp = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
             String newTableName = actualTableName + "_deprecated_" + timestamp;
 
-            if (syncDoris) {
-                // 在Doris中重命名表
-                dorisConnectionService.renameTable(actualClusterId, database, actualTableName, newTableName);
+            if (engine != null) {
+                engine.handler.renameTable(engine.clusterId, database, actualTableName, newTableName);
             }
 
             // 更新本地记录
@@ -600,11 +646,10 @@ public class DataTableService {
             throw new RuntimeException("恢复失败：目标表名冲突 " + restoreTableName);
         }
 
-        Long actualClusterId = clusterId != null ? clusterId : table.getClusterId();
-        boolean syncDoris = requiresDorisPhysicalSync(table, actualClusterId);
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
         try {
-            if (syncDoris) {
-                dorisConnectionService.renameTable(actualClusterId, tableRef.database, tableRef.tableName, restoreTableName);
+            if (engine != null) {
+                engine.handler.renameTable(engine.clusterId, tableRef.database, tableRef.tableName, restoreTableName);
             }
             return restoreDeprecatedTable(table, restoreTableName);
         } catch (Exception e) {
@@ -625,7 +670,6 @@ public class DataTableService {
             throw new RuntimeException("仅支持清理已废弃表");
         }
 
-        Long actualClusterId = clusterId != null ? clusterId : table.getClusterId();
         TableRef tableRef = resolveTableRef(table);
         if (tableRef == null) {
             throw new RuntimeException("表未配置数据库名，请先设置 dbName 字段");
@@ -633,11 +677,11 @@ public class DataTableService {
         if (!isConfirmTableNameMatched(confirmTableName, tableRef.tableName)) {
             throw new RuntimeException("确认失败：请输入正确的表名 " + tableRef.tableName);
         }
-        boolean syncDoris = requiresDorisPhysicalSync(table, actualClusterId);
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
 
         try {
-            if (syncDoris) {
-                dorisConnectionService.dropTable(actualClusterId, tableRef.database, tableRef.tableName);
+            if (engine != null) {
+                engine.handler.dropTable(engine.clusterId, tableRef.database, tableRef.tableName);
             }
             purgeTableMetadata(id);
         } catch (Exception e) {
@@ -699,16 +743,6 @@ public class DataTableService {
             return 0L;
         }
         return (seconds + 86_399) / 86_400;
-    }
-
-    /**
-     * Doris 同步过程中的「校验拒绝」标记异常：用于复刻原控制器在 rename/comment 之后
-     * 仍以原始文案直接返回的语义，避免被「同步 Doris 失败:」前缀包裹。
-     */
-    private static class DorisSyncRejectedException extends RuntimeException {
-        DorisSyncRejectedException(String message) {
-            super(message);
-        }
     }
 
     /**
@@ -820,21 +854,13 @@ public class DataTableService {
             throw new RuntimeException("字段名和类型不能为空");
         }
 
-        if (requiresDorisPhysicalSync(table, clusterId)) {
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
+        if (engine != null) {
             TableRef tableRef = resolveTableRef(table);
             if (tableRef == null) {
                 throw new RuntimeException("表未配置数据库名，请先设置 dbName 字段");
             }
-            if (isAggregateTable(table)) {
-                throw new RuntimeException("AGGREGATE 表字段变更需指定聚合方式，暂不支持同步");
-            }
-            boolean isKey = isKeyColumn(table, field);
-            if (isKey) {
-                throw new RuntimeException("Doris 不支持在线新增主键列");
-            }
-            String columnDef = dorisConnectionService.buildColumnDefinition(field, isKey);
-            dorisConnectionService.addColumn(resolveActualClusterId(table, clusterId),
-                    tableRef.database, tableRef.tableName, columnDef);
+            engine.handler.addColumn(engine.clusterId, table, tableRef.database, tableRef.tableName, field);
         }
 
         dataFieldMapper.insert(field);
@@ -868,37 +894,13 @@ public class DataTableService {
 
         DataField toUpdate = mergeField(exists, field);
 
-        if (requiresDorisPhysicalSync(table, clusterId)) {
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
+        if (engine != null) {
             TableRef tableRef = resolveTableRef(table);
             if (tableRef == null) {
                 throw new RuntimeException("表未配置数据库名，请先设置 dbName 字段");
             }
-            if (!Objects.equals(exists.getIsPrimary(), toUpdate.getIsPrimary())) {
-                throw new RuntimeException("Doris 不支持在线修改主键列");
-            }
-            boolean nameChanged = !Objects.equals(exists.getFieldName(), toUpdate.getFieldName());
-            if (isAggregateTable(table)) {
-                if (nameChanged || hasNonCommentChanges(exists, toUpdate)) {
-                    throw new RuntimeException("AGGREGATE 表字段变更需指定聚合方式，暂不支持同步");
-                }
-                if (onlyCommentChanged(exists, toUpdate)) {
-                    dorisConnectionService.modifyColumnComment(resolveActualClusterId(table, clusterId),
-                            tableRef.database, tableRef.tableName,
-                            toUpdate.getFieldName(), toUpdate.getFieldComment());
-                }
-            } else {
-                if (nameChanged) {
-                    dorisConnectionService.renameColumn(resolveActualClusterId(table, clusterId),
-                            tableRef.database, tableRef.tableName,
-                            exists.getFieldName(), toUpdate.getFieldName());
-                }
-                if (isColumnChanged(exists, toUpdate)) {
-                    boolean isKey = isKeyColumn(table, toUpdate);
-                    String columnDef = dorisConnectionService.buildColumnDefinition(toUpdate, isKey);
-                    dorisConnectionService.modifyColumn(resolveActualClusterId(table, clusterId),
-                            tableRef.database, tableRef.tableName, columnDef);
-                }
-            }
+            engine.handler.updateColumn(engine.clusterId, table, tableRef.database, tableRef.tableName, exists, toUpdate);
         }
 
         dataFieldMapper.updateById(toUpdate);
@@ -917,13 +919,13 @@ public class DataTableService {
         if (exists == null) {
             throw new RuntimeException("字段不存在");
         }
-        if (requiresDorisPhysicalSync(table, clusterId)) {
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
+        if (engine != null) {
             TableRef tableRef = resolveTableRef(table);
             if (tableRef == null) {
                 throw new RuntimeException("表未配置数据库名，请先设置 dbName 字段");
             }
-            dorisConnectionService.dropColumn(resolveActualClusterId(table, clusterId),
-                    tableRef.database, tableRef.tableName, exists.getFieldName());
+            engine.handler.dropColumn(engine.clusterId, tableRef.database, tableRef.tableName, exists.getFieldName());
         }
         dataFieldMapper.deleteById(fieldId);
         log.info("Deleted field: {}", fieldId);
@@ -975,22 +977,8 @@ public class DataTableService {
     }
 
     public boolean requiresDorisPhysicalSync(DataTable table, Long clusterId) {
-        if (!isSyncedPhysicalTable(table)) {
-            return false;
-        }
-        Long actualClusterId = resolveActualClusterId(table, clusterId);
-        if (actualClusterId == null) {
-            throw new RuntimeException("请指定数据源");
-        }
-        DorisCluster cluster = dorisClusterMapper.selectById(actualClusterId);
-        if (cluster == null) {
-            throw new RuntimeException("数据源不存在: " + actualClusterId);
-        }
-        DatasourceType sourceType = DatasourceType.from(cluster.getSourceType());
-        if (sourceType == DatasourceType.DORIS) {
-            return true;
-        }
-        throw new RuntimeException("暂不支持同步 " + sourceType.name() + " 数据源的表变更");
+        ResolvedTableEngine engine = resolveSyncedPhysicalEngine(table, clusterId);
+        return engine != null && engine.handler.sourceType() == DatasourceType.DORIS;
     }
 
     public boolean isSyncedPhysicalTable(DataTable table) {
@@ -1007,65 +995,21 @@ public class DataTableService {
         return table == null ? null : table.getClusterId();
     }
 
-    private boolean isAggregateTable(DataTable table) {
-        return table != null && StringUtils.hasText(table.getTableModel())
-                && "AGGREGATE".equalsIgnoreCase(table.getTableModel());
-    }
-
-    private boolean isKeyColumn(DataTable table, DataField field) {
-        if (field != null && field.getIsPrimary() != null && field.getIsPrimary() == 1) {
-            return true;
+    private ResolvedTableEngine resolveSyncedPhysicalEngine(DataTable table, Long clusterId) {
+        if (!isSyncedPhysicalTable(table)) {
+            return null;
         }
-        if (table == null || !StringUtils.hasText(table.getKeyColumns()) || field == null
-                || !StringUtils.hasText(field.getFieldName())) {
-            return false;
+        Long actualClusterId = resolveActualClusterId(table, clusterId);
+        if (actualClusterId == null) {
+            throw new RuntimeException("请指定数据源");
         }
-        String[] keys = table.getKeyColumns().split(",");
-        for (String key : keys) {
-            if (field.getFieldName().equalsIgnoreCase(key.trim())) {
-                return true;
-            }
+        DorisCluster cluster = dorisClusterMapper.selectById(actualClusterId);
+        if (cluster == null) {
+            throw new RuntimeException("数据源不存在: " + actualClusterId);
         }
-        return false;
-    }
-
-    private boolean isColumnChanged(DataField oldField, DataField newField) {
-        if (oldField == null || newField == null) {
-            return false;
-        }
-        return !Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
-                || !Objects.equals(normalize(oldField.getFieldComment()), normalize(newField.getFieldComment()))
-                || !Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
-                || !Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
-                || !Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()));
-    }
-
-    private boolean hasNonCommentChanges(DataField oldField, DataField newField) {
-        if (oldField == null || newField == null) {
-            return false;
-        }
-        return !Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
-                || !Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
-                || !Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
-                || !Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()));
-    }
-
-    private boolean onlyCommentChanged(DataField oldField, DataField newField) {
-        if (oldField == null || newField == null) {
-            return false;
-        }
-        return Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
-                && Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
-                && Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
-                && Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()))
-                && !Objects.equals(normalize(oldField.getFieldComment()), normalize(newField.getFieldComment()));
-    }
-
-    private Object normalize(Object value) {
-        if (value instanceof String) {
-            return ((String) value).trim();
-        }
-        return value;
+        DatasourceType sourceType = DatasourceType.from(cluster.getSourceType());
+        TableEngineHandler handler = tableEngineHandlerRegistry.require(sourceType);
+        return new ResolvedTableEngine(handler, actualClusterId);
     }
 
     private DataField mergeField(DataField exists, DataField incoming) {
@@ -1127,6 +1071,16 @@ public class DataTableService {
         private TableRef(String database, String tableName) {
             this.database = database;
             this.tableName = tableName;
+        }
+    }
+
+    private static class ResolvedTableEngine {
+        private final TableEngineHandler handler;
+        private final Long clusterId;
+
+        private ResolvedTableEngine(TableEngineHandler handler, Long clusterId) {
+            this.handler = handler;
+            this.clusterId = clusterId;
         }
     }
 

--- a/backend/src/main/java/com/onedata/portal/service/TableCreateService.java
+++ b/backend/src/main/java/com/onedata/portal/service/TableCreateService.java
@@ -7,8 +7,13 @@ import com.onedata.portal.dto.TableDesignPreviewResponse;
 import com.onedata.portal.dto.TableNameGenerateRequest;
 import com.onedata.portal.entity.DataField;
 import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.entity.DorisCluster;
 import com.onedata.portal.mapper.DataFieldMapper;
 import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DorisClusterMapper;
+import com.onedata.portal.service.table.TableEngineHandler;
+import com.onedata.portal.service.table.TableEngineHandlerRegistry;
+import com.onedata.portal.util.DatasourceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,11 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * 表创建服务
@@ -31,12 +32,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class TableCreateService {
 
-    private static final Pattern NUMERIC_PATTERN = Pattern.compile("^-?\\d+(\\.\\d+)?$");
-
     private final DataTableMapper dataTableMapper;
     private final DataFieldMapper dataFieldMapper;
+    private final DorisClusterMapper dorisClusterMapper;
     private final TableNameGeneratorService tableNameGeneratorService;
-    private final DorisConnectionService dorisConnectionService;
+    private final TableEngineHandlerRegistry tableEngineHandlerRegistry;
     private final TableMetadataVersionService tableMetadataVersionService;
 
     /**
@@ -45,7 +45,8 @@ public class TableCreateService {
     public TableDesignPreviewResponse preview(TableCreateRequest request) {
         validateRequest(request);
         TableNameComponentsWrapper components = buildComponents(request);
-        String ddl = buildCreateDdl(components.getTableName(), request);
+        TableEngineHandler dorisHandler = tableEngineHandlerRegistry.require(DatasourceType.DORIS);
+        String ddl = dorisHandler.buildCreateDdl(components.getTableName(), request);
         return new TableDesignPreviewResponse(components.getTableName(), ddl);
     }
 
@@ -55,21 +56,24 @@ public class TableCreateService {
     @Transactional
     public DataTable create(TableCreateRequest request) {
         validateRequest(request);
+        validateDorisDatasource(request);
         TableNameComponentsWrapper components = buildComponents(request);
+        TableEngineHandler dorisHandler = tableEngineHandlerRegistry.require(DatasourceType.DORIS);
 
         ensureTableNotExists(components.getTableName(), request.getDbName(), request.getDorisClusterId());
 
         String ddl = StringUtils.hasText(request.getDorisDdl())
             ? request.getDorisDdl().trim()
-            : buildCreateDdl(components.getTableName(), request);
+            : dorisHandler.buildCreateDdl(components.getTableName(), request);
 
-        DataTable dataTable = buildDataTableEntity(request, components, ddl);
+        DataTable dataTable = buildDataTableEntity(request, components);
+        dorisHandler.prepareCreateMetadata(dataTable, request, ddl);
         dataTableMapper.insert(dataTable);
 
         persistColumns(dataTable.getId(), request);
 
         if (!Boolean.FALSE.equals(request.getSyncToDoris())) {
-            dorisConnectionService.execute(request.getDorisClusterId(), request.getDbName(), ddl);
+            dorisHandler.executeCreateTable(request.getDorisClusterId(), request.getDbName(), ddl);
             dataTable.setIsSynced(1);
             dataTable.setSyncTime(LocalDateTime.now());
         }
@@ -117,6 +121,24 @@ public class TableCreateService {
         }
     }
 
+    private void validateDorisDatasource(TableCreateRequest request) {
+        Long datasourceId = request.getDorisClusterId();
+        if (datasourceId == null) {
+            if (!Boolean.FALSE.equals(request.getSyncToDoris())) {
+                throw new RuntimeException("请指定 Doris 数据源");
+            }
+            return;
+        }
+        DorisCluster datasource = dorisClusterMapper.selectById(datasourceId);
+        if (datasource == null) {
+            throw new RuntimeException("数据源不存在: " + datasourceId);
+        }
+        DatasourceType sourceType = DatasourceType.from(datasource.getSourceType());
+        if (sourceType != DatasourceType.DORIS) {
+            throw new RuntimeException("表设计器仅支持 Doris 数据源: " + sourceType.name());
+        }
+    }
+
     private TableNameComponentsWrapper buildComponents(TableCreateRequest request) {
         TableNameGenerateRequest generateRequest = tableNameGeneratorService.fromCreateRequest(request);
         TableNameGeneratorService.TableNameComponents components = tableNameGeneratorService.buildComponents(generateRequest);
@@ -125,9 +147,8 @@ public class TableCreateService {
             components.getCustomIdentifier(), components.getStatisticsCycle(), components.getUpdateType());
     }
 
-    private DataTable buildDataTableEntity(TableCreateRequest request, TableNameComponentsWrapper components, String ddl) {
+    private DataTable buildDataTableEntity(TableCreateRequest request, TableNameComponentsWrapper components) {
         DataTable table = new DataTable();
-        table.setClusterId(request.getDorisClusterId());
         table.setTableName(components.getTableName());
         table.setTableComment(request.getTableComment());
         table.setLayer(components.getLayer());
@@ -138,13 +159,6 @@ public class TableCreateService {
         table.setUpdateType(components.getUpdateType());
         table.setDbName(request.getDbName());
         table.setOwner(request.getOwner());
-        table.setTableModel(resolveTableModel(request.getTableModel()));
-        table.setBucketNum(request.getBucketNum() != null ? request.getBucketNum() : 10);
-        table.setReplicaNum(request.getReplicaNum() != null ? request.getReplicaNum() : 3);
-        table.setPartitionColumn(request.getPartitionColumn());
-        table.setDistributionColumn(joinColumns(request.getDistributionColumns()));
-        table.setKeyColumns(joinColumns(request.getKeyColumns()));
-        table.setDorisDdl(ddl);
         table.setIsSynced(0);
         table.setStatus("active");
         return table;
@@ -177,68 +191,6 @@ public class TableCreateService {
         }
     }
 
-    private String buildCreateDdl(String tableName, TableCreateRequest request) {
-        List<String> columnDefinitions = new ArrayList<>();
-        for (TableColumnRequest column : request.getColumns()) {
-            columnDefinitions.add(buildColumnDefinition(column));
-        }
-
-        String tableModel = resolveTableModel(request.getTableModel());
-        List<String> keyColumns = normalizeList(request.getKeyColumns());
-        String tableModelClause = buildTableModelClause(tableModel, keyColumns);
-
-        StringBuilder ddl = new StringBuilder();
-        ddl.append("CREATE TABLE `").append(request.getDbName()).append("`.`").append(tableName).append("` (\n  ");
-        ddl.append(String.join(",\n  ", columnDefinitions));
-        ddl.append("\n) ENGINE=OLAP\n");
-
-        if (StringUtils.hasText(tableModelClause)) {
-            ddl.append(tableModelClause).append("\n");
-        }
-
-        if (StringUtils.hasText(request.getTableComment())) {
-            ddl.append("COMMENT '").append(escapeSingleQuote(request.getTableComment())).append("'\n");
-        }
-
-        if (StringUtils.hasText(request.getPartitionColumn())) {
-            ddl.append("PARTITION BY RANGE(").append(wrapColumn(request.getPartitionColumn())).append(") ()\n");
-        }
-
-        List<String> distributionColumns = normalizeList(request.getDistributionColumns());
-        if (!distributionColumns.isEmpty()) {
-            ddl.append("DISTRIBUTED BY HASH(")
-                .append(distributionColumns.stream().map(this::wrapColumn).collect(Collectors.joining(", ")))
-                .append(") BUCKETS ")
-                .append(request.getBucketNum() != null ? request.getBucketNum() : 10)
-                .append("\n");
-        }
-
-        ddl.append("PROPERTIES (\n");
-        ddl.append("  \"replication_num\" = \"").append(request.getReplicaNum() != null ? request.getReplicaNum() : 3).append("\",\n");
-        ddl.append("  \"storage_format\" = \"V2\",\n");
-        ddl.append("  \"compression\" = \"LZ4\"\n");
-        ddl.append(");");
-
-        return ddl.toString();
-    }
-
-    private String buildColumnDefinition(TableColumnRequest column) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(wrapColumn(column.getColumnName())).append(" ").append(buildColumnType(column));
-        if (Boolean.FALSE.equals(column.getNullable())) {
-            builder.append(" NOT NULL");
-        } else {
-            builder.append(" NULL");
-        }
-        if (StringUtils.hasText(column.getDefaultValue())) {
-            builder.append(" DEFAULT ").append(formatDefaultValue(column.getDefaultValue()));
-        }
-        if (StringUtils.hasText(column.getComment())) {
-            builder.append(" COMMENT '").append(escapeSingleQuote(column.getComment())).append("'");
-        }
-        return builder.toString();
-    }
-
     private String buildColumnType(TableColumnRequest column) {
         String dataType = column.getDataType() != null ? column.getDataType().toUpperCase() : "";
         String typeParams = column.getTypeParams();
@@ -252,48 +204,14 @@ public class TableCreateService {
         return dataType;
     }
 
-    private String resolveTableModel(String model) {
-        if (!StringUtils.hasText(model)) {
-            return "DUPLICATE";
-        }
-        String upper = model.trim().toUpperCase();
-        if (upper.endsWith(" KEY")) {
-            upper = upper.substring(0, upper.length() - 4).trim();
-        }
-        return upper;
-    }
-
-    private String buildTableModelClause(String model, List<String> keyColumns) {
-        if (!StringUtils.hasText(model)) {
-            return null;
-        }
-        StringBuilder builder = new StringBuilder();
-        builder.append(model).append(" KEY");
-        if (!CollectionUtils.isEmpty(keyColumns)) {
-            builder.append("(")
-                .append(keyColumns.stream().map(this::wrapColumn).collect(Collectors.joining(", ")))
-                .append(")");
-        }
-        return builder.toString();
-    }
-
-    private String joinColumns(List<String> columns) {
-        if (CollectionUtils.isEmpty(columns)) {
-            return null;
-        }
-        return columns.stream()
-            .filter(StringUtils::hasText)
-            .collect(Collectors.joining(","));
-    }
-
     private List<String> normalizeList(List<String> columns) {
         if (CollectionUtils.isEmpty(columns)) {
-            return Collections.emptyList();
+            return java.util.Collections.emptyList();
         }
         return columns.stream()
             .filter(StringUtils::hasText)
             .map(String::trim)
-            .collect(Collectors.toList());
+            .collect(java.util.stream.Collectors.toList());
     }
 
     private boolean containsIgnoreCase(List<String> list, String value) {
@@ -306,31 +224,6 @@ public class TableCreateService {
             }
         }
         return false;
-    }
-
-    private String wrapColumn(String column) {
-        return "`" + column + "`";
-    }
-
-    private String formatDefaultValue(String defaultValue) {
-        String value = defaultValue.trim();
-        if ("null".equalsIgnoreCase(value)) {
-            return "NULL";
-        }
-        if ("current_timestamp".equalsIgnoreCase(value) || value.toUpperCase().startsWith("NOW(")) {
-            return value;
-        }
-        if (NUMERIC_PATTERN.matcher(value).matches()) {
-            return value;
-        }
-        if (value.startsWith("'") && value.endsWith("'")) {
-            return value;
-        }
-        return "'" + escapeSingleQuote(value) + "'";
-    }
-
-    private String escapeSingleQuote(String input) {
-        return input.replace("'", "''");
     }
 
     /**

--- a/backend/src/main/java/com/onedata/portal/service/table/DorisTableEngineHandler.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/DorisTableEngineHandler.java
@@ -1,0 +1,334 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.dto.TableColumnRequest;
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.service.DorisConnectionService;
+import com.onedata.portal.util.DatasourceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Doris-specific table metadata and physical DDL operations.
+ */
+@Component
+@RequiredArgsConstructor
+public class DorisTableEngineHandler implements TableEngineHandler {
+
+    private static final Pattern NUMERIC_PATTERN = Pattern.compile("^-?\\d+(\\.\\d+)?$");
+
+    private final DorisConnectionService dorisConnectionService;
+
+    @Override
+    public DatasourceType sourceType() {
+        return DatasourceType.DORIS;
+    }
+
+    @Override
+    public void prepareCreateMetadata(DataTable table, TableCreateRequest request, String ddl) {
+        table.setClusterId(request.getDorisClusterId());
+        table.setTableModel(resolveTableModel(request.getTableModel()));
+        table.setBucketNum(request.getBucketNum() != null ? request.getBucketNum() : 10);
+        table.setReplicaNum(request.getReplicaNum() != null ? request.getReplicaNum() : 3);
+        table.setPartitionColumn(request.getPartitionColumn());
+        table.setDistributionColumn(joinColumns(request.getDistributionColumns()));
+        table.setKeyColumns(joinColumns(request.getKeyColumns()));
+        table.setDorisDdl(ddl);
+    }
+
+    @Override
+    public String buildCreateDdl(String tableName, TableCreateRequest request) {
+        List<String> columnDefinitions = request.getColumns().stream()
+                .map(this::buildColumnDefinition)
+                .collect(Collectors.toList());
+
+        String tableModel = resolveTableModel(request.getTableModel());
+        List<String> keyColumns = normalizeList(request.getKeyColumns());
+        String tableModelClause = buildTableModelClause(tableModel, keyColumns);
+
+        StringBuilder ddl = new StringBuilder();
+        ddl.append("CREATE TABLE `").append(request.getDbName()).append("`.`").append(tableName).append("` (\n  ");
+        ddl.append(String.join(",\n  ", columnDefinitions));
+        ddl.append("\n) ENGINE=OLAP\n");
+
+        if (StringUtils.hasText(tableModelClause)) {
+            ddl.append(tableModelClause).append("\n");
+        }
+
+        if (StringUtils.hasText(request.getTableComment())) {
+            ddl.append("COMMENT '").append(escapeSingleQuote(request.getTableComment())).append("'\n");
+        }
+
+        if (StringUtils.hasText(request.getPartitionColumn())) {
+            ddl.append("PARTITION BY RANGE(").append(wrapColumn(request.getPartitionColumn())).append(") ()\n");
+        }
+
+        List<String> distributionColumns = normalizeList(request.getDistributionColumns());
+        if (!distributionColumns.isEmpty()) {
+            ddl.append("DISTRIBUTED BY HASH(")
+                    .append(distributionColumns.stream().map(this::wrapColumn).collect(Collectors.joining(", ")))
+                    .append(") BUCKETS ")
+                    .append(request.getBucketNum() != null ? request.getBucketNum() : 10)
+                    .append("\n");
+        }
+
+        ddl.append("PROPERTIES (\n");
+        ddl.append("  \"replication_num\" = \"")
+                .append(request.getReplicaNum() != null ? request.getReplicaNum() : 3)
+                .append("\",\n");
+        ddl.append("  \"storage_format\" = \"V2\",\n");
+        ddl.append("  \"compression\" = \"LZ4\"\n");
+        ddl.append(");");
+        return ddl.toString();
+    }
+
+    @Override
+    public void executeCreateTable(Long datasourceId, String database, String ddl) {
+        dorisConnectionService.execute(datasourceId, database, ddl);
+    }
+
+    @Override
+    public void alterTableComment(Long datasourceId, String database, String tableName, String comment) {
+        dorisConnectionService.alterTableComment(datasourceId, database, tableName, comment);
+    }
+
+    @Override
+    public void renameTable(Long datasourceId, String database, String oldTableName, String newTableName) {
+        dorisConnectionService.renameTable(datasourceId, database, oldTableName, newTableName);
+    }
+
+    @Override
+    public void dropTable(Long datasourceId, String database, String tableName) {
+        dorisConnectionService.dropTable(datasourceId, database, tableName);
+    }
+
+    @Override
+    public void addColumn(Long datasourceId, DataTable table, String database, String tableName, DataField field) {
+        if (isAggregateTable(table)) {
+            throw new RuntimeException("AGGREGATE 表字段变更需指定聚合方式，暂不支持同步");
+        }
+        boolean isKey = isKeyColumn(table, field);
+        if (isKey) {
+            throw new RuntimeException("Doris 不支持在线新增主键列");
+        }
+        String columnDef = dorisConnectionService.buildColumnDefinition(field, false);
+        dorisConnectionService.addColumn(datasourceId, database, tableName, columnDef);
+    }
+
+    @Override
+    public void updateColumn(Long datasourceId, DataTable table, String database, String tableName,
+            DataField oldField, DataField newField) {
+        if (!Objects.equals(oldField.getIsPrimary(), newField.getIsPrimary())) {
+            throw new RuntimeException("Doris 不支持在线修改主键列");
+        }
+        boolean nameChanged = !Objects.equals(oldField.getFieldName(), newField.getFieldName());
+        if (isAggregateTable(table)) {
+            if (nameChanged || hasNonCommentChanges(oldField, newField)) {
+                throw new RuntimeException("AGGREGATE 表字段变更需指定聚合方式，暂不支持同步");
+            }
+            if (onlyCommentChanged(oldField, newField)) {
+                dorisConnectionService.modifyColumnComment(datasourceId, database, tableName,
+                        newField.getFieldName(), newField.getFieldComment());
+            }
+            return;
+        }
+        if (nameChanged) {
+            dorisConnectionService.renameColumn(datasourceId, database, tableName,
+                    oldField.getFieldName(), newField.getFieldName());
+        }
+        if (isColumnChanged(oldField, newField)) {
+            boolean isKey = isKeyColumn(table, newField);
+            String columnDef = dorisConnectionService.buildColumnDefinition(newField, isKey);
+            dorisConnectionService.modifyColumn(datasourceId, database, tableName, columnDef);
+        }
+    }
+
+    @Override
+    public void dropColumn(Long datasourceId, String database, String tableName, String columnName) {
+        dorisConnectionService.dropColumn(datasourceId, database, tableName, columnName);
+    }
+
+    @Override
+    public void modifyDistribution(Long datasourceId, DataTable table, String database, String tableName,
+            Integer bucketNum) {
+        if (!StringUtils.hasText(table.getDistributionColumn())) {
+            throw new RuntimeException("缺少分桶字段，无法同步分桶数到 Doris");
+        }
+        dorisConnectionService.modifyDistribution(datasourceId, database, tableName,
+                table.getDistributionColumn(), bucketNum);
+    }
+
+    @Override
+    public void setReplicationNum(Long datasourceId, String database, String tableName, Integer replicaNum) {
+        dorisConnectionService.setReplicationNum(datasourceId, database, tableName, replicaNum);
+    }
+
+    private String buildColumnDefinition(TableColumnRequest column) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(wrapColumn(column.getColumnName())).append(" ").append(buildColumnType(column));
+        if (Boolean.FALSE.equals(column.getNullable())) {
+            builder.append(" NOT NULL");
+        } else {
+            builder.append(" NULL");
+        }
+        if (StringUtils.hasText(column.getDefaultValue())) {
+            builder.append(" DEFAULT ").append(formatDefaultValue(column.getDefaultValue()));
+        }
+        if (StringUtils.hasText(column.getComment())) {
+            builder.append(" COMMENT '").append(escapeSingleQuote(column.getComment())).append("'");
+        }
+        return builder.toString();
+    }
+
+    private String buildColumnType(TableColumnRequest column) {
+        String dataType = column.getDataType() != null ? column.getDataType().toUpperCase() : "";
+        String typeParams = column.getTypeParams();
+        if (StringUtils.hasText(typeParams)) {
+            String trimmed = typeParams.trim();
+            if (trimmed.startsWith("(") && trimmed.endsWith(")")) {
+                return dataType + trimmed;
+            }
+            return dataType + "(" + trimmed + ")";
+        }
+        return dataType;
+    }
+
+    private String resolveTableModel(String model) {
+        if (!StringUtils.hasText(model)) {
+            return "DUPLICATE";
+        }
+        String upper = model.trim().toUpperCase();
+        if (upper.endsWith(" KEY")) {
+            upper = upper.substring(0, upper.length() - 4).trim();
+        }
+        return upper;
+    }
+
+    private String buildTableModelClause(String model, List<String> keyColumns) {
+        if (!StringUtils.hasText(model)) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(model).append(" KEY");
+        if (!CollectionUtils.isEmpty(keyColumns)) {
+            builder.append("(")
+                    .append(keyColumns.stream().map(this::wrapColumn).collect(Collectors.joining(", ")))
+                    .append(")");
+        }
+        return builder.toString();
+    }
+
+    private String joinColumns(List<String> columns) {
+        if (CollectionUtils.isEmpty(columns)) {
+            return null;
+        }
+        return columns.stream()
+                .filter(StringUtils::hasText)
+                .collect(Collectors.joining(","));
+    }
+
+    private List<String> normalizeList(List<String> columns) {
+        if (CollectionUtils.isEmpty(columns)) {
+            return Collections.emptyList();
+        }
+        return columns.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isAggregateTable(DataTable table) {
+        return table != null && StringUtils.hasText(table.getTableModel())
+                && "AGGREGATE".equalsIgnoreCase(table.getTableModel());
+    }
+
+    private boolean isKeyColumn(DataTable table, DataField field) {
+        if (field != null && field.getIsPrimary() != null && field.getIsPrimary() == 1) {
+            return true;
+        }
+        if (table == null || !StringUtils.hasText(table.getKeyColumns()) || field == null
+                || !StringUtils.hasText(field.getFieldName())) {
+            return false;
+        }
+        String[] keys = table.getKeyColumns().split(",");
+        for (String key : keys) {
+            if (field.getFieldName().equalsIgnoreCase(key.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isColumnChanged(DataField oldField, DataField newField) {
+        if (oldField == null || newField == null) {
+            return false;
+        }
+        return !Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
+                || !Objects.equals(normalize(oldField.getFieldComment()), normalize(newField.getFieldComment()))
+                || !Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
+                || !Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
+                || !Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()));
+    }
+
+    private boolean hasNonCommentChanges(DataField oldField, DataField newField) {
+        if (oldField == null || newField == null) {
+            return false;
+        }
+        return !Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
+                || !Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
+                || !Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
+                || !Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()));
+    }
+
+    private boolean onlyCommentChanged(DataField oldField, DataField newField) {
+        if (oldField == null || newField == null) {
+            return false;
+        }
+        return Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
+                && Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
+                && Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()))
+                && Objects.equals(normalize(oldField.getIsPrimary()), normalize(newField.getIsPrimary()))
+                && !Objects.equals(normalize(oldField.getFieldComment()), normalize(newField.getFieldComment()));
+    }
+
+    private Object normalize(Object value) {
+        if (value instanceof String) {
+            return ((String) value).trim();
+        }
+        return value;
+    }
+
+    private String wrapColumn(String column) {
+        return "`" + column + "`";
+    }
+
+    private String formatDefaultValue(String defaultValue) {
+        String value = defaultValue.trim();
+        if ("null".equalsIgnoreCase(value)) {
+            return "NULL";
+        }
+        if ("current_timestamp".equalsIgnoreCase(value) || value.toUpperCase().startsWith("NOW(")) {
+            return value;
+        }
+        if (NUMERIC_PATTERN.matcher(value).matches()) {
+            return value;
+        }
+        if (value.startsWith("'") && value.endsWith("'")) {
+            return value;
+        }
+        return "'" + escapeSingleQuote(value) + "'";
+    }
+
+    private String escapeSingleQuote(String input) {
+        return input.replace("'", "''");
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/table/MysqlTableEngineHandler.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/MysqlTableEngineHandler.java
@@ -1,0 +1,193 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.util.DatasourceType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * MySQL table handler. It owns MySQL physical DDL and metadata normalization so
+ * Doris-only fields never leak into MySQL table records.
+ */
+@Component
+@RequiredArgsConstructor
+public class MysqlTableEngineHandler implements TableEngineHandler {
+
+    private static final Pattern NUMERIC_PATTERN = Pattern.compile("^-?\\d+(\\.\\d+)?$");
+
+    private final TableEngineJdbcExecutor jdbcExecutor;
+
+    @Override
+    public DatasourceType sourceType() {
+        return DatasourceType.MYSQL;
+    }
+
+    @Override
+    public void alterTableComment(Long datasourceId, String database, String tableName, String comment) {
+        String escapedComment = escapeSingleQuote(comment == null ? "" : comment);
+        String sql = String.format("ALTER TABLE %s COMMENT = '%s'",
+                qualifiedName(database, tableName), escapedComment);
+        execute(datasourceId, database, sql);
+    }
+
+    @Override
+    public void renameTable(Long datasourceId, String database, String oldTableName, String newTableName) {
+        String sql = String.format("RENAME TABLE %s TO %s",
+                qualifiedName(database, oldTableName), qualifiedName(database, newTableName));
+        execute(datasourceId, database, sql);
+    }
+
+    @Override
+    public void dropTable(Long datasourceId, String database, String tableName) {
+        String sql = String.format("DROP TABLE IF EXISTS %s", qualifiedName(database, tableName));
+        execute(datasourceId, database, sql);
+    }
+
+    @Override
+    public void addColumn(Long datasourceId, DataTable table, String database, String tableName, DataField field) {
+        String columnDefinition = buildColumnDefinition(field, false);
+        String sql = String.format("ALTER TABLE %s ADD COLUMN %s",
+                qualifiedName(database, tableName), columnDefinition);
+        if (isPrimary(field)) {
+            sql += ", ADD PRIMARY KEY (" + wrapIdentifier(field.getFieldName()) + ")";
+        }
+        execute(datasourceId, database, sql);
+    }
+
+    @Override
+    public void updateColumn(Long datasourceId, DataTable table, String database, String tableName,
+            DataField oldField, DataField newField) {
+        if (!Objects.equals(oldField.getIsPrimary(), newField.getIsPrimary())) {
+            throw new RuntimeException("MySQL 暂不支持在线修改主键列");
+        }
+        String currentColumnName = oldField.getFieldName();
+        if (!Objects.equals(oldField.getFieldName(), newField.getFieldName())) {
+            String renameSql = String.format("ALTER TABLE %s RENAME COLUMN %s TO %s",
+                    qualifiedName(database, tableName),
+                    wrapIdentifier(oldField.getFieldName()),
+                    wrapIdentifier(newField.getFieldName()));
+            execute(datasourceId, database, renameSql);
+            currentColumnName = newField.getFieldName();
+        }
+        if (isColumnChanged(oldField, newField)) {
+            DataField modifiedField = copyWithName(newField, currentColumnName);
+            String modifySql = String.format("ALTER TABLE %s MODIFY COLUMN %s",
+                    qualifiedName(database, tableName), buildColumnDefinition(modifiedField, false));
+            execute(datasourceId, database, modifySql);
+        }
+    }
+
+    @Override
+    public void dropColumn(Long datasourceId, String database, String tableName, String columnName) {
+        String sql = String.format("ALTER TABLE %s DROP COLUMN %s",
+                qualifiedName(database, tableName), wrapIdentifier(columnName));
+        execute(datasourceId, database, sql);
+    }
+
+    @Override
+    public void modifyDistribution(Long datasourceId, DataTable table, String database, String tableName,
+            Integer bucketNum) {
+        throw new RuntimeException("MySQL 数据源不支持分桶设置");
+    }
+
+    @Override
+    public void setReplicationNum(Long datasourceId, String database, String tableName, Integer replicaNum) {
+        throw new RuntimeException("MySQL 数据源不支持副本数设置");
+    }
+
+    private void execute(Long datasourceId, String database, String sql) {
+        jdbcExecutor.execute(datasourceId, database, sql, sourceType());
+    }
+
+    private String buildColumnDefinition(DataField field, boolean includePrimary) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(wrapIdentifier(field.getFieldName())).append(" ").append(field.getFieldType());
+        if (isPrimary(field) || (field.getIsNullable() != null && field.getIsNullable() == 0)) {
+            builder.append(" NOT NULL");
+        } else {
+            builder.append(" NULL");
+        }
+        if (StringUtils.hasText(field.getDefaultValue())) {
+            builder.append(" DEFAULT ").append(formatDefaultValue(field.getDefaultValue()));
+        }
+        if (StringUtils.hasText(field.getFieldComment())) {
+            builder.append(" COMMENT '").append(escapeSingleQuote(field.getFieldComment())).append("'");
+        }
+        if (includePrimary && isPrimary(field)) {
+            builder.append(" PRIMARY KEY");
+        }
+        return builder.toString();
+    }
+
+    private boolean isColumnChanged(DataField oldField, DataField newField) {
+        if (oldField == null || newField == null) {
+            return false;
+        }
+        return !Objects.equals(normalize(oldField.getFieldType()), normalize(newField.getFieldType()))
+                || !Objects.equals(normalize(oldField.getFieldComment()), normalize(newField.getFieldComment()))
+                || !Objects.equals(normalize(oldField.getDefaultValue()), normalize(newField.getDefaultValue()))
+                || !Objects.equals(normalize(oldField.getIsNullable()), normalize(newField.getIsNullable()));
+    }
+
+    private Object normalize(Object value) {
+        if (value instanceof String) {
+            return ((String) value).trim();
+        }
+        return value;
+    }
+
+    private boolean isPrimary(DataField field) {
+        return field != null && field.getIsPrimary() != null && field.getIsPrimary() == 1;
+    }
+
+    private DataField copyWithName(DataField source, String fieldName) {
+        DataField copy = new DataField();
+        copy.setId(source.getId());
+        copy.setTableId(source.getTableId());
+        copy.setFieldName(fieldName);
+        copy.setFieldType(source.getFieldType());
+        copy.setFieldComment(source.getFieldComment());
+        copy.setIsNullable(source.getIsNullable());
+        copy.setIsPrimary(source.getIsPrimary());
+        copy.setIsPartition(source.getIsPartition());
+        copy.setDefaultValue(source.getDefaultValue());
+        copy.setFieldOrder(source.getFieldOrder());
+        copy.setCreatedAt(source.getCreatedAt());
+        copy.setUpdatedAt(source.getUpdatedAt());
+        return copy;
+    }
+
+    private String qualifiedName(String database, String tableName) {
+        return wrapIdentifier(database) + "." + wrapIdentifier(tableName);
+    }
+
+    private String wrapIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
+    private String formatDefaultValue(String defaultValue) {
+        String value = defaultValue.trim();
+        if ("null".equalsIgnoreCase(value)) {
+            return "NULL";
+        }
+        if ("current_timestamp".equalsIgnoreCase(value) || value.toUpperCase().startsWith("NOW(")) {
+            return value;
+        }
+        if (NUMERIC_PATTERN.matcher(value).matches()) {
+            return value;
+        }
+        if (value.startsWith("'") && value.endsWith("'")) {
+            return value;
+        }
+        return "'" + escapeSingleQuote(value) + "'";
+    }
+
+    private String escapeSingleQuote(String input) {
+        return input.replace("'", "''");
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/table/TableEngineHandler.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/TableEngineHandler.java
@@ -1,0 +1,77 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.util.DatasourceType;
+
+/**
+ * Engine-specific table metadata normalization and physical DDL operations.
+ */
+public interface TableEngineHandler {
+
+    DatasourceType sourceType();
+
+    default void prepareCreateMetadata(DataTable table, TableCreateRequest request, String ddl) {
+        clearDorisPhysicalMetadata(table);
+    }
+
+    default String buildCreateDdl(String tableName, TableCreateRequest request) {
+        throw unsupported();
+    }
+
+    default void executeCreateTable(Long datasourceId, String database, String ddl) {
+        throw unsupported();
+    }
+
+    default void alterTableComment(Long datasourceId, String database, String tableName, String comment) {
+        throw unsupported();
+    }
+
+    default void renameTable(Long datasourceId, String database, String oldTableName, String newTableName) {
+        throw unsupported();
+    }
+
+    default void dropTable(Long datasourceId, String database, String tableName) {
+        throw unsupported();
+    }
+
+    default void addColumn(Long datasourceId, DataTable table, String database, String tableName, DataField field) {
+        throw unsupported();
+    }
+
+    default void updateColumn(Long datasourceId, DataTable table, String database, String tableName,
+            DataField oldField, DataField newField) {
+        throw unsupported();
+    }
+
+    default void dropColumn(Long datasourceId, String database, String tableName, String columnName) {
+        throw unsupported();
+    }
+
+    default void modifyDistribution(Long datasourceId, DataTable table, String database, String tableName,
+            Integer bucketNum) {
+        throw unsupported();
+    }
+
+    default void setReplicationNum(Long datasourceId, String database, String tableName, Integer replicaNum) {
+        throw unsupported();
+    }
+
+    default RuntimeException unsupported() {
+        return new RuntimeException("暂不支持同步 " + sourceType().name() + " 数据源的表变更");
+    }
+
+    static void clearDorisPhysicalMetadata(DataTable table) {
+        if (table == null) {
+            return;
+        }
+        table.setTableModel(null);
+        table.setBucketNum(null);
+        table.setReplicaNum(null);
+        table.setPartitionColumn(null);
+        table.setDistributionColumn(null);
+        table.setKeyColumns(null);
+        table.setDorisDdl(null);
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/table/TableEngineHandlerRegistry.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/TableEngineHandlerRegistry.java
@@ -1,0 +1,40 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.util.DatasourceType;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registry for datasource-engine table handlers.
+ */
+@Service
+public class TableEngineHandlerRegistry {
+
+    private final Map<DatasourceType, TableEngineHandler> handlers;
+
+    public TableEngineHandlerRegistry(List<TableEngineHandler> handlerList) {
+        EnumMap<DatasourceType, TableEngineHandler> registry = new EnumMap<>(DatasourceType.class);
+        for (TableEngineHandler handler : handlerList) {
+            TableEngineHandler previous = registry.put(handler.sourceType(), handler);
+            if (previous != null) {
+                throw new IllegalStateException("Duplicate table engine handler for " + handler.sourceType());
+            }
+        }
+        this.handlers = registry;
+    }
+
+    public TableEngineHandler require(DatasourceType sourceType) {
+        TableEngineHandler handler = handlers.get(sourceType);
+        if (handler == null) {
+            throw new RuntimeException("暂不支持数据源类型: " + sourceType.name());
+        }
+        return handler;
+    }
+
+    public TableEngineHandler find(DatasourceType sourceType) {
+        return handlers.get(sourceType);
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/table/TableEngineJdbcExecutor.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/TableEngineJdbcExecutor.java
@@ -1,0 +1,76 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.mapper.DorisClusterMapper;
+import com.onedata.portal.util.DatasourceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Plain JDBC executor for non-Doris table engines configured in doris_cluster.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TableEngineJdbcExecutor {
+
+    private final DorisClusterMapper dorisClusterMapper;
+
+    public void execute(Long datasourceId, String database, String sql, DatasourceType expectedType) {
+        DorisCluster datasource = resolveDatasource(datasourceId, expectedType);
+        try (Connection connection = getConnection(datasource, database);
+                Statement statement = connection.createStatement()) {
+            log.info("Executing SQL on {} datasource {} (db={}): {}",
+                    expectedType.name(), datasource.getClusterName(), database, abbreviate(sql));
+            statement.execute(sql);
+        } catch (SQLException e) {
+            log.error("Failed to execute SQL on {} datasource {} (db={})",
+                    expectedType.name(), datasource.getClusterName(), database, e);
+            throw new RuntimeException("执行 " + expectedType.name() + " SQL 失败: " + e.getMessage(), e);
+        }
+    }
+
+    private Connection getConnection(DorisCluster datasource, String database) throws SQLException {
+        String url = buildJdbcUrl(datasource, database);
+        String username = datasource.getUsername();
+        String password = datasource.getPassword() == null ? "" : datasource.getPassword();
+        return DriverManager.getConnection(url, username, password);
+    }
+
+    private String buildJdbcUrl(DorisCluster datasource, String database) {
+        String targetDb = StringUtils.hasText(database) ? database : "information_schema";
+        return String.format(
+                "jdbc:mysql://%s:%d/%s?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai&useSSL=false&allowPublicKeyRetrieval=true",
+                datasource.getFeHost(), datasource.getFePort(), targetDb);
+    }
+
+    private DorisCluster resolveDatasource(Long datasourceId, DatasourceType expectedType) {
+        if (datasourceId == null) {
+            throw new RuntimeException("请指定数据源");
+        }
+        DorisCluster datasource = dorisClusterMapper.selectById(datasourceId);
+        if (datasource == null) {
+            throw new RuntimeException("数据源不存在: " + datasourceId);
+        }
+        DatasourceType actualType = DatasourceType.from(datasource.getSourceType());
+        if (actualType != expectedType) {
+            throw new RuntimeException("数据源类型不匹配，期望 " + expectedType.name() + "，实际 " + actualType.name());
+        }
+        return datasource;
+    }
+
+    private String abbreviate(String sql) {
+        if (!StringUtils.hasText(sql)) {
+            return "";
+        }
+        String trimmed = sql.replaceAll("\\s+", " ").trim();
+        return trimmed.length() > 200 ? trimmed.substring(0, 200) + "..." : trimmed;
+    }
+}

--- a/backend/src/main/resources/db/migration/V46__data_table_clear_non_doris_physical_fields.sql
+++ b/backend/src/main/resources/db/migration/V46__data_table_clear_non_doris_physical_fields.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `data_table`
+    MODIFY COLUMN `replica_num` INT DEFAULT NULL COMMENT '副本数';
+
+UPDATE `data_table` dt
+LEFT JOIN `doris_cluster` dc ON dt.`cluster_id` = dc.`id`
+SET dt.`table_model` = NULL,
+    dt.`bucket_num` = NULL,
+    dt.`replica_num` = NULL,
+    dt.`partition_column` = NULL,
+    dt.`distribution_column` = NULL,
+    dt.`key_columns` = NULL,
+    dt.`doris_ddl` = NULL
+WHERE dt.`cluster_id` IS NULL
+   OR UPPER(COALESCE(dc.`source_type`, '')) <> 'DORIS';

--- a/backend/src/test/java/com/onedata/portal/service/DataTableServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DataTableServiceTest.java
@@ -10,6 +10,9 @@ import com.onedata.portal.mapper.DataTaskMapper;
 import com.onedata.portal.mapper.DorisClusterMapper;
 import com.onedata.portal.mapper.TableTaskRelationMapper;
 import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import com.onedata.portal.service.table.TableEngineHandler;
+import com.onedata.portal.service.table.TableEngineHandlerRegistry;
+import com.onedata.portal.util.DatasourceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,11 +20,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -51,7 +54,13 @@ class DataTableServiceTest {
     private DorisClusterMapper dorisClusterMapper;
 
     @Mock
-    private DorisConnectionService dorisConnectionService;
+    private TableEngineHandlerRegistry tableEngineHandlerRegistry;
+
+    @Mock
+    private TableEngineHandler dorisHandler;
+
+    @Mock
+    private TableEngineHandler mysqlHandler;
 
     @Mock
     private TableMetadataVersionService tableMetadataVersionService;
@@ -68,8 +77,64 @@ class DataTableServiceTest {
                 taskExecutionLogMapper,
                 dataLineageMapper,
                 dorisClusterMapper,
-                dorisConnectionService,
+                tableEngineHandlerRegistry,
                 tableMetadataVersionService);
+    }
+
+    @Test
+    void createClearsDorisPhysicalFieldsWhenTableHasNoDatasource() {
+        DataTable table = table(null, null, 0);
+        table.setDbName("dw");
+        table.setTableName("metadata_table");
+        table.setTableModel("DUPLICATE");
+        table.setBucketNum(10);
+        table.setReplicaNum(1);
+        table.setPartitionColumn("dt");
+        table.setDistributionColumn("id");
+        table.setKeyColumns("id");
+        table.setDorisDdl("CREATE TABLE ...");
+        when(dataTableMapper.selectOne(any())).thenReturn(null);
+
+        DataTable result = service.create(table);
+
+        assertSame(table, result);
+        assertNull(table.getTableModel());
+        assertNull(table.getBucketNum());
+        assertNull(table.getReplicaNum());
+        assertNull(table.getPartitionColumn());
+        assertNull(table.getDistributionColumn());
+        assertNull(table.getKeyColumns());
+        assertNull(table.getDorisDdl());
+        verify(dataTableMapper).insert(table);
+        verifyNoInteractions(dorisClusterMapper);
+        verifyNoInteractions(tableEngineHandlerRegistry);
+    }
+
+    @Test
+    void createClearsDorisPhysicalFieldsForMysqlDatasource() {
+        DataTable table = table(null, 8L, 0);
+        table.setDbName("dw");
+        table.setTableName("metadata_table");
+        table.setTableModel("DUPLICATE");
+        table.setBucketNum(10);
+        table.setReplicaNum(1);
+        table.setDistributionColumn("id");
+        when(dorisClusterMapper.selectById(8L)).thenReturn(cluster(8L, "MYSQL"));
+        when(tableEngineHandlerRegistry.find(DatasourceType.MYSQL)).thenReturn(mysqlHandler);
+        doAnswer(invocation -> {
+            TableEngineHandler.clearDorisPhysicalMetadata(invocation.getArgument(0));
+            return null;
+        }).when(mysqlHandler).prepareCreateMetadata(eq(table), isNull(), isNull());
+        when(dataTableMapper.selectOne(any())).thenReturn(null);
+
+        DataTable result = service.create(table);
+
+        assertSame(table, result);
+        assertNull(table.getTableModel());
+        assertNull(table.getBucketNum());
+        assertNull(table.getReplicaNum());
+        assertNull(table.getDistributionColumn());
+        verify(dataTableMapper).insert(table);
     }
 
     @Test
@@ -88,7 +153,7 @@ class DataTableServiceTest {
         verify(tableMetadataVersionService).captureVersion(
                 eq(10L), eq(TableMetadataVersionService.TRIGGER_MANUAL_EDIT), eq(null));
         verifyNoInteractions(dorisClusterMapper);
-        verifyNoInteractions(dorisConnectionService);
+        verifyNoInteractions(tableEngineHandlerRegistry);
     }
 
     @Test
@@ -99,33 +164,33 @@ class DataTableServiceTest {
         when(dataTableMapper.selectById(10L)).thenReturn(table);
         when(dataFieldMapper.selectOne(any())).thenReturn(null);
         when(dorisClusterMapper.selectById(7L)).thenReturn(cluster(7L, "DORIS"));
+        when(tableEngineHandlerRegistry.require(DatasourceType.DORIS)).thenReturn(dorisHandler);
 
         DataField field = field("amount", "BIGINT");
-        when(dorisConnectionService.buildColumnDefinition(field, false)).thenReturn("`amount` BIGINT");
 
         DataField result = service.createField(10L, field, null);
 
         assertSame(field, result);
-        verify(dorisConnectionService).addColumn(7L, "dw", "fact_orders", "`amount` BIGINT");
+        verify(dorisHandler).addColumn(7L, table, "dw", "fact_orders", field);
         verify(dataFieldMapper).insert(field);
     }
 
     @Test
-    void createFieldRejectsSyncedNonDorisTableInsteadOfCallingDorisDdl() {
+    void createFieldDelegatesSyncedMysqlTableToMysqlHandler() {
         DataTable table = table(10L, 8L, 1);
         table.setDbName("dw");
         table.setTableName("fact_orders");
         when(dataTableMapper.selectById(10L)).thenReturn(table);
         when(dataFieldMapper.selectOne(any())).thenReturn(null);
         when(dorisClusterMapper.selectById(8L)).thenReturn(cluster(8L, "MYSQL"));
+        when(tableEngineHandlerRegistry.require(DatasourceType.MYSQL)).thenReturn(mysqlHandler);
 
-        RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> service.createField(10L, field("amount", "BIGINT"), null));
+        DataField field = field("amount", "BIGINT");
+        DataField result = service.createField(10L, field, null);
 
-        assertEquals("暂不支持同步 MYSQL 数据源的表变更", exception.getMessage());
-        verify(dorisConnectionService, never()).addColumn(any(), any(), any(), any());
-        verify(dataFieldMapper, never()).insert(any());
-        verifyNoInteractions(tableMetadataVersionService);
+        assertSame(field, result);
+        verify(mysqlHandler).addColumn(8L, table, "dw", "fact_orders", field);
+        verify(dataFieldMapper).insert(field);
     }
 
     @Test
@@ -144,11 +209,11 @@ class DataTableServiceTest {
         assertSame(update, result);
         verify(dataTableMapper).updateById(update);
         verifyNoInteractions(dorisClusterMapper);
-        verifyNoInteractions(dorisConnectionService);
+        verifyNoInteractions(tableEngineHandlerRegistry);
     }
 
     @Test
-    void updateTableRejectsPhysicalChangeForSyncedNonDorisTable() {
+    void updateTableDelegatesPhysicalChangeForSyncedMysqlTable() {
         DataTable existing = table(10L, 8L, 1);
         existing.setDbName("dw");
         existing.setTableName("fact_orders");
@@ -159,13 +224,13 @@ class DataTableServiceTest {
         DataTable update = new DataTable();
         update.setLayer("DWD");
         update.setTableComment("new comment");
+        when(tableEngineHandlerRegistry.require(DatasourceType.MYSQL)).thenReturn(mysqlHandler);
 
-        RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> service.updateTable(10L, update, null));
+        DataTable result = service.updateTable(10L, update, null);
 
-        assertEquals("暂不支持同步 MYSQL 数据源的表变更", exception.getMessage());
-        verify(dataTableMapper, never()).updateById(any());
-        verifyNoInteractions(dorisConnectionService);
+        assertSame(update, result);
+        verify(mysqlHandler).alterTableComment(8L, "dw", "fact_orders", "new comment");
+        verify(dataTableMapper).updateById(update);
     }
 
     private DataTable table(Long id, Long clusterId, Integer isSynced) {

--- a/backend/src/test/java/com/onedata/portal/service/TableCreateServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/TableCreateServiceTest.java
@@ -1,0 +1,96 @@
+package com.onedata.portal.service;
+
+import com.onedata.portal.dto.TableColumnRequest;
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.entity.DorisCluster;
+import com.onedata.portal.mapper.DataFieldMapper;
+import com.onedata.portal.mapper.DataTableMapper;
+import com.onedata.portal.mapper.DorisClusterMapper;
+import com.onedata.portal.service.table.TableEngineHandlerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TableCreateServiceTest {
+
+    @Mock
+    private DataTableMapper dataTableMapper;
+
+    @Mock
+    private DataFieldMapper dataFieldMapper;
+
+    @Mock
+    private DorisClusterMapper dorisClusterMapper;
+
+    @Mock
+    private TableNameGeneratorService tableNameGeneratorService;
+
+    @Mock
+    private TableEngineHandlerRegistry tableEngineHandlerRegistry;
+
+    @Mock
+    private TableMetadataVersionService tableMetadataVersionService;
+
+    private TableCreateService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TableCreateService(
+                dataTableMapper,
+                dataFieldMapper,
+                dorisClusterMapper,
+                tableNameGeneratorService,
+                tableEngineHandlerRegistry,
+                tableMetadataVersionService);
+    }
+
+    @Test
+    void createRejectsMysqlDatasourceForDorisDesigner() {
+        TableCreateRequest request = request();
+        request.setDorisClusterId(8L);
+        when(dorisClusterMapper.selectById(8L)).thenReturn(cluster("MYSQL"));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> service.create(request));
+
+        assertEquals("表设计器仅支持 Doris 数据源: MYSQL", exception.getMessage());
+    }
+
+    @Test
+    void createRequiresDatasourceWhenSyncingToDoris() {
+        TableCreateRequest request = request();
+        request.setSyncToDoris(true);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> service.create(request));
+
+        assertEquals("请指定 Doris 数据源", exception.getMessage());
+    }
+
+    private TableCreateRequest request() {
+        TableColumnRequest column = new TableColumnRequest();
+        column.setColumnName("id");
+        column.setDataType("BIGINT");
+
+        TableCreateRequest request = new TableCreateRequest();
+        request.setLayer("DWD");
+        request.setDbName("dw");
+        request.setColumns(Collections.singletonList(column));
+        return request;
+    }
+
+    private DorisCluster cluster(String sourceType) {
+        DorisCluster cluster = new DorisCluster();
+        cluster.setId(8L);
+        cluster.setClusterName("test");
+        cluster.setSourceType(sourceType);
+        return cluster;
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/table/MysqlTableEngineHandlerTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/table/MysqlTableEngineHandlerTest.java
@@ -1,0 +1,96 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.entity.DataField;
+import com.onedata.portal.entity.DataTable;
+import com.onedata.portal.util.DatasourceType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MysqlTableEngineHandlerTest {
+
+    @Mock
+    private TableEngineJdbcExecutor jdbcExecutor;
+
+    @Test
+    void alterTableCommentExecutesMysqlCommentDdl() {
+        MysqlTableEngineHandler handler = new MysqlTableEngineHandler(jdbcExecutor);
+
+        handler.alterTableComment(8L, "dw", "fact_orders", "order's table");
+
+        verify(jdbcExecutor).execute(8L, "dw",
+                "ALTER TABLE `dw`.`fact_orders` COMMENT = 'order''s table'",
+                DatasourceType.MYSQL);
+    }
+
+    @Test
+    void addColumnExecutesMysqlAddColumnDdl() {
+        MysqlTableEngineHandler handler = new MysqlTableEngineHandler(jdbcExecutor);
+        DataField field = new DataField();
+        field.setFieldName("amount");
+        field.setFieldType("BIGINT");
+        field.setIsNullable(0);
+        field.setDefaultValue("0");
+        field.setFieldComment("order's amount");
+
+        handler.addColumn(8L, new DataTable(), "dw", "fact_orders", field);
+
+        verify(jdbcExecutor).execute(8L, "dw",
+                "ALTER TABLE `dw`.`fact_orders` ADD COLUMN `amount` BIGINT NOT NULL DEFAULT 0 COMMENT 'order''s amount'",
+                DatasourceType.MYSQL);
+    }
+
+    @Test
+    void updateColumnExecutesRenameThenModifyWhenNameAndDefinitionChange() {
+        MysqlTableEngineHandler handler = new MysqlTableEngineHandler(jdbcExecutor);
+        DataField oldField = new DataField();
+        oldField.setFieldName("amount");
+        oldField.setFieldType("BIGINT");
+        oldField.setIsNullable(0);
+
+        DataField newField = new DataField();
+        newField.setFieldName("total_amount");
+        newField.setFieldType("DECIMAL(12,2)");
+        newField.setIsNullable(1);
+        newField.setFieldComment("total");
+
+        handler.updateColumn(8L, new DataTable(), "dw", "fact_orders", oldField, newField);
+
+        InOrder inOrder = inOrder(jdbcExecutor);
+        inOrder.verify(jdbcExecutor).execute(8L, "dw",
+                "ALTER TABLE `dw`.`fact_orders` RENAME COLUMN `amount` TO `total_amount`",
+                DatasourceType.MYSQL);
+        inOrder.verify(jdbcExecutor).execute(8L, "dw",
+                "ALTER TABLE `dw`.`fact_orders` MODIFY COLUMN `total_amount` DECIMAL(12,2) NULL COMMENT 'total'",
+                DatasourceType.MYSQL);
+    }
+
+    @Test
+    void dropColumnExecutesMysqlDropColumnDdl() {
+        MysqlTableEngineHandler handler = new MysqlTableEngineHandler(jdbcExecutor);
+
+        handler.dropColumn(8L, "dw", "fact_orders", "amount");
+
+        verify(jdbcExecutor).execute(8L, "dw",
+                "ALTER TABLE `dw`.`fact_orders` DROP COLUMN `amount`",
+                DatasourceType.MYSQL);
+    }
+
+    @Test
+    void mysqlRejectsDorisOnlyReplicationSetting() {
+        MysqlTableEngineHandler handler = new MysqlTableEngineHandler(jdbcExecutor);
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> handler.setReplicationNum(8L, "dw", "fact_orders", 3));
+
+        assertEquals("MySQL 数据源不支持副本数设置", exception.getMessage());
+    }
+}

--- a/docs/design/2026-06-22-data-table-source-type-design.md
+++ b/docs/design/2026-06-22-data-table-source-type-design.md
@@ -77,7 +77,26 @@ AND datasource.source_type = DORIS
 
 本轮不扩大 `DorisClusterService` 当前支持范围；未知或未来类型仅用于避免误走 Doris DDL。
 
-### 5.2 收敛 Doris DDL 判定
+### 5.2 引擎 handler 分发
+
+新增 `TableEngineHandler` 策略接口和 registry:
+
+- `DorisTableEngineHandler`
+  - 负责 Doris 建表 DDL 生成。
+  - 负责 Doris 专属元数据字段填充: `table_model`、`bucket_num`、`replica_num`、`distribution_column`、`key_columns`、`partition_column`、`doris_ddl`。
+  - 负责 Doris 物理变更: rename/drop table、alter comment、add/modify/drop column、分桶和副本调整。
+- `MysqlTableEngineHandler`
+  - 负责清理 Doris 专属元数据字段，确保 MySQL 表不会保存 `replica_num` 等 Doris 属性。
+  - 负责 MySQL 物理变更: rename/drop table、alter comment、add/modify/drop column。
+  - 对 Doris 专属的分桶、副本调整明确拒绝。
+- `UNKNOWN`/无数据源
+  - 按 metadata-only 处理，清理 Doris 专属字段，不执行外部物理 DDL。
+
+`DataTableService` 只根据 `cluster_id -> source_type` 选择 handler，并维护本地元数据事务；不再直接拼接或执行具体引擎 DDL。
+
+`TableCreateService` 保留现有 API，但 Doris 建表 DDL 和 Doris 专属字段写入委托给 `DorisTableEngineHandler`。创建时会校验 `dorisClusterId` 对应的数据源必须是 `source_type=DORIS`；后续如果新增 MySQL/OceanBase 建表入口，应新增对应 request/handler，而不是在 Doris 建表器中加分支。
+
+### 5.3 收敛 Doris DDL 判定
 
 在 `DataTableService` 内新增统一判定:
 
@@ -85,7 +104,7 @@ AND datasource.source_type = DORIS
   - 未同步表直接返回 `false`
   - 已同步表必须解析实际数据源
   - `source_type=DORIS` 返回 `true`
-  - 非 Doris 类型抛出明确“不支持同步该数据源表变更”的异常，避免静默只改本地导致物理库不一致
+  - 非 Doris 类型返回 `false`；写路径不再依赖它决定是否同步，而是通过 `resolveSyncedPhysicalEngine` 委托给对应 handler
 
 所有表结构和生命周期写路径使用该判定:
 
@@ -98,25 +117,38 @@ AND datasource.source_type = DORIS
 - `updateField`
 - `deleteField`
 
-### 5.3 自动清理任务
+### 5.4 自动清理任务
 
-`DataTableAutoPurgeTask` 不再复制 `isDorisTable` 启发式逻辑。它委托 `DataTableService.requiresDorisPhysicalSync(table)` 判断是否需要 Doris 物理删除:
+`DataTableAutoPurgeTask` 不再复制 `isDorisTable` 启发式逻辑。它委托 `DataTableService.dropPhysicalTableIfRequired(table)` 判断并执行物理删除:
 
 - 未同步表: 只清理元数据。
-- 已同步 Doris 表: 先 drop Doris 表，再清理元数据。
-- 已同步非 Doris 表或缺失数据源: 抛出明确异常并保留记录，等待后续对应 handler。
+- 已同步 Doris 表: Doris handler 先 drop Doris 表，再清理元数据。
+- 已同步 MySQL 表: MySQL handler 先 drop MySQL 表，再清理元数据。
+- 已同步未知类型或缺失数据源: 抛出明确异常并保留记录，等待补充对应 handler 或修复归属数据。
+
+### 5.5 schema 默认值修正
+
+`replica_num` 默认值改为 `NULL`。该字段是 Doris 专属副本数，不应污染 metadata-only 或 MySQL 表。迁移同时清理无数据源或非 Doris 数据源表上的 Doris 专属字段:
+
+- `table_model`
+- `bucket_num`
+- `replica_num`
+- `partition_column`
+- `distribution_column`
+- `key_columns`
+- `doris_ddl`
 
 ## 6. 不做范围
 
 - 不重命名 `doris_cluster` 表；这是更大规模的数据源模型重命名。
 - 不新增 OceanBase 物理 DDL handler。
 - 不把 Doris 建表字段迁移到独立扩展表。
-- 不修改 `replica_num` schema 默认值；误判根因由判定逻辑修复，后续如需清理历史数据可单独做数据修正。
+- 不实现 MySQL 建表设计器；本轮只覆盖已同步 MySQL 表的常见物理变更。
 
 ## 7. 风险与权衡
 
 - 已同步但 `cluster_id` 缺失的历史记录将不再凭 `is_synced=1` 直接走 Doris DDL；调用方需要传入 `clusterId`，或先修复表归属数据。
-- 已同步非 Doris 表的结构/生命周期写操作会从“误调用 Doris API”变为明确拒绝。这是行为修正，但可能暴露以前被错误路径掩盖的数据源类型问题。
+- 已同步 MySQL 表的结构/生命周期写操作会改走 MySQL DDL；Doris 专属属性如分桶/副本调整会被明确拒绝。
 - 本轮保持 `source_type` 字符串模型，不引入跨模块 datasource 抽象，避免扩大 PR #376 的 refactor 面。
 
 ## 8. 验证
@@ -124,6 +156,8 @@ AND datasource.source_type = DORIS
 - 新增 `DataTableServiceTest` 覆盖:
   - `replicaNum=1` 的未同步表新增字段不要求 Doris 集群、不调用 Doris DDL。
   - 已同步 Doris 表使用表所属 `cluster_id` 执行 Doris DDL。
-  - 已同步 MySQL 表拒绝 Doris DDL 路径。
+  - 已同步 MySQL 表委托 MySQL handler，不调用 Doris DDL。
+  - MySQL handler 生成 rename/comment/field DDL，并拒绝 Doris 专属副本设置。
+  - Doris 表设计器拒绝 MySQL 数据源。
 - 运行 PR #376 既有目标测试。
 - 如本地 MySQL/Redis 可用，重复表生命周期 HTTP smoke，确认不再需要手工清空 `replica_num`。

--- a/docs/plans/2026-06-22-data-table-source-type-plan.md
+++ b/docs/plans/2026-06-22-data-table-source-type-plan.md
@@ -21,21 +21,38 @@
 - 验证:
   - 编译通过。
 
-## T3 — 收敛 DataTableService 判定
+## T3 — 引入 TableEngineHandler
+
+- 目标: 将 Doris/MySQL/未知数据源的建表元数据规范化和物理 DDL 操作分到不同类。
+- 触及文件:
+  - 新增 `backend/src/main/java/com/onedata/portal/service/table/TableEngineHandler.java`
+  - 新增 `backend/src/main/java/com/onedata/portal/service/table/TableEngineHandlerRegistry.java`
+  - 新增 `backend/src/main/java/com/onedata/portal/service/table/DorisTableEngineHandler.java`
+  - 新增 `backend/src/main/java/com/onedata/portal/service/table/MysqlTableEngineHandler.java`
+- 做法:
+  - Doris handler 负责 Doris DDL 生成、Doris 专属字段填充和 Doris 物理操作。
+  - MySQL handler 清理 Doris 专属字段，并负责 MySQL rename/drop table、alter comment、add/modify/drop column。
+  - MySQL handler 对 Doris 专属分桶/副本设置明确拒绝。
+  - 无数据源/未知数据源走 metadata-only 规范化，不写 Doris 专属字段。
+- 验证:
+  - handler 单测或服务单测覆盖 Doris/MySQL/metadata-only 分发。
+
+## T4 — 收敛 DataTableService 判定
 
 - 目标: 删除 `replica_num/table_model/bucket_num` 等 Doris 属性推断逻辑，按 `is_synced + actual cluster source_type` 判断是否需要 Doris DDL。
 - 触及文件:
   - `backend/src/main/java/com/onedata/portal/service/DataTableService.java`
 - 做法:
-  - 新增 `requiresDorisPhysicalSync(DataTable, Long)`。
+  - Doris 表设计器创建时校验目标数据源必须是 `source_type=DORIS`。
+  - 新增 `resolveSyncedPhysicalEngine(DataTable, Long)`。
   - 请求参数 `clusterId` 优先，表上的 `cluster_id` 兜底。
   - 未同步表仅改本地元数据。
-  - 已同步 Doris 表执行 Doris DDL。
-  - 已同步非 Doris 表明确拒绝。
+  - 已同步表由对应 `TableEngineHandler` 处理物理 DDL。
+  - metadata-only/MySQL 表创建时清理 Doris 专属字段。
 - 验证:
   - 新增/更新服务单测。
 
-## T4 — 自动清理任务委托统一判定
+## T5 — 自动清理任务委托统一判定
 
 - 目标: `DataTableAutoPurgeTask` 不再复制旧 `isDorisTable` 启发式逻辑。
 - 触及文件:
@@ -43,46 +60,62 @@
 - 验证:
   - 服务单测覆盖判定；编译确认任务调用签名正确。
 
-## T5 — 单元测试
+## T6 — schema 默认值修正
+
+- 目标: `replica_num` 从 Doris 专属字段回归为可空属性，不再污染新建普通表/MySQL 表。
+- 触及文件:
+  - 新增 `backend/src/main/resources/db/migration/V46__data_table_clear_non_doris_physical_fields.sql`
+- 做法:
+  - 修改 `data_table.replica_num` 默认值为 `NULL`。
+  - 清理无数据源或非 Doris 数据源表上的 Doris 专属字段。
+
+## T7 — 单元测试
 
 - 目标: 锁定修复场景和未来非 Doris 扩展行为。
 - 触及文件:
   - 新增 `backend/src/test/java/com/onedata/portal/service/DataTableServiceTest.java`
 - 覆盖:
-  - 未同步表带默认 `replicaNum=1` 时新增字段只写元数据。
+  - metadata-only 创建不会保留 `replicaNum=1`。
+  - MySQL 表创建不会保留 Doris 专属字段。
+  - 未同步表新增字段只写元数据。
   - 已同步 Doris 表即使请求未传 `clusterId`，也使用表所属数据源执行 Doris DDL。
-  - 已同步 MySQL 表结构变更返回明确不支持，不调用 Doris DDL、不写入本地字段。
+  - 已同步 MySQL 表结构变更委托 MySQL handler，不调用 Doris DDL。
+  - MySQL handler SQL 生成覆盖表注释、字段新增、字段重命名/修改、字段删除和 Doris 专属副本拒绝。
+  - Doris 表设计器拒绝 MySQL 数据源。
 
-## T6 — 验证
+## T8 — 验证
 
 - 目标: 证明 PR #376 原有重构测试仍通过，并补一轮生命周期 smoke。
 - 命令:
-  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest,DataTableControllerTest,DataTableMetadataSyncServiceTest test`
+  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest,TableCreateServiceTest,MysqlTableEngineHandlerTest,DataTableControllerTest,DataTableMetadataSyncServiceTest test`
   - `mvn -pl backend -am -DskipTests compile`
 - 可选有状态验证:
   - 使用本地 Podman MySQL/Redis 启动 backend。
-  - 创建普通元数据表后直接走字段 CRUD、软删除、恢复、清理，不再执行手工 SQL 清空 `replica_num`。
+  - 创建普通 metadata-only 表后确认 Doris 专属字段为空。
+  - 创建已同步 MySQL 表元数据后，通过 HTTP 驱动 MySQL 字段 CRUD、软删除、恢复、清理。
 
 ### 2026-06-22 本地验证结果
 
 - 单元/控制器测试:
-  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest test`
-    - 结果: `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`
-  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest,DataTableControllerTest,DataTableMetadataSyncServiceTest test`
-    - 结果: `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`
+  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest,TableCreateServiceTest,MysqlTableEngineHandlerTest,DataTableControllerTest,DataTableMetadataSyncServiceTest test`
+    - 结果: `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0`
 - 编译/打包:
   - `mvn -pl backend -am -DskipTests compile` 通过。
   - `mvn -pl backend -am -DskipTests package` 通过。
 - 有状态 smoke:
-  - MySQL: Podman 容器 `data-portal-mysql`，`127.0.0.1:3306`，临时 schema `opendataworks_pr376_type_e2e`。
-  - Backend: `SERVER_PORT=18080`，`AUTH_ANONYMOUS_ENABLED=true`，临时 schema 上 Flyway 成功应用 45 个迁移。
+  - MySQL: Podman 容器 `data-portal-mysql`，`127.0.0.1:3306`。
+  - 平台临时 schema: `opendataworks_pr376_engine_e2e`。
+  - 物理 MySQL 临时 schema: `odw_mysql_engine_physical`。
+  - Backend: `SERVER_PORT=18080`，`AUTH_ANONYMOUS_ENABLED=true`，临时 schema 上 Flyway 成功应用 46 个迁移。
   - HTTP 流程:
-    - `POST /api/v1/tables` 创建普通 metadata-only 表。
-    - 直接查询 DB 确认新表为 `replica_num=1`、`is_synced=0`、`cluster_id=NULL`。
-    - 不传 `clusterId` 完成字段新增、字段更新、字段删除、表注释更新、软删除、恢复、再次软删除、立即清理。
-    - 清理后确认 `data_table.deleted=1`。
-  - 结论: metadata-only 表即使保留默认 `replica_num=1`，也不再误触发 Doris DDL/cluster 校验。
-  - 清理: 已停止临时 backend，并删除 `opendataworks_pr376_type_e2e` schema。
+    - 插入 `source_type=MYSQL` 数据源，物理库创建 `mysql_orders` 表。
+    - `POST /api/v1/tables` 创建已同步 MySQL 表元数据，并确认 `replica_num/table_model/bucket_num` 入库为 `NULL`。
+    - `PUT /api/v1/tables/{id}/comment` 确认物理 MySQL 表注释更新。
+    - `POST/PUT/DELETE /api/v1/tables/{id}/fields` 确认物理 MySQL 字段新增、重命名/改类型、删除。
+    - `soft-delete -> restore -> soft-delete -> purge-now` 确认物理 MySQL 表重命名、恢复和删除。
+    - 查询 `information_schema.COLUMNS` 确认 `data_table.replica_num` 默认值为 `NULL`。
+  - 结论: 已同步 MySQL 表走 MySQL handler/JDBC DDL，不再误调用 Doris；metadata-only/MySQL 表不再保留 Doris 专属副本字段。
+  - 清理: 已停止临时 backend，并删除 `opendataworks_pr376_engine_e2e` 和 `odw_mysql_engine_physical` schema。
 
 ## 回滚
 


### PR DESCRIPTION
## 简介 (Introduction)
本 PR 将 Doris/MySQL/未知数据源的建表元数据规范化和物理 DDL 操作分到不同 Handler，收敛了 `DataTableService` 里的判定逻辑。

## 主要变更 (Proposed Changes)
- **多数据源引擎路由支持**:
  - 新增 `TableEngineHandler` 接口，定义了不同引擎的 metadata 规范化和物理 DDL 执行逻辑。
  - 实现 `DorisTableEngineHandler` 和 `MysqlTableEngineHandler`，分别负责 Doris 和 MySQL 专属物理表操作。
  - 引入 `TableEngineHandlerRegistry` 对 Handler 进行管理与分发。
- **收敛 `DataTableService` 判定**:
  - 移除 Doris 属性（如 `replica_num`, `table_model`, `bucket_num`）的旧有启发式推断逻辑。
  - 改为通过 `is_synced` 和数据源的真实 `source_type` 精确路由物理 DDL 和元数据规范化。
  - 对于 metadata-only 和 MySQL 数据源，创建时会自动清理 Doris 专属字段。
- **清理自动任务逻辑**:
  - `DataTableAutoPurgeTask` 不再复制 `isDorisTable` 的判定逻辑，改用统一的物理引擎判定。
- **Schema 回归与清理 (Migration)**:
  - 修正 schema 中 `data_table.replica_num` 的默认值为 `NULL`（原为 1，曾导致非 Doris 表也误写此属性）。
  - 清理了非 Doris 数据源的历史表元数据，抹除 Doris 专属字段的残留。
- **完整测试覆写**:
  - 新增 `DataTableServiceTest`、`TableCreateServiceTest` 和 `MysqlTableEngineHandlerTest` 单元测试，覆盖不同引擎的分发与物理 DDL 生成。

## 验证结果 (Verification Results)
- 本地 Maven 编译与单测全量通过：
  - `mvn -pl backend -am -DfailIfNoTests=false -Dtest=DataTableServiceTest,TableCreateServiceTest,MysqlTableEngineHandlerTest,DataTableControllerTest,DataTableMetadataSyncServiceTest test` 成功通过 18 个测试。
  - `mvn -pl backend -am -DskipTests compile` 编译成功。