### PR TITLE
[codex] Persist permission and input waits as parked tasks

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -680,26 +680,26 @@ async def api_submit_permission_decision(task_id: str, payload: PermissionDecisi
     decision = str(payload.decision or "").strip().lower()
     if decision not in {"allow", "deny"}:
         raise HTTPException(status_code=400, detail="decision must be allow or deny")
-    if str(task.get("task_status") or "") != "waiting_permission":
-        raise HTTPException(status_code=409, detail="task is not awaiting a permission decision")
-    pending_request_id = store.get_pending_permission_request_id(task_id)
-    if pending_request_id and pending_request_id != request_id:
-        raise HTTPException(status_code=409, detail="request_id does not match the current pending permission request")
-    coordinator = get_task_coordinator()
-    if not pending_request_id:
-        existing = await coordinator.read_permission_decision(task_id, request_id)
-        if not existing:
-            raise HTTPException(status_code=409, detail="task has no pending permission request")
-    effective = await coordinator.submit_permission_decision(task_id, request_id, decision)
-    if pending_request_id:
-        store.append_permission_decision_record(
+    current = store.get_current_permission_interaction(task_id=task_id, request_id=request_id)
+    if current and str(current.get("status") or "") == "resolved":
+        effective = str(current.get("decision") or decision)
+    else:
+        append_result = store.append_permission_decision_if_waiting(
             task_id=task_id,
             request_id=request_id,
-            decision=effective,
+            decision=decision,
             note=str(payload.note or ""),
         )
-    # Return the canonical persisted form (allowed/denied) so the immediate
-    # response matches the streamed/reloaded SDK record.
+        if append_result not in {"appended", "already_resolved"}:
+            detail = (
+                "task is not awaiting this permission decision"
+                if append_result in {"not_found", "status_mismatch"}
+                else "failed to record permission decision"
+            )
+            raise HTTPException(status_code=409, detail=detail)
+        resolved = store.get_current_permission_interaction(task_id=task_id, request_id=request_id)
+        effective = str((resolved or {}).get("decision") or decision)
+
     return PermissionDecisionResponse.model_validate(
         {"task_id": task_id, "request_id": request_id, "decision": normalize_permission_decision(effective)}
     )
@@ -715,26 +715,23 @@ async def api_submit_question_answer(task_id: str, payload: QuestionAnswerReques
     request_id = str(payload.request_id or "").strip()
     if not request_id:
         raise HTTPException(status_code=400, detail="request_id is required")
-    if str(task.get("task_status") or "") != "waiting_input":
-        raise HTTPException(status_code=409, detail="task is not awaiting a user answer")
-    pending_request_id = store.get_pending_question_request_id(task_id)
-    if pending_request_id and pending_request_id != request_id:
-        raise HTTPException(status_code=409, detail="request_id does not match the current pending question")
-    coordinator = get_task_coordinator()
-    if not pending_request_id:
-        existing = await coordinator.read_question_answer(task_id, request_id)
-        if not existing:
-            raise HTTPException(status_code=409, detail="task has no pending question")
     answers = [a for a in (payload.answers or []) if isinstance(a, dict)]
-    accepted = await coordinator.submit_question_answer(task_id, request_id, answers)
-    if pending_request_id:
-        store.append_question_answer_record(
+    current = store.get_current_question_interaction(task_id=task_id, request_id=request_id)
+    if not current or str(current.get("status") or "") != "resolved":
+        append_result = store.append_question_answer_if_waiting(
             task_id=task_id,
             request_id=request_id,
             answers=answers,
         )
+        if append_result not in {"appended", "already_resolved"}:
+            detail = (
+                "task is not awaiting this user answer"
+                if append_result in {"not_found", "status_mismatch"}
+                else "failed to record user answer"
+            )
+            raise HTTPException(status_code=409, detail=detail)
     return QuestionAnswerResponse.model_validate(
-        {"task_id": task_id, "request_id": request_id, "accepted": bool(accepted)}
+        {"task_id": task_id, "request_id": request_id, "accepted": True}
     )
 
 

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -44,7 +44,8 @@ class Settings(BaseSettings):
     task_heartbeat_seconds: int = 5
     task_recovery_scan_interval_seconds: int = 2
     task_recovery_batch_size: int = 20
-    # Max time a run waits at a permission confirmation before timing out (deny).
+    # Deprecated for permission/input waits. Confirmations and user-input cards
+    # are parked durably in MySQL and no longer auto-deny by this timeout.
     task_permission_wait_seconds: int = 600
     schedule_scan_interval_seconds: int = 10
     schedule_scan_batch_size: int = 10

--- a/dataagent/dataagent-backend/core/ask_user_question.py
+++ b/dataagent/dataagent-backend/core/ask_user_question.py
@@ -9,17 +9,16 @@ returning ``PermissionResultAllow(updated_input={questions, answers, ...})``.
 This module owns the host side of that round-trip, mirroring the
 permission-confirmation flow (``permission_wait`` / ``permission_gate``): record
 a ``question_request`` block (rendered as a selection card), park the task in
-``waiting_input``, wait on Redis for the user's answer, then map the answer onto
-the SDK ``updated_input`` shape so the same run resumes with the selection.
+``waiting_input``, wait on MySQL for the user's answer, then map the answer
+onto the SDK ``updated_input`` shape so the same run resumes with the selection.
 """
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Any
 
-from config import get_settings
+from core.task_control import RunnerStoppedError, TaskCancelledError
 
 logger = logging.getLogger(__name__)
 
@@ -29,16 +28,6 @@ ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
 
 def is_ask_user_question_tool(tool_name: str) -> bool:
     return str(tool_name or "").strip() == ASK_USER_QUESTION_TOOL_NAME
-
-
-def ask_question_answer_redis_key(task_id: str, request_id: str) -> str:
-    """Redis key carrying the user's answer for a waiting ``AskUserQuestion``.
-
-    Single source of truth shared by the API answer endpoint (writer, via the
-    coordinator) and the ``can_use_tool`` wait (reader), mirroring the
-    permission-decision key pattern.
-    """
-    return f"da:task:answer:{task_id}:{request_id}"
 
 
 def to_sdk_answer_input(questions: list[dict[str, Any]], answers: list[dict[str, Any]]) -> dict[str, Any]:
@@ -87,68 +76,43 @@ async def wait_for_answer(
     task_id: str,
     request_id: str,
     *,
-    timeout_seconds: int,
     poll_interval_seconds: float = 1.0,
-    is_cancel_requested: Any = None,
+    cancel_reason: Any = None,
 ) -> list[dict[str, Any]] | None:
-    """Poll Redis for the user's answer; return the answers list or ``None``.
+    """Poll MySQL for the user's answer; return the answers list."""
+    from core.topic_task_store import get_topic_task_store
 
-    ``None`` means the wait ended without an answer (timeout or cancellation).
-    Self-connects to Redis from settings so it works in-process and in the
-    sandbox runner subprocess, exactly like :func:`permission_wait.wait_for_decision`.
-    """
-    cfg = get_settings()
-    key = ask_question_answer_redis_key(task_id, request_id)
-    try:
-        import redis.asyncio as redis
-
-        client = redis.Redis(
-            host=cfg.redis_host,
-            port=int(cfg.redis_port or 6379),
-            password=cfg.redis_password or None,
-            db=int(cfg.redis_db or 0),
-            decode_responses=True,
-        )
-    except Exception:
-        logger.exception("ask_user wait: redis unavailable; request_id=%s", request_id)
-        return None
-
-    deadline = asyncio.get_event_loop().time() + max(1, int(timeout_seconds or 600))
-    try:
-        while True:
-            try:
-                value = await client.get(key)
-            except Exception:
-                logger.exception("ask_user wait: redis read failed; request_id=%s", request_id)
-                return None
-            if value:
-                return _parse_answers(value)
-            if is_cancel_requested is not None:
-                try:
-                    cancelled = is_cancel_requested()
-                    if asyncio.iscoroutine(cancelled):
-                        cancelled = await cancelled
-                    if cancelled:
-                        return None
-                except Exception:
-                    pass
-            if asyncio.get_event_loop().time() >= deadline:
-                return None
-            await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
-    finally:
+    store = get_topic_task_store()
+    while True:
+        reason = await _read_cancel_reason(cancel_reason)
+        if reason == "user_cancel":
+            raise TaskCancelledError("task cancelled")
+        if reason == "runner_stop":
+            raise RunnerStoppedError("runner stopped")
         try:
-            await client.aclose()
+            answers = store.get_resolved_question_answer(task_id=task_id, request_id=request_id)
         except Exception:
-            pass
+            logger.warning(
+                "ask_user wait: durable read failed; retrying task_id=%s request_id=%s",
+                task_id,
+                request_id,
+                exc_info=True,
+            )
+        else:
+            if answers is not None:
+                return answers
+        await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
 
 
-def _parse_answers(value: Any) -> list[dict[str, Any]]:
+async def _read_cancel_reason(cancel_reason: Any) -> str | None:
+    if cancel_reason is None:
+        return None
     try:
-        parsed = json.loads(value) if isinstance(value, str) else value
+        result = cancel_reason()
+        if asyncio.iscoroutine(result):
+            result = await result
+        reason = str(result or "").strip()
+        return reason if reason in {"user_cancel", "runner_stop"} else None
     except Exception:
-        return []
-    if isinstance(parsed, dict):
-        parsed = parsed.get("answers")
-    if not isinstance(parsed, list):
-        return []
-    return [item for item in parsed if isinstance(item, dict)]
+        logger.warning("ask_user wait: cancel_reason check failed; continuing", exc_info=True)
+        return None

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -55,25 +55,13 @@ def strip_card_annotations(tool_input: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in tool_input.items() if k not in CARD_ANNOTATION_KEYS}
 
 
-# Canonical permission-decision values persisted in SDK records and surfaced to
-# clients. The request side accepts the bare ``allow``/``deny`` verbs; both the
-# stored record and the API response use these normalized forms so the immediate
-# response and the later streamed/reloaded record never diverge.
-_PERMISSION_DECISION_NORMALIZATION = {
-    "allow": "allowed",
-    "allowed": "allowed",
-    "deny": "denied",
-    "denied": "denied",
-    "timeout": "timeout",
-}
-
-
 def normalize_permission_decision(decision: Any) -> str:
     """Coerce a permission decision to its canonical persisted form.
 
-    ``allow`` -> ``allowed``, ``deny`` -> ``denied``, ``timeout`` stays; anything
-    unknown collapses to ``denied`` (fail-closed)."""
-    return _PERMISSION_DECISION_NORMALIZATION.get(str(decision or "").strip().lower(), "denied")
+    ``allow``/``deny``/``timeout`` stay as-is; anything unknown collapses to
+    ``deny`` (fail-closed)."""
+    value = str(decision or "").strip().lower()
+    return value if value in {"allow", "deny", "timeout"} else "deny"
 
 
 def _bare_tool_name(tool_name: str) -> str:

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -76,15 +76,6 @@ def normalize_permission_decision(decision: Any) -> str:
     return _PERMISSION_DECISION_NORMALIZATION.get(str(decision or "").strip().lower(), "denied")
 
 
-def permission_decision_redis_key(task_id: str, request_id: str) -> str:
-    """Redis key carrying a user's permission decision for a waiting run.
-
-    Single source of truth shared by the coordinator (writer) and the executor's
-    confirmation wait (reader), mirroring the cancel-flag key pattern.
-    """
-    return f"da:task:permission:{task_id}:{request_id}"
-
-
 def _bare_tool_name(tool_name: str) -> str:
     """Reduce an SDK-qualified MCP tool name to its bare tool name.
 

--- a/dataagent/dataagent-backend/core/permission_wait.py
+++ b/dataagent/dataagent-backend/core/permission_wait.py
@@ -65,8 +65,8 @@ async def _read_cancel_reason(cancel_reason: Any) -> str | None:
 
 def _to_callback_decision(decision: Any) -> str | None:
     value = str(decision or "").strip().lower()
-    if value in {"allow", "allowed"}:
+    if value == "allow":
         return "allow"
-    if value in {"deny", "denied", "timeout"}:
+    if value in {"deny", "timeout"}:
         return "deny"
     return None

--- a/dataagent/dataagent-backend/core/permission_wait.py
+++ b/dataagent/dataagent-backend/core/permission_wait.py
@@ -1,10 +1,8 @@
 """Wait for a user permission decision during a run.
 
-Used by the ``can_use_tool`` confirmation callback. Self-connects to Redis from
-settings so it works both in the in-process executor and in the sandbox runner
-subprocess (neither needs to thread a callback through). The decision is written
-by the API decision endpoint via the coordinator under the shared key
-:func:`core.permission_gate.permission_decision_redis_key`.
+The API endpoint persists decisions in MySQL. This module polls that durable
+record so the in-process executor and sandbox child use the same authoritative
+path without Redis delivery timeouts.
 """
 from __future__ import annotations
 
@@ -12,8 +10,8 @@ import asyncio
 import logging
 from typing import Any
 
-from config import get_settings
-from core.permission_gate import permission_decision_redis_key
+from core.task_control import RunnerStoppedError, TaskCancelledError
+from core.topic_task_store import get_topic_task_store
 
 logger = logging.getLogger(__name__)
 
@@ -22,56 +20,53 @@ async def wait_for_decision(
     task_id: str,
     request_id: str,
     *,
-    timeout_seconds: int,
     poll_interval_seconds: float = 1.0,
-    is_cancel_requested: Any = None,
+    cancel_reason: Any = None,
 ) -> str:
-    """Poll Redis for the user's decision; return ``allow`` / ``deny`` / ``timeout``.
-
-    A cancellation observed while waiting resolves to ``deny`` so the run can
-    unwind promptly. If Redis is unavailable the wait fails closed (``deny``).
-    """
-    cfg = get_settings()
-    key = permission_decision_redis_key(task_id, request_id)
-    try:
-        import redis.asyncio as redis
-
-        client = redis.Redis(
-            host=cfg.redis_host,
-            port=int(cfg.redis_port or 6379),
-            password=cfg.redis_password or None,
-            db=int(cfg.redis_db or 0),
-            decode_responses=True,
-        )
-    except Exception:
-        logger.exception("permission_wait: redis unavailable; denying request_id=%s", request_id)
-        return "deny"
-
-    deadline = asyncio.get_event_loop().time() + max(1, int(timeout_seconds or 600))
-    try:
-        while True:
-            try:
-                value = await client.get(key)
-            except Exception:
-                logger.exception("permission_wait: redis read failed; denying request_id=%s", request_id)
-                return "deny"
-            if value:
-                decision = str(value).strip().lower()
-                return decision if decision in {"allow", "deny"} else "deny"
-            if is_cancel_requested is not None:
-                try:
-                    cancelled = is_cancel_requested()
-                    if asyncio.iscoroutine(cancelled):
-                        cancelled = await cancelled
-                    if cancelled:
-                        return "deny"
-                except Exception:
-                    pass
-            if asyncio.get_event_loop().time() >= deadline:
-                return "timeout"
-            await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
-    finally:
+    """Poll MySQL for the user's decision; return callback verb ``allow``/``deny``."""
+    store = get_topic_task_store()
+    while True:
+        reason = await _read_cancel_reason(cancel_reason)
+        if reason == "user_cancel":
+            raise TaskCancelledError("task cancelled")
+        if reason == "runner_stop":
+            raise RunnerStoppedError("runner stopped")
         try:
-            await client.aclose()
+            decision = store.get_resolved_permission_decision(task_id=task_id, request_id=request_id)
         except Exception:
-            pass
+            logger.warning(
+                "permission_wait: durable read failed; retrying task_id=%s request_id=%s",
+                task_id,
+                request_id,
+                exc_info=True,
+            )
+        else:
+            if decision:
+                callback_decision = _to_callback_decision(decision)
+                if callback_decision:
+                    return callback_decision
+                return "deny"
+        await asyncio.sleep(max(0.1, float(poll_interval_seconds)))
+
+
+async def _read_cancel_reason(cancel_reason: Any) -> str | None:
+    if cancel_reason is None:
+        return None
+    try:
+        result = cancel_reason()
+        if asyncio.iscoroutine(result):
+            result = await result
+        reason = str(result or "").strip()
+        return reason if reason in {"user_cancel", "runner_stop"} else None
+    except Exception:
+        logger.warning("permission_wait: cancel_reason check failed; continuing", exc_info=True)
+        return None
+
+
+def _to_callback_decision(decision: Any) -> str | None:
+    value = str(decision or "").strip().lower()
+    if value in {"allow", "allowed"}:
+        return "allow"
+    if value in {"deny", "denied", "timeout"}:
+        return "deny"
+    return None

--- a/dataagent/dataagent-backend/core/sdk_block_writer.py
+++ b/dataagent/dataagent-backend/core/sdk_block_writer.py
@@ -401,7 +401,7 @@ class SdkBlockWriter:
     ) -> None:
         """Record the user's decision for a prior permission request.
 
-        ``decision`` is one of ``allowed`` / ``denied`` / ``timeout``; it merges
+        ``decision`` is one of ``allow`` / ``deny`` / ``timeout``; it merges
         onto the matching ``permission_request`` block during projection.
         """
         self._store.append_sdk_record(

--- a/dataagent/dataagent-backend/core/task_control.py
+++ b/dataagent/dataagent-backend/core/task_control.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Literal
+
+CancelReason = Literal["user_cancel", "runner_stop"]
+PARKED_TASK_STATUSES = {"waiting_permission", "waiting_input"}
+
+
+class TaskCancelledError(Exception):
+    """Raised when the user explicitly cancels a task."""
+
+
+class RunnerStoppedError(Exception):
+    """Raised when the execution runner/lease stops while a task is active."""

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import socket
@@ -12,8 +11,7 @@ from typing import Any
 import redis.asyncio as redis
 
 from config import get_settings
-from core.ask_user_question import ask_question_answer_redis_key
-from core.permission_gate import permission_decision_redis_key
+from core.task_control import PARKED_TASK_STATUSES, CancelReason
 from core.task_submission_service import compute_next_run_at, current_utc_naive, submit_message_task
 from core.task_executor import TaskExecutionInput, execute_task_stream
 from core.topic_files import diff_generated_files, snapshot_workspace_state
@@ -118,50 +116,6 @@ class TaskCoordinator:
             return True
         return self.store.is_task_cancel_requested(task_id)
 
-    async def submit_permission_decision(self, task_id: str, request_id: str, decision: str) -> str:
-        """Publish a user permission decision for a waiting run (allow/deny).
-
-        Idempotent: the first decision for a ``request_id`` wins; later calls
-        return the recorded value. Mirrors the cancel-flag pattern so both the
-        in-process executor and the sandbox runner can observe it via Redis.
-        Returns the effective decision.
-        """
-        effective = str(decision or "denied")
-        if self._redis is None:
-            return effective
-        key = self._permission_key(task_id, request_id)
-        ttl = max(60, int(self.settings.task_permission_wait_seconds or 600) + 60)
-        await self._redis.set(key, effective, ex=ttl, nx=True)
-        current = await self._redis.get(key)
-        return str(current) if current is not None else effective
-
-    async def read_permission_decision(self, task_id: str, request_id: str) -> str | None:
-        if self._redis is None:
-            return None
-        value = await self._redis.get(self._permission_key(task_id, request_id))
-        return str(value) if value is not None else None
-
-    async def submit_question_answer(self, task_id: str, request_id: str, answers: list[dict[str, Any]]) -> bool:
-        """Publish the user's answer for a waiting ``ask_user_question`` run.
-
-        Idempotent: the first answer for a ``request_id`` wins. Mirrors the
-        permission-decision flow so the executor's tool handler observes it via
-        Redis. Returns whether a value is present after the call.
-        """
-        if self._redis is None:
-            return False
-        key = self._answer_key(task_id, request_id)
-        ttl = max(60, int(self.settings.task_permission_wait_seconds or 600) + 60)
-        payload = json.dumps({"answers": answers}, ensure_ascii=False)
-        await self._redis.set(key, payload, ex=ttl, nx=True)
-        return bool(await self._redis.exists(key))
-
-    async def read_question_answer(self, task_id: str, request_id: str) -> str | None:
-        if self._redis is None:
-            return None
-        value = await self._redis.get(self._answer_key(task_id, request_id))
-        return str(value) if value is not None else None
-
     async def _queue_loop(self) -> None:
         while not self._closing:
             task_id = await self._queue.get()
@@ -256,7 +210,7 @@ class TaskCoordinator:
                         task_id=task_id,
                         record=record,
                     ),
-                    is_cancel_requested=lambda: self._should_stop_task(task_id, lease_lost),
+                    is_cancel_requested=lambda: self._task_stop_reason(task_id, lease_lost),
                 )
                 logger.info(
                     "task.run.result task_id=%s topic_id=%s provider=%s model=%s task_status=%s error_code=%s content_len=%s session_id_set=%s usage_set=%s",
@@ -270,6 +224,15 @@ class TaskCoordinator:
                     bool(result.session_id),
                     bool(result.usage),
                 )
+                if self._is_parked_waiting(task_id) and str((result.error or {}).get("code") or "") != "task_cancelled":
+                    logger.info(
+                        "task.run.left_parked task_id=%s topic_id=%s result_status=%s error_code=%s",
+                        task_id,
+                        topic_id,
+                        result.task_status,
+                        str((result.error or {}).get("code") or ""),
+                    )
+                    return
                 attachments = self._collect_generated_files(topic_id, task_id, workspace_before)
                 self.store.update_assistant_message(
                     topic_id=topic_id,
@@ -311,6 +274,14 @@ class TaskCoordinator:
             raise
         except Exception as exc:
             logger.exception("Task execution crashed task_id=%s", task_id)
+            if topic_id and self._is_parked_waiting(task_id):
+                logger.info(
+                    "task.run.crash_left_parked task_id=%s topic_id=%s error_type=%s",
+                    task_id,
+                    topic_id,
+                    exc.__class__.__name__,
+                )
+                return
             error = {"code": "task_execution_failed", "message": str(exc)}
             if topic_id:
                 self.store.update_assistant_message(
@@ -415,10 +386,16 @@ class TaskCoordinator:
             self.store.heartbeat_task(task_id)
         return await self._renew_lease(task_id)
 
-    async def _should_stop_task(self, task_id: str, lease_lost: asyncio.Event) -> bool:
+    async def _task_stop_reason(self, task_id: str, lease_lost: asyncio.Event) -> CancelReason | None:
         if lease_lost.is_set():
-            return True
-        return await self.is_cancel_requested(task_id)
+            return "runner_stop"
+        if await self.is_cancel_requested(task_id):
+            return "user_cancel"
+        return None
+
+    def _is_parked_waiting(self, task_id: str) -> bool:
+        task = self.store.get_task(task_id)
+        return str((task or {}).get("task_status") or "") in PARKED_TASK_STATUSES
 
     def _build_history(self, *, topic_id: str, task_id: str) -> list[dict[str, str]]:
         messages = self.store.list_topic_messages(topic_id)
@@ -448,6 +425,7 @@ class TaskCoordinator:
                     try:
                         await self._recover_waiting_tasks(batch_size=batch_size)
                         await self._recover_expired_tasks(batch_size=batch_size)
+                        await self._recover_parked_tasks(batch_size=batch_size)
                     finally:
                         await self._release_recovery_lock()
             except asyncio.CancelledError:
@@ -488,6 +466,42 @@ class TaskCoordinator:
                     str(replacement.get("topic_id") or ""),
                 )
                 await self.submit_task(str(replacement.get("task_id") or ""))
+
+    async def _recover_parked_tasks(self, *, batch_size: int) -> None:
+        for task in self.store.list_parked_tasks(limit=batch_size):
+            task_id = str(task.get("task_id") or "")
+            topic_id = str(task.get("topic_id") or "")
+            if not task_id:
+                continue
+            if await self._lease_exists(task_id):
+                continue
+            error: dict[str, Any] | None = None
+            if self.store.is_task_cancel_requested(task_id):
+                error = {"code": "task_cancelled", "message": "任务已取消"}
+            elif self.store.has_resolved_waiting_interaction(task_id):
+                error = {
+                    "code": "run_lost",
+                    "message": "确认/输入已提交，但原运行器已释放，请重新发送请求继续。",
+                }
+            if not error:
+                continue
+            logger.warning(
+                "task.recovery.parked_suspend task_id=%s topic_id=%s task_status=%s error_code=%s",
+                task_id,
+                topic_id,
+                str(task.get("task_status") or ""),
+                str(error.get("code") or ""),
+            )
+            if topic_id:
+                self.store.update_assistant_message(
+                    topic_id=topic_id,
+                    task_id=task_id,
+                    status="suspended",
+                    content="",
+                    usage=None,
+                    error=error,
+                )
+            self.store.finish_task(task_id=task_id, task_status="suspended", error=error)
 
     async def _schedule_loop(self) -> None:
         interval = max(5, int(self.settings.schedule_scan_interval_seconds or 10))
@@ -650,12 +664,6 @@ class TaskCoordinator:
 
     def _cancel_key(self, task_id: str) -> str:
         return f"da:task:cancel:{task_id}"
-
-    def _permission_key(self, task_id: str, request_id: str) -> str:
-        return permission_decision_redis_key(task_id, request_id)
-
-    def _answer_key(self, task_id: str, request_id: str) -> str:
-        return ask_question_answer_redis_key(task_id, request_id)
 
     def _recovery_key(self) -> str:
         return "da:task:recovery:lock"

--- a/dataagent/dataagent-backend/core/task_coordinator.py
+++ b/dataagent/dataagent-backend/core/task_coordinator.py
@@ -478,7 +478,11 @@ class TaskCoordinator:
             error: dict[str, Any] | None = None
             if self.store.is_task_cancel_requested(task_id):
                 error = {"code": "task_cancelled", "message": "任务已取消"}
-            elif self.store.has_resolved_waiting_interaction(task_id):
+            elif (
+                self.store.get_pending_permission_request(task_id) is None
+                and self.store.get_pending_question_request(task_id) is None
+                and self.store.has_resolved_waiting_interaction(task_id)
+            ):
                 error = {
                     "code": "run_lost",
                     "message": "确认/输入已提交，但原运行器已释放，请重新发送请求继续。",

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -8,11 +8,9 @@ import os
 import time
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-import anyio
 import httpx
 
 from config import get_settings
@@ -26,7 +24,6 @@ from core.ask_user_question import (
 from core.permission_gate import (
     is_high_risk_tool,
     is_write_tool,
-    normalize_permission_decision,
     plan_denies_tool,
     requires_confirmation,
     strip_card_annotations,
@@ -59,6 +56,7 @@ from core.agent_runtime import (
 from core.claude_cli import resolve_claude_cli_path
 from core.sdk_block_writer import SdkBlockWriter
 from core.slash_command_cache import record_agent_slash_commands
+from core.task_control import PARKED_TASK_STATUSES, CancelReason, RunnerStoppedError, TaskCancelledError
 from core.topic_task_store import get_topic_task_store
 from core.topic_workspace import prepare_topic_workspace
 
@@ -84,7 +82,9 @@ class TaskExecutionInput:
         provider_id / model: selected runtime provider and model id.
         database_hint: optional default schema/database for SQL tools.
         debug: enable verbose runtime diagnostics.
-        timeout_seconds: total bounded wall-clock budget for this single run.
+        timeout_seconds: legacy submission-time budget retained for recovery
+            heuristics and compatibility; the SDK message loop is not wrapped in
+            this value while confirmation/input waits are parked.
         sql_read_timeout_seconds: per read-query budget exposed to skill SQL tools.
         sql_write_timeout_seconds: per write-statement budget.
         execution_mode: ``interactive`` or ``background``/``auto`` timeout tier.
@@ -528,16 +528,14 @@ async def _handle_ask_user_question(
     sdk_writer: SdkBlockWriter,
     store: Any,
     task_id: str,
-    wait_seconds: int,
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+    cancel_reason: Callable[[], Awaitable[Any] | Any] | None,
 ):
     """Resolve a built-in ``AskUserQuestion`` call against the user.
 
     Records a question_request block (rendered as a selection card), parks the
-    task in ``waiting_input``, waits on Redis for the user's selection, records
-    question_answer, then returns ``PermissionResultAllow`` with the answer mapped
-    onto the tool's ``updated_input`` so the run resumes with the selection. With
-    no answer (timeout/cancel) the tool's own "did not answer" result is used.
+    task in ``waiting_input``, waits on MySQL for the user's persisted selection,
+    then returns ``PermissionResultAllow`` with the answer mapped onto the tool's
+    ``updated_input`` so the same live run resumes with the selection.
     """
     questions = tool_input.get("questions")
     if not isinstance(questions, list) or not questions:
@@ -554,23 +552,13 @@ async def _handle_ask_user_question(
     answers = await wait_for_answer(
         task_id,
         request_id,
-        timeout_seconds=wait_seconds,
-        is_cancel_requested=is_cancel_requested,
+        cancel_reason=cancel_reason,
     )
     answers = answers or []
     try:
-        append_answer = getattr(store, "append_question_answer_record", None)
-        if callable(append_answer):
-            append_answer(task_id=task_id, request_id=request_id, answers=answers)
-        else:
-            sdk_writer.append_question_answer(
-                request_id=request_id,
-                answers=answers,
-                answered_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            )
         store.set_task_status(task_id, "running")
     except Exception:
-        logger.exception("ask_user: failed to record question answer task_id=%s", task_id)
+        logger.exception("ask_user: failed to restore running status task_id=%s", task_id)
 
     return _allow_result(to_sdk_answer_input(questions, answers))
 
@@ -581,8 +569,7 @@ def _build_can_use_tool_callback(
     store: Any,
     task_id: str,
     permission_mode: str,
-    wait_seconds: int,
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None,
+    cancel_reason: Callable[[], Awaitable[Any] | Any] | None,
 ):
     """Build the SDK can_use_tool callback enforcing session permission policy.
 
@@ -590,8 +577,8 @@ def _build_can_use_tool_callback(
     a multiple-choice answer (recorded as a question_request/answer block and
     returned via updated_input). Write/high-risk tools (per session mode) pause
     the run: a permission_request block is recorded, the task moves to
-    waiting_permission, and the run waits for the user's decision (Redis) before
-    recording the decision and resuming. Plan-denied tools are rejected outright.
+    waiting_permission, and the run waits for the user's persisted decision before
+    resuming. Plan-denied tools are rejected outright.
     """
 
     async def can_use_tool(tool_name: str, tool_input: dict[str, Any] | None = None, context: Any = None):
@@ -603,8 +590,7 @@ def _build_can_use_tool_callback(
                 sdk_writer=sdk_writer,
                 store=store,
                 task_id=task_id,
-                wait_seconds=wait_seconds,
-                is_cancel_requested=is_cancel_requested,
+                cancel_reason=cancel_reason,
             )
         # For write tools the skill may attach card-annotation keys (title/summary)
         # that no downstream tool schema accepts; the card reads them from the raw
@@ -638,35 +624,15 @@ def _build_can_use_tool_callback(
         decision = await wait_for_decision(
             task_id,
             request_id,
-            timeout_seconds=wait_seconds,
-            is_cancel_requested=is_cancel_requested,
+            cancel_reason=cancel_reason,
         )
-        recorded = normalize_permission_decision(decision)
         try:
-            append_decision = getattr(store, "append_permission_decision_record", None)
-            if callable(append_decision):
-                appended = append_decision(
-                    task_id=task_id,
-                    request_id=request_id,
-                    decision=recorded,
-                    decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                )
-                if not appended and decision == "timeout":
-                    logger.warning("can_use_tool: timeout decision was already recorded task_id=%s request_id=%s", task_id, request_id)
-            else:
-                sdk_writer.append_permission_decision(
-                    request_id=request_id,
-                    decision=recorded,
-                    decided_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                )
             store.set_task_status(task_id, "running")
         except Exception:
-            logger.exception("can_use_tool: failed to record permission decision task_id=%s", task_id)
+            logger.exception("can_use_tool: failed to restore running status task_id=%s", task_id)
 
         if decision == "allow":
             return _allow_result(forwarded_input)
-        if decision == "timeout":
-            return _deny_result("等待确认超时，已自动拒绝该操作。")
         return _deny_result("用户拒绝了该操作。")
 
     return can_use_tool
@@ -709,7 +675,7 @@ async def execute_task_stream(
     params: TaskExecutionInput,
     *,
     emit: Callable[[dict[str, Any]], Awaitable[None] | None],
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+    is_cancel_requested: Callable[[], Awaitable[Any] | Any] | None = None,
 ) -> TaskExecutionResult:
     """Execute one NL2SQL run and return the terminal result.
 
@@ -719,8 +685,8 @@ async def execute_task_stream(
     ``emit`` is for records forwarded by the sandbox-runner protocol and should
     not be read as the single persistence boundary for all SDK records. The
     awaited return value is the final :class:`TaskExecutionResult` (status,
-    content, usage, error, session id). ``is_cancel_requested`` is polled to
-    abort a long/stalled run.
+    content, usage, error, session id). ``is_cancel_requested`` is polled and may
+    return ``True``/``user_cancel`` or ``runner_stop``.
     """
     cfg = get_settings()
     if _should_use_sandbox_runner(cfg):
@@ -741,11 +707,27 @@ def _should_use_sandbox_runner(cfg: Any) -> bool:
     return bool(str(getattr(cfg, "dataagent_sandbox_mode", "") or "").strip())
 
 
+def _normalize_cancel_reason(value: Any) -> CancelReason | None:
+    if isinstance(value, str):
+        reason = value.strip()
+        return reason if reason in {"user_cancel", "runner_stop"} else None  # type: ignore[return-value]
+    return "user_cancel" if bool(value) else None
+
+
+def _task_is_parked(task_id: str) -> bool:
+    try:
+        task = get_topic_task_store().get_task(task_id)
+    except Exception:
+        logger.warning("task.cancel_watch: failed to read task status task_id=%s", task_id, exc_info=True)
+        return False
+    return str((task or {}).get("task_status") or "") in PARKED_TASK_STATUSES
+
+
 async def _execute_task_stream_via_runner(
     params: TaskExecutionInput,
     *,
     emit: Callable[[dict[str, Any]], Awaitable[None] | None],
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+    is_cancel_requested: Callable[[], Awaitable[Any] | Any] | None = None,
 ) -> TaskExecutionResult:
     cfg = get_settings()
     runner_url = str(getattr(cfg, "dataagent_sandbox_runner_url", "") or "").strip().rstrip("/")
@@ -757,13 +739,13 @@ async def _execute_task_stream_via_runner(
     cancel_sent = False
     stream_done = False
 
-    async def _cancelled() -> bool:
+    async def _cancel_reason() -> CancelReason | None:
         if is_cancel_requested is None:
-            return False
+            return None
         result = is_cancel_requested()
         if inspect.isawaitable(result):
-            return bool(await result)
-        return bool(result)
+            result = await result
+        return _normalize_cancel_reason(result)
 
     async def _emit(record: dict[str, Any]) -> None:
         result = emit(record)
@@ -774,9 +756,20 @@ async def _execute_task_stream_via_runner(
         async def _watch_cancel() -> None:
             nonlocal cancel_sent
             while not stream_done:
-                if not cancel_sent and await _cancelled():
+                reason = await _cancel_reason()
+                if not cancel_sent and reason:
+                    if reason == "user_cancel" and _task_is_parked(params.task_id):
+                        cancel_sent = True
+                        await client.post(
+                            f"{runner_url}/internal/sandbox/runs/{params.task_id}/cancel",
+                            json={"task_id": params.task_id, "reason": reason, "kill": False},
+                        )
+                        return
                     cancel_sent = True
-                    await client.post(f"{runner_url}/internal/sandbox/runs/{params.task_id}/cancel", json={"task_id": params.task_id})
+                    await client.post(
+                        f"{runner_url}/internal/sandbox/runs/{params.task_id}/cancel",
+                        json={"task_id": params.task_id, "reason": reason},
+                    )
                     return
                 await asyncio.sleep(0.25)
 
@@ -828,7 +821,7 @@ async def _execute_task_stream_local(
     params: TaskExecutionInput,
     *,
     emit: Callable[[dict[str, Any]], Awaitable[None] | None],
-    is_cancel_requested: Callable[[], Awaitable[bool] | bool] | None = None,
+    is_cancel_requested: Callable[[], Awaitable[Any] | Any] | None = None,
     prepared_workspace_dir: str | Path | None = None,
 ) -> TaskExecutionResult:
     cfg = get_settings()
@@ -843,6 +836,14 @@ async def _execute_task_stream_local(
 
     accumulator = SdkResultAccumulator(params, provider_id=provider_id, model=model)
     sdk_writer = SdkBlockWriter(get_topic_task_store(), params.task_id, params.topic_id)
+
+    async def _cancel_reason() -> CancelReason | None:
+        if is_cancel_requested is None:
+            return None
+        result = is_cancel_requested()
+        if inspect.isawaitable(result):
+            result = await result
+        return _normalize_cancel_reason(result)
 
     prompt = str(params.question or "").strip() if params.resume_session_id else _build_prompt(params.history, params.question)
     agent_snapshot = normalize_agent_snapshot(params.agent_snapshot) if params.agent_snapshot else None
@@ -944,8 +945,7 @@ async def _execute_task_stream_local(
             store=get_topic_task_store(),
             task_id=params.task_id,
             permission_mode=logical_permission_mode,
-            wait_seconds=int(getattr(cfg, "task_permission_wait_seconds", 600) or 600),
-            is_cancel_requested=is_cancel_requested,
+            cancel_reason=_cancel_reason,
         )
 
     options_kwargs = dict(
@@ -976,7 +976,7 @@ async def _execute_task_stream_local(
     cli_path = resolve_claude_cli_path(cfg)
     if cli_path:
         options_kwargs["cli_path"] = cli_path
-    timeout_seconds = max(10, int(params.timeout_seconds or cfg.agent_timeout_seconds))
+    legacy_timeout_seconds = max(10, int(params.timeout_seconds or cfg.agent_timeout_seconds))
 
     def _make_options(resume_session_id: str | None = None):
         current_options = dict(options_kwargs)
@@ -1003,21 +1003,19 @@ async def _execute_task_stream_local(
         bool(str(runtime_target.get("api_key") or "").strip()),
     )
 
-    async def _cancelled() -> bool:
-        if is_cancel_requested is None:
-            return False
-        result = is_cancel_requested()
-        if inspect.isawaitable(result):
-            return bool(await result)
-        return bool(result)
-
     terminal_error_record_written = False
+
+    async def _raise_if_stopped() -> None:
+        reason = await _cancel_reason()
+        if reason == "user_cancel":
+            raise TaskCancelledError("task cancelled")
+        if reason == "runner_stop":
+            raise RunnerStoppedError("runner stopped")
 
     async def _run_sdk_turn(
         *,
         turn_prompt: str,
         turn_options: Any,
-        turn_timeout_seconds: int,
         phase: str,
     ) -> TaskExecutionResult:
         nonlocal terminal_error_record_written
@@ -1026,45 +1024,57 @@ async def _execute_task_stream_local(
         next_progress_threshold_index = 0
         turn_started_at = time.monotonic()
         try:
-            with anyio.fail_after(turn_timeout_seconds):
-                sdk_prompt = _single_user_prompt_stream(turn_prompt) if can_use_tool is not None else turn_prompt
-                async for msg in claude_query(prompt=sdk_prompt, options=turn_options):
-                    sdk_message_count += 1
-                    if type(msg).__name__ == "StreamEvent":
-                        sdk_stream_event_count += 1
-                    while (
-                        next_progress_threshold_index < len(_SDK_TURN_PROGRESS_THRESHOLDS)
-                        and sdk_message_count >= _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
-                    ):
-                        threshold = _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
-                        next_progress_threshold_index += 1
-                        logger.info(
-                            "task.sdk_turn.progress task_id=%s topic_id=%s provider=%s model=%s phase=%s sdk_messages=%s stream_events=%s threshold=%s elapsed_ms=%s",
-                            params.task_id,
-                            params.topic_id,
-                            provider_id,
-                            model,
-                            phase,
-                            sdk_message_count,
-                            sdk_stream_event_count,
-                            threshold,
-                            int((time.monotonic() - turn_started_at) * 1000),
-                        )
-                    if await _cancelled():
-                        error = {"code": "task_cancelled", "message": "任务已取消"}
-                        sdk_writer.append_error(**error)
-                        terminal_error_record_written = True
-                        return TaskExecutionResult(
-                            task_status="suspended",
-                            content=accumulator.current_answer_text(),
-                            usage=accumulator.usage or None,
-                            error=error,
-                            provider_id=provider_id,
-                            model=model,
-                            session_id=accumulator.session_id,
-                        )
-                    accumulator.ingest(msg)
-                    sdk_writer.ingest(msg)
+            sdk_prompt = _single_user_prompt_stream(turn_prompt) if can_use_tool is not None else turn_prompt
+            async for msg in claude_query(prompt=sdk_prompt, options=turn_options):
+                sdk_message_count += 1
+                if type(msg).__name__ == "StreamEvent":
+                    sdk_stream_event_count += 1
+                while (
+                    next_progress_threshold_index < len(_SDK_TURN_PROGRESS_THRESHOLDS)
+                    and sdk_message_count >= _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
+                ):
+                    threshold = _SDK_TURN_PROGRESS_THRESHOLDS[next_progress_threshold_index]
+                    next_progress_threshold_index += 1
+                    logger.info(
+                        "task.sdk_turn.progress task_id=%s topic_id=%s provider=%s model=%s phase=%s sdk_messages=%s stream_events=%s threshold=%s elapsed_ms=%s",
+                        params.task_id,
+                        params.topic_id,
+                        provider_id,
+                        model,
+                        phase,
+                        sdk_message_count,
+                        sdk_stream_event_count,
+                        threshold,
+                        int((time.monotonic() - turn_started_at) * 1000),
+                    )
+                await _raise_if_stopped()
+                accumulator.ingest(msg)
+                sdk_writer.ingest(msg)
+            await _raise_if_stopped()
+        except TaskCancelledError:
+            error = {"code": "task_cancelled", "message": "任务已取消"}
+            sdk_writer.append_error(**error)
+            terminal_error_record_written = True
+            return TaskExecutionResult(
+                task_status="suspended",
+                content=accumulator.current_answer_text(),
+                usage=accumulator.usage or None,
+                error=error,
+                provider_id=provider_id,
+                model=model,
+                session_id=accumulator.session_id,
+            )
+        except RunnerStoppedError:
+            error = {"code": "runner_stopped", "message": "执行资源已停止"}
+            return TaskExecutionResult(
+                task_status="suspended",
+                content=accumulator.current_answer_text(),
+                usage=accumulator.usage or None,
+                error=error,
+                provider_id=provider_id,
+                model=model,
+                session_id=accumulator.session_id,
+            )
         except Exception as exc:
             reason = _format_exception_reason(exc)
             partial = accumulator.current_answer_text()
@@ -1146,12 +1156,11 @@ async def _execute_task_stream_local(
     result = await _run_sdk_turn(
         turn_prompt=prompt,
         turn_options=_make_options(params.resume_session_id),
-        turn_timeout_seconds=timeout_seconds,
         phase="initial",
     )
     if _is_empty_completion_result(result):
         recovery_session_id = str(result.session_id or accumulator.session_id or params.resume_session_id or "").strip()
-        recovery_timeout = _empty_completion_recovery_timeout(timeout_seconds)
+        recovery_timeout = _empty_completion_recovery_timeout(legacy_timeout_seconds)
         logger.warning(
             "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s timeout=%s session_id_set=%s",
             params.task_id,
@@ -1164,7 +1173,6 @@ async def _execute_task_stream_local(
         result = await _run_sdk_turn(
             turn_prompt=_build_empty_completion_recovery_prompt(params.question),
             turn_options=_make_options(recovery_session_id or None),
-            turn_timeout_seconds=recovery_timeout,
             phase="empty_completion_recovery",
         )
         logger.info(

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -653,10 +653,6 @@ def _is_empty_completion_result(result: TaskExecutionResult) -> bool:
     )
 
 
-def _empty_completion_recovery_timeout(timeout_seconds: int) -> int:
-    return max(10, min(120, max(10, int(timeout_seconds or 0)) // 2))
-
-
 def _build_empty_completion_recovery_prompt(question: str) -> str:
     original_question = _clip_text(str(question or "").strip(), 2000)
     if not original_question:
@@ -976,8 +972,6 @@ async def _execute_task_stream_local(
     cli_path = resolve_claude_cli_path(cfg)
     if cli_path:
         options_kwargs["cli_path"] = cli_path
-    legacy_timeout_seconds = max(10, int(params.timeout_seconds or cfg.agent_timeout_seconds))
-
     def _make_options(resume_session_id: str | None = None):
         current_options = dict(options_kwargs)
         resume_value = str(resume_session_id or "").strip()
@@ -1160,14 +1154,12 @@ async def _execute_task_stream_local(
     )
     if _is_empty_completion_result(result):
         recovery_session_id = str(result.session_id or accumulator.session_id or params.resume_session_id or "").strip()
-        recovery_timeout = _empty_completion_recovery_timeout(legacy_timeout_seconds)
         logger.warning(
-            "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s timeout=%s session_id_set=%s",
+            "task.empty_completion.recover_start task_id=%s topic_id=%s provider=%s model=%s session_id_set=%s",
             params.task_id,
             params.topic_id,
             provider_id,
             model,
-            recovery_timeout,
             bool(recovery_session_id),
         )
         result = await _run_sdk_turn(

--- a/dataagent/dataagent-backend/core/topic_task_store.py
+++ b/dataagent/dataagent-backend/core/topic_task_store.py
@@ -1386,6 +1386,32 @@ class TopicTaskStore:
             conn.close()
         return [self._normalize_task_row(row) for row in rows]
 
+    def list_parked_tasks(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT task_id, topic_id, from_task_id, source_queue_id, source_schedule_id, source_schedule_log_id,
+                           task_status, prompt, provider_id, model_name,
+                           agent_id, agent_snapshot_json,
+                           database_hint, debug_enabled, timeout_seconds, sql_read_timeout_seconds,
+                           sql_write_timeout_seconds, last_event_seq, cancel_requested_at, started_at,
+                           heartbeat_at, finished_at, error_json, created_at, updated_at
+                    FROM da_agent_task
+                    WHERE task_status IN ('waiting_permission', 'waiting_input')
+                      AND finished_at IS NULL
+                    ORDER BY updated_at ASC
+                    LIMIT %s
+                    """,
+                    (max(1, limit),),
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+        return [self._normalize_task_row(row) for row in rows]
+
     def has_active_child_task(self, parent_task_id: str) -> bool:
         self._ensure_ready()
         conn = self._connect(database=self._schema_name())
@@ -1572,6 +1598,37 @@ class TopicTaskStore:
         )
         return True
 
+    def get_current_permission_interaction(self, *, task_id: str, request_id: str) -> dict[str, Any] | None:
+        return self._get_interaction(task_id=task_id, request_id=request_id, kind="permission")
+
+    def get_resolved_permission_decision(self, *, task_id: str, request_id: str) -> str | None:
+        interaction = self.get_current_permission_interaction(task_id=task_id, request_id=request_id)
+        if not interaction or str(interaction.get("status") or "") != "resolved":
+            return None
+        return str(interaction.get("decision") or "") or None
+
+    def append_permission_decision_if_waiting(
+        self,
+        *,
+        task_id: str,
+        request_id: str,
+        decision: str,
+        note: str = "",
+        decided_at: str = "",
+    ) -> str:
+        return self._append_interaction_if_waiting(
+            task_id=task_id,
+            request_id=request_id,
+            kind="permission",
+            waiting_status="waiting_permission",
+            payload={
+                "request_id": str(request_id),
+                "decision": normalize_permission_decision(decision),
+                "note": str(note or ""),
+                "decided_at": decided_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+        )
+
     def get_pending_question_request_id(self, task_id: str) -> str | None:
         """Return the request_id of the latest ``question_request`` record for a
         task that has no corresponding ``question_answer`` yet, or None."""
@@ -1642,6 +1699,234 @@ class TopicTaskStore:
             },
         )
         return True
+
+    def get_current_question_interaction(self, *, task_id: str, request_id: str) -> dict[str, Any] | None:
+        return self._get_interaction(task_id=task_id, request_id=request_id, kind="question")
+
+    def get_resolved_question_answer(self, *, task_id: str, request_id: str) -> list[dict[str, Any]] | None:
+        interaction = self.get_current_question_interaction(task_id=task_id, request_id=request_id)
+        if not interaction or str(interaction.get("status") or "") != "resolved":
+            return None
+        answers = interaction.get("answers")
+        return answers if isinstance(answers, list) else []
+
+    def append_question_answer_if_waiting(
+        self,
+        *,
+        task_id: str,
+        request_id: str,
+        answers: Any,
+        answered_at: str = "",
+    ) -> str:
+        return self._append_interaction_if_waiting(
+            task_id=task_id,
+            request_id=request_id,
+            kind="question",
+            waiting_status="waiting_input",
+            payload={
+                "request_id": str(request_id),
+                "answers": answers if isinstance(answers, list) else [],
+                "answered_at": answered_at or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            },
+        )
+
+    def has_resolved_waiting_interaction(self, task_id: str) -> bool:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT record_type
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s
+                      AND record_type IN ('permission_decision', 'question_answer')
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """,
+                    (task_id,),
+                )
+                row = cur.fetchone()
+        finally:
+            conn.close()
+        return bool(row)
+
+    def _get_interaction(self, *, task_id: str, request_id: str, kind: str) -> dict[str, Any] | None:
+        request_id = str(request_id or "").strip()
+        if not request_id:
+            return None
+        if kind == "permission":
+            request_type = "permission_request"
+            resolved_type = "permission_decision"
+        else:
+            request_type = "question_request"
+            resolved_type = "question_answer"
+        rows = self._fetch_interaction_rows(task_id=task_id, record_types=(request_type, resolved_type))
+        return self._interaction_from_rows(rows, request_id=request_id, kind=kind)
+
+    def _append_interaction_if_waiting(
+        self,
+        *,
+        task_id: str,
+        request_id: str,
+        kind: str,
+        waiting_status: str,
+        payload: dict[str, Any],
+    ) -> str:
+        self._ensure_ready()
+        request_id = str(request_id or "").strip()
+        if not request_id:
+            return "not_found"
+        if kind == "permission":
+            request_type = "permission_request"
+            resolved_type = "permission_decision"
+        else:
+            request_type = "question_request"
+            resolved_type = "question_answer"
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT task_status, cancel_requested_at
+                    FROM da_agent_task
+                    WHERE task_id = %s
+                    LIMIT 1
+                    FOR UPDATE
+                    """,
+                    (task_id,),
+                )
+                task_row = cur.fetchone()
+                if not task_row:
+                    conn.rollback()
+                    return "not_found"
+                if str(task_row.get("task_status") or "") != waiting_status or task_row.get("cancel_requested_at") is not None:
+                    conn.rollback()
+                    return "status_mismatch"
+                cur.execute(
+                    """
+                    SELECT id, topic_id, turn_index, record_type, data
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s
+                      AND record_type IN (%s, %s)
+                    ORDER BY id ASC
+                    LIMIT 500
+                    """,
+                    (task_id, request_type, resolved_type),
+                )
+                interaction = self._interaction_from_rows(cur.fetchall() or [], request_id=request_id, kind=kind)
+                if not interaction:
+                    conn.rollback()
+                    return "not_found"
+                if str(interaction.get("status") or "") == "resolved":
+                    conn.rollback()
+                    return "already_resolved"
+                cur.execute(
+                    """
+                    INSERT INTO da_agent_sdk_record (topic_id, task_id, turn_index, record_type, event_type, data)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        str(interaction.get("topic_id") or ""),
+                        task_id,
+                        int(interaction.get("turn_index") or 0),
+                        resolved_type,
+                        None,
+                        json.dumps(payload, ensure_ascii=False, default=_json_default),
+                    ),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        return "appended"
+
+    def _fetch_interaction_rows(self, *, task_id: str, record_types: tuple[str, str]) -> list[dict[str, Any]]:
+        self._ensure_ready()
+        conn = self._connect(database=self._schema_name())
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, topic_id, turn_index, record_type, data
+                    FROM da_agent_sdk_record
+                    WHERE task_id = %s
+                      AND record_type IN (%s, %s)
+                    ORDER BY id ASC
+                    LIMIT 500
+                    """,
+                    (task_id, record_types[0], record_types[1]),
+                )
+                rows = cur.fetchall() or []
+        finally:
+            conn.close()
+        return list(rows)
+
+    def _interaction_from_rows(self, rows: list[dict[str, Any]], *, request_id: str, kind: str) -> dict[str, Any] | None:
+        request: dict[str, Any] | None = None
+        resolved: dict[str, Any] | None = None
+        if kind == "permission":
+            request_type = "permission_request"
+            resolved_type = "permission_decision"
+        else:
+            request_type = "question_request"
+            resolved_type = "question_answer"
+        for row in rows:
+            data = _safe_json_load(row.get("data")) or {}
+            if str(data.get("request_id") or "") != request_id:
+                continue
+            record_type = str(row.get("record_type") or "")
+            if record_type == request_type:
+                request = {
+                    "request_id": request_id,
+                    "topic_id": str(row.get("topic_id") or ""),
+                    "turn_index": int(row.get("turn_index") or 0),
+                    "status": "pending",
+                }
+                if kind == "permission":
+                    request.update(
+                        {
+                            "tool_name": str(data.get("tool_name") or ""),
+                            "risk_level": str(data.get("risk_level") or ""),
+                            "title": str(data.get("title") or ""),
+                            "summary": str(data.get("summary") or ""),
+                            "payload_preview": data.get("payload_preview"),
+                        }
+                    )
+                else:
+                    questions = data.get("questions")
+                    request["questions"] = questions if isinstance(questions, list) else []
+            elif record_type == resolved_type:
+                resolved = {
+                    "request_id": request_id,
+                    "topic_id": str(row.get("topic_id") or ""),
+                    "turn_index": int(row.get("turn_index") or 0),
+                    "status": "resolved",
+                }
+                if kind == "permission":
+                    resolved.update(
+                        {
+                            "decision": str(data.get("decision") or ""),
+                            "note": str(data.get("note") or ""),
+                            "decided_at": str(data.get("decided_at") or ""),
+                        }
+                    )
+                else:
+                    answers = data.get("answers")
+                    resolved.update(
+                        {
+                            "answers": answers if isinstance(answers, list) else [],
+                            "answered_at": str(data.get("answered_at") or ""),
+                        }
+                    )
+        if resolved:
+            if request:
+                resolved.setdefault("topic_id", request.get("topic_id"))
+                resolved.setdefault("turn_index", request.get("turn_index"))
+            return resolved
+        return request
 
     def heartbeat_task(self, task_id: str):
         self._ensure_ready()

--- a/dataagent/dataagent-backend/sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/sandbox_runner_main.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from config import get_settings
 from core.agent_profile_service import normalize_agent_snapshot
 from core.skill_admin_service import resolve_enabled_skill_runtime
+from core.task_control import CancelReason
 from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
 from core.topic_workspace import CONTAINER_RUNTIME_ROOT, LOGS_DIRNAME, sanitize_topic_id
 
@@ -81,7 +82,15 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-CANCELLED_TASK_IDS: set[str] = set()
+class _CancelledTaskMap(dict[str, CancelReason]):
+    def add(self, task_id: str) -> None:
+        self[str(task_id)] = "user_cancel"
+
+    def discard(self, task_id: str) -> None:
+        self.pop(str(task_id), None)
+
+
+CANCELLED_TASK_IDS: _CancelledTaskMap = _CancelledTaskMap()
 RUNNING_CONTAINERS: dict[str, tuple[str, str]] = {}
 RUNNING_CONTAINERS_LOCK = asyncio.Lock()
 
@@ -121,8 +130,8 @@ async def run_sandbox_task(payload: dict[str, Any]):
         async def emit(record: dict[str, Any]) -> None:
             await queue.put({"type": "record", "record": record})
 
-        async def is_cancel_requested() -> bool:
-            return params.task_id in CANCELLED_TASK_IDS
+        async def is_cancel_requested() -> CancelReason | None:
+            return CANCELLED_TASK_IDS.get(params.task_id)
 
         async def execute() -> None:
             try:
@@ -154,7 +163,7 @@ async def run_sandbox_task(payload: dict[str, Any]):
                     model=params.model,
                 )
             finally:
-                CANCELLED_TASK_IDS.discard(params.task_id)
+                CANCELLED_TASK_IDS.pop(params.task_id, None)
 
             await queue.put({"type": "result", "result": asdict(result)})
             await queue.put(None)
@@ -177,13 +186,21 @@ async def run_sandbox_task(payload: dict[str, Any]):
 @app.post("/internal/sandbox/runs/{task_id}/cancel")
 async def cancel_sandbox_task(task_id: str, payload: dict[str, Any] | None = None):
     normalized_task_id = str(task_id or "")
-    CANCELLED_TASK_IDS.add(normalized_task_id)
-    async with RUNNING_CONTAINERS_LOCK:
-        running = RUNNING_CONTAINERS.get(normalized_task_id)
-    if running:
-        backend, container_name = running
-        await _kill_container(backend, container_name)
+    reason = _normalize_cancel_reason((payload or {}).get("reason")) or "user_cancel"
+    should_kill = bool((payload or {}).get("kill", True))
+    CANCELLED_TASK_IDS[normalized_task_id] = reason
+    if should_kill:
+        async with RUNNING_CONTAINERS_LOCK:
+            running = RUNNING_CONTAINERS.get(normalized_task_id)
+        if running:
+            backend, container_name = running
+            await _kill_container(backend, container_name)
     return {"accepted": True, "task_id": task_id}
+
+
+def _normalize_cancel_reason(value: Any) -> CancelReason | None:
+    reason = str(value or "").strip()
+    return reason if reason in {"user_cancel", "runner_stop"} else None  # type: ignore[return-value]
 
 
 def _should_use_container_backend() -> bool:
@@ -681,12 +698,15 @@ async def _execute_task_stream_container(
 
     if result is not None:
         return result
-    if params.task_id in CANCELLED_TASK_IDS:
-        _append_task_log(log_path, "result task_status=suspended error=task cancelled")
+    cancel_reason = CANCELLED_TASK_IDS.get(params.task_id)
+    if cancel_reason:
+        code = "runner_stopped" if cancel_reason == "runner_stop" else "task_cancelled"
+        message = "执行资源已停止" if cancel_reason == "runner_stop" else "任务已取消"
+        _append_task_log(log_path, f"result task_status=suspended error={code}")
         return TaskExecutionResult(
             task_status="suspended",
-            content="task cancelled",
-            error={"code": "cancelled", "message": "task cancelled"},
+            content=message,
+            error={"code": code, "message": message},
             provider_id=params.provider_id,
             model=params.model,
         )
@@ -944,12 +964,15 @@ async def _run_on_warm_child(
     # No result line: the child stream ended (killed/cancelled/crashed). The
     # child can no longer be trusted for reuse, so mark it for removal on release.
     child.healthy = False
-    if params.task_id in CANCELLED_TASK_IDS:
-        _append_task_log(log_path, "result task_status=suspended error=task cancelled")
+    cancel_reason = CANCELLED_TASK_IDS.get(params.task_id)
+    if cancel_reason:
+        code = "runner_stopped" if cancel_reason == "runner_stop" else "task_cancelled"
+        message = "执行资源已停止" if cancel_reason == "runner_stop" else "任务已取消"
+        _append_task_log(log_path, f"result task_status=suspended error={code}")
         return TaskExecutionResult(
             task_status="suspended",
-            content="task cancelled",
-            error={"code": "cancelled", "message": "task cancelled"},
+            content=message,
+            error={"code": code, "message": message},
             provider_id=params.provider_id,
             model=params.model,
         )
@@ -981,7 +1004,7 @@ async def _release_warm_child(child: WarmChild, task_id: str) -> None:
     condition = _warm_pool_condition()
     async with condition:
         RUNNING_CONTAINERS.pop(task_id, None)
-        CANCELLED_TASK_IDS.discard(task_id)
+        CANCELLED_TASK_IDS.pop(task_id, None)
         child.busy = False
         child.current_task_id = None
         child.last_used = time.monotonic()

--- a/dataagent/dataagent-backend/sandbox_task_main.py
+++ b/dataagent/dataagent-backend/sandbox_task_main.py
@@ -10,7 +10,9 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+from core.task_control import CancelReason
 from core.task_executor import TaskExecutionInput, TaskExecutionResult, _execute_task_stream_local
+from core.topic_task_store import get_topic_task_store
 
 
 logging.basicConfig(level=logging.INFO, stream=sys.stderr)
@@ -38,6 +40,13 @@ async def _execute_and_emit(params: TaskExecutionInput) -> TaskExecutionResult:
     async def emit(record: dict[str, Any]) -> None:
         print(json.dumps({"type": "record", "record": record}, ensure_ascii=False), flush=True)
 
+    async def cancel_reason() -> CancelReason | None:
+        try:
+            return "user_cancel" if get_topic_task_store().is_task_cancel_requested(params.task_id) else None
+        except Exception:
+            logger.warning("sandbox task cancel check failed task_id=%s", params.task_id, exc_info=True)
+            return None
+
     try:
         logger.info(
             "sandbox.task.start task_id=%s topic_id=%s provider_id=%s model=%s "
@@ -56,7 +65,7 @@ async def _execute_and_emit(params: TaskExecutionInput) -> TaskExecutionResult:
         result = await _execute_task_stream_local(
             params,
             emit=emit,
-            is_cancel_requested=lambda: False,
+            is_cancel_requested=cancel_reason,
             prepared_workspace_dir=Path.cwd(),
         )
     except Exception as exc:

--- a/dataagent/dataagent-backend/tests/test_permission_waits.py
+++ b/dataagent/dataagent-backend/tests/test_permission_waits.py
@@ -11,7 +11,7 @@ from core.task_control import RunnerStoppedError, TaskCancelledError
 def test_wait_for_decision_returns_persisted_decision(monkeypatch):
     class Store:
         def get_resolved_permission_decision(self, *, task_id: str, request_id: str):
-            return "allowed"
+            return "allow"
 
     monkeypatch.setattr(permission_wait, "get_topic_task_store", lambda: Store())
 

--- a/dataagent/dataagent-backend/tests/test_permission_waits.py
+++ b/dataagent/dataagent-backend/tests/test_permission_waits.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core import ask_user_question, permission_wait
+from core.task_control import RunnerStoppedError, TaskCancelledError
+
+
+def test_wait_for_decision_returns_persisted_decision(monkeypatch):
+    class Store:
+        def get_resolved_permission_decision(self, *, task_id: str, request_id: str):
+            return "allowed"
+
+    monkeypatch.setattr(permission_wait, "get_topic_task_store", lambda: Store())
+
+    result = asyncio.run(permission_wait.wait_for_decision("task-1", "req-1", poll_interval_seconds=0.1))
+
+    assert result == "allow"
+
+
+def test_wait_for_decision_raises_on_cancel_reason():
+    with pytest.raises(TaskCancelledError):
+        asyncio.run(
+            permission_wait.wait_for_decision(
+                "task-1",
+                "req-1",
+                poll_interval_seconds=0.1,
+                cancel_reason=lambda: "user_cancel",
+            )
+        )
+
+    with pytest.raises(RunnerStoppedError):
+        asyncio.run(
+            permission_wait.wait_for_decision(
+                "task-1",
+                "req-1",
+                poll_interval_seconds=0.1,
+                cancel_reason=lambda: "runner_stop",
+            )
+        )
+
+
+def test_wait_for_answer_returns_persisted_answers(monkeypatch):
+    answers = [{"question": "维度?", "selected": ["按天"]}]
+
+    class Store:
+        def get_resolved_question_answer(self, *, task_id: str, request_id: str):
+            return answers
+
+    from core import topic_task_store
+
+    monkeypatch.setattr(topic_task_store, "get_topic_task_store", lambda: Store())
+
+    result = asyncio.run(ask_user_question.wait_for_answer("task-1", "req-1", poll_interval_seconds=0.1))
+
+    assert result == answers
+
+
+def test_wait_for_answer_raises_on_cancel_reason():
+    with pytest.raises(TaskCancelledError):
+        asyncio.run(
+            ask_user_question.wait_for_answer(
+                "task-1",
+                "req-1",
+                poll_interval_seconds=0.1,
+                cancel_reason=lambda: "user_cancel",
+            )
+        )
+
+    with pytest.raises(RunnerStoppedError):
+        asyncio.run(
+            ask_user_question.wait_for_answer(
+                "task-1",
+                "req-1",
+                poll_interval_seconds=0.1,
+                cancel_reason=lambda: "runner_stop",
+            )
+        )

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -184,6 +184,103 @@ class _FakeStore:
         )
         return True
 
+    def get_current_permission_interaction(self, *, task_id: str, request_id: str):
+        return self._get_interaction(task_id=task_id, request_id=request_id, kind="permission")
+
+    def append_permission_decision_if_waiting(self, *, task_id: str, request_id: str, decision: str, note: str = "", decided_at: str = ""):
+        task = self.tasks.get(task_id)
+        if not task:
+            return "not_found"
+        if task.get("task_status") != "waiting_permission" or task.get("cancel_requested_at"):
+            return "status_mismatch"
+        interaction = self.get_current_permission_interaction(task_id=task_id, request_id=request_id)
+        if not interaction:
+            return "not_found"
+        if interaction.get("status") == "resolved":
+            return "already_resolved"
+        normalized = {"allow": "allowed", "deny": "denied"}.get(decision, decision)
+        self.append_sdk_record(
+            task_id=task_id,
+            topic_id=interaction.get("topic_id") or "",
+            turn_index=int(interaction.get("turn_index") or 0),
+            record_type="permission_decision",
+            event_type=None,
+            data={
+                "request_id": request_id,
+                "decision": normalized,
+                "note": note,
+                "decided_at": decided_at or _now(),
+            },
+        )
+        return "appended"
+
+    def get_current_question_interaction(self, *, task_id: str, request_id: str):
+        return self._get_interaction(task_id=task_id, request_id=request_id, kind="question")
+
+    def append_question_answer_if_waiting(self, *, task_id: str, request_id: str, answers, answered_at: str = ""):
+        task = self.tasks.get(task_id)
+        if not task:
+            return "not_found"
+        if task.get("task_status") != "waiting_input" or task.get("cancel_requested_at"):
+            return "status_mismatch"
+        interaction = self.get_current_question_interaction(task_id=task_id, request_id=request_id)
+        if not interaction:
+            return "not_found"
+        if interaction.get("status") == "resolved":
+            return "already_resolved"
+        self.append_sdk_record(
+            task_id=task_id,
+            topic_id=interaction.get("topic_id") or "",
+            turn_index=int(interaction.get("turn_index") or 0),
+            record_type="question_answer",
+            event_type=None,
+            data={
+                "request_id": request_id,
+                "answers": answers if isinstance(answers, list) else [],
+                "answered_at": answered_at or _now(),
+            },
+        )
+        return "appended"
+
+    def _get_interaction(self, *, task_id: str, request_id: str, kind: str):
+        if kind == "permission":
+            request_type = "permission_request"
+            resolved_type = "permission_decision"
+        else:
+            request_type = "question_request"
+            resolved_type = "question_answer"
+        request = None
+        resolved = None
+        for rec in self.sdk_records.get(task_id, []):
+            data = rec.get("data") or {}
+            if str(data.get("request_id") or "") != request_id:
+                continue
+            if rec.get("record_type") == request_type:
+                request = {
+                    "request_id": request_id,
+                    "topic_id": rec.get("topic_id") or "",
+                    "turn_index": int(rec.get("turn_index") or 0),
+                    "status": "pending",
+                }
+            elif rec.get("record_type") == resolved_type:
+                resolved = {
+                    "request_id": request_id,
+                    "topic_id": rec.get("topic_id") or "",
+                    "turn_index": int(rec.get("turn_index") or 0),
+                    "status": "resolved",
+                }
+                if kind == "permission":
+                    resolved["decision"] = str(data.get("decision") or "")
+                else:
+                    answers = data.get("answers")
+                    resolved["answers"] = answers if isinstance(answers, list) else []
+        if resolved:
+            if request:
+                resolved["topic_id"] = request["topic_id"]
+                resolved["turn_index"] = request["turn_index"]
+            return resolved
+        return request
+
     def delete_topic(self, topic_id: str, context=None):
         self.topics.pop(topic_id, None)
         self.topic_messages.pop(topic_id, None)
@@ -551,19 +648,6 @@ class _FakeCoordinator:
     async def request_cancel(self, task_id: str):
         self.cancelled.append(task_id)
 
-    def __init_decisions(self):
-        if not hasattr(self, "decisions"):
-            self.decisions = {}
-
-    async def submit_permission_decision(self, task_id: str, request_id: str, decision: str) -> str:
-        self.__init_decisions()
-        # first decision wins (idempotent)
-        return self.decisions.setdefault((task_id, request_id), decision)
-
-    async def read_permission_decision(self, task_id: str, request_id: str) -> str | None:
-        self.__init_decisions()
-        return self.decisions.get((task_id, request_id))
-
 
 def _submit_message_task_factory(store: _FakeStore, calls: list[dict]):
     async def _submit_message_task(**kwargs):
@@ -916,6 +1000,44 @@ def test_permission_decision_endpoint(monkeypatch):
             "/api/v1/nl2sql/tasks/task_missing/permission-decision",
             json={"request_id": "req-1", "decision": "allow"},
         ).status_code == 404
+
+
+def test_question_answer_endpoint(monkeypatch):
+    client, store, _coordinator, _submit_calls = _build_client(monkeypatch)
+    with client:
+        topic_id = client.post("/api/v1/nl2sql/topics", json={"title": "追问流"}).json()["topic_id"]
+        delivered = client.post(
+            "/api/v1/nl2sql/tasks/deliver-message",
+            json={"topic_id": topic_id, "content": "需要选择维度"},
+        ).json()
+        task_id = delivered["task_id"]
+        base = f"/api/v1/nl2sql/tasks/{task_id}/question-answer"
+
+        assert client.post(base, json={"request_id": "q-1", "answers": []}).status_code == 409
+
+        store.tasks[task_id]["task_status"] = "waiting_input"
+        store.append_sdk_record(
+            task_id=task_id,
+            topic_id=topic_id,
+            turn_index=1,
+            record_type="question_request",
+            event_type=None,
+            data={"request_id": "q-1", "questions": [{"question": "按哪个维度?"}]},
+        )
+
+        answers = [{"question": "按哪个维度?", "selected": ["按天"]}]
+        ok = client.post(base, json={"request_id": "q-1", "answers": answers})
+        assert ok.status_code == 200
+        assert ok.json() == {"task_id": task_id, "request_id": "q-1", "accepted": True}
+        records = [rec for rec in store.sdk_records[task_id] if rec["record_type"] == "question_answer"]
+        assert len(records) == 1
+        assert records[0]["data"]["answers"] == answers
+
+        again = client.post(base, json={"request_id": "q-1", "answers": []})
+        assert again.status_code == 200
+        records = [rec for rec in store.sdk_records[task_id] if rec["record_type"] == "question_answer"]
+        assert len(records) == 1
+        assert client.post(base, json={"request_id": "q-2", "answers": []}).status_code == 409
 
 
 def test_followup_suggestions_route_generates_without_changing_message_contract(monkeypatch):

--- a/dataagent/dataagent-backend/tests/test_routes_contract.py
+++ b/dataagent/dataagent-backend/tests/test_routes_contract.py
@@ -168,7 +168,6 @@ class _FakeStore:
         pending = self.get_pending_permission_request(task_id)
         if not pending or pending.get("request_id") != request_id:
             return False
-        normalized = {"allow": "allowed", "deny": "denied"}.get(decision, decision)
         self.append_sdk_record(
             task_id=task_id,
             topic_id=pending.get("topic_id") or "",
@@ -177,7 +176,7 @@ class _FakeStore:
             event_type=None,
             data={
                 "request_id": request_id,
-                "decision": normalized,
+                "decision": decision,
                 "note": note,
                 "decided_at": decided_at or _now(),
             },
@@ -198,7 +197,6 @@ class _FakeStore:
             return "not_found"
         if interaction.get("status") == "resolved":
             return "already_resolved"
-        normalized = {"allow": "allowed", "deny": "denied"}.get(decision, decision)
         self.append_sdk_record(
             task_id=task_id,
             topic_id=interaction.get("topic_id") or "",
@@ -207,7 +205,7 @@ class _FakeStore:
             event_type=None,
             data={
                 "request_id": request_id,
-                "decision": normalized,
+                "decision": decision,
                 "note": note,
                 "decided_at": decided_at or _now(),
             },
@@ -976,18 +974,17 @@ def test_permission_decision_endpoint(monkeypatch):
         # Valid allow.
         ok = client.post(base, json={"request_id": "req-1", "decision": "allow"})
         assert ok.status_code == 200
-        # Response uses the canonical persisted form, matching the SDK record below.
-        assert ok.json() == {"task_id": task_id, "request_id": "req-1", "decision": "allowed"}
+        assert ok.json() == {"task_id": task_id, "request_id": "req-1", "decision": "allow"}
         decisions = [
             rec for rec in store.sdk_records[task_id]
             if rec["record_type"] == "permission_decision"
         ]
         assert len(decisions) == 1
-        assert decisions[0]["data"]["decision"] == "allowed"
+        assert decisions[0]["data"]["decision"] == "allow"
 
         # Idempotent: a later deny for the same request_id returns the first decision.
         again = client.post(base, json={"request_id": "req-1", "decision": "deny"})
-        assert again.json()["decision"] == "allowed"
+        assert again.json()["decision"] == "allow"
         decisions = [
             rec for rec in store.sdk_records[task_id]
             if rec["record_type"] == "permission_decision"

--- a/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
+++ b/dataagent/dataagent-backend/tests/test_sandbox_runner_main.py
@@ -107,6 +107,28 @@ def test_sandbox_runner_cancel_endpoint_marks_task_cancelled():
     assert "task-1" in sandbox_runner_main.CANCELLED_TASK_IDS
 
 
+def test_sandbox_runner_cancel_endpoint_can_skip_container_kill(monkeypatch):
+    killed: list[tuple[str, str]] = []
+    sandbox_runner_main.CANCELLED_TASK_IDS.clear()
+    sandbox_runner_main.RUNNING_CONTAINERS["task-1"] = ("docker", "container-1")
+
+    async def fake_kill(backend: str, container_name: str) -> None:
+        killed.append((backend, container_name))
+
+    monkeypatch.setattr(sandbox_runner_main, "_kill_container", fake_kill)
+    client = TestClient(sandbox_runner_main.app)
+
+    response = client.post(
+        "/internal/sandbox/runs/task-1/cancel",
+        json={"task_id": "task-1", "reason": "user_cancel", "kill": False},
+    )
+
+    sandbox_runner_main.RUNNING_CONTAINERS.pop("task-1", None)
+    assert response.status_code == 200
+    assert sandbox_runner_main.CANCELLED_TASK_IDS["task-1"] == "user_cancel"
+    assert killed == []
+
+
 def test_sandbox_runner_task_log_captures_child_sdk_stream_stderr(tmp_path: Path):
     log_path = tmp_path / "topic-1" / "logs" / "task-1.log"
 

--- a/dataagent/dataagent-backend/tests/test_task_coordinator.py
+++ b/dataagent/dataagent-backend/tests/test_task_coordinator.py
@@ -101,3 +101,94 @@ def test_task_coordinator_persists_only_emitted_sdk_records():
             "data": {"type": "message_start"},
         }
     ]
+
+
+def test_task_stop_reason_distinguishes_lease_loss_from_user_cancel():
+    class FakeStore:
+        def __init__(self):
+            self.cancel_requested = False
+
+        def is_task_cancel_requested(self, task_id):
+            return self.cancel_requested
+
+    store = FakeStore()
+    coordinator = TaskCoordinator(store=store)
+
+    async def run():
+        lease_lost = asyncio.Event()
+        none_reason = await coordinator._task_stop_reason("task-1", lease_lost)
+        store.cancel_requested = True
+        user_reason = await coordinator._task_stop_reason("task-1", lease_lost)
+        lease_lost.set()
+        runner_reason = await coordinator._task_stop_reason("task-1", lease_lost)
+        return none_reason, user_reason, runner_reason
+
+    assert anyio.run(run) == (None, "user_cancel", "runner_stop")
+
+
+def test_recover_parked_tasks_leaves_unresolved_parked_task_untouched():
+    class FakeStore:
+        def __init__(self):
+            self.finished = []
+            self.messages = []
+
+        def list_parked_tasks(self, *, limit=20):
+            return [{"task_id": "task-1", "topic_id": "topic-1", "task_status": "waiting_permission"}]
+
+        def is_task_cancel_requested(self, task_id):
+            return False
+
+        def has_resolved_waiting_interaction(self, task_id):
+            return False
+
+        def update_assistant_message(self, **kwargs):
+            self.messages.append(kwargs)
+
+        def finish_task(self, **kwargs):
+            self.finished.append(kwargs)
+
+    coordinator = TaskCoordinator(store=FakeStore())
+
+    anyio.run(lambda: coordinator._recover_parked_tasks(batch_size=10))
+
+    assert coordinator.store.messages == []
+    assert coordinator.store.finished == []
+
+
+def test_recover_parked_tasks_suspends_resolved_orphan():
+    class FakeStore:
+        def __init__(self):
+            self.finished = []
+            self.messages = []
+
+        def list_parked_tasks(self, *, limit=20):
+            return [{"task_id": "task-1", "topic_id": "topic-1", "task_status": "waiting_input"}]
+
+        def is_task_cancel_requested(self, task_id):
+            return False
+
+        def has_resolved_waiting_interaction(self, task_id):
+            return True
+
+        def update_assistant_message(self, **kwargs):
+            self.messages.append(kwargs)
+
+        def finish_task(self, **kwargs):
+            self.finished.append(kwargs)
+
+    coordinator = TaskCoordinator(store=FakeStore())
+
+    anyio.run(lambda: coordinator._recover_parked_tasks(batch_size=10))
+
+    assert coordinator.store.messages[0]["status"] == "suspended"
+    assert coordinator.store.messages[0]["error"]["code"] == "run_lost"
+    assert coordinator.store.finished == [
+        {
+            "task_id": "task-1",
+            "task_status": "suspended",
+            "error": {
+                "code": "run_lost",
+                "message": "确认/输入已提交，但原运行器已释放，请重新发送请求继续。",
+            },
+        }
+    ]

--- a/dataagent/dataagent-backend/tests/test_task_coordinator.py
+++ b/dataagent/dataagent-backend/tests/test_task_coordinator.py
@@ -141,6 +141,12 @@ def test_recover_parked_tasks_leaves_unresolved_parked_task_untouched():
         def has_resolved_waiting_interaction(self, task_id):
             return False
 
+        def get_pending_permission_request(self, task_id):
+            return {"request_id": "req-1"}
+
+        def get_pending_question_request(self, task_id):
+            return None
+
         def update_assistant_message(self, **kwargs):
             self.messages.append(kwargs)
 
@@ -170,6 +176,12 @@ def test_recover_parked_tasks_suspends_resolved_orphan():
         def has_resolved_waiting_interaction(self, task_id):
             return True
 
+        def get_pending_permission_request(self, task_id):
+            return None
+
+        def get_pending_question_request(self, task_id):
+            return None
+
         def update_assistant_message(self, **kwargs):
             self.messages.append(kwargs)
 
@@ -192,3 +204,40 @@ def test_recover_parked_tasks_suspends_resolved_orphan():
             },
         }
     ]
+
+
+def test_recover_parked_tasks_keeps_later_unresolved_request_parked():
+    class FakeStore:
+        def __init__(self):
+            self.finished = []
+            self.messages = []
+
+        def list_parked_tasks(self, *, limit=20):
+            return [{"task_id": "task-1", "topic_id": "topic-1", "task_status": "waiting_permission"}]
+
+        def is_task_cancel_requested(self, task_id):
+            return False
+
+        def has_resolved_waiting_interaction(self, task_id):
+            # A prior permission in the same run was already answered, but the
+            # current request is still pending and must remain visible.
+            return True
+
+        def get_pending_permission_request(self, task_id):
+            return {"request_id": "req-2"}
+
+        def get_pending_question_request(self, task_id):
+            return None
+
+        def update_assistant_message(self, **kwargs):
+            self.messages.append(kwargs)
+
+        def finish_task(self, **kwargs):
+            self.finished.append(kwargs)
+
+    coordinator = TaskCoordinator(store=FakeStore())
+
+    anyio.run(lambda: coordinator._recover_parked_tasks(batch_size=10))
+
+    assert coordinator.store.messages == []
+    assert coordinator.store.finished == []

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -61,7 +61,7 @@ def _build_gate(monkeypatch, decision, *, mode="default"):
     writer = _RecordingWriter()
     store = _RecordingStore()
 
-    async def fake_wait(task_id, request_id, *, timeout_seconds, is_cancel_requested=None, **kw):
+    async def fake_wait(task_id, request_id, *, cancel_reason=None, **kw):
         return decision
 
     monkeypatch.setattr(task_executor, "wait_for_decision", fake_wait)
@@ -70,8 +70,7 @@ def _build_gate(monkeypatch, decision, *, mode="default"):
         store=store,
         task_id="task-1",
         permission_mode=mode,
-        wait_seconds=5,
-        is_cancel_requested=None,
+        cancel_reason=None,
     )
     return cb, writer, store
 
@@ -107,7 +106,7 @@ def test_can_use_tool_confirms_write_tool_allowed(monkeypatch):
     assert _permission_behavior(result) == "allow"
     assert len(writer.requests) == 1
     assert writer.requests[0]["tool_name"] == "mcp__portal__portal_create_task"
-    assert writer.decisions[0]["decision"] == "allowed"
+    assert writer.decisions == []
     assert store.statuses == ["waiting_permission", "running"]
 
 
@@ -116,7 +115,7 @@ def test_can_use_tool_confirms_write_tool_denied(monkeypatch):
     result = asyncio.run(cb("mcp__portal__portal_publish_workflow", {"summary": "发布", "operation": "deploy"}))
     assert _permission_behavior(result) == "deny"
     assert writer.requests[0]["risk_level"] == "critical"
-    assert writer.decisions[0]["decision"] == "denied"
+    assert writer.decisions == []
     assert store.statuses == ["waiting_permission", "running"]
 
 
@@ -157,18 +156,18 @@ def test_can_use_tool_auto_allow_strips_card_annotations(monkeypatch):
     assert _permission_updated_input(result) == {"task": {"name": "t"}}
 
 
-def test_can_use_tool_timeout_denies(monkeypatch):
-    cb, writer, store = _build_gate(monkeypatch, "timeout")
+def test_can_use_tool_denies_after_persisted_denial(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "deny")
     result = asyncio.run(cb("mcp__portal__portal_create_task", {}))
     assert _permission_behavior(result) == "deny"
-    assert writer.decisions[0]["decision"] == "timeout"
+    assert writer.decisions == []
 
 
 def _build_ask_gate(monkeypatch, answers, *, mode="default"):
     writer = _RecordingWriter()
     store = _RecordingStore()
 
-    async def fake_answer(task_id, request_id, *, timeout_seconds, is_cancel_requested=None, **kw):
+    async def fake_answer(task_id, request_id, *, cancel_reason=None, **kw):
         return answers
 
     monkeypatch.setattr(task_executor, "wait_for_answer", fake_answer)
@@ -177,8 +176,7 @@ def _build_ask_gate(monkeypatch, answers, *, mode="default"):
         store=store,
         task_id="task-1",
         permission_mode=mode,
-        wait_seconds=5,
-        is_cancel_requested=None,
+        cancel_reason=None,
     )
     return cb, writer, store
 
@@ -205,7 +203,7 @@ def test_can_use_tool_ask_user_question_answers_in_any_mode(monkeypatch, mode):
     assert updated["answers"] == {"按哪个维度统计?": "按天"}
     assert updated["annotations"] == {"按哪个维度统计?": {"notes": "含节假日"}}
     assert writer.question_requests[0]["request_id"] == "tu-9"
-    assert store.question_answer_records[0]["answers"] == answers
+    assert store.question_answer_records == []
     assert store.statuses == ["waiting_input", "running"]
 
 
@@ -1388,6 +1386,32 @@ def _patch_default_provider(monkeypatch):
             "supports_partial_messages": True,
         },
     )
+
+
+def test_execute_task_stream_runner_stop_returns_suspended_without_sdk_error(monkeypatch, tmp_path: Path):
+    _install_fake_sdk(
+        monkeypatch,
+        [
+            StreamEvent({"type": "message_start", "message": {"id": "req-1"}}),
+        ],
+    )
+    _patch_default_provider(monkeypatch)
+    _patch_skill_runtime(monkeypatch, tmp_path)
+    store = _SdkRecordStore()
+    monkeypatch.setattr(task_executor, "get_topic_task_store", lambda: store)
+
+    async def _run():
+        return await task_executor.execute_task_stream(
+            _build_input(),
+            emit=lambda record: None,
+            is_cancel_requested=lambda: "runner_stop",
+        )
+
+    result = asyncio.run(_run())
+
+    assert result.task_status == "suspended"
+    assert result.error == {"code": "runner_stopped", "message": "执行资源已停止"}
+    assert not [record for record in store.records if record["record_type"] == "error"]
 
 
 def test_execute_task_stream_keeps_leaked_pseudo_tag_in_thinking_as_finish(monkeypatch, tmp_path: Path):

--- a/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
@@ -50,9 +50,9 @@ const prettyPreview = computed(() => {
 })
 const resultLabel = computed(() => {
   switch (props.block.decision) {
-    case 'allowed':
+    case 'allow':
       return '✓ 已允许执行'
-    case 'denied':
+    case 'deny':
       return '✕ 已拒绝'
     case 'timeout':
       return '⏱ 等待确认超时，已自动拒绝'
@@ -122,6 +122,6 @@ function decide(decision) {
 .v2-perm-btn.allow { background: #2c9c5a; color: #fff; }
 .v2-perm-btn.deny { background: #eef1f6; color: #333; }
 .v2-perm-result { margin-top: 6px; font-size: 13px; font-weight: 600; }
-.v2-perm-result.allowed { color: #2c9c5a; }
-.v2-perm-result.denied, .v2-perm-result.timeout { color: #c0392b; }
+.v2-perm-result.allow { color: #2c9c5a; }
+.v2-perm-result.deny, .v2-perm-result.timeout { color: #c0392b; }
 </style>

--- a/docs/design/2026-06-26-permission-confirmation-wait-design.md
+++ b/docs/design/2026-06-26-permission-confirmation-wait-design.md
@@ -1,0 +1,134 @@
+# Permission Confirmation Wait Design
+
+## Context
+
+DataAgent pauses an SDK run when a write/high-risk tool needs permission, or when
+`AskUserQuestion` needs an answer. Today that pause is still inside two timeout
+paths:
+
+- the SDK turn is wrapped by a total wall-clock `anyio.fail_after(...)`;
+- permission/input waits use a bounded Redis wait and fail closed on Redis errors.
+
+If the runner exits while the task is parked, the coordinator also finalizes the
+task without checking the current persisted state. A task in
+`waiting_permission` or `waiting_input` can therefore be overwritten as terminal.
+
+## Goal
+
+In v1, confirmation/input is a durable task state, not an execution-resource
+lifetime. A task may stay in `waiting_permission` or `waiting_input` until the
+user acts or cancels.
+
+When the runner is alive, the user's decision is consumed by the original SDK
+callback and the run continues in place. When the runner has already been
+released, v1 does not attempt automatic continuation because the SDK cannot
+inject a tool result into a lost callback. The task is finalized as
+`suspended` with `run_lost` after the user submits a decision/answer.
+
+## Non-Goals
+
+v1 intentionally does not implement:
+
+- orphan automatic continuation;
+- `create_continuation_task`;
+- parent handoff/CAS linkage transfer;
+- `finish_task(propagate_downstream=False)`;
+- resume-plus-continuation prompts;
+- early session persistence only for orphan continuation;
+- Redis fast-path delivery or Redis delivery TTLs for confirmation.
+
+Normal follow-up after a completed run is not an orphan path. It remains a new
+task that resumes the persisted SDK session.
+
+## Design
+
+### Durable Waiting
+
+`can_use_tool` and `AskUserQuestion` keep writing `permission_request` and
+`question_request` SDK records and set task status to `waiting_permission` or
+`waiting_input`.
+
+The wait functions no longer have deadlines. They poll MySQL for the resolved
+decision/answer and retry transient MySQL errors instead of failing closed.
+
+Permission records persist canonical values (`allowed`/`denied`), while SDK
+callbacks need callback verbs (`allow`/`deny`). The wait path maps
+`allowed -> allow` and `denied -> deny`.
+
+### MySQL as Authority
+
+The API endpoint is the only writer of durable decision/answer records. The SDK
+callback only consumes those records, moves the task back to `running`, and
+returns the corresponding allow/deny or updated input to the SDK.
+
+Redis `submit_*`/`read_*` helpers are removed from the confirmation main path.
+`task_permission_wait_seconds` is no longer a confirmation wait timeout.
+
+### Idempotent Endpoints
+
+Endpoints resolve by `(task_id, request_id)`.
+
+- If the request is already resolved, return the recorded result regardless of
+  task status.
+- If the request is still pending, append only when the task is still in the
+  corresponding waiting state and `cancel_requested_at IS NULL`.
+- Unknown request IDs return conflict.
+
+The append operation is atomic. It locks the task row with
+`SELECT ... FOR UPDATE`, verifies task state/cancel state, derives pending state
+from SDK records, and writes the decision/answer in one transaction.
+
+### Cancellation and Runner Stop
+
+Cancellation is split by reason:
+
+- `user_cancel`: user explicitly cancels the task; wait/message loop raises
+  `TaskCancelledError` and finalizes as `suspended` / `task_cancelled`.
+- `runner_stop`: lease loss or execution resource stop; wait/message loop raises
+  `RunnerStoppedError`. For parked tasks, coordinator finalization is suppressed
+  so the task remains `waiting_*`. For active running tasks, the task finalizes
+  as `suspended` / `runner_stopped`.
+
+Sandbox cancellation is reasoned:
+
+- `user_cancel + waiting_*`: do not kill the container; let the child observe the
+  cancel request and finalize cleanly;
+- `user_cancel + running`: keep the fast parent-side cancel/kill behavior;
+- `runner_stop`: stop the execution resource.
+
+In-process cancellation depends on the SDK loop returning to a check point; it
+is not guaranteed to interrupt a stuck SDK await immediately.
+
+### Parked Finalization Guard
+
+Before successful or crash finalization, the coordinator fresh-reads the task.
+If the status is still `waiting_permission` or `waiting_input` and the result is
+a benign runner-stop/crash path, it skips assistant-message update and
+`finish_task`, releases the lease, and leaves the task parked.
+
+Explicit user cancellation is not blocked by this guard.
+
+### Lost Runner
+
+The recovery loop adds a parked-task scan:
+
+- waiting task + no lease + cancel requested -> `suspended` / `task_cancelled`;
+- waiting task + no lease + durable decision/answer -> `suspended` / `run_lost`;
+- waiting task + no lease + no user action -> remain parked.
+
+## Frontend Behavior
+
+No frontend code change is expected in v1.
+
+- Normal confirmation/answer writes a decision/answer record, so the card closes.
+- `run_lost` happens after the decision/answer was recorded; the card is already
+  closed and the task shows the terminal error.
+- `cancel` does not write a decision/answer; the historical card may remain
+  pending but is disabled once the task stream is terminal.
+
+## Tradeoffs
+
+Removing the SDK turn wall-clock timeout means active runs are no longer bounded
+by that timer. In production sandbox/container mode, parent-side cancellation can
+still stop the execution resource. In in-process mode, cancellation is cooperative
+with SDK message loop progress.

--- a/docs/design/2026-06-26-permission-confirmation-wait-design.md
+++ b/docs/design/2026-06-26-permission-confirmation-wait-design.md
@@ -51,15 +51,14 @@ task that resumes the persisted SDK session.
 The wait functions no longer have deadlines. They poll MySQL for the resolved
 decision/answer and retry transient MySQL errors instead of failing closed.
 
-Permission records persist canonical values (`allowed`/`denied`), while SDK
-callbacks need callback verbs (`allow`/`deny`). The wait path maps
-`allowed -> allow` and `denied -> deny`.
+Permission records persist the same canonical verbs used by the SDK callback:
+`allow` / `deny` / `timeout`. There is no `allowed` / `denied` translation layer.
 
 ### MySQL as Authority
 
 The API endpoint is the only writer of durable decision/answer records. The SDK
 callback only consumes those records, moves the task back to `running`, and
-returns the corresponding allow/deny or updated input to the SDK.
+returns the corresponding `allow` / `deny` or updated input to the SDK.
 
 Redis `submit_*`/`read_*` helpers are removed from the confirmation main path.
 `task_permission_wait_seconds` is no longer a confirmation wait timeout.

--- a/docs/plans/2026-06-26-permission-confirmation-wait-plan.md
+++ b/docs/plans/2026-06-26-permission-confirmation-wait-plan.md
@@ -1,0 +1,76 @@
+# Permission Confirmation Wait Plan
+
+## Scope
+
+Implement v1 of persistent permission/input waiting for DataAgent:
+
+- remove confirmation/input wait deadlines;
+- use MySQL as the authoritative decision/answer channel;
+- keep parked task status durable;
+- preserve exact continuation only while the original runner is alive;
+- finalize lost-runner confirmed tasks as `suspended` / `run_lost`;
+- avoid orphan automatic continuation.
+
+## Tasks
+
+1. Update docs and config comments.
+   - Add this plan and matching design.
+   - Mark `task_permission_wait_seconds` as deprecated for confirmation waits.
+
+2. Replace Redis wait paths.
+   - Update `permission_wait.wait_for_decision` to poll MySQL with no timeout.
+   - Update `ask_user_question.wait_for_answer` similarly.
+   - Add `TaskCancelledError` and `RunnerStoppedError` handling.
+   - Map canonical permission decisions to callback verbs.
+
+3. Make endpoint writes authoritative and idempotent.
+   - Remove confirmation endpoint calls to Redis submit/read helpers.
+   - Add request-id based current/resolved interaction readers.
+   - Add atomic `append_*_if_waiting` methods using task row `FOR UPDATE`.
+   - Reject pending writes after cancel or terminal/running status.
+
+4. Simplify callbacks.
+   - Remove `wait_seconds` parameters.
+   - Remove callback-side decision/answer append.
+   - Callback only consumes, sets task status back to `running`, and returns to
+     the SDK.
+
+5. Update coordinator lifecycle.
+   - Replace boolean cancellation with `cancel_reason`.
+   - Add parked finalization guard.
+   - Add minimal parked recovery: cancel -> `task_cancelled`, decision/answer
+     after runner loss -> `run_lost`, otherwise leave parked.
+
+6. Update sandbox cancellation.
+   - Child checks user cancel through MySQL.
+   - Cancel route carries reason.
+   - Parent watch cancel branches on reason plus DB status.
+
+7. Tests.
+   - Unit tests for no-deadline MySQL polling and decision mapping.
+   - Route tests for resolved idempotency, pending writes, and terminal/cancel
+     rejection.
+   - Coordinator tests for parked finalization guard and `run_lost`.
+   - Executor tests for no `fail_after`, callback no second append, and cancel
+     exception routing.
+   - Sandbox tests for parked cancel, active cancel, and runner stop.
+
+## Verification
+
+Run:
+
+```bash
+cd dataagent/dataagent-backend
+.venv-py313/bin/python -m pytest tests -q
+```
+
+When local services and provider credentials are available, run one DataAgent
+smoke flow:
+
+- trigger a write-tool permission card;
+- wait beyond the old 360s timeout and confirm the task remains
+  `waiting_permission`;
+- approve and verify `waiting_permission -> running -> success`;
+- cancel while parked and verify `suspended` / `task_cancelled`;
+- simulate runner loss while parked, submit approval, and verify
+  `suspended` / `run_lost`.

--- a/docs/plans/2026-06-26-permission-confirmation-wait-plan.md
+++ b/docs/plans/2026-06-26-permission-confirmation-wait-plan.md
@@ -21,7 +21,7 @@ Implement v1 of persistent permission/input waiting for DataAgent:
    - Update `permission_wait.wait_for_decision` to poll MySQL with no timeout.
    - Update `ask_user_question.wait_for_answer` similarly.
    - Add `TaskCancelledError` and `RunnerStoppedError` handling.
-   - Map canonical permission decisions to callback verbs.
+   - Keep persisted permission decisions aligned with callback verbs.
 
 3. Make endpoint writes authoritative and idempotent.
    - Remove confirmation endpoint calls to Redis submit/read helpers.
@@ -47,7 +47,7 @@ Implement v1 of persistent permission/input waiting for DataAgent:
    - Parent watch cancel branches on reason plus DB status.
 
 7. Tests.
-   - Unit tests for no-deadline MySQL polling and decision mapping.
+   - Unit tests for no-deadline MySQL polling and decision handling.
    - Route tests for resolved idempotency, pending writes, and terminal/cancel
      rejection.
    - Coordinator tests for parked finalization guard and `run_lost`.


### PR DESCRIPTION
## Summary
- Make DataAgent permission confirmations and AskUserQuestion answers durable parked task states instead of Redis-delivered waits tied to runner lifetime.
- Use MySQL SDK records as the authoritative decision/answer channel, while keeping exact continuation only when the original runner is still alive.

## What Changed

### Behavior Changes
- Permission/input waits no longer use Redis decision/answer keys or wait deadlines.
- Confirmation and question-answer API endpoints append durable SDK records idempotently by `(task_id, request_id)`.
- SDK callbacks only consume persisted records, restore task status to `running`, and return to the SDK.
- Coordinator distinguishes `user_cancel` from `runner_stop`, preserves unresolved parked tasks, and marks resolved orphaned waits as `suspended/run_lost`.
- Sandbox cancellation now carries a reason and supports non-killing parked cancellation.

### Key Files
- `dataagent/dataagent-backend/core/task_executor.py`: removes SDK turn `fail_after`, consumes durable wait results, and routes cancel reasons.
- `dataagent/dataagent-backend/core/topic_task_store.py`: adds interaction readers and atomic append-if-waiting methods.
- `dataagent/dataagent-backend/core/task_coordinator.py`: adds parked finalization guard and parked recovery.
- `dataagent/dataagent-backend/api/routes.py`: makes permission/answer endpoints MySQL-authoritative.
- `docs/design/2026-06-26-permission-confirmation-wait-design.md` and `docs/plans/2026-06-26-permission-confirmation-wait-plan.md`: document the v1 scope and tradeoffs.

## Validation
- Command: `cd dataagent/dataagent-backend && .venv-py313/bin/python -m pytest tests -q`
  Result: pass, `344 passed`, with existing Pydantic/FastAPI deprecation warnings.

## Risks
- Active SDK runs are no longer bounded by the previous SDK-loop wall-clock timeout; sandbox/container cancellation remains the operational stop path, while in-process cancellation is cooperative.

## Rollback
- Revert commit `aa74d1b` to restore the previous Redis-delivered bounded wait behavior.

## Checklist
- [x] No secrets/credentials committed.
- [x] Compatibility impact reviewed.
- [x] Docs/config updates completed when needed.