### PR TITLE
Add trailing activity indicator for running tasks with rendered content

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -248,6 +248,15 @@
                     </template>
                   </template>
 
+                  <!-- Trailing activity cue: keeps a loading indicator visible
+                       at the bottom for the whole run once content has started
+                       rendering, so the user always sees that work continues
+                       between turns / tool calls (the pre-content case uses the
+                       top indicator above). -->
+                  <div v-if="showTrailingActivity(msg)" class="v2-typing-indicator v2-typing-indicator-trailing">
+                    <span /><span /><span />
+                  </div>
+
                   <!-- Error from stream -->
                   <div v-if="msg._v2state.status === 'error'" class="v2-error-card">
                     <span class="v2-error-label">错误</span>
@@ -1042,6 +1051,36 @@ function showTypingIndicator(msg) {
   // whose backend task id has not been assigned yet (task_id still '').
   const taskId = String(msg?.task_id || '')
   return taskId ? taskId === activeTaskId.value : true
+}
+
+// A block conveys its own live progress: streaming text/thinking shows the
+// blinking cursor (or the "深度思考" badge dot) and a running tool_use shows its
+// own pending state. While one of those is the tail block, trailing dots would
+// duplicate that cue.
+function isBlockActivelyProgressing(block) {
+  if (!block) return false
+  if (block.type === 'text' || block.type === 'thinking') return block.status === 'streaming'
+  if (block.type === 'tool_use') return block.output == null
+  return false
+}
+
+// Keep a loading cue at the bottom of the reply for the whole run, not just
+// before the first block: show trailing dots whenever the active run has already
+// rendered content but its tail block is not itself streaming (between turns,
+// before a new turn's first block, after a tool/text block settled). The
+// pre-content case is covered by showTypingIndicator; a pending permission /
+// question card means the run is parked on the user, so suppress.
+function showTrailingActivity(msg) {
+  if (!isStreaming.value) return false
+  if (String(msg?.task_id || '') !== activeTaskId.value || !activeTaskId.value) return false
+  if (!hasRenderedBlocks(msg)) return false
+  const state = msg?._v2state
+  if (!state || state.status === 'done' || state.status === 'error') return false
+  const lastTurn = state.turns?.[state.turns.length - 1]
+  const lastBlock = lastTurn?.blocks?.[lastTurn.blocks.length - 1]
+  if (lastBlock?.type === 'permission_request' && lastBlock.decision === 'pending') return false
+  if (lastBlock?.type === 'question_request' && !lastBlock.answered) return false
+  return !isBlockActivelyProgressing(lastBlock)
 }
 
 // ── Suggestions ───────────────────────────────────────────────────────────
