### PR TITLE
feat(intelligent-query): expand chart_spec to area/scatter/combo/radar/funnel/gauge

### DIFF
--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/area.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/area.json
@@ -1,0 +1,22 @@
+{
+  "chart_type": "area",
+  "label": "面积图",
+  "when_to_use": [
+    "时间趋势且强调累积量或总量规模",
+    "多指标随时间的叠加结构演变（配合 stack）"
+  ],
+  "avoid_when": [
+    "只有分类维度没有时间维度",
+    "需要精确读取单点数值"
+  ],
+  "required_fields": [
+    "x_field",
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "max_series": 3,
+    "time_order_required": true,
+    "stackable": true
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/combo.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/combo.json
@@ -1,0 +1,22 @@
+{
+  "chart_type": "combo",
+  "label": "组合双轴图",
+  "when_to_use": [
+    "同一维度上量级与比率/增速混合对比",
+    "数量用柱、占比或环比用折线"
+  ],
+  "avoid_when": [
+    "所有指标量级相近，单轴即可",
+    "只有一个数值字段"
+  ],
+  "required_fields": [
+    "x_field",
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "min_series": 2,
+    "first_series_bar_left_axis": true,
+    "other_series_line_right_axis": true
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/funnel.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/funnel.json
@@ -1,0 +1,21 @@
+{
+  "chart_type": "funnel",
+  "label": "漏斗图",
+  "when_to_use": [
+    "阶段转化与逐级流失分析",
+    "有明确先后顺序的环节对比"
+  ],
+  "avoid_when": [
+    "阶段之间没有先后/包含关系",
+    "需要时间趋势"
+  ],
+  "required_fields": [
+    "x_field",
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "single_metric_only": true,
+    "stage_order_required": true
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/gauge.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/gauge.json
@@ -1,0 +1,21 @@
+{
+  "chart_type": "gauge",
+  "label": "仪表盘",
+  "when_to_use": [
+    "单一关键指标的当前值或达成度",
+    "KPI 进度展示"
+  ],
+  "avoid_when": [
+    "需要对比多个对象或多个时间点",
+    "结果是多行明细"
+  ],
+  "required_fields": [
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "single_metric_only": true,
+    "uses_first_row": true,
+    "x_field_optional": true
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/radar.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/radar.json
@@ -1,0 +1,21 @@
+{
+  "chart_type": "radar",
+  "label": "雷达图",
+  "when_to_use": [
+    "少数对象在多个指标上的综合对比",
+    "能力/画像多维评估"
+  ],
+  "avoid_when": [
+    "指标轴少于 3 个",
+    "类别数量很多"
+  ],
+  "required_fields": [
+    "x_field",
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "min_indicators": 3,
+    "max_series": 3
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/scatter.json
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/assets/chart-template/scatter.json
@@ -1,0 +1,21 @@
+{
+  "chart_type": "scatter",
+  "label": "散点图",
+  "when_to_use": [
+    "两个数值字段的相关性分析",
+    "分布与离群点观察"
+  ],
+  "avoid_when": [
+    "x 轴是分类或时间而非数值",
+    "只有单个数值字段"
+  ],
+  "required_fields": [
+    "x_field",
+    "series",
+    "dataset"
+  ],
+  "spec_hints": {
+    "x_field_must_be_numeric": true,
+    "max_series": 3
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/reference/50-tool-output-contract.md
@@ -109,10 +109,16 @@
 
 图表输出统一通过 `chart_spec`，由 `chart_type` 区分：
 
-- `table`
-- `bar`
-- `line`
-- `pie`
+- `table`：明细表格
+- `bar`：分类对比 / TopN（`--stack` 可堆叠，`orientation:horizontal` 可横向）
+- `line`：时间趋势
+- `area`：趋势 + 累积量强调（line 的填充版，`--stack` 可堆叠）
+- `scatter`：两个数值字段的相关性（x、y 均为数值轴）
+- `combo`：组合双轴，首个数值走柱状/左轴，其余走折线/右轴
+- `radar`：多指标对比（每行一个指标轴，建议指标轴 ≥ 3）
+- `funnel`：转化漏斗（阶段 + 单数值）
+- `gauge`：单 KPI 仪表盘（取首行单数值）
+- `pie`：占比（类别 2~8）
 
 ```json
 {
@@ -134,9 +140,14 @@
 
 ## 图表规则
 
-- 时间维度 + 数值指标：优先 `line`
-- 分类维度 + 对比或 TopN：优先 `bar`
+- 时间维度 + 数值指标：优先 `line`；强调累积量用 `area`
+- 分类维度 + 对比或 TopN：优先 `bar`；多分组堆叠用 `--stack`
 - 占比分析且类别数 2 到 8：优先 `pie`
+- 两个数值字段的相关性：用 `scatter`
+- 同一维度上量级与比率/增速混合对比：用 `combo`（双轴）
+- 少数对象在多指标上的对比：用 `radar`
+- 阶段转化、逐级流失：用 `funnel`
+- 单一关键指标当前值：用 `gauge`
 - 明细场景且明确要求独立表格时，才输出 `table`
 - 不适合图表时，不输出 `chart_spec`，只保留 `sql_execution`
 - 生成图表时，优先把完整 `sql_execution` JSON 直接作为输入传入；只有 JSON 过长时才落临时文件。
@@ -148,7 +159,10 @@
 
 - 前端是唯一图表渲染器；后端和脚本不生成 PNG、SVG 或静态图片 URL。
 - `table` 必须显式提供 `columns`。
-- `bar` / `line` / `pie` 必须显式提供 `x_field` 和 `series`。
-- `pie` 必须且只能提供 1 个 `series`。
+- `bar` / `line` / `area` / `scatter` / `combo` / `radar` 必须显式提供 `x_field` 和 `series`。
+- `pie` / `funnel` 必须且只能提供 1 个 `series`。
+- `gauge` 必须且只能提供 1 个 `series`，`x_field` 可选（取首行单值）。
+- `combo` 的 `series[].axis` 取 `left`/`right`，`series[].type` 取 `bar`/`line`。
+- `scatter` 的 `x_field` 必须是数值字段。
 - `dataset` 顺序由技能决定，前端按原顺序渲染。
 - `version` 当前固定为 `1`。

--- a/dataagent/.claude/skills/opendataworks-platform-tools/scripts/build_chart_spec.py
+++ b/dataagent/.claude/skills/opendataworks-platform-tools/scripts/build_chart_spec.py
@@ -76,6 +76,42 @@ def choose_chart(
             return "pie", dimension_fields[0], numeric_fields[:1]
         return None, None, []
 
+    if preferred == "area":
+        x_field = time_field or (dimension_fields[0] if dimension_fields else None)
+        if x_field and numeric_fields:
+            return "area", x_field, numeric_fields[: min(3, len(numeric_fields))]
+        return None, None, []
+
+    if preferred == "scatter":
+        # 散点图需要两个数值轴：x 为数值字段，y 为其余数值字段。
+        if len(numeric_fields) >= 2:
+            return "scatter", numeric_fields[0], numeric_fields[1 : 1 + min(3, len(numeric_fields) - 1)]
+        return None, None, []
+
+    if preferred == "combo":
+        # 组合双轴：首个数值走柱状/左轴，其余走折线/右轴。
+        if dimension_fields and len(numeric_fields) >= 2:
+            x_field = time_field or dimension_fields[0]
+            return "combo", x_field, numeric_fields[: min(3, len(numeric_fields))]
+        return None, None, []
+
+    if preferred == "radar":
+        # 雷达图：每行作为一个指标轴，至少 3 个指标轴才有意义。
+        if dimension_fields and numeric_fields and len(rows) >= 3:
+            return "radar", dimension_fields[0], numeric_fields[: min(3, len(numeric_fields))]
+        return None, None, []
+
+    if preferred == "funnel":
+        if dimension_fields and numeric_fields:
+            return "funnel", dimension_fields[0], numeric_fields[:1]
+        return None, None, []
+
+    if preferred == "gauge":
+        # 单 KPI：x_field 可选，仅取首行首个数值。
+        if numeric_fields:
+            return "gauge", (dimension_fields[0] if dimension_fields else None), numeric_fields[:1]
+        return None, None, []
+
     if preferred == "table":
         return "table", None, []
 
@@ -126,6 +162,7 @@ def main():
     parser.add_argument("--data", default="")
     parser.add_argument("--category-field", "--x-field", dest="category_field", default="")
     parser.add_argument("--value-field", "--y-field", dest="value_field", default="")
+    parser.add_argument("--stack", dest="stack", action="store_true")
     args = parser.parse_args()
 
     try:
@@ -185,7 +222,8 @@ def main():
             print_json(chart_payload)
             return
 
-        if not chart_type or not x_field or not series_fields:
+        # gauge 允许空 x_field（单 KPI 取首行），其余轴类图表必须有 x_field。
+        if not chart_type or not series_fields or (chart_type != "gauge" and not x_field):
             print_json(
                 error_payload(
                     "chart_spec",
@@ -200,22 +238,37 @@ def main():
             )
             return
 
-        series = [
-            {"name": field, "field": field, "type": chart_type}
-            for field in series_fields
-        ]
+        def series_type_for(index: int) -> str:
+            if chart_type == "combo":
+                return "bar" if index == 0 else "line"
+            if chart_type == "area":
+                return "line"
+            if chart_type == "scatter":
+                return "scatter"
+            return chart_type
+
+        series = []
+        for index, field in enumerate(series_fields):
+            item = {"name": field, "field": field, "type": series_type_for(index)}
+            if chart_type == "combo":
+                item["axis"] = "left" if index == 0 else "right"
+            series.append(item)
+
         chart_payload = base_chart_payload(
             chart_type,
             title,
-            f"基于 {x_field} 绘制 {chart_type} 图",
+            f"基于 {x_field} 绘制 {chart_type} 图" if x_field else f"绘制 {chart_type} 图",
             normalized_rows,
         )
-        chart_payload["x_field"] = x_field
+        if x_field:
+            chart_payload["x_field"] = x_field
         chart_payload["series"] = series
+        if bool(args.stack) and chart_type in ("bar", "area", "line"):
+            chart_payload["stack"] = True
         if chart_type == "pie":
             chart_payload["donut"] = False
-        if chart_type == "line":
-            chart_payload["area"] = False
+        if chart_type in ("line", "area"):
+            chart_payload["area"] = chart_type == "area"
         if chart_type == "bar":
             chart_payload["orientation"] = "vertical"
         print_json(chart_payload)

--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -48,10 +48,10 @@
 
 - 必须通过 Bash 工具实际调用 `build_chart_spec.py` 生成图表契约，不得凭记忆把契约 JSON 输出到文本里，也不得用 ASCII 或 Unicode 字符模拟图表。`build_chart_spec.py` 不是独立注册的工具名，它是通过 Bash 工具执行的脚本，调用命令模板：
   ```
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|pie|table> --input '<sql_execution JSON>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>]
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|area|scatter|combo|radar|funnel|gauge|pie|table> --input '<sql_execution JSON>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>] [--stack]
   ```
 - 图表契约必须基于真实且完整的查询结果构建，不得捏造、抽样或只截取前 N 个数据点；若 SQL 结果已被 `has_more`、`truncated_by_size` 或 `result_truncated` 标记为不完整，不得生成图表，必须先改写 SQL 聚合/过滤到完整有界结果；
-- 图表类型与数据结构匹配：趋势用折线图、占比用饼图、排行/对比用柱状图、明细用表格；
+- 图表类型与数据结构匹配：趋势用折线图（强调累积量用面积图 area）、占比用饼图、排行/对比用柱状图（多分组堆叠加 `--stack`）、明细用表格；相关性用散点图 scatter、量级+比率混合对比用组合双轴 combo、少数对象多指标对比用雷达图 radar、阶段转化用漏斗图 funnel、单一关键指标用仪表盘 gauge；
 - 查询结果为空或不足以构成有意义的图表时，说明原因，不强行生成空图表；纯元数据或语义解释类回答不需要图表。
 
 **结论与图表的关联要求：**

--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -50,6 +50,7 @@
   ```
   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|area|scatter|combo|radar|funnel|gauge|pie|table> --input '<sql_execution JSON>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>] [--stack]
   ```
+- 图表只能由 `build_chart_spec.py` 产出的 `chart_spec` JSON 契约表达：严禁用 Markdown 图片语法（`![](...)`）、图片链接、`chart_spec://`、`sandbox:`、`attachment:` 等任何伪 URL 或静态图片地址来"渲染"图表；后端与脚本从不生成 PNG/SVG/图片 URL，前端是唯一渲染器，写出图片链接只会让用户看到裂图。需要图表时，直接把脚本输出的完整 `chart_spec` JSON 放进回答（或保留为工具输出），不要再额外包一层图片或链接；
 - 图表契约必须基于真实且完整的查询结果构建，不得捏造、抽样或只截取前 N 个数据点；若 SQL 结果已被 `has_more`、`truncated_by_size` 或 `result_truncated` 标记为不完整，不得生成图表，必须先改写 SQL 聚合/过滤到完整有界结果；
 - 图表类型与数据结构匹配：趋势用折线图（强调累积量用面积图 area）、占比用饼图、排行/对比用柱状图（多分组堆叠加 `--stack`）、明细用表格；相关性用散点图 scatter、量级+比率混合对比用组合双轴 combo、少数对象多指标对比用雷达图 radar、阶段转化用漏斗图 funnel、单一关键指标用仪表盘 gauge；
 - 查询结果为空或不足以构成有意义的图表时，说明原因，不强行生成空图表；纯元数据或语义解释类回答不需要图表。

--- a/dataagent/dataagent-backend/tests/test_build_chart_spec_script.py
+++ b/dataagent/dataagent-backend/tests/test_build_chart_spec_script.py
@@ -211,3 +211,122 @@ def test_x_y_field_aliases_are_supported():
     assert chart["chart_type"] == "line"
     assert chart["x_field"] == "stat_day"
     assert chart["series"][0]["field"] == "publish_cnt"
+
+
+def test_area_chart_sets_area_flag_and_line_series():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"stat_day": "2026-03-01", "active_users": 120},
+            {"stat_day": "2026-03-02", "active_users": 150},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "area")
+
+    assert chart["chart_type"] == "area"
+    assert chart["x_field"] == "stat_day"
+    assert chart["area"] is True
+    assert chart["series"][0]["type"] == "line"
+
+
+def test_bar_chart_stack_flag_sets_stack_true():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"layer": "ODS", "a_count": 10, "b_count": 4},
+            {"layer": "DWD", "a_count": 6, "b_count": 9},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "bar", "--stack")
+
+    assert chart["chart_type"] == "bar"
+    assert chart["stack"] is True
+    assert len(chart["series"]) == 2
+
+
+def test_scatter_chart_uses_numeric_x_and_y_series():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"table_rows": 100, "column_count": 12},
+            {"table_rows": 250, "column_count": 18},
+            {"table_rows": 80, "column_count": 7},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "scatter")
+
+    assert chart["chart_type"] == "scatter"
+    assert chart["x_field"] == "table_rows"
+    assert chart["series"][0]["field"] == "column_count"
+    assert chart["series"][0]["type"] == "scatter"
+
+
+def test_combo_chart_splits_bar_left_and_line_right():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"month": "2026-01", "amount": 1200, "growth_rate": 0.12},
+            {"month": "2026-02", "amount": 1500, "growth_rate": 0.25},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "combo")
+
+    assert chart["chart_type"] == "combo"
+    assert chart["x_field"] == "month"
+    assert chart["series"][0]["type"] == "bar"
+    assert chart["series"][0]["axis"] == "left"
+    assert chart["series"][1]["type"] == "line"
+    assert chart["series"][1]["axis"] == "right"
+
+
+def test_radar_chart_requires_three_indicators():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"metric": "完整性", "score": 90},
+            {"metric": "及时性", "score": 80},
+            {"metric": "准确性", "score": 85},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "radar")
+
+    assert chart["chart_type"] == "radar"
+    assert chart["x_field"] == "metric"
+    assert chart["series"][0]["field"] == "score"
+
+
+def test_funnel_chart_keeps_single_series():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"stage": "曝光", "cnt": 1000},
+            {"stage": "点击", "cnt": 400},
+            {"stage": "下单", "cnt": 120},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "funnel")
+
+    assert chart["chart_type"] == "funnel"
+    assert chart["x_field"] == "stage"
+    assert len(chart["series"]) == 1
+
+
+def test_gauge_chart_allows_missing_x_field():
+    payload = {
+        "kind": "sql_execution",
+        "rows": [
+            {"completion_rate": 73},
+        ],
+    }
+
+    chart = _run_chart_spec(payload, "--chart-type", "gauge")
+
+    assert chart["chart_type"] == "gauge"
+    assert "x_field" not in chart or not chart["x_field"]
+    assert chart["series"][0]["field"] == "completion_rate"

