### PR TITLE
fix(widget): 悬浮聊天显示权限模式与模型选择

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -280,11 +280,6 @@
               </select>
             </div>
             <div class="query-model-selector">
-              <select v-model="selectedProvider" class="query-model-select" :disabled="!providers.length || isBusy" title="切换提供商">
-                <option v-for="provider in providers" :key="provider.provider_id" :value="provider.provider_id">
-                  {{ provider.display_name || provider.provider_id }}
-                </option>
-              </select>
               <select v-model="selectedModel" class="query-model-select" :disabled="!availableModels.length || isBusy" title="切换模型">
                 <option v-for="modelName in availableModels" :key="modelName" :value="modelName">{{ modelName }}</option>
               </select>

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -162,7 +162,6 @@ describe('WidgetChat history conversations', () => {
     expect(wrapper.find('.query-workbench').exists()).toBe(true)
     expect(wrapper.find('.query-sidebar').exists()).toBe(true)
     expect(wrapper.find('.query-main').exists()).toBe(true)
-    expect(wrapper.find('.query-model-selector').text()).toContain('Anthropic Compatible')
     expect(wrapper.find('.query-model-selector').text()).toContain('claude-opus-4-6')
     expect(wrapper.text()).toContain('最近 30 天工作流发布趋势')
     expect(wrapper.text()).toContain('smoke-ok 测试')

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -1130,10 +1130,6 @@ export const WIDGET_STYLES = `
   cursor: not-allowed;
 }
 
-.query-workbench.is-floating .query-composer-toolbar {
-  display: none;
-}
-
 .query-send-btn {
   width: 30px;
   height: 30px;


### PR DESCRIPTION
## 背景

Widget 悬浮聊天(floating)下方看不到**权限模式**和**模型**选择器。这两个控件其实已实现并在 inline 模式可用,但被一条样式规则在 floating 模式下整行隐藏。

## 改动

1. **显示工具栏**:移除 `.query-workbench.is-floating .query-composer-toolbar { display: none }`,让权限模式 / 模型控件在悬浮模式下也可见(与 Chat V2 一致,V2 的 composer 工具栏里这些控件始终可见)。
2. **精简控件**:去掉 provider 选择器,工具栏只保留两个控件 —— **权限模式在左、模型在右**(工具栏本身就是 `space-between`)。模型仍按当前 provider 的可用模型列出。
3. 保持 widget 既有的原生 `<select>` 文字下拉样式,改动最小、无新增组件。
4. 同步更新相关单元测试。

## 验证

- `vitest run src/widget/__tests__/WidgetChat.spec.js` → 24/24 通过。
- 改动主要为 CSS 与模板,未触及发送/流式逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM9vjUJqbsBAsWZMBhKbxL)_