### PR TITLE
feat(dataagent): add session execution observability and SDK stream lifecycle logs

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import mimetypes
 import json
@@ -568,6 +569,13 @@ async def api_stream_sdk_events(task_id: str, request: Request, after_id: int = 
     task = store.get_task(task_id, context=context)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
+    logger.info(
+        "sdk_events.stream.open task_id=%s topic_id=%s after_id=%s task_status=%s",
+        task_id,
+        str(task.get("topic_id") or ""),
+        after_id,
+        str(task.get("task_status") or ""),
+    )
     return StreamingResponse(
         _stream_sdk_events(task_id=task_id, after_id=after_id, context=context),
         media_type="text/event-stream",
@@ -585,29 +593,66 @@ async def _stream_sdk_events(task_id: str, after_id: int, context: dict[str, str
     ping_seconds = max(5, int(cfg.run_events_stream_ping_seconds or 10))
     next_after_id = max(0, after_id)
     since_ping = 0
+    delivered = 0
+    last_task_status = ""
     store = _get_store()
 
-    while True:
-        records = store.list_sdk_records(task_id=task_id, after_id=next_after_id, limit=200)
-        for rec in records:
-            next_after_id = max(next_after_id, int(rec.get("seq_id") or 0))
-            yield _encode_sse(rec)
-        if records:
-            since_ping = 0
-        else:
-            since_ping += poll_interval
-            if since_ping >= ping_seconds:
-                yield ": ping\n\n"
+    try:
+        while True:
+            records = store.list_sdk_records(task_id=task_id, after_id=next_after_id, limit=200)
+            for rec in records:
+                next_after_id = max(next_after_id, int(rec.get("seq_id") or 0))
+                delivered += 1
+                yield _encode_sse(rec)
+            if records:
                 since_ping = 0
+            else:
+                since_ping += poll_interval
+                if since_ping >= ping_seconds:
+                    yield ": ping\n\n"
+                    since_ping = 0
 
-        task = store.get_task(task_id, context=context)
-        if not task:
-            break
-        # Stop when: task is terminal AND we've delivered all SDK records (look for 'done'/'error')
-        if str(task.get("task_status") or "") in TERMINAL_TASK_STATUSES and not records:
-            # Check if we've already yielded a done/error record
-            break
-        await anyio.sleep(poll_interval)
+            task = store.get_task(task_id, context=context)
+            if not task:
+                last_task_status = "missing"
+                logger.info(
+                    "sdk_events.stream.terminate task_id=%s reason=missing_task last_seq=%s delivered=%s",
+                    task_id,
+                    next_after_id,
+                    delivered,
+                )
+                break
+            last_task_status = str(task.get("task_status") or "")
+            # Stop when: task is terminal and the latest DB poll had no new SDK records.
+            if last_task_status in TERMINAL_TASK_STATUSES and not records:
+                logger.info(
+                    "sdk_events.stream.terminate task_id=%s reason=terminal task_status=%s last_seq=%s delivered=%s",
+                    task_id,
+                    last_task_status,
+                    next_after_id,
+                    delivered,
+                )
+                break
+            await anyio.sleep(poll_interval)
+    except asyncio.CancelledError:
+        logger.info(
+            "sdk_events.stream.disconnected task_id=%s requested_after_id=%s last_seq=%s task_status=%s delivered=%s",
+            task_id,
+            after_id,
+            next_after_id,
+            last_task_status,
+            delivered,
+        )
+        raise
+    finally:
+        logger.info(
+            "sdk_events.stream.close task_id=%s requested_after_id=%s last_seq=%s task_status=%s delivered=%s",
+            task_id,
+            after_id,
+            next_after_id,
+            last_task_status,
+            delivered,
+        )
 
 
 @task_router.post("/{task_id}/cancel", response_model=CancelTaskResponse)

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -3,13 +3,40 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_THINKING_CHAR_WARN_THRESHOLDS = (4096, 8192, 16384, 32768)
+_THINKING_DELTA_WARN_THRESHOLDS = (1000, 3000, 6000, 10000)
+_THINKING_DURATION_WARN_SECONDS = 60
+_REPEATED_SEGMENT_WARN_COUNTS = {3, 5, 10, 20, 50}
+_SEGMENT_SPLIT_RE = re.compile(r"\n+|(?<=[。！？.!?])\s*")
+
+
+@dataclass
+class _BlockStats:
+    index: int
+    block_type: str
+    started_at: float = field(default_factory=time.monotonic)
+    delta_count: int = 0
+    char_count: int = 0
+    next_char_threshold_index: int = 0
+    next_delta_threshold_index: int = 0
+    long_logged: bool = False
+    segment_counts: dict[str, int] = field(default_factory=dict)
+
 
 class SdkBlockWriter:
-    """Writes raw Claude SDK messages into da_agent_sdk_record for the v2 stream endpoint."""
+    """Writes raw Claude SDK messages into da_agent_sdk_record for the v2 stream endpoint.
+
+    In sandbox mode this writer normally runs inside the task child process. Its
+    ``sdk_stream.*`` logs are execution-process observability: the sandbox runner
+    captures child stderr and mirrors those lines into the per-task log.
+    """
 
     def __init__(self, store: Any, task_id: str, topic_id: str) -> None:
         self._store = store
@@ -17,6 +44,7 @@ class SdkBlockWriter:
         self._topic_id = topic_id
         self._turn_index = 0
         self._saw_stream_event = False
+        self._active_blocks: dict[int, _BlockStats] = {}
 
     def ingest(self, msg: Any) -> None:
         """Process one SDK message from the claude_query() stream."""
@@ -170,6 +198,7 @@ class SdkBlockWriter:
         etype = str(evt.get("type") or "")
         if etype == "message_start":
             self._turn_index += 1
+        self._observe_stream_event(evt, etype)
         self._store.append_sdk_record(
             task_id=self._task_id,
             topic_id=self._topic_id,
@@ -178,6 +207,157 @@ class SdkBlockWriter:
             event_type=etype or None,
             data=evt,
         )
+
+    def _observe_stream_event(self, evt: dict[str, Any], etype: str) -> None:
+        if etype == "message_start":
+            logger.info(
+                "sdk_stream.message_start task_id=%s topic_id=%s turn_index=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+            )
+            return
+        if etype == "message_stop":
+            if self._active_blocks:
+                logger.warning(
+                    "sdk_stream.message_stop_unclosed_blocks task_id=%s topic_id=%s turn_index=%s block_indexes=%s",
+                    self._task_id,
+                    self._topic_id,
+                    self._turn_index,
+                    ",".join(str(index) for index in sorted(self._active_blocks)),
+                )
+            logger.info(
+                "sdk_stream.message_stop task_id=%s topic_id=%s turn_index=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+            )
+            self._active_blocks.clear()
+            return
+
+        if etype == "content_block_start":
+            index = _event_index(evt)
+            if index is None:
+                return
+            content_block = evt.get("content_block")
+            block_type = ""
+            if isinstance(content_block, dict):
+                block_type = str(content_block.get("type") or "")
+            self._active_blocks[index] = _BlockStats(index=index, block_type=block_type)
+            logger.info(
+                "sdk_stream.block_start task_id=%s topic_id=%s turn_index=%s block_index=%s block_type=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                index,
+                block_type,
+            )
+            return
+
+        if etype == "content_block_delta":
+            self._observe_stream_delta(evt)
+            return
+
+        if etype == "content_block_stop":
+            index = _event_index(evt)
+            if index is None:
+                return
+            stats = self._active_blocks.pop(index, None)
+            if stats is None:
+                return
+            elapsed_ms = int((time.monotonic() - stats.started_at) * 1000)
+            logger.info(
+                "sdk_stream.block_stop task_id=%s topic_id=%s turn_index=%s block_index=%s block_type=%s char_count=%s delta_count=%s elapsed_ms=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                index,
+                stats.block_type,
+                stats.char_count,
+                stats.delta_count,
+                elapsed_ms,
+            )
+
+    def _observe_stream_delta(self, evt: dict[str, Any]) -> None:
+        index = _event_index(evt)
+        if index is None:
+            return
+        delta = evt.get("delta")
+        if not isinstance(delta, dict):
+            return
+        delta_type = str(delta.get("type") or "")
+        if delta_type != "thinking_delta":
+            return
+        text = str(delta.get("thinking") or "")
+        if not text:
+            return
+        stats = self._active_blocks.setdefault(index, _BlockStats(index=index, block_type="thinking"))
+        stats.delta_count += 1
+        stats.char_count += len(text)
+        elapsed_seconds = time.monotonic() - stats.started_at
+
+        while (
+            stats.next_char_threshold_index < len(_THINKING_CHAR_WARN_THRESHOLDS)
+            and stats.char_count >= _THINKING_CHAR_WARN_THRESHOLDS[stats.next_char_threshold_index]
+        ):
+            threshold = _THINKING_CHAR_WARN_THRESHOLDS[stats.next_char_threshold_index]
+            stats.next_char_threshold_index += 1
+            logger.warning(
+                "sdk_stream.thinking_large task_id=%s topic_id=%s turn_index=%s block_index=%s char_count=%s threshold=%s delta_count=%s elapsed_ms=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                index,
+                stats.char_count,
+                threshold,
+                stats.delta_count,
+                int(elapsed_seconds * 1000),
+            )
+
+        while (
+            stats.next_delta_threshold_index < len(_THINKING_DELTA_WARN_THRESHOLDS)
+            and stats.delta_count >= _THINKING_DELTA_WARN_THRESHOLDS[stats.next_delta_threshold_index]
+        ):
+            threshold = _THINKING_DELTA_WARN_THRESHOLDS[stats.next_delta_threshold_index]
+            stats.next_delta_threshold_index += 1
+            logger.warning(
+                "sdk_stream.thinking_many_deltas task_id=%s topic_id=%s turn_index=%s block_index=%s delta_count=%s threshold=%s char_count=%s elapsed_ms=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                index,
+                stats.delta_count,
+                threshold,
+                stats.char_count,
+                int(elapsed_seconds * 1000),
+            )
+
+        if not stats.long_logged and elapsed_seconds >= _THINKING_DURATION_WARN_SECONDS:
+            stats.long_logged = True
+            logger.warning(
+                "sdk_stream.thinking_long task_id=%s topic_id=%s turn_index=%s block_index=%s elapsed_ms=%s char_count=%s delta_count=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                index,
+                int(elapsed_seconds * 1000),
+                stats.char_count,
+                stats.delta_count,
+            )
+
+        for segment in _meaningful_segments(text):
+            count = stats.segment_counts.get(segment, 0) + 1
+            stats.segment_counts[segment] = count
+            if count in _REPEATED_SEGMENT_WARN_COUNTS:
+                logger.warning(
+                    "sdk_stream.thinking_repeated_segment task_id=%s topic_id=%s turn_index=%s block_index=%s repeat_count=%s segment_preview=%s",
+                    self._task_id,
+                    self._topic_id,
+                    self._turn_index,
+                    index,
+                    count,
+                    _clip_log_text(segment),
+                )
 
     def append_permission_request(
         self,
@@ -305,6 +485,23 @@ class SdkBlockWriter:
 
     def _append_terminal_record(self, *, record_type: str, data: dict[str, Any]) -> None:
         try:
+            if self._active_blocks:
+                logger.warning(
+                    "sdk_stream.terminal_unclosed_blocks task_id=%s topic_id=%s turn_index=%s record_type=%s block_indexes=%s",
+                    self._task_id,
+                    self._topic_id,
+                    self._turn_index,
+                    record_type,
+                    ",".join(str(index) for index in sorted(self._active_blocks)),
+                )
+                self._active_blocks.clear()
+            logger.info(
+                "sdk_stream.terminal_record task_id=%s topic_id=%s turn_index=%s record_type=%s",
+                self._task_id,
+                self._topic_id,
+                self._turn_index,
+                record_type,
+            )
             self._store.append_sdk_record(
                 task_id=self._task_id,
                 topic_id=self._topic_id,
@@ -328,6 +525,29 @@ def _serialise_blocks(blocks: Any) -> Any:
         else:
             result.append(str(b))
     return result
+
+
+def _event_index(evt: dict[str, Any]) -> int | None:
+    try:
+        return int(evt.get("index"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _meaningful_segments(text: str) -> list[str]:
+    segments: list[str] = []
+    for raw in _SEGMENT_SPLIT_RE.split(str(text or "")):
+        segment = raw.strip()
+        if len(segment) >= 4:
+            segments.append(segment)
+    return segments
+
+
+def _clip_log_text(text: str, limit: int = 120) -> str:
+    value = " ".join(str(text or "").split())
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3] + "..."
 
 
 def _block_type(block: Any) -> str:

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -259,9 +259,11 @@ class TaskCoordinator:
                     is_cancel_requested=lambda: self._should_stop_task(task_id, lease_lost),
                 )
                 logger.info(
-                    "task.run.result task_id=%s topic_id=%s task_status=%s error_code=%s content_len=%s session_id_set=%s usage_set=%s",
+                    "task.run.result task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s content_len=%s session_id_set=%s usage_set=%s",
                     task_id,
                     topic_id,
+                    str(task.get("provider_id") or ""),
+                    str(task.get("model") or ""),
                     result.task_status,
                     str((result.error or {}).get("code") or ""),
                     len(str(result.content or "")),
@@ -297,9 +299,11 @@ class TaskCoordinator:
                     )
                 self.store.finish_task(task_id=task_id, task_status=result.task_status, error=result.error)
                 logger.info(
-                    "task.run.finished task_id=%s topic_id=%s task_status=%s error_code=%s",
+                    "task.run.finished task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s",
                     task_id,
                     topic_id,
+                    str(task.get("provider_id") or ""),
+                    str(task.get("model") or ""),
                     result.task_status,
                     str((result.error or {}).get("code") or ""),
                 )
@@ -362,6 +366,9 @@ class TaskCoordinator:
             return []
 
     def _persist_emitted_sdk_record(self, *, topic_id: str, task_id: str, record: dict[str, Any]) -> None:
+        # This is the sandbox-runner protocol sink. The current local/child
+        # execution path also writes SDK rows directly through SdkBlockWriter, so
+        # this method is intentionally not the only da_agent_sdk_record writer.
         if not isinstance(record, dict):
             return
         record_type = str(record.get("record_type") or "").strip()

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import os
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -62,6 +63,8 @@ from core.topic_task_store import get_topic_task_store
 from core.topic_workspace import prepare_topic_workspace
 
 logger = logging.getLogger(__name__)
+
+_SDK_TURN_PROGRESS_THRESHOLDS = (1000, 3000, 6000, 10000)
 
 
 @dataclass
@@ -708,13 +711,16 @@ async def execute_task_stream(
     emit: Callable[[dict[str, Any]], Awaitable[None] | None],
     is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
 ) -> TaskExecutionResult:
-    """Execute one NL2SQL run, streaming events via ``emit``, return the terminal result.
+    """Execute one NL2SQL run and return the terminal result.
 
     Dispatches to the sandbox runner when ``dataagent_sandbox_mode`` is set,
-    otherwise runs in-process. ``emit`` receives SDK/widget event dicts as they
-    occur (text deltas, tool calls, permission/question cards); the awaited return
-    value is the final :class:`TaskExecutionResult` (status, content, usage, error,
-    session id). ``is_cancel_requested`` is polled to abort a long/stalled run.
+    otherwise runs in-process. The current local/child execution path writes SDK
+    stream records directly through ``SdkBlockWriter`` into ``da_agent_sdk_record``;
+    ``emit`` is for records forwarded by the sandbox-runner protocol and should
+    not be read as the single persistence boundary for all SDK records. The
+    awaited return value is the final :class:`TaskExecutionResult` (status,
+    content, usage, error, session id). ``is_cancel_requested`` is polled to
+    abort a long/stalled run.
     """
     cfg = get_settings()
     if _should_use_sandbox_runner(cfg):
@@ -1015,10 +1021,35 @@ async def _execute_task_stream_local(
         phase: str,
     ) -> TaskExecutionResult:
         nonlocal terminal_error_record_written
+        sdk_message_count = 0
+        sdk_stream_event_count = 0
+        next_progress_threshold_index = 0
+        turn_started_at = time.monotonic()
         try:
             with anyio.fail_after(turn_timeout_seconds):
                 sdk_prompt = _single_user_prompt_stream(turn_prompt) if can_use_tool is not None else turn_prompt
                 async for msg in claude_query(prompt=sdk_prompt, options=turn_options):
+                    sdk_message_count += 1
+                    if type(msg).__name__ == "StreamEvent":
+                        sdk_stream_event_count += 1
+                    while (
+                        next_progress_threshold_index < len(_SDK_TURN_PROGRESS_THRESHOLDS)
+                        and sdk_message_count >= _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
+                    ):
+                        threshold = _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
+                        next_progress_threshold_index += 1
+                        logger.info(
+                            "task.sdk_turn.progress task_id=%s topic_id=%s provider=%s model=%s phase=%s sdk_messages=%s stream_events=%s threshold=%s elapsed_ms=%s",
+                            params.task_id,
+                            params.topic_id,
+                            provider_id,
+                            model,
+                            phase,
+                            sdk_message_count,
+                            sdk_stream_event_count,
+                            threshold,
+                            int((time.monotonic() - turn_started_at) * 1000),
+                        )
                     if await _cancelled():
                         error = {"code": "task_cancelled", "message": "任务已取消"}
                         sdk_writer.append_error(**error)
@@ -1099,6 +1130,17 @@ async def _execute_task_stream_local(
                 session_id=accumulator.session_id,
             )
 
+        logger.info(
+            "task.sdk_turn.end task_id=%s topic_id=%s provider=%s model=%s phase=%s sdk_messages=%s stream_events=%s elapsed_ms=%s",
+            params.task_id,
+            params.topic_id,
+            provider_id,
+            model,
+            phase,
+            sdk_message_count,
+            sdk_stream_event_count,
+            int((time.monotonic() - turn_started_at) * 1000),
+        )
         return accumulator.build_result()
 
     result = await _run_sdk_turn(

--- a/dataagent/dataagent-backend/core/task_submission_service.py
+++ b/dataagent/dataagent-backend/core/task_submission_service.py
@@ -127,9 +127,12 @@ async def submit_message_task(
         store.mark_message_queue_submitted(queue_id=source_queue_id, task_id=task_id)
     task = await coordinator.submit_task(task_id) or task
     logger.info(
-        "task.submit.enqueued task_id=%s topic_id=%s task_status=%s user_message_id=%s assistant_message_id=%s",
+        "task.submit.enqueued task_id=%s topic_id=%s provider=%s model=%s mode=%s task_status=%s user_message_id=%s assistant_message_id=%s",
         task_id,
         topic_id,
+        str(runtime_target.get("provider_id") or ""),
+        str(runtime_target.get("model") or ""),
+        str(execution_mode or ""),
         str(task.get("task_status") or "waiting"),
         str(user_message.get("message_id") or ""),
         str(assistant_message.get("message_id") or ""),

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -802,6 +803,58 @@ def test_topic_permission_mode_lifecycle(monkeypatch):
         # PUT with neither field is a 400.
         empty = client.put(f"/api/v1/nl2sql/topics/{topic_id}", json={})
         assert empty.status_code == 400
+
+
+def test_sdk_events_stream_reads_persisted_records_in_seq_order(monkeypatch):
+    client, store, _coordinator, _submit_calls = _build_client(monkeypatch)
+    with client:
+        topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "SDK SSE"}).json()["topic_id"]
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={"topic_id": topic_id, "content": "stream test"},
+        ).json()
+        task_id = delivered["task_id"]
+        store.append_sdk_record(
+            task_id=task_id,
+            topic_id=topic_id,
+            turn_index=1,
+            record_type="stream",
+            event_type="message_start",
+            data={"type": "message_start"},
+        )
+        store.append_sdk_record(
+            task_id=task_id,
+            topic_id=topic_id,
+            turn_index=1,
+            record_type="stream",
+            event_type="content_block_delta",
+            data={"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hello"}},
+        )
+        store.append_sdk_record(
+            task_id=task_id,
+            topic_id=topic_id,
+            turn_index=1,
+            record_type="done",
+            event_type=None,
+            data={"is_error": False, "subtype": "success"},
+        )
+        store.tasks[task_id]["task_status"] = "finished"
+
+        with client.stream(
+            "GET",
+            f"/api/v1/nl2sql/tasks/{task_id}/sdk-events/stream",
+            params={"after_id": 1},
+        ) as response:
+            assert response.status_code == 200
+            events = [
+                json.loads(line.removeprefix("data: "))
+                for line in response.iter_lines()
+                if line.startswith("data: ")
+            ]
+
+        assert [event["seq_id"] for event in events] == [2, 3]
+        assert [event["record_type"] for event in events] == ["stream", "done"]
+        assert events[0]["data"]["delta"]["text"] == "hello"
 
 
 def test_permission_decision_endpoint(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -107,6 +107,25 @@ def test_sandbox_runner_cancel_endpoint_marks_task_cancelled():
     assert "task-1" in sandbox_runner_main.CANCELLED_TASK_IDS
 
 
+def test_sandbox_runner_task_log_captures_child_sdk_stream_stderr(tmp_path: Path):
+    log_path = tmp_path / "topic-1" / "logs" / "task-1.log"
+
+    async def scenario() -> None:
+        reader = asyncio.StreamReader()
+        reader.feed_data(
+            b"sdk_stream.thinking_repeated_segment task_id=task-1 topic_id=topic-1 repeat_count=3\n"
+        )
+        reader.feed_eof()
+        await sandbox_runner_main._log_stderr(reader, "task-1", log_path=log_path)
+
+    asyncio.run(scenario())
+
+    text = log_path.read_text(encoding="utf-8")
+    assert "stderr sdk_stream.thinking_repeated_segment" in text
+    assert "task_id=task-1" in text
+    assert "topic_id=topic-1" in text
+
+
 def test_sandbox_runner_container_command_mounts_only_topic_workspace(monkeypatch, tmp_path: Path):
     settings = get_settings()
     originals = {

--- a/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
+++ b/dataagent/dataagent-backend/tests/test_sdk_block_writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -199,3 +200,34 @@ def test_sdk_dataclass_tool_use_without_type_field_is_recorded() -> None:
         "id": "call_skill_1",
         "name": "Skill",
     }
+
+
+def test_thinking_stream_observability_logs_repeated_segment(caplog) -> None:
+    store = FakeStore()
+    writer = SdkBlockWriter(store, task_id="task-obs", topic_id="topic-obs")
+    caplog.set_level(logging.WARNING, logger="core.sdk_block_writer")
+
+    writer.ingest(StreamEvent({"type": "message_start"}))
+    writer.ingest(
+        StreamEvent(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking"},
+            }
+        )
+    )
+    for _ in range(3):
+        writer.ingest(
+            StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "thinking_delta", "thinking": "让我生成。"},
+                }
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("sdk_stream.thinking_repeated_segment" in message for message in messages)
+    assert any("task_id=task-obs" in message for message in messages)

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -49,6 +49,14 @@ class _RecordingStore:
         self.question_answer_records.append(kwargs)
 
 
+class _SdkRecordStore:
+    def __init__(self):
+        self.records = []
+
+    def append_sdk_record(self, **kwargs):
+        self.records.append(kwargs)
+
+
 def _build_gate(monkeypatch, decision, *, mode="default"):
     writer = _RecordingWriter()
     store = _RecordingStore()
@@ -478,6 +486,47 @@ def test_execute_task_stream_persists_sdk_records_without_magic_records(monkeypa
     assert ClaudeAgentOptions.last_kwargs["env"]["DISABLE_PROMPT_CACHING"] == ""
 
     assert emitted == []
+
+
+def test_execute_task_stream_logs_sdk_iterator_progress(monkeypatch, tmp_path: Path, caplog):
+    monkeypatch.setenv("DATAAGENT_CLAUDE_CLI_PATH", "/tmp/claude-cli")
+    monkeypatch.setattr(task_executor, "_SDK_TURN_PROGRESS_THRESHOLDS", (3,))
+    monkeypatch.setattr(task_executor, "get_topic_task_store", lambda: _SdkRecordStore())
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            StreamEvent({"type": "message_start", "message": {"id": "req-progress"}}),
+            StreamEvent({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+            StreamEvent({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ok"}}),
+            StreamEvent({"type": "content_block_stop", "index": 0}),
+            StreamEvent({"type": "message_stop"}),
+            ResultMessage("success", session_id="sdk-session-progress"),
+        ],
+    )
+    monkeypatch.setattr(
+        task_executor,
+        "resolve_runtime_provider_selection",
+        lambda provider_id, model: {
+            "provider_id": provider_id,
+            "model": model,
+            "api_key": "",
+            "auth_token": "",
+            "base_url": "https://example.invalid",
+            "supports_partial_messages": True,
+        },
+    )
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    caplog.set_level(logging.INFO, logger="core.task_executor")
+
+    async def _run():
+        return await task_executor.execute_task_stream(_build_input(), emit=lambda record: None)
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "finished"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("task.sdk_turn.progress" in message and "sdk_messages=3" in message for message in messages)
+    assert any("task.sdk_turn.end" in message and "sdk_messages=6" in message for message in messages)
 
 
 def test_execute_task_stream_logs_safe_runtime_base_url_and_preserves_env(monkeypatch, tmp_path: Path, caplog):

--- a/docs/design/2026-06-23-dataagent-session-execution-observability-design.md
+++ b/docs/design/2026-06-23-dataagent-session-execution-observability-design.md
@@ -1,0 +1,87 @@
+# DataAgent Session Execution Observability Design
+
+**Date:** 2026-06-23
+**Status:** Active
+**Scope:** DataAgent backend session, sandbox execution, SDK stream persistence, and SSE observability
+
+## Current State
+
+DataAgent Chat V2 is split across a main FastAPI service, a task coordinator, an execution path, an optional sandbox runner, and the frontend SSE consumer.
+
+The important current behavior is intentional for this design:
+
+- The main service creates topics, tasks, user messages, assistant placeholder messages, and terminal assistant messages.
+- The execution process writes Claude SDK stream records through `SdkBlockWriter` into `da_agent_sdk_record`.
+- In sandbox mode, that execution process is usually the task child container, so the child can write `da_agent_sdk_record` directly.
+- The frontend never reads child stdout directly. It connects to the main service SSE endpoint, and the main service reads persisted `da_agent_sdk_record` rows.
+- The sandbox runner manages child lifecycle, cancellation, stdout protocol messages, stderr capture, and per-task logs.
+
+## Problem
+
+The runtime behavior is workable, but the architecture is not explicit enough for incident analysis. A repeated thinking stream can appear in the frontend while the `.claude` JSONL transcript has no duplicate completed assistant message. Without a clear ownership map and correlated logs, it is easy to confuse:
+
+- frontend rendering;
+- main service SSE replay;
+- runner stdout/stderr forwarding;
+- child process SDK streaming;
+- DB persistence.
+
+## Goals
+
+- Preserve the current child-executes-and-can-write-DB architecture.
+- Make the ownership boundary clear in docs and code comments.
+- Add low-risk observability so a single `topic_id/task_id` can be traced from submission, execution, SDK stream persistence, runner logs, and SSE delivery.
+- Keep HTTP APIs, DB schema, frontend protocol, and sandbox execution behavior unchanged.
+
+## Ownership Matrix
+
+| Layer | Primary responsibility | Writes session DB | Reads session DB | Streams to user |
+| --- | --- | --- | --- | --- |
+| Frontend | Render chat and SDK blocks | No | No direct DB read | Consumes main-service SSE |
+| Main service API | Topic/task/message API and SSE endpoint | `da_agent_topic`, `da_agent_task`, `da_agent_topic_message`; permission/user decisions through API endpoints | `da_agent_*`, especially `da_agent_sdk_record` for SSE | Yes, from persisted SDK rows |
+| Task coordinator | Queue pickup, leases, final result handling | Task running/terminal status, final assistant message, topic current state | Tasks, topics, history | Indirect, through API SSE |
+| Execution process | Run Claude SDK and tools | `da_agent_sdk_record` via `SdkBlockWriter`; current permission/question wait status updates | Task/session settings as needed | No direct user stream |
+| Sandbox runner | Start/reuse/cancel child, capture child logs | No business session table writes by design | No business session reads by design | Protocol forwarding only |
+| Persistence layer | Store normalized session state and raw SDK records | N/A | N/A | N/A |
+
+## Data Flow
+
+1. `POST /tasks/deliver-message` creates a task and topic messages in the main service.
+2. The task coordinator marks the task running and calls `execute_task_stream`.
+3. `execute_task_stream` runs locally or delegates to the sandbox runner.
+4. The local execution path constructs `SdkBlockWriter(get_topic_task_store(), task_id, topic_id)`.
+5. `SdkBlockWriter` writes raw SDK stream/tool/terminal/permission/question records to `da_agent_sdk_record`.
+6. In sandbox mode, child stderr is captured by the runner and mirrored into `<topic>/logs/<task>.log`.
+7. The frontend connects to `/tasks/{task_id}/sdk-events/stream`.
+8. The main service polls `da_agent_sdk_record` by `seq_id` and emits SSE events to the frontend.
+9. The coordinator persists the terminal assistant message and final task status after execution returns.
+
+## Observability
+
+The observability model is intentionally split by ownership:
+
+- Main service logs cover submission, enqueue, coordinator execution, final message persistence, final task status, and SSE stream open/terminate/disconnect/close.
+- Execution-process logs cover SDK iterator progress and SDK stream shape, including turn-level SDK message counts, message/block lifecycle, large thinking blocks, many thinking deltas, long thinking duration, repeated thinking segments, and terminal records with unclosed blocks.
+- Runner logs and task logs capture child stderr, so sandbox-mode `sdk_stream.*` execution logs remain searchable by `task_id`.
+
+All new logs should include `task_id`; logs that know the topic should also include `topic_id`.
+
+For loop diagnosis:
+
+- If `task.sdk_turn.progress` grows while `sdk_stream.thinking_repeated_segment` grows for the same `task_id`, the child is receiving repeated SDK messages from the upstream SDK/model stream.
+- If DB `seq_id` advances but `task.sdk_turn.progress` does not, investigate execution-side synthetic writes or a missing progress log path.
+- If the same `seq_id` is rendered repeatedly without new DB rows, investigate SSE replay or frontend rendering.
+- If `.claude` JSONL lacks the repeated thinking while `da_agent_sdk_record` contains it, treat that as expected for a cancelled/incomplete streaming turn; JSONL is not the live delta source.
+
+## Non-Goals
+
+- Do not move SDK record writes from child to main service.
+- Do not introduce a new event bus or single-writer persistence protocol.
+- Do not change DB schema, HTTP APIs, frontend SSE payload shape, or the `.claude` JSONL transcript.
+- Do not treat `.claude` JSONL as the authoritative source for incomplete streamed thinking; `da_agent_sdk_record` is the live stream source.
+
+## Verification
+
+- Unit test `SdkBlockWriter` observability for repeated thinking segments.
+- Route contract test that SSE reads persisted `da_agent_sdk_record` rows in `seq_id` order.
+- Sandbox runner test that child stderr containing `sdk_stream.*` is persisted into the task log with task context.

--- a/docs/plans/2026-06-23-dataagent-session-execution-observability-plan.md
+++ b/docs/plans/2026-06-23-dataagent-session-execution-observability-plan.md
@@ -1,0 +1,43 @@
+# DataAgent Session Execution Observability Plan
+
+**Date:** 2026-06-23
+**Related design:** `docs/design/2026-06-23-dataagent-session-execution-observability-design.md`
+
+## Objective
+
+Clarify DataAgent session/execution/persistence ownership and add minimum observability for troubleshooting repeated SDK thinking streams without changing the current child-write architecture.
+
+## Affected Stacks
+
+- DataAgent backend: API routes, task submission/coordinator comments and logs, SDK block writer.
+- Sandbox runner: child stderr/task-log observability tests.
+- Documentation: DataAgent architecture ownership and persistence matrix.
+
+## Tasks
+
+1. **Architecture docs**
+   - Document the current ownership boundary between frontend, main service, coordinator, execution process, runner, and persistence.
+   - Include a table showing which layer writes `da_agent_topic`, `da_agent_task`, `da_agent_topic_message`, and `da_agent_sdk_record`.
+   - State explicitly that child direct writes to `da_agent_sdk_record` are retained.
+
+2. **Comment and log cleanup**
+   - Correct `execute_task_stream` comments so `emit` is not described as the single SDK persistence boundary.
+   - Add submission/enqueue log fields for provider, model, and execution mode.
+   - Add SSE lifecycle logs for open, terminal/missing-task termination, disconnect, and close with `task_id`, `after_id`, `last_seq`, and task status.
+
+3. **Execution-process SDK observability**
+   - Add `sdk_stream.*` logs in `SdkBlockWriter` for message/block lifecycle and abnormal thinking signals.
+   - Treat these as execution-process logs; in sandbox mode they are captured from child stderr by the runner and written to per-task logs.
+
+4. **Regression tests**
+   - Extend `test_sdk_block_writer.py` to assert repeated thinking segments produce `sdk_stream.thinking_repeated_segment`.
+   - Extend route contract tests to assert `/sdk-events/stream` emits persisted SDK records in `seq_id` order.
+   - Extend sandbox runner tests to assert child stderr containing `sdk_stream.*` is written to the task log.
+
+5. **Verification**
+   - Run focused pytest for `test_sdk_block_writer.py`, `test_routes_contract.py`, and `test_sandbox_runner_main.py`.
+   - Do not claim full DataAgent E2E validation unless a real local smoke flow is run separately.
+
+## Backout
+
+Revert the docs and logging/test changes. No schema migration, API contract, frontend protocol, or persistence ownership changes are involved.


### PR DESCRIPTION
## Description
This PR implements the DataAgent Session Execution Observability Plan to clarify session/execution/persistence ownership and improve troubleshooting of repeated thinking blocks without changing the child-write architecture.

### Key Changes
1. **Architecture docs**:
   - Added docs clarifying boundaries and persistence matrix between frontend, main service, coordinator, execution process, and runner.
2. **Lifecycle Logging & Cleanups**:
   - Corrected comments in `execute_task_stream` regarding SSE stream persistence boundary.
   - Added submission/enqueue log fields for model, provider, and execution mode.
   - Added SSE connection lifecycle logs (open, term/missing, disconnect, close) with `task_id`, `after_id`, `last_seq`, etc.
3. **Execution-Process SDK Observability**:
   - Added `sdk_stream.*` logs in `SdkBlockWriter` for message/block lifecycle and abnormal thinking patterns.
   - Captured child stderr containing `sdk_stream.*` logs in the runner and wrote them to task log.
4. **Regression Tests**:
   - Extended test suites for routes contract, sandbox runner, block writer, and task executor.

## Verification
- Run `./.venv-py313/bin/pytest tests/test_routes_contract.py tests/test_sandbox_runner_main.py tests/test_sdk_block_writer.py tests/test_task_executor.py` successfully.