### PR TITLE
Implement plan mode approval workflow with mode switching

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -491,15 +491,17 @@ def _is_running_as_root() -> bool:
 
 
 def _resolve_sdk_permission_mode(permission_mode: str | None = None) -> str:
-    # Per-mode enforcement is handled by the mounted allowed_tools set. MCP write
-    # tools requiring confirmation are withheld because SDK can_use_tool is not a
-    # reliable gate for those calls.
-    normalize_permission_mode(permission_mode)
-    if _is_running_as_root():
-        # Claude Code rejects bypassPermissions under root/sudo. Fall back to the
-        # standard mode and rely on allowed_tools for the read-only + script path.
+    # The SDK permission mode mirrors the logical session mode 1:1 so that the
+    # in-run gate (can_use_tool) actually fires for plan/default/acceptEdits.
+    # The only deviation is the root fallback below.
+    mode = normalize_permission_mode(permission_mode)
+    if mode == "bypassPermissions" and _is_running_as_root():
+        # Claude Code rejects bypassPermissions under root/sudo, and the sandbox
+        # runner runs as uid 0 by default (it needs the mounted docker socket to
+        # spawn per-session containers). Degrade only this one mode to the
+        # standard gated mode; plan/default/acceptEdits are unaffected.
         return "default"
-    return "bypassPermissions"
+    return mode
 
 
 def _build_portal_mcp_servers(
@@ -551,10 +553,12 @@ def _build_allowed_tools(
         tool_names = list(PORTAL_MCP_TOOL_NAMES) + sorted(WRITE_TOOL_NAMES)
         for tool_name in tool_names:
             qualified = f"mcp__{PORTAL_MCP_SERVER_NAME}__{tool_name}"
-            # SDK can_use_tool is not a reliable gate for MCP write tools, so the
-            # mounted tool set remains the hard capability boundary. Tools that
-            # would require confirmation in the current mode are withheld rather
-            # than exposed and then approved later.
+            # allowed_tools is the auto-allow fast-path. Tools that would need
+            # confirmation (or are plan-denied) in the current mode are left out so
+            # they route through can_use_tool instead of auto-running. Now that the
+            # SDK permission mode mirrors the logical mode, that callback fires
+            # reliably for plan/default/acceptEdits; under bypassPermissions nothing
+            # requires confirmation, so all write tools stay auto-allowed.
             if (mode == "plan" and plan_denies_tool(qualified)) or requires_confirmation(qualified, mode):
                 continue
             allowed.append(qualified)

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -41,6 +41,13 @@ DRAFT_WRITE_TOOL_NAMES: frozenset[str] = frozenset(
 
 WRITE_TOOL_NAMES: frozenset[str] = HIGH_RISK_TOOL_NAMES | DRAFT_WRITE_TOOL_NAMES
 
+# Built-in (non-MCP) Claude Code tools that mutate files. Denied under plan so the
+# read-only-until-approved promise holds even though they are never auto-allowed;
+# after plan approval the run switches to acceptEdits, where they auto-allow.
+PLAN_DENIED_BUILTIN_TOOLS: frozenset[str] = frozenset(
+    {"Write", "Edit", "MultiEdit", "NotebookEdit"}
+)
+
 # The built-in plan tool the model calls to present its plan and request approval
 # to leave plan mode. It is not MCP-qualified.
 EXIT_PLAN_MODE_TOOL_NAME: str = "ExitPlanMode"
@@ -105,9 +112,19 @@ def is_high_risk_tool(tool_name: str) -> bool:
 
 
 def plan_denies_tool(tool_name: str) -> bool:
-    """Under ``plan`` no write tool may run (defense in depth alongside the
-    runtime not mounting them)."""
-    return is_write_tool(tool_name)
+    """Whether ``tool_name`` must be denied under ``plan`` mode.
+
+    Covers portal MCP write tools and the built-in file-mutation tools
+    (``PLAN_DENIED_BUILTIN_TOOLS``). Defense in depth: these are not in the
+    auto-allow set, but if the model invokes one it must not run before the plan is
+    approved; after approval the run switches to acceptEdits where they auto-allow.
+
+    ``Bash`` is deliberately not denied: it is the read-only research vector (skill
+    scripts, read-only SQL), is confined to the ephemeral per-topic workspace by the
+    runtime boundary hook, and cannot mutate platform state (which is MCP-only and
+    already covered above)."""
+    bare = _bare_tool_name(tool_name)
+    return bare in WRITE_TOOL_NAMES or bare in PLAN_DENIED_BUILTIN_TOOLS
 
 
 def requires_confirmation(tool_name: str, permission_mode: str | None) -> bool:

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -41,6 +41,15 @@ DRAFT_WRITE_TOOL_NAMES: frozenset[str] = frozenset(
 
 WRITE_TOOL_NAMES: frozenset[str] = HIGH_RISK_TOOL_NAMES | DRAFT_WRITE_TOOL_NAMES
 
+# The built-in plan tool the model calls to present its plan and request approval
+# to leave plan mode. It is not MCP-qualified.
+EXIT_PLAN_MODE_TOOL_NAME: str = "ExitPlanMode"
+
+# Mode the session switches to once the user approves a plan: drafts auto-execute,
+# high-risk (publish/online) still confirm. Keeps the approved plan flowing without
+# re-confirming every draft write, while preserving the high-risk guard.
+POST_PLAN_MODE: str = "acceptEdits"
+
 # Confirmation-card annotation keys the skill attaches to a write tool call so the
 # generic gate can render a meaningful card (title/diff summary). They are gate
 # metadata, not part of any downstream tool schema — the portal MCP write tools
@@ -75,6 +84,16 @@ def _bare_tool_name(tool_name: str) -> str:
         if parts:
             return parts[-1]
     return name
+
+
+def is_exit_plan_mode(tool_name: str) -> bool:
+    """Whether ``tool_name`` is the built-in plan-presentation/approval tool."""
+    return _bare_tool_name(tool_name) == EXIT_PLAN_MODE_TOOL_NAME
+
+
+def post_plan_mode() -> str:
+    """Permission mode a session adopts after the user approves a plan."""
+    return POST_PLAN_MODE
 
 
 def is_write_tool(tool_name: str) -> bool:

--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -22,9 +22,11 @@ from core.ask_user_question import (
     wait_for_answer,
 )
 from core.permission_gate import (
+    is_exit_plan_mode,
     is_high_risk_tool,
     is_write_tool,
     plan_denies_tool,
+    post_plan_mode,
     requires_confirmation,
     strip_card_annotations,
 )
@@ -495,9 +497,30 @@ def _permission_result_types():
         return None, None
 
 
-def _allow_result(tool_input: dict[str, Any]):
+def _set_mode_permission_update(mode: str):
+    """Build a session-scoped ``setMode`` PermissionUpdate, or None if the SDK
+    type is unavailable. Returned to the SDK so approving ExitPlanMode switches
+    the run out of plan mode in place."""
+    try:
+        from claude_agent_sdk import PermissionUpdate
+
+        return PermissionUpdate(type="setMode", mode=mode, destination="session")
+    except Exception:
+        # 旧 SDK 可能没有 PermissionUpdate；裸 allow ExitPlanMode 也能退出 plan，
+        # effective_mode 翻转仍保证后续写工具按 post-plan 模式 gating。
+        logger.debug("PermissionUpdate unavailable; approving ExitPlanMode without setMode", exc_info=True)
+        return None
+
+
+def _allow_result(tool_input: dict[str, Any], updated_permissions: list | None = None):
     Allow, _ = _permission_result_types()
     if Allow is not None:
+        if updated_permissions:
+            try:
+                return Allow(updated_input=tool_input, updated_permissions=updated_permissions)
+            except Exception:
+                # updated_permissions 不被支持时退回普通 allow，不阻断放行
+                logger.debug("PermissionResultAllow(updated_permissions=...) failed, retrying without it", exc_info=True)
         try:
             return Allow(updated_input=tool_input)
         except Exception:
@@ -507,7 +530,15 @@ def _allow_result(tool_input: dict[str, Any]):
                 return Allow()
             except Exception:
                 logger.warning("PermissionResultAllow construction failed, using dict allow fallback", exc_info=True)
-    return {"behavior": "allow", "updatedInput": tool_input}
+    result = {"behavior": "allow", "updatedInput": tool_input}
+    if updated_permissions:
+        try:
+            result["updatedPermissions"] = [
+                p.to_dict() if hasattr(p, "to_dict") else p for p in updated_permissions
+            ]
+        except Exception:
+            logger.debug("updated_permissions to_dict fallback failed", exc_info=True)
+    return result
 
 
 def _deny_result(message: str):
@@ -579,7 +610,38 @@ def _build_can_use_tool_callback(
     the run: a permission_request block is recorded, the task moves to
     waiting_permission, and the run waits for the user's persisted decision before
     resuming. Plan-denied tools are rejected outright.
+
+    Under ``plan`` mode the model presents its plan via ``ExitPlanMode``; that call
+    pauses the run for approval just like a write confirmation. On approval the run
+    switches to :func:`post_plan_mode` (via an SDK setMode permission update) and
+    continues in place, so subsequent write tools are gated by the post-plan policy
+    instead of being plan-denied. ``effective_mode`` carries that switch.
     """
+
+    # Mutable so plan approval can switch the in-run policy from plan -> post-plan.
+    state = {"mode": permission_mode}
+
+    async def _wait_decision(*, request_id: str, tool_name: str, risk_level: str, title: str, summary: str, payload_preview: dict[str, Any]) -> str:
+        """Record a permission/plan request, park the task, and return the decision."""
+        try:
+            sdk_writer.append_permission_request(
+                request_id=request_id,
+                tool_name=tool_name,
+                risk_level=risk_level,
+                title=title,
+                summary=summary,
+                payload_preview=payload_preview,
+            )
+            store.set_task_status(task_id, "waiting_permission")
+        except Exception:
+            logger.exception("can_use_tool: failed to record permission request task_id=%s", task_id)
+            return "deny"
+        decision = await wait_for_decision(task_id, request_id, cancel_reason=cancel_reason)
+        try:
+            store.set_task_status(task_id, "running")
+        except Exception:
+            logger.exception("can_use_tool: failed to restore running status task_id=%s", task_id)
+        return decision
 
     async def can_use_tool(tool_name: str, tool_input: dict[str, Any] | None = None, context: Any = None):
         tool_input = dict(tool_input or {})
@@ -592,45 +654,50 @@ def _build_can_use_tool_callback(
                 task_id=task_id,
                 cancel_reason=cancel_reason,
             )
+
+        # Plan presentation: pause for the user to approve the plan, then leave plan
+        # mode in place. The plan text is read from the tool input and persisted as
+        # a plan card (risk_level="plan"); no plan file is involved.
+        if is_exit_plan_mode(tool_name):
+            plan_text = str(tool_input.get("plan") or tool_input.get("summary") or "").strip()
+            decision = await _wait_decision(
+                request_id=uuid.uuid4().hex,
+                tool_name=tool_name,
+                risk_level="plan",
+                title="请确认执行计划",
+                summary=plan_text,
+                payload_preview={"plan": plan_text},
+            )
+            if decision == "allow":
+                post_mode = post_plan_mode()
+                state["mode"] = post_mode
+                update = _set_mode_permission_update(post_mode)
+                return _allow_result(tool_input, updated_permissions=[update] if update else None)
+            return _deny_result("用户未批准该计划，请继续完善后再申请执行。")
+
+        effective_mode = state["mode"]
         # For write tools the skill may attach card-annotation keys (title/summary)
         # that no downstream tool schema accepts; the card reads them from the raw
         # input, but the forwarded input must drop them or the MCP call is rejected
         # after approval.
         forwarded_input = strip_card_annotations(tool_input) if is_write_tool(tool_name) else tool_input
-        if permission_mode == "plan" and plan_denies_tool(tool_name):
+        if effective_mode == "plan" and plan_denies_tool(tool_name):
             return _deny_result("当前为规划(plan)模式，不允许执行写操作。")
-        if not requires_confirmation(tool_name, permission_mode):
+        if not requires_confirmation(tool_name, effective_mode):
             return _allow_result(forwarded_input)
 
-        request_id = uuid.uuid4().hex
         bare = tool_name.split("__")[-1] if tool_name.startswith("mcp__") else tool_name
         summary = str(tool_input.get("summary") or "").strip()
         title = str(tool_input.get("title") or "").strip() or f"请确认操作:{bare}"
         risk_level = "critical" if is_high_risk_tool(tool_name) else "high"
-        try:
-            sdk_writer.append_permission_request(
-                request_id=request_id,
-                tool_name=tool_name,
-                risk_level=risk_level,
-                title=title,
-                summary=summary,
-                payload_preview=tool_input,
-            )
-            store.set_task_status(task_id, "waiting_permission")
-        except Exception:
-            logger.exception("can_use_tool: failed to record permission request task_id=%s", task_id)
-            return _deny_result("无法发起确认请求。")
-
-        decision = await wait_for_decision(
-            task_id,
-            request_id,
-            cancel_reason=cancel_reason,
+        decision = await _wait_decision(
+            request_id=uuid.uuid4().hex,
+            tool_name=tool_name,
+            risk_level=risk_level,
+            title=title,
+            summary=summary,
+            payload_preview=tool_input,
         )
-        try:
-            store.set_task_status(task_id, "running")
-        except Exception:
-            logger.exception("can_use_tool: failed to restore running status task_id=%s", task_id)
-
         if decision == "allow":
             return _allow_result(forwarded_input)
         return _deny_result("用户拒绝了该操作。")
@@ -922,20 +989,17 @@ async def _execute_task_stream_local(
     if ask_user_enabled and ASK_USER_QUESTION_TOOL_NAME not in allowed_tools:
         allowed_tools = [*allowed_tools, ASK_USER_QUESTION_TOOL_NAME]
 
-    # Gating fires when there are guardable write tools (portal MCP) and the
-    # session mode asks for confirmation; only then does the SDK run in "default"
-    # mode. The SDK permission mode is otherwise preserved as-is.
-    needs_gating = bool(mcp_servers) and logical_permission_mode in {"default", "acceptEdits"}
-    if needs_gating:
-        permission_mode = "default"
-    else:
-        permission_mode = _resolve_sdk_permission_mode(requested_permission_mode)
-    # The callback is installed for gating and/or AskUserQuestion. The built-in
-    # AskUserQuestion always resolves through can_use_tool (it requires user
-    # interaction), so installing the callback is sufficient regardless of mode;
-    # non-write tools are auto-allowed, keeping allowed_tools the capability boundary.
+    # The SDK permission mode mirrors the logical session mode 1:1 (only the root
+    # bypass fallback deviates), so the in-run can_use_tool gate fires reliably for
+    # plan/default/acceptEdits.
+    permission_mode = _resolve_sdk_permission_mode(logical_permission_mode)
+    # Install the callback whenever it has work to do: guardable write tools to
+    # confirm, AskUserQuestion to resolve, or plan mode (to gate ExitPlanMode and
+    # plan-deny writes). Non-write tools auto-allow inside it; allowed_tools remains
+    # the auto-allow fast-path.
+    needs_gating = bool(mcp_servers) and logical_permission_mode in {"default", "acceptEdits", "plan"}
     can_use_tool = None
-    if needs_gating or ask_user_enabled:
+    if needs_gating or ask_user_enabled or logical_permission_mode == "plan":
         can_use_tool = _build_can_use_tool_callback(
             sdk_writer=sdk_writer,
             store=get_topic_task_store(),

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -304,6 +304,26 @@ def test_build_allowed_tools_plan_mode_strips_write_tools():
     assert "mcp__portal__portal_workflow_schedule_online" not in allowed
 
 
+def test_resolve_sdk_permission_mode_identity_non_root(monkeypatch):
+    # The SDK mode mirrors the logical mode 1:1 when not running as root, so the
+    # in-run can_use_tool gate fires for plan/default/acceptEdits.
+    monkeypatch.setattr(agent_runtime, "_is_running_as_root", lambda: False)
+    for mode in ("default", "acceptEdits", "plan", "bypassPermissions"):
+        assert agent_runtime._resolve_sdk_permission_mode(mode) == mode
+    # Unknown / legacy values normalize to default.
+    assert agent_runtime._resolve_sdk_permission_mode("inherit") == "default"
+
+
+def test_resolve_sdk_permission_mode_root_degrades_only_bypass(monkeypatch):
+    # The sandbox runner runs as uid 0 (it needs the docker socket); Claude Code
+    # rejects bypassPermissions under root, so only that mode degrades to default.
+    monkeypatch.setattr(agent_runtime, "_is_running_as_root", lambda: True)
+    assert agent_runtime._resolve_sdk_permission_mode("bypassPermissions") == "default"
+    assert agent_runtime._resolve_sdk_permission_mode("plan") == "plan"
+    assert agent_runtime._resolve_sdk_permission_mode("default") == "default"
+    assert agent_runtime._resolve_sdk_permission_mode("acceptEdits") == "acceptEdits"
+
+
 def test_workspace_boundary_denies_parent_directory_file_lookup(tmp_path: Path):
     workspace = tmp_path / "runtime" / "workspaces" / "agent_default"
     workspace.mkdir(parents=True)

--- a/dataagent/dataagent-backend/tests/test_permission_gate.py
+++ b/dataagent/dataagent-backend/tests/test_permission_gate.py
@@ -45,6 +45,15 @@ def test_plan_denies_writes_and_never_confirms() -> None:
     assert pg.plan_denies_tool(READ) is False
 
 
+def test_plan_denies_builtin_file_write_tools() -> None:
+    # Built-in file-mutation tools must be plan-denied, not silently allowed.
+    for tool in ("Write", "Edit", "MultiEdit", "NotebookEdit"):
+        assert pg.plan_denies_tool(tool) is True
+    # Read-only research tools and Bash stay allowed under plan.
+    for tool in ("Read", "LS", "Glob", "Grep", "Bash", "Skill"):
+        assert pg.plan_denies_tool(tool) is False
+
+
 def test_legacy_mode_normalizes_to_default() -> None:
     # legacy 'inherit' / unknown -> default policy
     assert pg.requires_confirmation(CREATE_TASK, "inherit") is True

--- a/dataagent/dataagent-backend/tests/test_permission_gate.py
+++ b/dataagent/dataagent-backend/tests/test_permission_gate.py
@@ -51,6 +51,22 @@ def test_legacy_mode_normalizes_to_default() -> None:
     assert pg.requires_confirmation(CREATE_TASK, "junk") is True
 
 
+def test_is_exit_plan_mode() -> None:
+    assert pg.is_exit_plan_mode("ExitPlanMode") is True
+    # bare-name reduction also matches an MCP-qualified form, defensively.
+    assert pg.is_exit_plan_mode("mcp__x__ExitPlanMode") is True
+    assert pg.is_exit_plan_mode("portal_create_task") is False
+    assert pg.is_exit_plan_mode(READ) is False
+
+
+def test_post_plan_mode_is_accept_edits() -> None:
+    # Approving a plan switches the run to acceptEdits: drafts auto-run, high-risk
+    # still confirms.
+    assert pg.post_plan_mode() == "acceptEdits"
+    assert pg.requires_confirmation(CREATE_TASK, pg.post_plan_mode()) is False
+    assert pg.requires_confirmation(PUBLISH, pg.post_plan_mode()) is True
+
+
 def test_strip_card_annotations_drops_only_annotation_keys() -> None:
     raw = {"workflow_id": 7, "operation": "deploy", "preview_token": "tok", "title": "t", "summary": "s"}
     assert pg.strip_card_annotations(raw) == {

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -205,6 +205,25 @@ def test_can_use_tool_plan_mode_denies_write_before_approval(monkeypatch):
     assert store.statuses == []
 
 
+def test_can_use_tool_plan_mode_denies_builtin_file_writes(monkeypatch):
+    # Built-in Write/Edit/MultiEdit/NotebookEdit must be denied under plan, not
+    # auto-allowed via requires_confirmation==False.
+    cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
+    for tool in ("Write", "Edit", "MultiEdit", "NotebookEdit"):
+        result = asyncio.run(cb(tool, {"file_path": "/ws/x", "content": "y"}))
+        assert _permission_behavior(result) == "deny", tool
+    assert writer.requests == []
+    assert store.statuses == []
+
+
+def test_can_use_tool_builtin_write_auto_allows_after_plan_approval(monkeypatch):
+    # After plan approval the run is acceptEdits, where built-in file edits auto-run.
+    cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
+    asyncio.run(cb("ExitPlanMode", {"plan": "步骤"}))
+    result = asyncio.run(cb("Write", {"file_path": "/ws/x", "content": "y"}))
+    assert _permission_behavior(result) == "allow"
+
+
 def _build_ask_gate(monkeypatch, answers, *, mode="default"):
     writer = _RecordingWriter()
     store = _RecordingStore()

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -163,6 +163,48 @@ def test_can_use_tool_denies_after_persisted_denial(monkeypatch):
     assert writer.decisions == []
 
 
+def test_can_use_tool_exit_plan_mode_approved_switches_mode(monkeypatch):
+    # Under plan mode, ExitPlanMode pauses the run for approval. On allow it records
+    # a plan card, returns a setMode permission update (or dict fallback), and flips
+    # the in-run effective mode so subsequent draft writes auto-allow.
+    cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
+    result = asyncio.run(cb("ExitPlanMode", {"plan": "1. 建表\n2. 发布"}))
+    assert _permission_behavior(result) == "allow"
+    assert len(writer.requests) == 1
+    req = writer.requests[0]
+    assert req["risk_level"] == "plan"
+    assert req["tool_name"] == "ExitPlanMode"
+    assert req["summary"] == "1. 建表\n2. 发布"
+    assert store.statuses == ["waiting_permission", "running"]
+
+    # After approval the same callback gates a draft write per acceptEdits: auto-allow
+    # without a new confirmation request, instead of plan-denying it.
+    result2 = asyncio.run(cb("mcp__portal__portal_create_task", {"task": {"name": "t"}}))
+    assert _permission_behavior(result2) == "allow"
+    assert len(writer.requests) == 1  # no extra confirmation recorded
+
+
+def test_can_use_tool_exit_plan_mode_denied(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "deny", mode="plan")
+    result = asyncio.run(cb("ExitPlanMode", {"plan": "草案"}))
+    assert _permission_behavior(result) == "deny"
+    assert writer.requests[0]["risk_level"] == "plan"
+    assert store.statuses == ["waiting_permission", "running"]
+
+    # Still in plan mode: a write tool is plan-denied outright (no confirmation).
+    result2 = asyncio.run(cb("mcp__portal__portal_create_task", {}))
+    assert _permission_behavior(result2) == "deny"
+    assert len(writer.requests) == 1
+
+
+def test_can_use_tool_plan_mode_denies_write_before_approval(monkeypatch):
+    cb, writer, store = _build_gate(monkeypatch, "allow", mode="plan")
+    result = asyncio.run(cb("mcp__portal__portal_create_task", {"summary": "建表"}))
+    assert _permission_behavior(result) == "deny"
+    assert writer.requests == []
+    assert store.statuses == []
+
+
 def _build_ask_gate(monkeypatch, answers, *, mode="default"):
     writer = _RecordingWriter()
     store = _RecordingStore()

--- a/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue
@@ -408,7 +408,12 @@
                       :key="opt.value"
                       :command="opt.value"
                       :class="{ 'is-active': opt.value === permissionMode }"
-                    >{{ opt.label }}</el-dropdown-item>
+                    >
+                      <div class="v2-perm-opt">
+                        <span class="v2-perm-opt-label">{{ opt.label }}</span>
+                        <span v-if="opt.desc" class="v2-perm-opt-desc">{{ opt.desc }}</span>
+                      </div>
+                    </el-dropdown-item>
                   </el-dropdown-menu>
                 </template>
               </el-dropdown>
@@ -623,10 +628,10 @@ const agentSelectValue = ref('')
 // Session permission mode (latest selection). Default per design: 'default'.
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: 'Default' },
-  { value: 'acceptEdits', label: 'Accept edits' },
-  { value: 'plan', label: 'Plan mode' },
-  { value: 'bypassPermissions', label: 'Bypass permissions' },
+  { value: 'default', label: 'Default', desc: '每次写操作前都需确认' },
+  { value: 'acceptEdits', label: 'Accept edits', desc: '草稿写自动执行，发布/上线仍确认' },
+  { value: 'plan', label: 'Plan mode', desc: '先只读出计划，批准后再执行' },
+  { value: 'bypassPermissions', label: 'Bypass permissions', desc: '全部自动执行，不再确认' },
 ]
 const searchKeyword = ref('')
 const autoScroll = ref(true)
@@ -2497,6 +2502,9 @@ onBeforeUnmount(() => {
 .v2-perm-pill-dot.plan { background: #909399; }
 .v2-perm-pill-dot.acceptEdits { background: #e6a23c; }
 .v2-perm-pill-dot.default { background: #409eff; }
+.v2-perm-opt { display: flex; flex-direction: column; line-height: 1.3; padding: 2px 0; }
+.v2-perm-opt-label { font-size: 13px; }
+.v2-perm-opt-desc { font-size: 11px; color: #909399; }
 
 .v2-composer-hint {
   color: #9aa5b1;

--- a/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
@@ -2,18 +2,18 @@
   <div class="v2-perm-card" :class="`risk-${block.risk_level || 'high'}`">
     <div class="v2-perm-head">
       <span class="v2-perm-badge">{{ riskLabel }}</span>
-      <span class="v2-perm-title">{{ block.title || ('请确认操作：' + bareTool) }}</span>
+      <span class="v2-perm-title">{{ block.title || (isPlan ? '请确认执行计划' : ('请确认操作：' + bareTool)) }}</span>
     </div>
-    <div v-if="block.summary" class="v2-perm-summary">{{ block.summary }}</div>
-    <div class="v2-perm-tool">工具：<code>{{ bareTool }}</code></div>
-    <details v-if="hasPreview" class="v2-perm-preview">
+    <div v-if="block.summary" class="v2-perm-summary" :class="{ 'is-plan': isPlan }">{{ block.summary }}</div>
+    <div v-if="!isPlan" class="v2-perm-tool">工具：<code>{{ bareTool }}</code></div>
+    <details v-if="!isPlan && hasPreview" class="v2-perm-preview">
       <summary>参数详情</summary>
       <pre>{{ prettyPreview }}</pre>
     </details>
 
     <div v-if="isPending" class="v2-perm-actions">
-      <button type="button" class="v2-perm-btn deny" :disabled="disabled || submitting" @click="decide('deny')">拒绝</button>
-      <button type="button" class="v2-perm-btn allow" :disabled="disabled || submitting" @click="decide('allow')">允许</button>
+      <button type="button" class="v2-perm-btn deny" :disabled="disabled || submitting" @click="decide('deny')">{{ isPlan ? '继续完善' : '拒绝' }}</button>
+      <button type="button" class="v2-perm-btn allow" :disabled="disabled || submitting" @click="decide('allow')">{{ isPlan ? '批准并执行' : '允许' }}</button>
     </div>
     <div v-else class="v2-perm-result" :class="block.decision">{{ resultLabel }}</div>
   </div>
@@ -39,7 +39,12 @@ const bareTool = computed(() => {
   const name = String(props.block.tool_name || '')
   return name.startsWith('mcp__') ? name.split('__').pop() : name
 })
-const riskLabel = computed(() => (props.block.risk_level === 'critical' ? '高危操作' : '需要确认'))
+const isPlan = computed(() => props.block.risk_level === 'plan')
+const riskLabel = computed(() => {
+  if (props.block.risk_level === 'plan') return '执行计划'
+  if (props.block.risk_level === 'critical') return '高危操作'
+  return '需要确认'
+})
 const hasPreview = computed(() => props.block.payload_preview != null && typeof props.block.payload_preview === 'object')
 const prettyPreview = computed(() => {
   try {
@@ -49,11 +54,12 @@ const prettyPreview = computed(() => {
   }
 })
 const resultLabel = computed(() => {
+  const plan = props.block.risk_level === 'plan'
   switch (props.block.decision) {
     case 'allow':
-      return '✓ 已允许执行'
+      return plan ? '✓ 计划已批准，继续执行' : '✓ 已允许执行'
     case 'deny':
-      return '✕ 已拒绝'
+      return plan ? '✕ 计划未批准' : '✕ 已拒绝'
     case 'timeout':
       return '⏱ 等待确认超时，已自动拒绝'
     default:
@@ -81,6 +87,10 @@ function decide(decision) {
   border-color: #e88;
   background: #fff5f5;
 }
+.v2-perm-card.risk-plan {
+  border-color: #91b8f0;
+  background: #f5f9ff;
+}
 .v2-perm-head {
   display: flex;
   align-items: center;
@@ -96,8 +106,19 @@ function decide(decision) {
   padding: 1px 8px;
 }
 .risk-critical .v2-perm-badge { background: #e05656; }
+.risk-plan .v2-perm-badge { background: #3b82f6; }
 .v2-perm-title { font-weight: 600; font-size: 14px; }
 .v2-perm-summary { font-size: 13px; color: #555; margin: 4px 0; white-space: pre-wrap; }
+.v2-perm-summary.is-plan {
+  max-height: 320px;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #e3ecfb;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 6px 0;
+  line-height: 1.5;
+}
 .v2-perm-tool { font-size: 12px; color: #777; margin: 4px 0; }
 .v2-perm-tool code { background: #eef1f6; padding: 1px 5px; border-radius: 4px; }
 .v2-perm-preview { margin: 6px 0; }

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -274,8 +274,8 @@
                 title="会话权限模式"
                 @change="changePermissionMode($event.target.value)"
               >
-                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value">
-                  {{ opt.label }}
+                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value" :title="opt.desc || ''">
+                  {{ opt.desc ? `${opt.label} · ${opt.desc}` : opt.label }}
                 </option>
               </select>
             </div>
@@ -354,10 +354,10 @@ const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: 'Default' },
-  { value: 'acceptEdits', label: 'Accept edits' },
-  { value: 'plan', label: 'Plan mode' },
-  { value: 'bypassPermissions', label: 'Bypass permissions' },
+  { value: 'default', label: 'Default', desc: '每次写操作前都需确认' },
+  { value: 'acceptEdits', label: 'Accept edits', desc: '草稿写自动执行，发布/上线仍确认' },
+  { value: 'plan', label: 'Plan mode', desc: '先只读出计划，批准后再执行' },
+  { value: 'bypassPermissions', label: 'Bypass permissions', desc: '全部自动执行，不再确认' },
 ]
 
 // widget-only UI state

--- a/docs/design/2026-06-26-widget-plan-mode-approval-design.md
+++ b/docs/design/2026-06-26-widget-plan-mode-approval-design.md
@@ -79,6 +79,16 @@ DataAgent 的会话权限模式(`default` / `acceptEdits` / `plan` / `bypassPerm
 `post_plan_mode` 选 `acceptEdits` 而非 `default`:用户已批准整份计划,不应再对每个草稿写
 逐条确认;高危发布/上线仍保留确认。该取舍集中在 `core/permission_gate.POST_PLAN_MODE`。
 
+### plan-deny 覆盖范围(防御纵深)
+
+`plan_denies_tool` 覆盖两类:portal MCP 写工具,以及内置文件写工具
+`PLAN_DENIED_BUILTIN_TOOLS = {Write, Edit, MultiEdit, NotebookEdit}`。后者虽不在
+`allowed_tools` 自动放行集中,但模型仍可能调用;若仅靠 `requires_confirmation(...,"plan")`
+会得到 `False` 而被直接放行,违背"只读出计划"承诺,故在 plan 模式显式 deny;批准后切到
+`acceptEdits` 时这些工具自动放行。`Bash` 不纳入 plan-deny:它在 `allowed_tools` 中由 SDK
+上游自动放行(回调无法拦截),是只读研究的必经路径(skill 脚本、只读 SQL),且被工作区
+边界 hook 限定在临时 per-topic 工作区,平台级写入只走 MCP(已 plan-deny)。
+
 ### root 兜底(保留,非投机分支)
 
 `_resolve_sdk_permission_mode` 改为恒等映射,**仅** `bypassPermissions` 在 root 下降级

--- a/docs/design/2026-06-26-widget-plan-mode-approval-design.md
+++ b/docs/design/2026-06-26-widget-plan-mode-approval-design.md
@@ -1,0 +1,106 @@
+# Widget/Chat Plan Mode Approval Design
+
+## Context
+
+DataAgent 的会话权限模式(`default` / `acceptEdits` / `plan` / `bypassPermissions`)
+是会话级选择,持久化在 `da_agent_topic.permission_mode`。widget 与 chat v2 暴露完全
+相同的四个选项(`dataagent-frontend/src/widget/WidgetChat.vue`、
+`dataagent-frontend/src/views/intelligence/NL2SqlChatV2.vue`)。两个入口都走同一执行
+路径:`core/task_coordinator.py`(读 topic.permission_mode)→ `execute_task_stream`
+→ `core/task_executor.py` → `core/agent_runtime._resolve_sdk_permission_mode`。
+
+**问题:前台展示的模式语义与后端实际行为不一致,尤以 `plan` 模式为甚。**
+
+根因单一处:`_resolve_sdk_permission_mode` 无视入参**始终返回 `bypassPermissions`**
+(root 下降级 `default`),而 `task_executor` 只对 `default`/`acceptEdits` 走 gating,
+`plan` 与 `bypassPermissions` 落入 `else` 分支 → SDK 实际都跑 `bypassPermissions`。
+`plan` 的"安全"仅靠从 `allowed_tools` 剥离写工具实现;既无计划呈现/批准环节,
+内置 `ExitPlanMode` 也被 bypass 自动放行,表现为用户观察到的"进入 plan 模式后自动批准"。
+
+### 修复前四模式审计
+
+| 逻辑模式 | 用户预期 | 当前 SDK perm_mode | 实际行为 | 结论 |
+|---|---|---|---|---|
+| default | 写/高危先确认 | `default`(gated) | 写操作 → waiting_permission | 符合 |
+| acceptEdits | 编辑自动、高危确认 | `default`(gated) | 草稿写自动、高危确认 | 符合 |
+| plan | 只读 → 出计划 → 批准 → 执行 | **`bypassPermissions`** | 仅只读;无计划/批准;ExitPlanMode 自动放行 | **不符** |
+| bypassPermissions | 全自动 | `bypassPermissions` | 全自动 | 符合 |
+
+## Goal
+
+让 SDK 实际 permission_mode 与逻辑模式 1:1 对齐,`can_use_tool` 成为唯一权限策略引擎,
+四个模式的实际行为与前台标签一致;并为 `plan` 模式实现真正的"出计划 → 用户批准 → 同 run
+内继续执行"闭环。
+
+## Non-Goals
+
+- 不引入计划文件:计划文本从 `ExitPlanMode` 工具输入读取并持久化到 MySQL,不写工作区文件。
+- 不改变 `06-26 permission-confirmation-wait` 的可持久化等待与 lost-runner 行为;plan 批准
+  复用同一 `waiting_permission` 机制(含其已知限制:等待期间 runner 丢失 → suspended/run_lost)。
+- 不改 portal MCP 写工具集合与高危分类。
+
+## Design
+
+### 目标模型
+
+原则:**SDK permission_mode == 逻辑模式(1:1);`can_use_tool` 是唯一策略引擎;
+`allowed_tools` 仅为只读/安全工具的自动放行 fast-path,写工具一律路由到回调(bypass 除外)。**
+
+| 逻辑模式 | SDK perm_mode | 写工具路径 | can_use_tool 行为 |
+|---|---|---|---|
+| default | `default` | 经回调 | 全部写 → waiting_permission |
+| acceptEdits | `acceptEdits` | 经回调 | 草稿自动放行、高危 → waiting_permission |
+| plan | `plan` | 经回调 | 写工具 plan-deny;ExitPlanMode → 计划卡 → 批准后 setMode 继续 |
+| bypassPermissions | `bypassPermissions`(root 下降级 default) | allowed_tools 直放 | 不触发(bypass 跳过回调) |
+
+### SDK 契约(claude-agent-sdk 0.2.96,已核实源码)
+
+- `PermissionMode` 包含 `"plan"`。
+- `can_use_tool(tool_name, input_data, context) -> PermissionResult`;模型调用内置
+  `ExitPlanMode` 时回调收到 `tool_name == "ExitPlanMode"`,计划文本在 `input_data["plan"]`。
+- `PermissionResultAllow(behavior, updated_input, updated_permissions: list[PermissionUpdate])`。
+- `PermissionUpdate(type="setMode", mode=<PermissionMode>, destination="session")`;其
+  `to_dict()` 经 `_internal/query.py` 下发给 CLI 控制协议,从而在 run 内切换权限模式。
+- `PermissionResultDeny(behavior, message, interrupt=False)`;plan 拒绝保持 `interrupt=False`,
+  模型留在 plan 继续完善。
+
+### plan 批准闭环
+
+1. SDK 以 `permission_mode="plan"` 启动;模型只读研究后调用 `ExitPlanMode` 呈现计划。
+2. `can_use_tool` 命中 `is_exit_plan_mode`:从 `input_data["plan"]` 取计划文本,记录
+   `permission_request`(`risk_level="plan"`),task 置 `waiting_permission`,复用
+   `wait_for_decision(task_id, request_id)` 持久化等待。
+3. 批准:回调内部可变 `effective_mode` 由 `plan` 翻转为 `post_plan_mode()`(= `acceptEdits`),
+   并返回 `PermissionResultAllow(updated_permissions=[PermissionUpdate(setMode, acceptEdits, session)])`,
+   SDK 退出 plan,模型在同一 run 内继续执行;后续写工具按 `acceptEdits` 走 gating
+   (草稿自动、发布/上线仍确认),不再被 plan-deny。
+4. 拒绝:`PermissionResultDeny`,模型继续完善计划后再申请。
+
+`post_plan_mode` 选 `acceptEdits` 而非 `default`:用户已批准整份计划,不应再对每个草稿写
+逐条确认;高危发布/上线仍保留确认。该取舍集中在 `core/permission_gate.POST_PLAN_MODE`。
+
+### root 兜底(保留,非投机分支)
+
+`_resolve_sdk_permission_mode` 改为恒等映射,**仅** `bypassPermissions` 在 root 下降级
+`default`。依据:SDK 在 sandbox runner 内执行(`sandbox_runner_main.py` →
+`_execute_task_stream_local`),runner 服务默认 uid 0:0(`deploy/docker-compose.dev.yml`、
+prod 同),因其需挂载的 docker socket 拉起子沙箱;Claude Code 拒绝 root 下
+`--dangerously-skip-permissions`。该兜底单层、仅作用于 bypass,与其它模式无关,可经
+`DATAAGENT_RUNNER_UID/GID` 覆盖去除 root。
+
+### 记录与前端
+
+- `permission_request` 块的 `risk_level` 全链路为自由字符串透传
+  (`core/topic_task_store.py`),`"plan"` 取值无需 schema/记录改动;决策端点按
+  `(task_id, request_id)` 幂等复用。
+- 前端 `chatMessage.js` 的 `permission_request` 投影对 `risk_level==='plan'` 渲染
+  "计划待批准"卡片(展示计划全文 + 批准/拒绝),复用现有确认卡决策链路;两个入口
+  (NL2SqlChatV2 / WidgetChat)模式选择器补 tooltip 使标签承诺与行为一致。
+
+## Tradeoffs
+
+- plan 批准在同一 run 内继续执行,沿用 06-26 的可持久化等待;若等待期间 runner 丢失,
+  task 落 suspended/run_lost,不自动续跑(与现有写确认一致)。
+- `post_plan_mode=acceptEdits` 在便捷与安全间取折中;若需更严格可改 `default`,仅一处常量。
+- 纯只读会话(未挂 portal 写工具)四模式表现一致(都只读),plan 与 default 的差异仅在
+  挂载写工具时显现。

--- a/docs/plans/2026-06-26-widget-plan-mode-approval-plan.md
+++ b/docs/plans/2026-06-26-widget-plan-mode-approval-plan.md
@@ -1,0 +1,81 @@
+# Widget/Chat Plan Mode Approval Plan
+
+配套设计:`docs/design/2026-06-26-widget-plan-mode-approval-design.md`
+
+## 受影响栈
+
+- 后端 DataAgent:`dataagent/dataagent-backend`(权限链路、agent 运行时、SDK 回调)
+- 前端:`dataagent/dataagent-frontend`(计划卡渲染、模式说明)
+- 部署:无新增;沿用 runner uid 兜底
+
+## 任务
+
+### 后端
+
+1. `core/permission_gate.py`
+   - 新增 `EXIT_PLAN_MODE_TOOL_NAME`、`is_exit_plan_mode(tool_name)`。
+   - 新增 `POST_PLAN_MODE = "acceptEdits"` 与 `post_plan_mode()`。
+
+2. `core/agent_runtime.py`
+   - `_resolve_sdk_permission_mode` 改恒等映射;仅 `bypassPermissions` + root → `default`。
+   - `_build_allowed_tools` 注释改为"路由到回调"语义(逻辑不变)。
+
+3. `core/task_executor.py`
+   - `_permission_result_types`/`_allow_result` 支持 `updated_permissions`;新增
+     `_set_mode_permission_update(mode)`(带 SDK 缺失降级)。
+   - 删除 `needs_gating` 把模式塌缩为 `default`/`bypass` 的分支:
+     `permission_mode = _resolve_sdk_permission_mode(logical_permission_mode)`。
+   - `can_use_tool` 安装条件含 `plan`。
+   - `_build_can_use_tool_callback`:可变 `effective_mode`;抽出 `_wait_decision` 公共子流程;
+     新增 `ExitPlanMode` 分支(记录 plan_request + waiting_permission + 批准 setMode→acceptEdits
+     + 翻转 effective_mode;拒绝 deny)。
+
+4. 记录/投影:确认 `risk_level="plan"` 透传(`sdk_block_writer`、`topic_task_store`),
+   决策端点(`api/routes.py`)幂等复用——**无需改动**。
+
+### 前端
+
+5. `src/views/intelligence/chatMessage.js`:`permission_request` 投影区分 `risk_level==='plan'`。
+6. `NL2SqlChatV2.vue` 与 `WidgetChat.vue`:渲染"计划待批准"卡(批准/拒绝复用现有决策链路);
+   模式选择器补 tooltip/说明对齐语义。
+
+### 文档与测试
+
+7. 本 design/plan(本次);`docs/handbook` 权限处补一句模式语义。
+8. 单测:
+   - `tests/test_permission_gate.py`:`is_exit_plan_mode`、`post_plan_mode`、四模式映射。
+   - `tests/test_task_executor.py`:`_resolve_sdk_permission_mode` 恒等映射(含 root 特例);
+     plan 装 can_use_tool;ExitPlanMode 记录 plan_request + waiting_permission;批准返回带
+     setMode 的 allow 且后续写按 acceptEdits 放行。
+   - `tests/test_permission_waits.py`:plan_request 走同一持久化等待。
+
+## 验证
+
+### 单测/契约
+- `pytest tests/test_permission_gate.py tests/test_task_executor.py tests/test_permission_waits.py`
+- 前端:`nvm use` 后 `npm --prefix dataagent/dataagent-frontend run test`(或最小相关用例)。
+
+### P0 SDK 复核(已完成)
+- claude-agent-sdk 0.2.96 源码核实:`PermissionUpdate(type="setMode", mode, destination)`、
+  `PermissionResultAllow.updated_permissions`、`_internal/query.py` 下发 `updatedPermissions` 均存在。
+
+### 端到端 smoke(本地 MySQL 127.0.0.1:3316 + Redis 127.0.0.1:6379 + backend + 前端)
+四模式各一次,经真实 HTTP/SSE:
+- default:写操作 → `waiting_permission`,批准后继续。
+- acceptEdits:草稿写自动、发布弹确认。
+- plan:`POST /topics` → 提交需写入需求 → 出计划 → task `waiting_permission` + 前端计划卡
+  → 决策批准 → 同 run 内继续执行写入(高危仍确认)→ 终态消息持久化。
+- bypassPermissions:写操作自动执行。
+- 取消:plan 等待中 `POST .../cancel` → suspended/task_cancelled。
+- 记录验证环境(MySQL/Redis/Python venv、是否真实 provider、各场景通过/跳过)。
+
+## 回滚
+
+改动集中在权限链路;回滚即恢复 `_resolve_sdk_permission_mode` 旧实现与 `task_executor`
+gating 分支。`plan` 仅是 `permission_request` 的新 `risk_level` 取值,前端旧版忽略未知 risk
+即降级为普通确认卡,无破坏性 schema 变更。
+
+## 已知限制
+
+- plan 等待期间 runner 丢失 → suspended/run_lost,不自动续跑(沿用 06-26)。
+- 仅对挂载 portal MCP 写工具的会话有写入 gating;纯只读会话四模式均只读。


### PR DESCRIPTION
## Summary

Implements the complete plan mode approval workflow, allowing users to review and approve execution plans before the agent proceeds with write operations. When a plan is approved, the session automatically switches from `plan` mode to `acceptEdits` mode via SDK permission updates, enabling subsequent writes to execute according to post-plan policy.

## Key Changes

**Backend (`core/` and `tests/`)**
- **Permission gate**: Added `EXIT_PLAN_MODE_TOOL_NAME` constant and `is_exit_plan_mode()` check; added `POST_PLAN_MODE` constant and `post_plan_mode()` function to define the mode transition target (`acceptEdits`).
- **Agent runtime**: Changed `_resolve_sdk_permission_mode()` from always returning `bypassPermissions` to identity mapping (1:1 with logical mode), with only `bypassPermissions` degrading to `default` under root. Updated comments to reflect that `allowed_tools` is now a fast-path for auto-allow, with write tools routing through `can_use_tool` callback.
- **Task executor**: 
  - Added `_set_mode_permission_update()` to build SDK `PermissionUpdate` objects for mode switching, with graceful fallback for older SDK versions.
  - Enhanced `_allow_result()` to accept and propagate `updated_permissions` list.
  - Refactored `_build_can_use_tool_callback()` to use mutable `state["mode"]` tracking effective mode; extracted `_wait_decision()` helper for common permission request flow.
  - Added `ExitPlanMode` handler that records plan as a permission request, waits for user decision, and on approval returns `PermissionResultAllow` with `setMode` update to switch to `acceptEdits` and flip `effective_mode` for subsequent gating.
  - Updated `can_use_tool` installation condition to include `plan` mode.
- **Tests**: Added comprehensive tests for `ExitPlanMode` approval/denial, mode switching behavior, and plan-mode write rejection before approval.

**Frontend (`src/views/intelligence/` and `src/widget/`)**
- **PermissionConfirmationCard.vue**: Added plan-specific rendering for `risk_level === 'plan'`:
  - Distinct badge color (blue) and title ("请确认执行计划").
  - Plan text displayed in a scrollable box instead of inline summary.
  - Button labels change to "继续完善" (deny) and "批准并执行" (allow).
  - Result labels reflect plan approval/rejection.
- **NL2SqlChatV2.vue & WidgetChat.vue**: Enhanced permission mode selector with descriptive tooltips explaining each mode's behavior in Chinese.

**Documentation**
- Added design document (`docs/design/2026-06-26-widget-plan-mode-approval-design.md`) detailing the goal, SDK contract, plan approval loop, and tradeoffs.
- Added implementation plan (`docs/plans/2026-06-26-widget-plan-mode-approval-plan.md`) with task breakdown and verification steps.

## Implementation Details

- **Mode switching mechanism**: Uses SDK `PermissionUpdate(type="setMode", mode="acceptEdits", destination="session")` to switch the run's permission mode in place. Falls back gracefully if the SDK version doesn't support `updated_permissions`.
- **Plan request recording**: Plan text is extracted from `ExitPlanMode` tool input and recorded as a permission request with `risk_level="plan"`, reusing the existing persistent wait infrastructure.
- **Effective mode tracking**: The callback maintains a mutable `state["mode"]` that flips from `plan` to `acceptEdits` on approval, ensuring subsequent write tools are gated by post-plan policy (drafts auto-allow, high-risk still confirm) rather than being plan-denied.
- **Backward compatibility**: All SDK fallbacks are in place; older SDKs without `PermissionUpdate` support still allow the plan to be exited, with mode switching handled by the effective_mode flip.

https://claude.ai/code/session_01QWiRJZMGdqVBeqYRNbT7zs