### PR TITLE
Portal-MCP: stateless mode + version pinning + docs update

### DIFF
--- a/dataagent/portal-mcp/requirements.txt
+++ b/dataagent/portal-mcp/requirements.txt
@@ -1,5 +1,12 @@
-mcp[cli]>=1.0.0
+# mcp / uvicorn are pinned to specific versions so the streamable-HTTP session
+# semantics (stateless_http, connection-close behavior) cannot drift across image
+# rebuilds — an unpinned ">=" let a rebuilt image silently change session-expiry
+# behavior. Versions below are locally verified (portal-mcp test suite green on
+# Python 3.11), not read from the running target image. Only the top-level
+# SDK/server are pinned; transitive deps can still move, so this is not a fully
+# reproducible build (a constraints/lockfile would be a separate change).
+mcp[cli]==1.28.1
 httpx>=0.27.0
-uvicorn[standard]>=0.27.0
+uvicorn[standard]==0.49.0
 pydantic>=2.5.0
 pytest>=8.0.0

--- a/dataagent/portal-mcp/tests/test_app.py
+++ b/dataagent/portal-mcp/tests/test_app.py
@@ -13,7 +13,7 @@ SERVICE_ROOT = Path(__file__).resolve().parents[1]
 if str(SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(SERVICE_ROOT))
 
-from portal_mcp.app import create_app
+from portal_mcp.app import build_mcp_server, create_app
 from portal_mcp.backend_client import BackendApiError
 from portal_mcp.config import Settings
 from portal_mcp.service import PortalToolService
@@ -93,6 +93,15 @@ def test_mcp_path_accepts_valid_frontdoor_token():
     assert response.status_code != 401
 
 
+def test_build_mcp_server_is_stateless():
+    # Stateless mode is what keeps the server from tracking/expiring per-client
+    # sessions: with no server-side session there is no `Mcp-Session-Id` to go
+    # stale, so the `MCP server "portal" session expired` 404/session-invalid path
+    # cannot occur. Assert the flag on the real server object, not via an abstraction.
+    mcp = build_mcp_server(PortalToolService(FakeBackendClient()))
+    assert mcp.settings.stateless_http is True
+
+
 def test_mcp_path_accepts_docker_hostname():
     # Regression: FastMCP 1.x DNS-rebinding protection defaults to
     # localhost-only and returns 421 for Host: portal-mcp:8801.
