### PR TITLE
Enable sandbox container mode by default in offline packages

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -101,6 +101,9 @@ DATAAGENT_RUNNER_GID=0
 #     compose 前统一展开成宿主机绝对路径，保证 backend 卷挂载与 sandbox runner 反查的
 #     child bind 源指向同一目录。若不经 start.sh 直接运行 compose，请填写绝对路径。
 DATAAGENT_HOST_ROOT=/dataagent_runtime
+# Sandbox 模式：留空表示 backend 进程内直接执行（源码/开发部署默认）；置为 container
+# 时 backend 把每个 task 流式委托给 sandbox runner，由 runner 启动独立 child 容器执行。
+# 离线包默认改写为 container（见 scripts/create-offline-package.sh）。
 DATAAGENT_SANDBOX_MODE=
 DATAAGENT_SANDBOX_BACKEND=docker
 DATAAGENT_DOCKER_SOCKET=/var/run/docker.sock

--- a/scripts/create-offline-package.sh
+++ b/scripts/create-offline-package.sh
@@ -236,6 +236,8 @@ rewrite_offline_env_file() {
         -e "s|^OPENDATAWORKS_PORTAL_MCP_IMAGE=.*|OPENDATAWORKS_PORTAL_MCP_IMAGE=opendataworks-portal-mcp:${PARSER_TAG}|" \
         -e "s|^DATAAGENT_LLM_JSON_FILE=.*|DATAAGENT_LLM_JSON_FILE=./dataagent-runtime/settings.json|" \
         -e "s|^DATAAGENT_SKILLS_DIR=.*|DATAAGENT_SKILLS_DIR=./dataagent-runtime/skills|" \
+        -e "s|^# *DATAAGENT_SANDBOX_MODE=.*|DATAAGENT_SANDBOX_MODE=container|" \
+        -e "s|^DATAAGENT_SANDBOX_MODE=.*|DATAAGENT_SANDBOX_MODE=container|" \
         "$env_file" > "${env_file}.tmp" && mv "${env_file}.tmp" "$env_file"
 
     grep -q '^OPENDATAWORKS_BACKEND_IMAGE=' "$env_file" 2>/dev/null || \
@@ -258,6 +260,10 @@ rewrite_offline_env_file() {
         echo "DATAAGENT_LLM_JSON_FILE=./dataagent-runtime/settings.json" >> "$env_file"
     grep -q '^DATAAGENT_SKILLS_DIR=' "$env_file" 2>/dev/null || \
         echo "DATAAGENT_SKILLS_DIR=./dataagent-runtime/skills" >> "$env_file"
+    # 离线包默认开启 sandbox 容器模式（每个 task 由 sandbox runner 启动独立 child 容器执行），
+    # 源码部署仍以 .env.example 中的空值（关闭）为默认，二者不混淆。
+    grep -q '^DATAAGENT_SANDBOX_MODE=' "$env_file" 2>/dev/null || \
+        echo "DATAAGENT_SANDBOX_MODE=container" >> "$env_file"
 }
 
 rewrite_offline_env_file "$PACKAGED_DEPLOY_DIR/.env"


### PR DESCRIPTION
## Summary
Configure offline packages to use sandbox container mode by default for DataAgent task execution, while maintaining backward compatibility with source code deployments.

## Changes
- **scripts/create-offline-package.sh**: Updated `rewrite_offline_env_file()` to set `DATAAGENT_SANDBOX_MODE=container` in offline package `.env` files
  - Added sed patterns to handle both commented and uncommented existing values
  - Added logic to append the setting if not already present
  - Included explanatory comments distinguishing offline package behavior from source deployments

- **deploy/.env.example**: Added documentation for `DATAAGENT_SANDBOX_MODE` configuration
  - Clarified that empty value (default for source/dev deployments) executes tasks in-process
  - Documented that `container` mode delegates tasks to sandbox runner for isolated execution
  - Noted that offline packages override this to `container` mode

## Implementation Details
The offline package generation now ensures sandbox container mode is enabled by default, where each task is executed in an isolated child container via the sandbox runner. Source code deployments retain the original behavior (in-process execution) as specified in `.env.example`, preventing unintended mode mixing between deployment types.

https://claude.ai/code/session_01FFVm9PCj1AQdFzY6dZBtuk