### PR TITLE
Handle missing tasks in BackendAgentTaskService.getTask()

### DIFF
--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
 import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
 import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.exception.BusinessException;
 import com.onedata.portal.service.DataTaskService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +47,14 @@ public class BackendAgentTaskService implements AgentTaskService {
 
     @Override
     public Object getTask(Long taskId) {
-        return dataTaskService.getById(taskId);
+        DataTask task = dataTaskService.getById(taskId);
+        if (task == null) {
+            // A missing task would otherwise serialize as a null body (empty
+            // response), which the portal MCP client rejects as "not valid JSON".
+            // Throw so the global handler returns a proper JSON error instead.
+            throw new BusinessException("任务不存在: " + taskId);
+        }
+        return task;
     }
 
     @Override

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTaskServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTaskServiceTest.java
@@ -1,0 +1,46 @@
+package com.onedata.portal.agentapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.service.BackendAgentTaskService;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.exception.BusinessException;
+import com.onedata.portal.service.DataTaskService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BackendAgentTaskServiceTest {
+
+    @Mock
+    private DataTaskService dataTaskService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private BackendAgentTaskService service() {
+        return new BackendAgentTaskService(dataTaskService, objectMapper);
+    }
+
+    @Test
+    void getTaskReturnsTaskWhenFound() {
+        DataTask task = new DataTask();
+        task.setId(7L);
+        when(dataTaskService.getById(7L)).thenReturn(task);
+
+        assertSame(task, service().getTask(7L));
+    }
+
+    @Test
+    void getTaskThrowsWhenMissingSoResponseStaysJson() {
+        // A null task would otherwise serialize as an empty body, which the
+        // portal MCP client rejects as "not valid JSON". The service must throw
+        // so the global handler emits a proper JSON error instead.
+        when(dataTaskService.getById(999L)).thenReturn(null);
+
+        assertThrows(BusinessException.class, () -> service().getTask(999L));
+    }
+}


### PR DESCRIPTION
## Summary
Fixed a bug in `BackendAgentTaskService.getTask()` where null responses were not properly handled, causing the portal MCP client to reject responses as invalid JSON. The service now throws a `BusinessException` when a task is not found, allowing the global error handler to return a proper JSON error response.

## Changes
- **BackendAgentTaskService.getTask()**: Added null check that throws `BusinessException` with a descriptive message when the requested task is not found
- **BackendAgentTaskServiceTest**: Added comprehensive unit tests covering:
  - Successful task retrieval when task exists
  - Exception handling when task is missing (ensuring JSON error response is generated)

## Implementation Details
The fix ensures that missing tasks result in a proper JSON error response rather than an empty/null body. This is critical for client compatibility, as the portal MCP client expects valid JSON in all responses. The global exception handler will catch the `BusinessException` and serialize it appropriately.

https://claude.ai/code/session_0115vUB8hybQtFmq1wpNJxie