@@ -101,7 +110,14 @@ def test_mcp_path_accepts_docker_hostname():
     with TestClient(app, base_url="http://portal-mcp:8801") as client:
         response = client.post(
             "/mcp/",
-            headers={"X-Portal-MCP-Token": "portal-token", "Content-Type": "application/json"},
+            headers={
+                "X-Portal-MCP-Token": "portal-token",
+                "Content-Type": "application/json",
+                # Streamable HTTP requires the client to accept both; sending it
+                # makes initialize return 200 so the no-session-id assertion below
+                # is meaningful (a stateful server would emit Mcp-Session-Id here).
+                "Accept": "application/json, text/event-stream",
+            },
             json={
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -116,6 +132,10 @@ def test_mcp_path_accepts_docker_hostname():
 
     assert response.status_code != 421, "MCP server must not reject Docker service hostname"
     assert response.status_code != 401
+    # Stateless server must not hand out a session id on a successful initialize;
+    # if it did, the client could later send a stale id and hit session-expired.
+    assert response.status_code == 200
+    assert "mcp-session-id" not in response.headers
 
 
 @pytest.mark.anyio

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -38,6 +38,15 @@ PORTAL_MCP_MOUNT_PATH=/mcp
 # portal-mcp HTTP 空闲 keep-alive 超时（秒）。uvicorn 默认仅 5s，会在模型思考间隙
 # 关闭 MCP 客户端的空闲连接，导致对话到后面执行工具报 `session expired`。
 # 默认 600，需大于交互 agent run 总超时（360s）。后台重场景可上调。
+# 注意：keepalive 只覆盖 uvicorn 的「空闲连接被关闭」一类，不处理 server 重启/OOM 或
+# MCP SDK 的 session eviction；那几类 keepalive 无效，需靠 portal-mcp 无状态（已固定
+# stateless_http=True 并钉死 mcp/uvicorn 版本，见 dataagent/portal-mcp/requirements.txt）
+# 来消除「服务端 session 过期」路径。
+# 升级 portal-mcp 时注意：latest 是浮动 tag，`docker compose up` 不会自动重拉旧缓存镜像，
+# 需显式 `docker compose pull portal-mcp && docker compose up -d portal-mcp`。
+# 若仍偶发 session expired，先查 portal-mcp 是否在 churn：
+#   docker inspect opendataworks-portal-mcp --format 'RestartCount={{.RestartCount}} OOMKilled={{.State.OOMKilled}}'
+# RestartCount>0 / OOMKilled=true 表示 OOM 在反复重启容器、撕断连接，应调大其资源限制。
 PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS=600
 
 # 平台登录认证（odw-auth）

--- a/docs/design/2026-06-24-portal-mcp-keepalive-session-expired-design.md
+++ b/docs/design/2026-06-24-portal-mcp-keepalive-session-expired-design.md
@@ -29,7 +29,9 @@ MCP server "portal" session expired
 - 无状态模式下每个请求新建一次性 transport（`mcp_session_id=None`），不跟踪、不校验、不淘汰 session，因此**不会**返回 `404 Session not found`。
 - 即便返回 `404`，Python SDK 用的是 `INVALID_REQUEST = -32600`，并非 CLI 路径 M 所需的 `-32001`。
 
-结论：路径 M 不成立；真正触发的是**路径 P（`-32000 Connection closed`）**，即 CLI↔portal-mcp 的连接在工具调用在途/会话存续期间被断开。
+结论（当时）：路径 M 不成立；真正触发的是**路径 P（`-32000 Connection closed`）**，即 CLI↔portal-mcp 的连接在工具调用在途/会话存续期间被断开。
+
+> 校正见文末「更新（2026-06-30）」：keepalive 仅解决路径 P 的「uvicorn 空闲关闭」这一**子情况**；server 重启/OOM、MCP SDK 的 session eviction、以及 Claude CLI 客户端不按规范重连，都会以同一报错复现，且 keepalive 对它们无效。
 
 ### 被验证的服务端缺陷：uvicorn 空闲 keep-alive = 5s
 
@@ -95,3 +97,40 @@ CMD ["uvicorn", "portal_mcp.app:app", "--host", "0.0.0.0", "--port", "8801"]
 - 取值过小仍可能在深会话中复发；过大仅延长失活连接回收时间，对单客户端内部服务影响可忽略。
 - 若上线后仍偶发 `session expired`，下一步排查方向：portal-mcp 进程因 OOM/崩溃触发 `restart: always` 重启导致主通道断开，或标准 GET SSE 通道在重连churn中被撕裂；可结合 portal-mcp 重启计数与 CLI MCP 调试日志定位。
 - 回退：将 Dockerfile `CMD` 恢复为 `["uvicorn", "portal_mcp.app:app", "--host", "0.0.0.0", "--port", "8801"]`，移除 compose 和 `.env.example` 中的 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS` 即可。
+
+## 更新（2026-06-30）：根因校正与范围收窄
+
+### 现场新事实
+
+keepalive=600 已确认在运行容器生效，但在**很小的旧 topic、追问间隔远小于 10 分钟**时仍复发。这与「空闲连接被回收」时序不符，说明本次复发不属于 uvicorn idle close 子情况。
+
+### 校正后的根因（已查证）
+
+`MCP server "portal" session expired` 是 **MCP Streamable HTTP 的已知通用问题**：服务端 session 因①空闲过期、②server 重启/OOM、或③MCP SDK 的 session TTL/eviction 失效后，**Claude Code 的 MCP 客户端不按规范重新握手重连**，直接抛该错。
+
+- MCP 规范（Streamable HTTP transport）要求：客户端收到带 `Mcp-Session-Id` 请求的 404/session 失效时，**MUST** 丢弃旧 session、用不带 session id 的新 `InitializeRequest` 重新握手并重试。
+- 但客户端普遍未实现：官方 `anthropics/claude-code#27142`；同类 `openai/codex#13969`、`danny-avila/LibreChat#11868`；server 端 session TTL 过短见 `Doist/todoist-ai#304`。
+- httpx 社区对同类「连接池僵尸连接」的标准结论（`encode/httpx#2056`）：**重试** 或 **不用连接池/每次新连接**；server 端单纯调大 keepalive 不能根治。
+
+keepalive 仅覆盖①。②③与「客户端不重连」均在 keepalive 之外。
+
+### 范围决策（本次收窄）
+
+真正的「丢弃失效 session→新握手→重试」属于 Claude CLI **客户端行为，不在本仓库可控边界**。若在 dataagent-backend 做「外层重跑整个 turn」兜底，会从 MCP 连接问题扩散到 stream 持久化、前端渲染、权限/副作用判断（需要 deferred terminal、半截工具块清理、写工具门控、fresh accumulator 等一连串补偿逻辑），风险与本问题不成比例。
+
+因此**本次不在 dataagent-backend 做外层 turn retry**，只做低风险主线：
+
+1. **portal-mcp 无状态 + 依赖版本钉死**：`app.py` 已 `stateless_http=True`（无状态 = 不发 `Mcp-Session-Id` = 没有服务端 session 可过期，从源头消除 ②③ 与 404/session-invalid 路径）；将 `requirements.txt` 的 `mcp[cli]`/`uvicorn[standard]` 从 `>=` 钉到具体版本（本地验证 `mcp==1.28.1`、`uvicorn==0.49.0`，非从目标镜像实测），消除镜像重建导致的 session 语义漂移。仅 pin 顶层包，transitive 仍可能变动，非完全可复现构建。
+2. **keepalive 保留**：继续处理 uvicorn idle close（①），默认 600 不变。
+3. **运维/认知文档更正**：`latest` 浮动 tag 升级需显式 `docker compose pull`；keepalive 适用边界；OOM churn 排查；compose `healthcheck` 已存在但只标记健康、`restart: always` 不因「仅 unhealthy」重启，真要自动重启需外部 watchdog（本次不做）。
+
+外层重跑/客户端层重连作为**后续设计项**：若无状态化后仍复发，再单独立项设计。
+
+### 测试与验证
+
+- `pytest dataagent/portal-mcp/tests -q`：新增断言 `build_mcp_server(...).settings.stateless_http is True`，以及成功 `initialize`（200）响应**不含** `mcp-session-id` 头（无状态生效证据）。
+- DataAgent 后端本次无代码改动，仅 docs/static 检查。
+
+### 参考
+
+`anthropics/claude-code#27142`、`openai/codex#13969`、`danny-avila/LibreChat#11868`、`Doist/todoist-ai#304`、`encode/httpx#2056`、modelcontextprotocol.io — Transports。

--- a/docs/plans/2026-06-24-portal-mcp-keepalive-session-expired-plan.md
+++ b/docs/plans/2026-06-24-portal-mcp-keepalive-session-expired-plan.md
@@ -7,28 +7,43 @@
 - DataAgent / portal-mcp（Python，FastMCP + uvicorn）
 - 部署（deploy compose、`.env.example`、Dockerfile）
 
-## 执行步骤
+## 阶段一（2026-06-24，已完成）：keepalive
 
-1. `dataagent/portal-mcp/Dockerfile`
-   - `CMD` 改为 `sh -c` 形式，追加 `--timeout-keep-alive ${PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS:-600}`
-   - 不修改 `config.py` 或 `app.py`
-2. `deploy/docker-compose.dev.yml`、`deploy/docker-compose.prod.yml`
-   - `portal-mcp.environment` 增加 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS: ${PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS:-600}`
+1. `dataagent/portal-mcp/Dockerfile`：`CMD` 改 `sh -c`，追加 `--timeout-keep-alive ${PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS:-600}`。
+2. `deploy/docker-compose.dev.yml`、`prod.yml`：`portal-mcp.environment` 增加 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS`。
+3. `deploy/.env.example`：增加 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS=600` 及说明。
+
+> 该阶段只解决 uvicorn idle close 子情况。现场在 keepalive 已生效、小 topic、短间隔下仍复发，触发下面阶段二的根因校正与范围收窄（详见设计文档「更新（2026-06-30）」）。
+
+## 阶段二（2026-06-30，本次）：无状态固化 + 版本钉死 + 文档更正
+
+范围决策：不在 dataagent-backend 做外层 turn retry（属 Claude CLI 客户端边界，且会扩散到 stream 持久化/前端/副作用判断）。只做低风险主线。
+
+1. `dataagent/portal-mcp/requirements.txt`
+   - `mcp[cli]`、`uvicorn[standard]` 从 `>=` 钉到具体版本（本地验证 `mcp==1.28.1`、`uvicorn==0.49.0`，非从目标镜像实测；仅 pin 顶层，transitive 仍可变，非完全可复现构建）。
+2. `dataagent/portal-mcp/tests/test_app.py`
+   - 新增 `test_build_mcp_server_is_stateless`：断言 `build_mcp_server(PortalToolService(FakeBackendClient())).settings.stateless_http is True`。
+   - 在 `test_mcp_path_accepts_docker_hostname` 的 `initialize` POST 补 `Accept: application/json, text/event-stream`（使其 200），并断言 `"mcp-session-id" not in response.headers`。
 3. `deploy/.env.example`
-   - 增加 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS=600` 及说明
+   - keepalive 注释补充：适用边界（仅 idle close）、`latest` 浮动 tag 升级需 `docker compose pull`、OOM churn 排查命令。
+4. `docs/design/2026-06-24-portal-mcp-keepalive-session-expired-design.md`
+   - 追加「更新（2026-06-30）」：根因校正、范围收窄、明确不做外层 turn retry。
+5. 不做：`Dockerfile` 启动方式、`config.py`/`app.py` 逻辑、`dataagent-backend`（task_executor / sdk_block_writer / accumulator / permission gate）、前端。
 
 ## 验证
 
-- portal-mcp 单元测试：`pytest dataagent/portal-mcp/tests -q`
-- 复现脚本（本地）：默认 keep-alive 空闲 7s 断连；设 600 后空闲 7s/30s 复用成功
-- 文档：设计/计划同 slug、目录与命名符合规范
+- portal-mcp 单元测试：`pytest dataagent/portal-mcp/tests -q`（含 stateless 与无 `mcp-session-id` 头断言）。
+- 阶段一复现脚本（本地）：默认 keep-alive 空闲 7s 断连；设 600 后空闲 7s/30s 复用成功。
+- DataAgent 后端本次无代码改动，仅 docs/static 检查（同 slug 设计/计划目录与命名一致）。
+- 端到端 smoke（可选）：同一 topic 连续两轮真实 NL2SQL，观察是否仍复发；若复发，据此立「外层重试/客户端层」后续设计项。
 
 ## 回退
 
-- 还原 `Dockerfile` 的 `CMD` 为 `["uvicorn", "portal_mcp.app:app", "--host", "0.0.0.0", "--port", "8801"]`
-- 移除 compose 和 `.env.example` 中的 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS`
+- 阶段二：`requirements.txt` 版本回 `>=`；`test_app.py` 新断言、docs/.env 注释为低风险项，可独立保留或回退。
+- 阶段一：还原 `Dockerfile` 的 `CMD` 为 `["uvicorn", "portal_mcp.app:app", "--host", "0.0.0.0", "--port", "8801"]`，移除 compose/.env 中的 `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS`。
 
 ## 备注
 
-- 默认 600s 的取值依据见设计文档“超时链分析”（≥ 交互 run 总超时 360s）。
-- 本变更不触碰 CLI、权限门与技能链路；CLI→portal-mcp 为容器内直连，不涉及反向代理超时。
+- 默认 600s 取值依据见设计文档「超时链分析」（≥ 交互 run 总超时 360s）。
+- 真正的「丢弃失效 session→新握手→重试」属 Claude CLI 客户端边界，本次不做外层重跑；复发再单独设计。
+- 参考：`anthropics/claude-code#27142`、`openai/codex#13969`、`danny-avila/LibreChat#11868`、`Doist/todoist-ai#304`、`encode/httpx#2056`、modelcontextprotocol.io — Transports。


### PR DESCRIPTION
## Summary

This PR hardens portal-mcp against session expiry issues by enforcing stateless HTTP mode, pinning critical dependencies to verified versions, and updating documentation with root cause analysis and operational guidance.

## Key Changes

### Code Changes
- **`dataagent/portal-mcp/requirements.txt`**: Pin `mcp[cli]` to `==1.28.1` and `uvicorn[standard]` to `==0.49.0` (previously `>=`). Added detailed comments explaining why pinning prevents session semantics drift across image rebuilds.
- **`dataagent/portal-mcp/tests/test_app.py`**: 
  - New test `test_build_mcp_server_is_stateless()` asserts that `build_mcp_server(...).settings.stateless_http is True`, ensuring the server never issues `Mcp-Session-Id` headers.
  - Enhanced `test_mcp_path_accepts_docker_hostname()` to send `Accept: application/json, text/event-stream` header (required by Streamable HTTP spec) and assert response status is 200 with no `mcp-session-id` header present.

### Documentation Updates
- **`deploy/.env.example`**: Expanded `PORTAL_MCP_KEEPALIVE_TIMEOUT_SECONDS` comments with:
  - Clarification that keepalive only addresses uvicorn idle close, not server restarts/OOM or MCP SDK session eviction
  - Warning that `latest` image tag requires explicit `docker compose pull` to take effect
  - OOM churn diagnostic command for troubleshooting persistent session expiry
- **`docs/plans/2026-06-24-portal-mcp-keepalive-session-expired-plan.md`**: Restructured into two phases:
  - Phase 1 (completed): keepalive timeout configuration
  - Phase 2 (this PR): stateless mode enforcement + version pinning + documentation corrections
  - Added rationale for not implementing outer-layer turn retry in dataagent-backend (out of scope for client-side MCP reconnection issues)
- **`docs/design/2026-06-24-portal-mcp-keepalive-session-expired-design.md`**: Added "Update (2026-06-30)" section documenting:
  - Root cause correction: keepalive only fixes uvicorn idle close; session expiry also occurs from server restarts, OOM, and MCP SDK eviction
  - Why stateless mode (`stateless_http=True`) eliminates the server-side session expiry path entirely
  - Scope decision: deferring outer-layer retry to future design work due to complexity and risk

## Implementation Details

- Stateless HTTP mode means the server never creates or tracks per-client sessions, so there is no `Mcp-Session-Id` to go stale and no 404/session-invalid error path.
- Version pinning is applied only to top-level packages; transitive dependencies may still vary (full reproducibility would require a lockfile, deferred as separate work).
- No changes to dataagent-backend logic, config.py, or app.py—the stateless setting was already in place.
- Tests verify both the stateless flag and the absence of session ID headers in successful responses.

https://claude.ai/code/session_01AzLGmBL8m93BaMG94dpaR7