--- a/dataagent/dataagent-frontend/src/views/intelligence/ChartSpecView.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/ChartSpecView.vue
@@ -56,12 +56,21 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import * as echarts from 'echarts/core'
 import { use } from 'echarts/core'
-import { BarChart, LineChart, PieChart } from 'echarts/charts'
+import {
+  BarChart,
+  LineChart,
+  PieChart,
+  ScatterChart,
+  RadarChart,
+  FunnelChart,
+  GaugeChart
+} from 'echarts/charts'
 import {
   GridComponent,
   LegendComponent,
   TitleComponent,
-  TooltipComponent
+  TooltipComponent,
+  RadarComponent
 } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
 import { buildChartRenderModel } from './chartSpec'
@@ -73,10 +82,15 @@ use([
   LineChart,
   BarChart,
   PieChart,
+  ScatterChart,
+  RadarChart,
+  FunnelChart,
+  GaugeChart,
   GridComponent,
   TooltipComponent,
   LegendComponent,
-  TitleComponent
+  TitleComponent,
+  RadarComponent
 ])
 
 const props = defineProps({

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/ChartSpecToolbar.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/ChartSpecToolbar.spec.js
@@ -17,12 +17,21 @@ vi.mock('echarts/core', () => ({
   init: echartsMocks.init
 }))
 
-vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {} }))
+vi.mock('echarts/charts', () => ({
+  BarChart: {},
+  LineChart: {},
+  PieChart: {},
+  ScatterChart: {},
+  RadarChart: {},
+  FunnelChart: {},
+  GaugeChart: {}
+}))
 vi.mock('echarts/components', () => ({
   GridComponent: {},
   LegendComponent: {},
   TitleComponent: {},
-  TooltipComponent: {}
+  TooltipComponent: {},
+  RadarComponent: {}
 }))
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -340,6 +340,41 @@ describe('chartSpec', () => {
     expect(renderModel.option.series[0].data[0].value).toBe(73)
   })
 