@@ -2438,6 +2477,10 @@ onBeforeUnmount(() => {
 
 .v2-typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
 .v2-typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+/* Trailing variant sits below already-rendered content; a touch of top spacing
+   separates it from the preceding block. */
+.v2-typing-indicator-trailing { padding-top: 4px; }
 
 @keyframes v2-typing {
   0%, 60%, 100% { transform: translateY(0); opacity: 0.35; }

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/NL2SqlChatV2.spec.js
@@ -668,6 +668,55 @@ describe('NL2SqlChatV2 URL location', () => {
     resolveStream()
   })
 
+  it('keeps a trailing loading indicator between rendered content and completion, then clears it when done', async () => {
+    let resolveStream
+    let recordSink
+    apiMocks.topicApi.listTopics.mockResolvedValue({
+      list: [
+        { ...makeTopic('topic-run', 'Running topic'), current_task_id: 'task-run', current_task_status: 'running' }
+      ]
+    })
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
+      topic_id: topicId,
+      page: 1,
+      page_size: 500,
+      order: 'asc',
+      total: 1,
+      items: [
+        { message_id: 'u-run', topic_id: topicId, sender_type: 'user', content: 'running question', created_at: '2026-05-30T02:00:00Z' }
+      ]
+    }))
+    // Stream one settled text block, then keep the run open: the tail block is no
+    // longer streaming but the run is still live, so the trailing dots must show.
+    apiMocks.taskApi.streamSdkEvents.mockImplementation((_taskId, opts) => {
+      recordSink = opts.onRecord
+      opts.onRecord({ record_type: 'stream', data: { type: 'message_start', usage: {} } })
+      opts.onRecord({ record_type: 'stream', data: { type: 'content_block_start', index: 0, content_block: { type: 'text' } } })
+      opts.onRecord({ record_type: 'stream', data: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'partial answer' } } })
+      opts.onRecord({ record_type: 'stream', data: { type: 'content_block_stop', index: 0 } })
+      return new Promise((resolve) => { resolveStream = resolve })
+    })
+    routeState.query = { tab: 'chat-v2', topic_id: 'topic-run' }
+
+    const wrapper = mountChat()
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toContain('partial answer')
+    // The pre-content top indicator is gone (content rendered) but the trailing
+    // cue keeps the run visibly active while it continues.
+    expect(wrapper.find('.v2-typing-indicator-trailing').exists()).toBe(true)
+
+    recordSink({ record_type: 'done', data: {} })
+    resolveStream()
+    await flushPromises()
+    await nextTick()
+
+    // Completion clears every activity cue.
+    expect(wrapper.find('.v2-typing-indicator-trailing').exists()).toBe(false)
+    expect(wrapper.find('.v2-typing-indicator').exists()).toBe(false)
+  })
+
   it('forwards the selected assistant to the widget topic query', async () => {
     routeState.query = { tab: 'chat-v2', agent_id: 'agent_sales' }
     const wrapper = mountChat()

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
@@ -274,6 +274,53 @@ describe('useNl2SqlChat engine', () => {
     await sendPromise
   })
 
+  it('resumes a running task from the loaded assistant message even when the topic row is not marked active', async () => {
+    const api = makeApi()
+    // The cached topic row lost its current_task_id/status, but the freshly
+    // loaded assistant message says the run is still going — re-entry must still
+    // re-attach the live stream (the leave-while-running / refresh recovery path).
+    api.topicApi.getTopicMessages.mockResolvedValue({
+      items: [
+        { message_id: 'u1', sender_type: 'user', content: '问题', seq_id: 1 },
+        { message_id: 'a1', sender_type: 'assistant', task_id: 'task-run', status: 'running', blocks: [], resume_after_seq: 5, seq_id: 2 },
+      ],
+    })
+    let resolveStream
+    api.taskApi.streamSdkEvents.mockImplementation(() => new Promise((resolve) => { resolveStream = resolve }))
+    const chat = await ready(api)
+    chat.topics.value = [{ topic_id: 'topic-run', title: '运行中', current_task_id: '', current_task_status: '' }]
+
+    await chat.selectTopic('topic-run')
+    await flushPromises()
+
+    expect(api.taskApi.streamSdkEvents).toHaveBeenCalledWith('task-run', expect.objectContaining({ afterId: 5 }))
+    expect(chat.activeTaskId.value).toBe('task-run')
+    expect(chat.isBusy.value).toBe(true)
+
+    resolveStream()
+  })
+
+  it('does not resume when the latest assistant message is already terminal', async () => {
+    const api = makeApi()
+    api.topicApi.getTopicMessages.mockResolvedValue({
+      items: [
+        { message_id: 'u1', sender_type: 'user', content: '问题', seq_id: 1 },
+        { message_id: 'a1', sender_type: 'assistant', task_id: 'task-done', status: 'success', blocks: [{ kind: 'main_text', text: '完成' }], seq_id: 2 },
+      ],
+    })
+    const chat = await ready(api)
+    // Even a stale topic row that still claims a current task must not re-stream a
+    // run whose assistant message is already terminal.
+    chat.topics.value = [{ topic_id: 'topic-done', title: '已完成', current_task_id: 'task-done', current_task_status: '' }]
+
+    await chat.selectTopic('topic-done')
+    await flushPromises()
+
+    expect(api.taskApi.streamSdkEvents).not.toHaveBeenCalled()
+    expect(chat.activeTaskId.value).toBe('')
+    expect(chat.isBusy.value).toBe(false)
+  })
+
   it('cancel aborts locally and cancels the backend task (suspended)', async () => {
     const api = makeApi()
     // Honor the abort signal so the in-flight send unwinds like a real fetch.

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/useNl2SqlChat.spec.js
@@ -309,8 +309,6 @@ describe('useNl2SqlChat engine', () => {
       ],
     })
     const chat = await ready(api)
-    // Even a stale topic row that still claims a current task must not re-stream a
-    // run whose assistant message is already terminal.
     chat.topics.value = [{ topic_id: 'topic-done', title: '已完成', current_task_id: 'task-done', current_task_status: '' }]
 
     await chat.selectTopic('topic-done')
@@ -319,6 +317,31 @@ describe('useNl2SqlChat engine', () => {
     expect(api.taskApi.streamSdkEvents).not.toHaveBeenCalled()
     expect(chat.activeTaskId.value).toBe('')
     expect(chat.isBusy.value).toBe(false)
+  })
+
+  it('does not re-stream a finished task when a stale topic row still says running', async () => {
+    const api = makeApi()
+    // The completed run's terminal assistant message must win over a topic-list
+    // row whose mirrored current_task_status lagged behind on 'running'.
+    api.topicApi.getTopicMessages.mockResolvedValue({
+      items: [
+        { message_id: 'u1', sender_type: 'user', content: '问题', seq_id: 1 },
+        { message_id: 'a1', sender_type: 'assistant', task_id: 'task-done', status: 'success', blocks: [{ kind: 'main_text', text: '完成' }], seq_id: 2 },
+      ],
+    })
+    const chat = await ready(api)
+    chat.topics.value = [{ topic_id: 'topic-done', title: '已完成', current_task_id: 'task-done', current_task_status: 'running' }]
+
+    await chat.selectTopic('topic-done')
+    await flushPromises()
+
+    expect(api.taskApi.streamSdkEvents).not.toHaveBeenCalled()
+    expect(chat.activeTaskId.value).toBe('')
+    expect(chat.isBusy.value).toBe(false)
+    // The finished reply stays terminal — not flipped back to running/streaming.
+    const assistant = chat.messages.value.find((m) => m.role === 'assistant')
+    expect(assistant.status).toBe('success')
+    expect(assistant._v2state.status).toBe('done')
   })
 
   it('cancel aborts locally and cancels the backend task (suspended)', async () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -350,6 +350,12 @@ export function useNl2SqlChat(options) {
   const RESUMABLE_ASSISTANT_STATUSES = new Set([
     'queued', 'waiting', 'running', 'waiting_input', 'waiting_permission',
   ])
+  const isResumableAssistant = (message) => Boolean(
+    message
+    && message.role === 'assistant'
+    && String(message?.task_id || '').trim()
+    && RESUMABLE_ASSISTANT_STATUSES.has(String(message?.status || '')),
+  )
 
   // The newest assistant message is the only resume candidate. Its persisted
   // task_id + status are reloaded on every topic entry, so reading the run state
@@ -361,8 +367,7 @@ export function useNl2SqlChat(options) {
     for (let i = messages.value.length - 1; i >= 0; i -= 1) {
       const message = messages.value[i]
       if (message?.role !== 'assistant') continue
-      const taskId = String(message?.task_id || '').trim()
-      return taskId && RESUMABLE_ASSISTANT_STATUSES.has(String(message?.status || '')) ? message : null
+      return isResumableAssistant(message) ? message : null
     }
     return null
   }
@@ -370,14 +375,26 @@ export function useNl2SqlChat(options) {
   const resumeActiveTopicTask = (targetTopicId = topicId.value) => {
     if (!targetTopicId || targetTopicId !== topicId.value) return
     const topic = topics.value.find((item) => item.topic_id === targetTopicId)
-    // Prefer the per-message run signal (authoritative, always freshly loaded);
-    // fall back to the topic-list row's current task.
-    const resumable = findResumableAssistant()
-    const taskId = String(resumable?.task_id || topic?.current_task_id || '').trim()
-    if (!taskId || activeTaskId.value === taskId) return
-    if (!resumable && !isTopicTaskActive(topic)) return
 
-    const assistant = resumable || findAssistantForTask(taskId) || appendAssistantMessage(taskId)
+    // Prefer the per-message run signal (authoritative, always freshly loaded).
+    let assistant = findResumableAssistant()
+    let taskId = String(assistant?.task_id || '').trim()
+
+    // Fall back to the topic-list row only when the freshly loaded history does
+    // not contradict it: a terminal assistant message already on file for that
+    // task means the row is stale (the run finished but the mirrored status
+    // lagged), so trust the message and never re-stream a completed task.
+    if (!taskId) {
+      const rowTaskId = String(topic?.current_task_id || '').trim()
+      const persisted = rowTaskId ? findAssistantForTask(rowTaskId) : null
+      if (rowTaskId && isTopicTaskActive(topic) && (!persisted || isResumableAssistant(persisted))) {
+        taskId = rowTaskId
+        assistant = persisted || appendAssistantMessage(rowTaskId)
+      }
+    }
+
+    if (!taskId || activeTaskId.value === taskId) return
+
     assistant.task_id = taskId
     assistant.status = 'running'
     if (assistant._v2state && assistant._v2state.status !== 'error') {

--- a/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/useNl2SqlChat.js
@@ -344,13 +344,40 @@ export function useNl2SqlChat(options) {
     message?.role === 'assistant' && String(message?.task_id || '') === String(taskId || '')
   ))
 
+  // Assistant-message statuses whose run is still live: waiting in the queue,
+  // running, or parked on the user. Anything else — success / failed / cancelled
+  // / suspended / error / finished — is terminal with nothing to re-attach to.
+  const RESUMABLE_ASSISTANT_STATUSES = new Set([
+    'queued', 'waiting', 'running', 'waiting_input', 'waiting_permission',
+  ])
+
+  // The newest assistant message is the only resume candidate. Its persisted
+  // task_id + status are reloaded on every topic entry, so reading the run state
+  // from the message (not just the cached topic-list row) lets resume re-attach
+  // even when current_task_status on the row is stale or was never set locally —
+  // e.g. detaching while delivery was still in flight, or re-entering a topic
+  // whose list row has not been refreshed since the run began.
+  const findResumableAssistant = () => {
+    for (let i = messages.value.length - 1; i >= 0; i -= 1) {
+      const message = messages.value[i]
+      if (message?.role !== 'assistant') continue
+      const taskId = String(message?.task_id || '').trim()
+      return taskId && RESUMABLE_ASSISTANT_STATUSES.has(String(message?.status || '')) ? message : null
+    }
+    return null
+  }
+
   const resumeActiveTopicTask = (targetTopicId = topicId.value) => {
     if (!targetTopicId || targetTopicId !== topicId.value) return
     const topic = topics.value.find((item) => item.topic_id === targetTopicId)
-    const taskId = String(topic?.current_task_id || '').trim()
-    if (!taskId || !isTopicTaskActive(topic) || activeTaskId.value === taskId) return
+    // Prefer the per-message run signal (authoritative, always freshly loaded);
+    // fall back to the topic-list row's current task.
+    const resumable = findResumableAssistant()
+    const taskId = String(resumable?.task_id || topic?.current_task_id || '').trim()
+    if (!taskId || activeTaskId.value === taskId) return
+    if (!resumable && !isTopicTaskActive(topic)) return
 
-    const assistant = findAssistantForTask(taskId) || appendAssistantMessage(taskId)
+    const assistant = resumable || findAssistantForTask(taskId) || appendAssistantMessage(taskId)
     assistant.task_id = taskId
     assistant.status = 'running'
     if (assistant._v2state && assistant._v2state.status !== 'error') {


### PR DESCRIPTION
## Summary
Improves the user experience for long-running tasks by displaying a persistent loading indicator at the bottom of rendered content, and enhances task resumption logic to handle stale topic state.

## Key Changes

### UI Enhancement (NL2SqlChatV2.vue)
- Added a trailing activity indicator (`.v2-typing-indicator-trailing`) that appears below rendered content while a task is still running
- Implemented `showTrailingActivity()` function to determine when to display the trailing indicator:
  - Shows only when content has already rendered (avoiding duplication with the pre-content indicator)
  - Hides when the tail block is actively progressing (streaming text, thinking, or pending tool_use)
  - Hides when parked on user input (permission/question requests)
- Added `isBlockActivelyProgressing()` helper to detect blocks with their own progress indicators

### Task Resumption Logic (useNl2SqlChat.js)
- Enhanced `resumeActiveTopicTask()` to read run state from the latest assistant message instead of relying solely on the cached topic-list row
- Added `findResumableAssistant()` function that identifies resumable tasks by checking message status against `RESUMABLE_ASSISTANT_STATUSES`
- Allows recovery when re-entering a topic whose cached `current_task_status` is stale or unset (e.g., after detaching mid-delivery or refreshing)
- Prevents resumption of terminal tasks (success, failed, cancelled, etc.)

### Test Coverage
- Added test in NL2SqlChatV2.spec.js verifying the trailing indicator appears during streaming and clears on completion
- Added tests in useNl2SqlChat.spec.js for:
  - Resuming a running task from the loaded message when topic row is stale
  - Not resuming when the latest assistant message is already terminal

## Implementation Details
- The trailing indicator uses the same animation as the pre-content indicator but with top padding to separate it from preceding content
- Task resumption now prioritizes the per-message task state (always freshly loaded) over the topic-list row's cached state, improving reliability across navigation and refresh scenarios

https://claude.ai/code/session_01CScrYSzk8tcs4jycgpu618