### PR TITLE
docs(dataagent): reframe plan-mode Bash note as a trust boundary

### DIFF
--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -120,9 +120,13 @@ def plan_denies_tool(tool_name: str) -> bool:
     approved; after approval the run switches to acceptEdits where they auto-allow.
 
     ``Bash`` is deliberately not denied: it is the read-only research vector (skill
-    scripts, read-only SQL), is confined to the ephemeral per-topic workspace by the
-    runtime boundary hook, and cannot mutate platform state (which is MCP-only and
-    already covered above)."""
+    scripts, read-only SQL) and is auto-allowed upstream via ``allowed_tools`` (the
+    callback never sees it), and its filesystem writes are confined to the ephemeral
+    per-topic workspace by the runtime boundary hook. This is an accepted trust
+    boundary, not a hard guarantee: the sandbox forwards DB/portal credentials
+    (``MYSQL_`` / ``DATAAGENT_PORTAL_`` / ``ODW_`` env) into the child, so Bash could
+    in principle reach platform state outside the gated MCP path. Plan mode relies on
+    the model honoring read-only research here rather than on Bash being incapable."""
     bare = _bare_tool_name(tool_name)
     return bare in WRITE_TOOL_NAMES or bare in PLAN_DENIED_BUILTIN_TOOLS
 

--- a/docs/design/2026-06-26-widget-plan-mode-approval-design.md
+++ b/docs/design/2026-06-26-widget-plan-mode-approval-design.md
@@ -86,8 +86,11 @@ DataAgent 的会话权限模式(`default` / `acceptEdits` / `plan` / `bypassPerm
 `allowed_tools` 自动放行集中,但模型仍可能调用;若仅靠 `requires_confirmation(...,"plan")`
 会得到 `False` 而被直接放行,违背"只读出计划"承诺,故在 plan 模式显式 deny;批准后切到
 `acceptEdits` 时这些工具自动放行。`Bash` 不纳入 plan-deny:它在 `allowed_tools` 中由 SDK
-上游自动放行(回调无法拦截),是只读研究的必经路径(skill 脚本、只读 SQL),且被工作区
-边界 hook 限定在临时 per-topic 工作区,平台级写入只走 MCP(已 plan-deny)。
+上游自动放行(回调无法拦截),是只读研究的必经路径(skill 脚本、只读 SQL),文件写入被
+工作区边界 hook 限定在临时 per-topic 工作区。这是一条**可接受的信任边界,而非硬保证**:
+sandbox 会把 DB/portal 凭证(`MYSQL_` / `DATAAGENT_PORTAL_` / `ODW_` 等 env,见
+`sandbox_runner_main.py:_FORWARDED_ENV_PREFIXES`)转发进子进程,Bash 理论上可绕过受控的
+MCP 路径直达平台状态;plan 阶段依赖模型遵守只读研究,而非 Bash 本身不可写。
 
 ### root 兜底(保留,非投机分支)
 


### PR DESCRIPTION
## Summary

Follow-up to #390 addressing a review caveat. The `permission_gate.py` comment claimed Bash "cannot mutate platform state" under plan mode, which is stronger than the code proves: `sandbox_runner_main.py` forwards DB/portal credentials (`MYSQL_` / `DATAAGENT_PORTAL_` / `ODW_` env prefixes) into the sandbox child, so a Bash command could in principle reach platform state outside the gated MCP path.

This reframes the rationale as an **accepted trust boundary** (plan mode relies on the model honoring read-only research) rather than a hard guarantee.

## Changes

- `core/permission_gate.py`: reword the `plan_denies_tool` docstring note about Bash.
- `docs/design/2026-06-26-widget-plan-mode-approval-design.md`: matching update.

Comment/doc only — no logic change, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWiRJZMGdqVBeqYRNbT7zs)_