+  it('drops a broken chart_spec:// markdown image instead of leaking a broken image', () => {
+    const message = '结论如下：发布次数整体上升。\n![趋势图](chart_spec://chart_1)\n以上为本次结论。'
+
+    const segments = splitChartSpecText(message)
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(segments.every((seg) => seg.type === 'text')).toBe(true)
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripped).toContain('结论如下：发布次数整体上升。')
+    expect(stripped).toContain('以上为本次结论。')
+    expect(stripped).not.toContain('chart_spec')
+    expect(stripped).not.toContain('![')
+  })
+
+  it('handles a full-width colon chart_spec：// link the same way', () => {
+    const message = '见图：[图表](chart_spec：//placeholder) 结束。'
+
+    const stripped = stripChartSpecsFromText(message)
+    expect(stripped).not.toContain('chart_spec')
+    expect(stripped).not.toContain('](')
+  })
+
+  it('recovers a real spec embedded in a chart_spec:// image url', () => {
+    const spec = '{"kind":"chart_spec","version":1,"chart_type":"bar","title":"层级表数量","x_field":"layer","series":[{"name":"表数量","field":"table_cnt","type":"bar"}],"dataset":[{"layer":"DWD","table_cnt":18}],"error":null}'
+    const message = `结论：\n![图](chart_spec://${spec})`
+
+    const specs = extractChartSpecsFromText(message)
+    const segments = splitChartSpecText(message)
+
+    expect(specs).toHaveLength(1)
+    expect(specs[0].chart_type).toBe('bar')
+    expect(segments.some((seg) => seg.type === 'chart')).toBe(true)
+    expect(stripChartSpecsFromText(message)).not.toContain('chart_spec')
+  })
+
   it('rejects funnel specs with more than one series', () => {
     const validation = validateChartSpec({
       kind: 'chart_spec',

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -207,4 +207,155 @@ describe('chartSpec', () => {
     expect(extractChartSpecsFromText(message)).toHaveLength(0)
     expect(stripChartSpecsFromText(message)).toContain('"foo":"bar"')
   })
+
+  it('builds an area chart with filled line series', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'area',
+      title: '活跃用户趋势',
+      x_field: 'stat_day',
+      area: true,
+      series: [{ name: '活跃用户', field: 'active_users', type: 'line' }],
+      dataset: [
+        { stat_day: '2026-03-01', active_users: 120 },
+        { stat_day: '2026-03-02', active_users: 150 }
+      ],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(renderModel.kind).toBe('echarts')
+    expect(renderModel.option.series[0].type).toBe('line')
+    expect(renderModel.option.series[0].areaStyle).toEqual({})
+    expect(renderModel.option.series[0].data).toEqual([120, 150])
+  })
+
+  it('builds a scatter chart with numeric x and [x, y] points', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'scatter',
+      title: '行数与字段数相关性',
+      x_field: 'table_rows',
+      series: [{ name: '字段数', field: 'column_count', type: 'scatter' }],
+      dataset: [
+        { table_rows: 100, column_count: 12 },
+        { table_rows: 250, column_count: 18 }
+      ],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(renderModel.option.xAxis.type).toBe('value')
+    expect(renderModel.option.series[0].type).toBe('scatter')
+    expect(renderModel.option.series[0].data).toEqual([[100, 12], [250, 18]])
+  })
+
+  it('builds a combo chart with dual value axes', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'combo',
+      title: '金额与增速',
+      x_field: 'month',
+      series: [
+        { name: '金额', field: 'amount', type: 'bar', axis: 'left' },
+        { name: '增速', field: 'growth_rate', type: 'line', axis: 'right' }
+      ],
+      dataset: [
+        { month: '2026-01', amount: 1200, growth_rate: 0.12 },
+        { month: '2026-02', amount: 1500, growth_rate: 0.25 }
+      ],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(Array.isArray(renderModel.option.yAxis)).toBe(true)
+    expect(renderModel.option.yAxis).toHaveLength(2)
+    expect(renderModel.option.series[0].type).toBe('bar')
+    expect(renderModel.option.series[0].yAxisIndex).toBe(0)
+    expect(renderModel.option.series[1].type).toBe('line')
+    expect(renderModel.option.series[1].yAxisIndex).toBe(1)
+  })
+
+  it('builds a radar chart with one indicator per dataset row', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'radar',
+      title: '数据质量评估',
+      x_field: 'metric',
+      series: [{ name: '评分', field: 'score', type: 'radar' }],
+      dataset: [
+        { metric: '完整性', score: 90 },
+        { metric: '及时性', score: 80 },
+        { metric: '准确性', score: 85 }
+      ],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(renderModel.option.radar.indicator.map((i) => i.name)).toEqual(['完整性', '及时性', '准确性'])
+    expect(renderModel.option.series[0].type).toBe('radar')
+    expect(renderModel.option.series[0].data[0].value).toEqual([90, 80, 85])
+  })
+
+  it('builds a funnel chart from stage + single value rows', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'funnel',
+      title: '转化漏斗',
+      x_field: 'stage',
+      series: [{ name: '人数', field: 'cnt', type: 'funnel' }],
+      dataset: [
+        { stage: '曝光', cnt: 1000 },
+        { stage: '点击', cnt: 400 }
+      ],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(renderModel.option.series[0].type).toBe('funnel')
+    expect(renderModel.option.series[0].data).toEqual([
+      { name: '曝光', value: 1000 },
+      { name: '点击', value: 400 }
+    ])
+  })
+
+  it('builds a gauge chart from the first row without requiring x_field', () => {
+    const renderModel = buildChartRenderModel({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'gauge',
+      title: '完成率',
+      series: [{ name: '完成率', field: 'completion_rate', type: 'gauge' }],
+      dataset: [{ completion_rate: 73 }],
+      error: null
+    })
+
+    expect(renderModel.state).toBe('renderable')
+    expect(renderModel.option.series[0].type).toBe('gauge')
+    expect(renderModel.option.series[0].data[0].value).toBe(73)
+  })
+
+  it('rejects funnel specs with more than one series', () => {
+    const validation = validateChartSpec({
+      kind: 'chart_spec',
+      version: 1,
+      chart_type: 'funnel',
+      title: '转化漏斗',
+      x_field: 'stage',
+      series: [
+        { name: '人数', field: 'cnt', type: 'funnel' },
+        { name: '占比', field: 'ratio', type: 'funnel' }
+      ],
+      dataset: [{ stage: '曝光', cnt: 1000, ratio: 1 }],
+      error: null
+    })
+
+    expect(validation.valid).toBe(false)
+    expect(validation.errors).toContain('funnel 类型必须且只能提供一个 series')
+  })
 })

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -1,6 +1,11 @@
-const CHART_TYPES = new Set(['table', 'bar', 'line', 'pie'])
-const ECHART_TYPES = new Set(['bar', 'line', 'pie'])
-const SERIES_TYPES = new Set(['bar', 'line', 'pie'])
+const CHART_TYPES = new Set(['table', 'bar', 'line', 'area', 'scatter', 'combo', 'radar', 'funnel', 'gauge', 'pie'])
+const ECHART_TYPES = new Set(['bar', 'line', 'area', 'scatter', 'combo', 'radar', 'funnel', 'gauge', 'pie'])
+// 笛卡尔轴类图表（共用 x 轴 + series 数组）
+const AXIS_CHART_TYPES = new Set(['bar', 'line', 'area', 'combo'])
+// 必须且只能一个 series 的类型
+const SINGLE_SERIES_TYPES = new Set(['pie', 'funnel', 'gauge'])
+// series.type 允许的 ECharts 系列类型
+const SERIES_TYPES = new Set(['bar', 'line', 'pie', 'scatter'])
 const DEFAULT_CHART_COLORS = ['#0f8c7b', '#f59e0b', '#3b82f6', '#ef4444', '#8b5cf6', '#14b8a6', '#f97316']
 
 const isPlainObject = (value) => value && typeof value === 'object' && !Array.isArray(value)
