### PR TITLE
Improve query selector styling and UX

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -271,16 +271,16 @@
                 :value="permissionMode"
                 class="query-model-select query-permission-select"
                 :disabled="isBusy"
-                title="会话权限模式"
+                title="Session permission mode"
                 @change="changePermissionMode($event.target.value)"
               >
                 <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value" :title="opt.desc || ''">
-                  {{ opt.desc ? `${opt.label} · ${opt.desc}` : opt.label }}
+                  {{ opt.label }}
                 </option>
               </select>
             </div>
             <div class="query-model-selector">
-              <select v-model="selectedModel" class="query-model-select" :disabled="!availableModels.length || isBusy" title="切换模型">
+              <select v-model="selectedModel" class="query-model-select" :disabled="!availableModels.length || isBusy" title="Switch model">
                 <option v-for="modelName in availableModels" :key="modelName" :value="modelName">{{ modelName }}</option>
               </select>
             </div>
@@ -354,10 +354,10 @@ const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: 'Default', desc: '每次写操作前都需确认' },
-  { value: 'acceptEdits', label: 'Accept edits', desc: '草稿写自动执行，发布/上线仍确认' },
-  { value: 'plan', label: 'Plan mode', desc: '先只读出计划，批准后再执行' },
-  { value: 'bypassPermissions', label: 'Bypass permissions', desc: '全部自动执行，不再确认' },
+  { value: 'default', label: 'Default', desc: 'Confirm before every write action' },
+  { value: 'acceptEdits', label: 'Accept edits', desc: 'Auto-run draft writes, still confirm publish' },
+  { value: 'plan', label: 'Plan mode', desc: 'Read-only plan first, run after approval' },
+  { value: 'bypassPermissions', label: 'Bypass permissions', desc: 'Auto-run everything, no confirmation' },
 ]
 
 // widget-only UI state

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -274,7 +274,7 @@
                 title="Session permission mode"
                 @change="changePermissionMode($event.target.value)"
               >
-                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value" :title="opt.desc || ''">
+                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value">
                   {{ opt.label }}
                 </option>
               </select>
@@ -354,10 +354,10 @@ const agentName = ref('智能数据助手')
 const suggestions = computed(() => agentPresetQuestions.value.length ? agentPresetQuestions.value : DEFAULT_SUGGESTIONS)
 const permissionMode = ref('default')
 const PERMISSION_MODE_OPTIONS = [
-  { value: 'default', label: 'Default', desc: 'Confirm before every write action' },
-  { value: 'acceptEdits', label: 'Accept edits', desc: 'Auto-run draft writes, still confirm publish' },
-  { value: 'plan', label: 'Plan mode', desc: 'Read-only plan first, run after approval' },
-  { value: 'bypassPermissions', label: 'Bypass permissions', desc: 'Auto-run everything, no confirmation' },
+  { value: 'default', label: 'Default' },
+  { value: 'acceptEdits', label: 'Accept edits' },
+  { value: 'plan', label: 'Plan mode' },
+  { value: 'bypassPermissions', label: 'Bypass permissions' },
 ]
 
 // widget-only UI state

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -1103,26 +1103,53 @@ export const WIDGET_STYLES = `
 }
 
 .query-model-select {
-  height: 24px;
-  padding: 0 6px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: #8a96a6;
+  height: 26px;
+  padding: 0 26px 0 11px;
+  border: 1px solid #e3e7ee;
+  border-radius: 13px;
+  background-color: #f6f7f9;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a96a6' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+  background-size: 10px 10px;
+  color: #5a6573;
   font: inherit;
   font-size: 11px;
+  font-weight: 500;
+  line-height: 24px;
   outline: none;
-  max-width: 120px;
+  max-width: 150px;
   cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  text-overflow: ellipsis;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .query-permission-select {
-  max-width: 92px;
+  max-width: 150px;
+  color: #4f76d6;
+  background-color: #eef3fd;
+  border-color: #d8e3fb;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%234f76d6' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
 }
 
 .query-model-select:hover {
-  background: #eef1f5;
-  color: #4a5568;
+  background-color: #eef1f5;
+  border-color: #d3d9e2;
+  color: #3a4456;
+}
+
+.query-permission-select:hover {
+  background-color: #e3ecfc;
+  border-color: #c4d6f9;
+  color: #3d63c4;
+}
+
+.query-model-select:focus-visible {
+  border-color: #b9c6e8;
+  box-shadow: 0 0 0 2px rgba(79, 118, 214, 0.15);
 }
 
 .query-model-select:disabled {


### PR DESCRIPTION
## Summary
Enhanced the visual design and user experience of the query model and permission mode selectors with improved styling, custom dropdown indicators, and better accessibility features.

## Key Changes
- **Styling improvements for `.query-model-select`:**
  - Increased height from 24px to 26px for better touch targets
  - Added border (1px solid #e3e7ee) and rounded corners (13px)
  - Changed background to light gray (#f6f7f9) with custom SVG dropdown arrow
  - Updated text color to #5a6573 with increased font-weight (500)
  - Added smooth transitions for hover/focus states
  - Removed browser default appearance with `-webkit-appearance` and `-moz-appearance`
  - Increased max-width from 120px to 150px

- **New styling for `.query-permission-select`:**
  - Applied blue color scheme (#4f76d6) with light blue background (#eef3fd)
  - Added custom SVG dropdown arrow matching the blue theme
  - Increased max-width from 92px to 150px
  - Added hover state with darker blue tones

- **Added focus state styling:**
  - New `.query-model-select:focus-visible` rule with border highlight and subtle shadow

- **Added hover state for permission select:**
  - New `.query-permission-select:hover` rule with color and background transitions

- **UI text updates in WidgetChat.vue:**
  - Changed select titles from Chinese to English ("会话权限模式" → "Session permission mode", "切换模型" → "Switch model")
  - Simplified permission mode options by removing description text from display (kept only labels)
  - Removed title attributes from option elements for cleaner markup

## Implementation Details
- Custom dropdown arrows implemented via `background-image` with inline SVG data URIs
- Consistent color palette: neutral gray for model selector, blue for permission selector
- Smooth 0.15s ease transitions for interactive state changes
- Accessibility improvements with focus-visible styling and proper appearance reset

https://claude.ai/code/session_01CH7EFJcYoURr2PAGjJ1Xgd