### PR TITLE
fix(intelligent-query): keep loading indicator after re-entering a running topic

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -186,8 +186,9 @@
               <div class="v2-assistant-body">
                 <!-- Streaming: render turns from v2 state -->
                 <template v-if="msg._v2state">
-                  <!-- Loading indicator: waiting for first block -->
-                  <div v-if="!msg._v2state.turns.length && isStreaming" class="v2-typing-indicator">
+                  <!-- Loading indicator: live run with no rendered content yet
+                       (initial send or a resumed run re-entered while waiting) -->
+                  <div v-if="showTypingIndicator(msg)" class="v2-typing-indicator">
                     <span /><span /><span />
                   </div>
 
@@ -1021,6 +1022,26 @@ function cleanTextForDisplay(content) {
 // (fenced, tagged, or raw JSON) renders as a real chart instead of leaking JSON.
 function answerSegments(content) {
   return splitChartSpecText(String(content || ''))
+}
+
+// The "thinking" dots show while a run is live but has not rendered any content
+// yet. Keying off rendered blocks (not turn count) keeps the indicator visible
+// after switching away and back: a resumed run rehydrates its assistant message
+// from the still-empty persisted placeholder, whose _v2state already carries one
+// empty turn, so `turns.length` is no longer 0 even though nothing has streamed.
+function hasRenderedBlocks(msg) {
+  const turns = msg?._v2state?.turns
+  return Array.isArray(turns) && turns.some((t) => Array.isArray(t.blocks) && t.blocks.length > 0)
+}
+
+function showTypingIndicator(msg) {
+  if (!isStreaming.value) return false
+  if (msg?._v2state?.status === 'error') return false
+  if (hasRenderedBlocks(msg)) return false
+  // Scope to the live message: the resumed/active task, or the just-sent message
+  // whose backend task id has not been assigned yet (task_id still '').
+  const taskId = String(msg?.task_id || '')
+  return taskId ? taskId === activeTaskId.value : true
 }
 
 // ── Suggestions ───────────────────────────────────────────────────────────

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -632,6 +632,42 @@ describe('NL2SqlChatV2 URL location', () => {
     resolveStream()
   })
 
+  it('keeps the loading indicator after re-entering a running topic that has not streamed content yet', async () => {
+    let resolveStream
+    apiMocks.topicApi.listTopics.mockResolvedValue({
+      list: [
+        { ...makeTopic('topic-run', 'Running topic'), current_task_id: 'task-run', current_task_status: 'running' }
+      ]
+    })
+    // The persisted placeholder assistant message (created at deliver time with
+    // status "waiting") rehydrates with a single empty turn — the case where the
+    // old `!turns.length` indicator condition wrongly hid the spinner on resume.
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
+      topic_id: topicId,
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 2,
+      items: [
+        { message_id: 'u-run', topic_id: topicId, sender_type: 'user', content: 'running question', created_at: '2026-05-30T02:00:00Z' },
+        { message_id: 'a-run', topic_id: topicId, sender_type: 'assistant', task_id: 'task-run', content: '', status: 'waiting', blocks: [], created_at: '2026-05-30T02:00:01Z' }
+      ]
+    }))
+    // Resume re-attaches but the backend has produced nothing yet (still waiting).
+    apiMocks.taskApi.streamSdkEvents.mockImplementation(() => new Promise((resolve) => { resolveStream = resolve }))
+    routeState.query = { tab: 'chat-v2', topic_id: 'topic-run' }
+
+    const wrapper = mountChat()
+    await flushPromises()
+    await nextTick()
+
+    expect(apiMocks.taskApi.streamSdkEvents).toHaveBeenCalledWith('task-run', expect.objectContaining({ afterId: 0 }))
+    // The "thinking" dots stay visible because the resumed run is still live.
+    expect(wrapper.find('.v2-typing-indicator').exists()).toBe(true)
+
+    resolveStream()
+  })
+
   it('forwards the selected assistant to the widget topic query', async () => {
     routeState.query = { tab: 'chat-v2', agent_id: 'agent_sales' }
     const wrapper = mountChat()


### PR DESCRIPTION
The portal chat (NL2SqlChatV2) hid the "thinking" dots when switching back
to a still-running conversation. The deliver flow persists a placeholder
assistant message at "waiting" time, and rehydrating it produces a _v2state
with one empty turn, so the old `!_v2state.turns.length` indicator condition
evaluated false on resume even though the run was still live.

Gate the indicator on rendered block content (and the active/just-sent task)
instead of turn count, so the spinner stays visible on resume and during the
initial send. Add a regression test covering re-entry of a running topic that
has not streamed content yet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ZidqTJHa6Z3Vk2QYHZSPv