@@ -80,21 +85,27 @@ const normalizeColumns = (value) => (
     : []
 )
 
-const normalizeSeries = (value, fallbackType) => (
-  Array.isArray(value)
+// area 在 ECharts 中由 line + areaStyle 实现，没有独立的 'area' 系列类型。
+const seriesEchartsType = (fallbackType) => (fallbackType === 'area' ? 'line' : fallbackType)
+
+const normalizeSeries = (value, fallbackType) => {
+  const defaultType = seriesEchartsType(fallbackType)
+  return Array.isArray(value)
     ? value
       .filter(isPlainObject)
       .map((item) => {
-        const type = textOrEmpty(item.type || fallbackType).toLowerCase()
+        const type = textOrEmpty(item.type || defaultType).toLowerCase()
+        const axis = textOrEmpty(item.axis).toLowerCase() === 'right' ? 'right' : 'left'
         return {
           name: textOrEmpty(item.name || item.field || '指标'),
           field: textOrEmpty(item.field),
-          type: SERIES_TYPES.has(type) ? type : fallbackType
+          type: SERIES_TYPES.has(type) ? type : (SERIES_TYPES.has(defaultType) ? defaultType : 'line'),
+          axis
         }
       })
       .filter((item) => item.field)
     : []
-)
+}
 
 export const parseChartSpec = (value) => {
   if (typeof value === 'string') {
@@ -143,7 +154,7 @@ export const validateChartSpec = (specInput) => {
     errors.push('仅支持 chart_spec version=1')
   }
   if (!CHART_TYPES.has(spec.chart_type)) {
-    errors.push('chart_type 必须为 table、bar、line 或 pie')
+    errors.push('chart_type 必须为 table、bar、line、area、scatter、combo、radar、funnel、gauge 或 pie')
   }
   if (!spec.title) {
     errors.push('title 不能为空')
@@ -157,14 +168,15 @@ export const validateChartSpec = (specInput) => {
       errors.push('table 类型必须提供 columns')
     }
   } else if (ECHART_TYPES.has(spec.chart_type)) {
-    if (!spec.x_field) {
+    // gauge 取单一 KPI，不要求 x_field；其余图表必须有 x_field。
+    if (spec.chart_type !== 'gauge' && !spec.x_field) {
       errors.push(`${spec.chart_type} 类型必须提供 x_field`)
     }
     if (!spec.series.length) {
       errors.push(`${spec.chart_type} 类型必须提供 series`)
     }
-    if (spec.chart_type === 'pie' && spec.series.length !== 1) {
-      errors.push('pie 类型必须且只能提供一个 series')
+    if (SINGLE_SERIES_TYPES.has(spec.chart_type) && spec.series.length !== 1) {
+      errors.push(`${spec.chart_type} 类型必须且只能提供一个 series`)
     }
   }
 
@@ -210,38 +222,48 @@ const buildPieOption = (spec) => {
   }
 }
 
+const buildTitleOption = (spec) => (spec.title
+  ? {
+      text: spec.title,
+      subtext: spec.description || '',
+      left: 'left',
+      top: 6,
+      textStyle: { fontSize: 14, fontWeight: 600, color: '#162131' },
+      subtextStyle: { color: '#607185', fontSize: 12 }
+    }
+  : undefined)
+
+const valueAxisOption = (name) => ({
+  type: 'value',
+  name: name || '',
+  scale: true,
+  axisLabel: { color: '#607185' },
+  splitLine: { lineStyle: { color: '#eef3f8' } }
+})
+
+// 柱状 / 折线 / 面积 / 组合双轴：共用类目 x 轴 + series 数组。
 const buildAxisOption = (spec) => {
+  const isCombo = spec.chart_type === 'combo'
+  const isArea = spec.chart_type === 'area'
   const horizontal = spec.chart_type === 'bar' && spec.orientation === 'horizontal'
   const categoryAxis = {
     type: 'category',
     data: spec.dataset.map((row) => row[spec.x_field]),
     axisLabel: {
       color: '#607185',
-      rotate: spec.chart_type === 'bar' && !horizontal && spec.dataset.length > 8 ? 25 : 0
+      rotate: (spec.chart_type === 'bar' || isCombo) && !horizontal && spec.dataset.length > 8 ? 25 : 0
     },
     axisLine: { lineStyle: { color: '#d7e4ef' } }
   }
-  const valueAxis = {
-    type: 'value',
-    name: spec.unit || '',
-    scale: true,
-    axisLabel: { color: '#607185' },
-    splitLine: { lineStyle: { color: '#eef3f8' } }
-  }
+  const valueAxis = valueAxisOption(spec.unit)
+  const yAxis = isCombo
+    ? [valueAxisOption(spec.series[0] ? spec.series[0].name : spec.unit), valueAxisOption('')]
+    : (horizontal ? categoryAxis : valueAxis)
 
   return {
     backgroundColor: 'transparent',
     color: spec.colors.length ? spec.colors : DEFAULT_CHART_COLORS,
-    title: spec.title
-      ? {
-          text: spec.title,
-          subtext: spec.description || '',
-          left: 'left',
-          top: 6,
-          textStyle: { fontSize: 14, fontWeight: 600, color: '#162131' },
-          subtextStyle: { color: '#607185', fontSize: 12 }
-        }
-      : undefined,
+    title: buildTitleOption(spec),
     tooltip: {
       trigger: 'axis',
       transitionDuration: 0,
@@ -251,19 +273,158 @@ const buildAxisOption = (spec) => {
     legend: { top: 8, right: 0, textStyle: { color: '#607185' } },
     grid: { left: 24, right: 16, top: spec.title ? 68 : 32, bottom: 40, containLabel: true },
     xAxis: horizontal ? valueAxis : categoryAxis,
-    yAxis: horizontal ? categoryAxis : valueAxis,
-    series: spec.series.map((series) => ({
-      type: series.type,
-      name: series.name,
-      smooth: spec.chart_type === 'line',
-      stack: spec.stack ? 'total' : undefined,
-      areaStyle: spec.chart_type === 'line' && spec.area ? {} : undefined,
-      lineStyle: spec.chart_type === 'line' ? { width: 3 } : undefined,
-      symbolSize: spec.chart_type === 'line' ? 8 : undefined,
-      barMaxWidth: spec.chart_type === 'bar' ? 34 : undefined,
-      itemStyle: spec.chart_type === 'bar' ? { borderRadius: horizontal ? [0, 8, 8, 0] : [8, 8, 0, 0] } : undefined,
-      data: spec.dataset.map((row) => toNumeric(row[series.field]))
-    }))
+    yAxis,
+    series: spec.series.map((series) => {
+      const seriesType = isCombo ? series.type : (isArea ? 'line' : series.type)
+      const isLineLike = seriesType === 'line'
+      return {
+        type: seriesType,
+        name: series.name,
+        yAxisIndex: isCombo ? (series.axis === 'right' ? 1 : 0) : undefined,
+        smooth: spec.chart_type === 'line' || isArea,
+        stack: spec.stack && !isCombo ? 'total' : undefined,
+        areaStyle: isArea || (isLineLike && spec.area && !isCombo) ? {} : undefined,
+        lineStyle: isLineLike ? { width: 3 } : undefined,
+        symbolSize: isLineLike ? 8 : undefined,
+        barMaxWidth: seriesType === 'bar' ? 34 : undefined,
+        itemStyle: seriesType === 'bar' ? { borderRadius: horizontal ? [0, 8, 8, 0] : [8, 8, 0, 0] } : undefined,
+        data: spec.dataset.map((row) => toNumeric(row[series.field]))
+      }
+    })
+  }
+}
+
+// 散点图：x、y 均为数值轴，数据点为 [x, y]。
+const buildScatterOption = (spec) => ({
+  backgroundColor: 'transparent',
+  color: spec.colors.length ? spec.colors : DEFAULT_CHART_COLORS,
+  title: buildTitleOption(spec),
+  tooltip: {
+    trigger: 'item',
+    valueFormatter: spec.unit ? (value) => `${value}${spec.unit}` : undefined
+  },
+  legend: { top: 8, right: 0, textStyle: { color: '#607185' } },
+  grid: { left: 24, right: 16, top: spec.title ? 68 : 32, bottom: 40, containLabel: true },
+  xAxis: { ...valueAxisOption(spec.x_field), name: spec.x_field },
+  yAxis: valueAxisOption(spec.unit),
+  series: spec.series.map((series) => ({
+    type: 'scatter',
+    name: series.name,
+    symbolSize: 12,
+    data: spec.dataset.map((row) => [toNumeric(row[spec.x_field]), toNumeric(row[series.field])])
+  }))
+})
+
+// 雷达图：每行作为一个指标轴，每个 series 为一圈。
+const buildRadarOption = (spec) => {
+  const indicators = spec.dataset.map((row) => {
+    const max = spec.series.reduce((acc, series) => {
+      const value = toNumeric(row[series.field])
+      return typeof value === 'number' && value > acc ? value : acc
+    }, 0)
+    return { name: String(row[spec.x_field] ?? ''), max: max > 0 ? max : undefined }
+  })
+  return {
+    backgroundColor: 'transparent',
+    color: spec.colors.length ? spec.colors : DEFAULT_CHART_COLORS,
+    title: buildTitleOption(spec),
+    tooltip: { trigger: 'item' },
+    legend: { top: 8, right: 0, textStyle: { color: '#607185' } },
+    radar: {
+      indicator: indicators,
+      radius: '62%',
+      center: ['50%', '55%'],
+      axisName: { color: '#607185' },
+      splitLine: { lineStyle: { color: '#e3ebf3' } },
+      splitArea: { areaStyle: { color: ['rgba(15,140,123,0.03)', 'rgba(15,140,123,0.06)'] } }
+    },
+    series: [
+      {
+        type: 'radar',
+        data: spec.series.map((series) => ({
+          name: series.name,
+          value: spec.dataset.map((row) => toNumeric(row[series.field])),
+          areaStyle: { opacity: 0.1 }
+        }))
+      }
+    ]
+  }
+}
+
+// 漏斗图：阶段 + 单数值。
+const buildFunnelOption = (spec) => {
+  const primarySeries = spec.series[0]
+  return {
+    backgroundColor: 'transparent',
+    color: spec.colors.length ? spec.colors : DEFAULT_CHART_COLORS,
+    title: buildTitleOption(spec),
+    tooltip: {
+      trigger: 'item',
+      valueFormatter: spec.unit ? (value) => `${value}${spec.unit}` : undefined
+    },
+    legend: { bottom: 0, textStyle: { color: '#607185' } },
+    series: [
+      {
+        type: 'funnel',
+        left: '10%',
+        right: '10%',
+        top: spec.title ? 68 : 24,
+        bottom: 32,
+        minSize: '20%',
+        sort: 'descending',
+        gap: 2,
+        label: { color: '#425466' },
+        labelLine: { lineStyle: { color: '#c5d2df' } },
+        itemStyle: { borderColor: '#ffffff', borderWidth: 1 },
+        data: spec.dataset.map((row) => ({
+          name: String(row[spec.x_field] ?? ''),
+          value: toNumeric(row[primarySeries.field] ?? 0)
+        }))
+      }
+    ]
+  }
+}
+
+const niceCeil = (value) => {
+  const num = typeof value === 'number' && Number.isFinite(value) ? value : 0
+  if (num <= 0) return 100
+  const magnitude = 10 ** Math.floor(Math.log10(num))
+  return Math.ceil(num / magnitude) * magnitude
+}
+
+// 仪表盘：取首行单一 KPI。
+const buildGaugeOption = (spec) => {
+  const primarySeries = spec.series[0]
+  const firstRow = spec.dataset[0] || {}
+  const value = toNumeric(firstRow[primarySeries.field] ?? 0)
+  const numericValue = typeof value === 'number' ? value : 0
+  const name = spec.x_field ? String(firstRow[spec.x_field] ?? primarySeries.name) : primarySeries.name
+  const max = spec.unit === '%' ? 100 : niceCeil(numericValue * 1.2)
+  return {
+    backgroundColor: 'transparent',
+    color: spec.colors.length ? spec.colors : DEFAULT_CHART_COLORS,
+    title: buildTitleOption(spec),
+    series: [
+      {
+        type: 'gauge',
+        min: 0,
+        max,
+        center: ['50%', '58%'],
+        radius: '78%',
+        progress: { show: true, width: 14 },
+        axisLine: { lineStyle: { width: 14 } },
+        axisLabel: { color: '#607185', distance: 18 },
+        pointer: { width: 5 },
+        detail: {
+          valueAnimation: true,
+          fontSize: 22,
+          color: '#162131',
+          formatter: spec.unit ? `{value}${spec.unit}` : '{value}'
+        },
+        title: { color: '#607185', offsetCenter: [0, '72%'] },
+        data: [{ value: numericValue, name }]
+      }
+    ]
   }
 }
 
@@ -321,9 +482,22 @@ export const buildChartRenderModel = (specInput) => {
     state: 'renderable',
     kind: 'echarts',
     spec,
-    option: spec.chart_type === 'pie' ? buildPieOption(spec) : buildAxisOption(spec),
+    option: buildEchartsOption(spec),
     errorText: ''
   }
+}
+
+const ECHART_OPTION_BUILDERS = {
+  pie: buildPieOption,
+  scatter: buildScatterOption,
+  radar: buildRadarOption,
+  funnel: buildFunnelOption,
+  gauge: buildGaugeOption
+}
+
+const buildEchartsOption = (spec) => {
+  const builder = ECHART_OPTION_BUILDERS[spec.chart_type]
+  return builder ? builder(spec) : buildAxisOption(spec)
 }
 
 export const buildChartOption = (specInput) => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -514,6 +514,26 @@ const CHART_SPEC_FENCE_PATTERNS = [
   /<chart_spec>\s*([\s\S]*?)<\/chart_spec>/gi
 ]
 
+// A model sometimes hallucinates a chart as a markdown image/link pointing at a
+// fake `chart_spec://` URL (full-width colon included), which marked turns into a
+// broken <img>. Charts are never images (the spec contract forbids static image
+// URLs), so we always neutralize this form: recover an embedded spec from the URL
+// when one is actually there, otherwise drop the artifact entirely so no broken
+// image leaks to the user. `!?` covers both `![alt](...)` and `[text](...)`.
+const CHART_SPEC_PSEUDO_URL_PATTERN = /!?\[[^\]]*\]\(\s*(chart_spec[:：][^)]*?)\s*\)/gi
+
+// Try to pull a real chart_spec JSON out of a `chart_spec://...` URL body; the
+// model may cram the JSON into the URL, but usually it is just a placeholder.
+const recoverSpecFromPseudoUrl = (url) => {
+  let body = String(url || '').replace(/^chart_spec[:：]/i, '').replace(/^\/*/, '')
+  try {
+    body = decodeURIComponent(body)
+  } catch (_error) {
+    // keep the raw body when it is not valid percent-encoding
+  }
+  return parseChartSpec(body)
+}
+
 // Locate the index of the brace that closes the object opened at `start`,
 // ignoring braces inside JSON strings. Returns -1 when unbalanced (e.g. a spec
 // still streaming in), so partial output is left as plain text until complete.
@@ -549,6 +569,19 @@ const findMatchingBrace = (source, start) => {
 // what the conclusion area renders.
 const collectChartSpecRanges = (source) => {
   const ranges = []
+
+  // Neutralize pseudo `chart_spec://` image/link artifacts first and claim their
+  // span, so the brace scanner below never re-parses the URL body and the text
+  // splitter can drop (spec === null) or render (recovered spec) the range.
+  CHART_SPEC_PSEUDO_URL_PATTERN.lastIndex = 0
+  let pseudoMatch
+  while ((pseudoMatch = CHART_SPEC_PSEUDO_URL_PATTERN.exec(source)) !== null) {
+    ranges.push({
+      start: pseudoMatch.index,
+      end: pseudoMatch.index + pseudoMatch[0].length,
+      spec: recoverSpecFromPseudoUrl(pseudoMatch[1])
+    })
+  }
 
   for (const pattern of CHART_SPEC_FENCE_PATTERNS) {
     pattern.lastIndex = 0
@@ -590,7 +623,9 @@ const collectChartSpecRanges = (source) => {
   return resolved
 }
 
-export const extractChartSpecsFromText = (text) => collectChartSpecRanges(String(text || '')).map((range) => range.spec)
+export const extractChartSpecsFromText = (text) => collectChartSpecRanges(String(text || ''))
+  .map((range) => range.spec)
+  .filter(Boolean)
 
 // Split answer text into ordered segments so the conclusion area can render the
 // surrounding prose as markdown and each embedded chart_spec as a real chart,
@@ -607,7 +642,9 @@ export const splitChartSpecText = (text) => {
   let cursor = 0
   for (const range of ranges) {
     pushText(source.slice(cursor, range.start))
-    segments.push({ type: 'chart', spec: range.spec })
+    // A null spec is an unrecoverable artifact (e.g. a broken `chart_spec://`
+    // image): drop its text without emitting a chart so nothing renders.
+    if (range.spec) segments.push({ type: 'chart', spec: range.spec })
     cursor = range.end
   }
   pushText(source.slice(cursor))

--- a/docs/design/2026-06-22-nl2sql-chart-types-design.md
+++ b/docs/design/2026-06-22-nl2sql-chart-types-design.md
@@ -1,0 +1,69 @@
+# 智能问数图表类型扩展 设计
+
+## 背景与现状
+
+智能问数（NL2SQL）的图表输出统一走 `chart_spec` 契约，链路分四层：
+
+- 技能脚本 `dataagent/.claude/skills/opendataworks-platform-tools/scripts/build_chart_spec.py`：从 `sql_execution` 结果推断并生成 `chart_spec`。
+- 前端解析 `dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js`：白名单校验 + 构建 ECharts option。
+- 前端渲染 `dataagent/dataagent-frontend/src/views/intelligence/ChartSpecView.vue`：按需注册 ECharts 图表组件并渲染。
+- 契约文档/系统提示词/模板/测试：约束模型可用的 `chart_type`。
+
+当前 `chart_type` 仅支持 `table`、`bar`、`line`、`pie`，无法覆盖相关性、转化、单 KPI、多指标对比等常见问数可视化诉求。`stack` 标志在前端已支持，但脚本没有 `--stack` 入口，堆叠柱实际不可达。
+
+## 问题
+
+- 可用图表类型过少，趋势/占比/排行之外的分析诉求（相关性、组合双轴、转化、单指标对比、单 KPI）无法可视化。
+- 堆叠柱缺少脚本入口。
+
+## 范围
+
+本轮新增 6 种 `chart_type` 并补齐堆叠入口；明确不纳入 heatmap / treemap / sankey / boxplot（数据形态特殊、契约更重，留待后续按需扩展）。
+
+新增类型与数据形态：
+
+| chart_type | x_field | series | 说明 |
+|---|---|---|---|
+| `area` | 时间/分类 | 1~3 数值 | line 的填充版，独立一等类型，语义更清晰 |
+| `scatter` | 数值 | 1~3 数值 | 相关性分析，x 轴为 value 轴 |
+| `combo` | 分类/时间 | ≥2 数值 | 首列柱（左轴），其余折线（右轴），双 Y 轴 |
+| `radar` | 分类(指标轴) | 1~3 数值 | 多指标对比，每行一个雷达指标 |
+| `funnel` | 阶段 | 1 数值 | 转化分析 |
+| `gauge` | 可选 | 1 数值 | 单 KPI，取首行 |
+
+堆叠：`bar`/`area` 通过新增脚本参数 `--stack` 设置 `stack:true`，前端复用已有 `stack` 渲染逻辑。
+
+## 接口与契约
+
+`chart_spec` 字段保持兼容，新增/复用：
+
+- `chart_type` 枚举扩展为 `table|bar|line|area|scatter|combo|radar|funnel|gauge|pie`。
+- `series[].axis`：`"left"|"right"`，仅 `combo` 使用，决定 Y 轴归属；缺省 `left`。
+- `series[].type`：`combo` 显式区分 `bar`/`line`；`area` 用 `line`；`scatter` 用 `scatter`；`radar/funnel/gauge` 的 type 不参与渲染（专用 builder 只读 `field`）。
+- `stack`：`bar`/`area` 堆叠开关，沿用现有字段。
+
+脚本调用契约扩展：
+
+```
+build_chart_spec.py --chart-type <table|bar|line|area|scatter|combo|radar|funnel|gauge|pie> \
+  --input '<sql_execution JSON>' [--title ...] [--x-field ...] [--y-field ...] [--stack]
+```
+
+校验分组（前端 `validateChartSpec`）：
+
+- `table`：必须 `columns`。
+- `bar|line|area|scatter|combo|radar`：必须 `x_field` + `series`。
+- `pie|funnel`：必须 `x_field` + 恰好 1 个 `series`。
+- `gauge`：必须 1 个 `series`，`x_field` 可选。
+
+## 渲染方案（前端）
+
+- `chartSpec.js`：扩展 `CHART_TYPES`/`ECHART_TYPES`/`SERIES_TYPES`；`normalizeSeries` 透传 `axis`；新增 `buildScatterOption`/`buildComboOption`/`buildRadarOption`/`buildFunnelOption`/`buildGaugeOption`；`buildAxisOption` 兼容 `area`（areaStyle）与 `combo`（双轴 + 逐 series type/yAxisIndex）。
+- `ChartSpecView.vue`：补注册 `ScatterChart`/`RadarChart`/`FunnelChart`/`GaugeChart` 与 `RadarComponent`。
+
+## 取舍
+
+- area 作为独立类型而非仅 `--area` 标志：模型按 `--chart-type area` 选用更直观，且与契约文档枚举一致。
+- combo 采用“首列柱 + 其余折线右轴”的固定约定，避免引入复杂的逐列轴编排参数，保持单一稳定契约。
+- gauge/funnel/radar 用专用 builder 而非复用轴 builder，数据形态差异大，专用实现更可控。
+- 不一次铺满 heatmap/sankey 等重契约类型，控制改动面与模型误用风险。

--- a/docs/plans/2026-06-22-nl2sql-chart-types-plan.md
+++ b/docs/plans/2026-06-22-nl2sql-chart-types-plan.md
@@ -1,0 +1,46 @@
+# 智能问数图表类型扩展 计划
+
+关联设计：`docs/design/2026-06-22-nl2sql-chart-types-design.md`
+
+## 受影响栈
+
+- DataAgent 技能脚本（Python）
+- DataAgent 前端（Vue/ECharts）
+- 技能契约文档与图表模板
+- 系统提示词
+- 单元/契约测试（pytest + vitest）
+
+## 任务
+
+1. 技能脚本 `scripts/build_chart_spec.py`
+   - `choose_chart` 支持 `area/scatter/combo/radar/funnel/gauge` 偏好分支。
+   - 新增 `--stack` 参数，写入 `stack`。
+   - `combo` 设置 `series[0]` 为 `bar`/左轴，其余 `line`/右轴；`scatter` series type=`scatter`；`area` series type=`line` 且 `area=true`。
+   - `gauge` 允许空 `x_field`。
+
+2. 前端解析 `chartSpec.js`
+   - 扩展类型白名单与 `SERIES_TYPES`；`normalizeSeries` 透传 `axis`。
+   - 扩展 `validateChartSpec` 分组规则。
+   - 新增专用 option builder，并在 `buildAxisOption` 兼容 area/combo。
+
+3. 前端渲染 `ChartSpecView.vue`
+   - 注册新增 ECharts 图表与 `RadarComponent`。
+
+4. 契约与提示词
+   - 更新 `reference/50-tool-output-contract.md` 图表类型枚举、规则、`--chart-type` 模板。
+   - 更新 `prompts/data_agent_system_prompt.md` 调用模板与类型选用指引。
+   - 新增图表模板 `assets/chart-template/{area,scatter,combo,radar,funnel,gauge}.json`。
+
+5. 测试
+   - `tests/test_build_chart_spec_script.py`：新增各类型用例与 `--stack`。
+   - `__tests__/chartSpec.spec.js`：新增各类型解析/校验/option 用例。
+
+## 验证
+
+- `python -m pytest dataagent/dataagent-backend/tests/test_build_chart_spec_script.py`
+- `dataagent/dataagent-frontend` 下 `nvm use` 后 `npm run test`（chartSpec 用例）。
+- 不涉及后端 API/schema/部署变更，无需 alembic 或全链路 smoke；记录未跑 UI 全链路。
+
+## 回滚
+
+- 改动集中在脚本、前端解析/渲染、文档、模板、测试；如需回滚直接 revert 本分支提交，契约向后兼容（新增枚举，不改旧字段语义）。


### PR DESCRIPTION
智能问数图表此前仅支持 bar/line/pie/table。本次新增 6 种图表类型并补齐
堆叠柱入口，覆盖相关性、组合双轴、多指标对比、转化、单 KPI 等常见可视化诉求：

- 技能脚本 build_chart_spec.py：choose_chart 支持 area/scatter/combo/radar/
  funnel/gauge 偏好分支；新增 --stack；combo 首列柱(左轴)其余折线(右轴)；
  gauge 允许空 x_field。
- 前端 chartSpec.js：扩展类型白名单与校验分组，series 透传 axis，新增
  scatter/combo/radar/funnel/gauge 专用 ECharts option builder，buildAxisOption
  兼容 area 与 combo 双轴。
- 前端 ChartSpecView.vue：注册 Scatter/Radar/Funnel/Gauge 图表与 RadarComponent。
- 契约文档、系统提示词、图表模板同步更新；新增 pytest 与 vitest 用例。

验证：脚本 16 个 pytest 用例、前端 intelligence 175 个 vitest 用例全部通过。
未运行真实模型/UI 全链路 smoke（需 MySQL+Redis+provider 凭据）。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FpErTA2HaXtN1sRzMGq7E3