### PR TITLE
Replace native select dropdowns with custom styled components

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -267,22 +267,54 @@
           <!-- Toolbar row -->
           <div class="query-composer-toolbar">
             <div class="query-composer-toolbar-left">
-              <select
-                :value="permissionMode"
-                class="query-model-select query-permission-select"
-                :disabled="isBusy"
-                title="Session permission mode"
-                @change="changePermissionMode($event.target.value)"
-              >
-                <option v-for="opt in PERMISSION_MODE_OPTIONS" :key="opt.value" :value="opt.value">
-                  {{ opt.label }}
-                </option>
-              </select>
+              <div ref="permissionDropdownRef" class="query-dropdown" :class="{ 'is-open': permissionMenuOpen }">
+                <button
+                  type="button"
+                  class="query-dropdown-trigger query-permission-select"
+                  :disabled="isBusy"
+                  title="Session permission mode"
+                  @click="togglePermissionMenu"
+                >
+                  <span class="query-dropdown-trigger-label">{{ permissionModeLabel }}</span>
+                  <svg class="query-dropdown-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="10" height="10"><polyline points="6 9 12 15 18 9" /></svg>
+                </button>
+                <div v-if="permissionMenuOpen" class="query-dropdown-menu">
+                  <button
+                    v-for="opt in PERMISSION_MODE_OPTIONS"
+                    :key="opt.value"
+                    type="button"
+                    class="query-dropdown-item"
+                    :class="{ 'is-active': opt.value === permissionMode }"
+                    @click="selectPermissionMode(opt.value)"
+                  >
+                    {{ opt.label }}
+                  </button>
+                </div>
+              </div>
             </div>
-            <div class="query-model-selector">
-              <select v-model="selectedModel" class="query-model-select" :disabled="!availableModels.length || isBusy" title="Switch model">
-                <option v-for="modelName in availableModels" :key="modelName" :value="modelName">{{ modelName }}</option>
-              </select>
+            <div ref="modelDropdownRef" class="query-model-selector query-dropdown" :class="{ 'is-open': modelMenuOpen }">
+              <button
+                type="button"
+                class="query-dropdown-trigger query-model-select"
+                :disabled="!availableModels.length || isBusy"
+                title="Switch model"
+                @click="toggleModelMenu"
+              >
+                <span class="query-dropdown-trigger-label">{{ selectedModel }}</span>
+                <svg class="query-dropdown-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" width="10" height="10"><polyline points="6 9 12 15 18 9" /></svg>
+              </button>
+              <div v-if="modelMenuOpen" class="query-dropdown-menu query-dropdown-menu-right">
+                <button
+                  v-for="modelName in availableModels"
+                  :key="modelName"
+                  type="button"
+                  class="query-dropdown-item"
+                  :class="{ 'is-active': modelName === selectedModel }"
+                  @click="selectModelOption(modelName)"
+                >
+                  {{ modelName }}
+                </button>
+              </div>
             </div>
           </div>
 
@@ -359,6 +391,45 @@ const PERMISSION_MODE_OPTIONS = [
   { value: 'plan', label: 'Plan mode' },
   { value: 'bypassPermissions', label: 'Bypass permissions' },
 ]
+const permissionModeLabel = computed(() => (
+  PERMISSION_MODE_OPTIONS.find((opt) => opt.value === permissionMode.value)?.label || 'Default'
+))
+
+// Composer toolbar dropdowns (permission mode + model). Plain buttons/menus
+// instead of native <select> so the closed/expanded look can be fully styled
+// (native select popups ignore most author styles across browsers).
+const permissionMenuOpen = ref(false)
+const modelMenuOpen = ref(false)
+const permissionDropdownRef = ref(null)
+const modelDropdownRef = ref(null)
+
+const togglePermissionMenu = () => {
+  if (isBusy.value) return
+  modelMenuOpen.value = false
+  permissionMenuOpen.value = !permissionMenuOpen.value
+}
+const toggleModelMenu = () => {
+  if (!availableModels.value.length || isBusy.value) return
+  permissionMenuOpen.value = false
+  modelMenuOpen.value = !modelMenuOpen.value
+}
+const selectPermissionMode = (value) => {
+  permissionMenuOpen.value = false
+  void changePermissionMode(value)
+}
+const selectModelOption = (modelName) => {
+  modelMenuOpen.value = false
+  selectedModel.value = modelName
+}
+const handleToolbarDropdownOutsideClick = (event) => {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : []
+  if (permissionMenuOpen.value && permissionDropdownRef.value && !path.includes(permissionDropdownRef.value)) {
+    permissionMenuOpen.value = false
+  }
+  if (modelMenuOpen.value && modelDropdownRef.value && !path.includes(modelDropdownRef.value)) {
+    modelMenuOpen.value = false
+  }
+}
 
 // widget-only UI state
 const inputSource = ref('typed')
@@ -889,6 +960,7 @@ watch(
 )
 
 onMounted(async () => {
+  document.addEventListener('click', handleToolbarDropdownOutsideClick, true)
   await loadConfig()
   if (agentId.value && agentId.value !== 'demo') {
     try {
@@ -905,6 +977,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  document.removeEventListener('click', handleToolbarDropdownOutsideClick, true)
   stopTopicStatusRefresh()
   if (copyNoticeTimer) window.clearTimeout(copyNoticeTimer)
   abortController.value?.abort()

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -94,6 +94,13 @@ const messagePage = (topicId, text) => ({
   ]
 })
 
+async function choosePermissionMode(wrapper, label) {
+  await wrapper.get('.query-permission-select').trigger('click')
+  const item = wrapper.findAll('.query-dropdown-item').find((el) => el.text() === label)
+  if (!item) throw new Error(`permission mode option not found: ${label}`)
+  await item.trigger('click')
+}
+
 function mountChat(options = {}) {
   const state = reactive({
     historyOpen: false,
@@ -407,7 +414,7 @@ describe('WidgetChat history conversations', () => {
     const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
     await flushPromises()
 
-    await wrapper.get('.query-permission-select').setValue('plan')
+    await choosePermissionMode(wrapper, 'Plan mode')
     await wrapper.get('textarea').setValue('只做规划')
     await wrapper.get('form').trigger('submit')
     await flushPromises()
@@ -425,7 +432,7 @@ describe('WidgetChat history conversations', () => {
 
     await wrapper.get('[data-testid="history-topic-topic-1"]').trigger('click')
     await flushPromises()
-    await wrapper.get('.query-permission-select').setValue('acceptEdits')
+    await choosePermissionMode(wrapper, 'Accept edits')
     await flushPromises()
 
     expect(apiMocks.topicApi.updateTopic).toHaveBeenCalledWith('topic-1', { permission_mode: 'acceptEdits' })

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -1102,52 +1102,106 @@ export const WIDGET_STYLES = `
   min-width: 0;
 }
 
-.query-model-select {
+.query-dropdown {
+  position: relative;
+}
+
+.query-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   height: 24px;
-  padding: 0 20px 0 8px;
+  max-width: 150px;
+  padding: 0 8px;
   border: none;
   border-radius: 6px;
   background-color: transparent;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a96a6' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 5px center;
-  background-size: 10px 10px;
   color: #8a96a6;
   font: inherit;
   font-size: 12px;
   font-weight: 500;
   line-height: 24px;
   outline: none;
-  max-width: 150px;
   cursor: pointer;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  text-overflow: ellipsis;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.query-model-select option {
-  background-color: #ffffff;
-  color: #1f2937;
+.query-dropdown-trigger-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.query-permission-select {
-  max-width: 150px;
+.query-dropdown-caret {
+  flex: none;
+  transition: transform 0.15s ease;
 }
 
-.query-model-select:hover {
+.query-dropdown.is-open .query-dropdown-caret {
+  transform: rotate(180deg);
+}
+
+.query-dropdown-trigger:hover,
+.query-dropdown.is-open .query-dropdown-trigger {
   background-color: #eef1f5;
   color: #4a5568;
 }
 
-.query-model-select:focus-visible {
+.query-dropdown-trigger:focus-visible {
   box-shadow: 0 0 0 2px rgba(79, 118, 214, 0.15);
 }
 
-.query-model-select:disabled {
+.query-dropdown-trigger:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.query-dropdown-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  min-width: 100%;
+  max-width: 220px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 4px;
+  border-radius: 10px;
+  background-color: #ffffff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14), 0 0 0 1px rgba(15, 23, 42, 0.06);
+}
+
+.query-dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+
+.query-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 6px;
+  background-color: transparent;
+  color: #374151;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.query-dropdown-item:hover {
+  background-color: #f3f5f8;
+}
+
+.query-dropdown-item.is-active {
+  background-color: #eef3fd;
+  color: #4f76d6;
+  font-weight: 600;
 }
 
 .query-send-btn {

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -1103,18 +1103,18 @@ export const WIDGET_STYLES = `
 }
 
 .query-model-select {
-  height: 26px;
-  padding: 0 26px 0 11px;
-  border: 1px solid #e3e7ee;
-  border-radius: 13px;
-  background-color: #f6f7f9;
+  height: 24px;
+  padding: 0 20px 0 8px;
+  border: none;
+  border-radius: 6px;
+  background-color: transparent;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a96a6' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 9px center;
+  background-position: right 5px center;
   background-size: 10px 10px;
-  color: #5a6573;
+  color: #8a96a6;
   font: inherit;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 24px;
   outline: none;
@@ -1124,31 +1124,24 @@ export const WIDGET_STYLES = `
   -moz-appearance: none;
   appearance: none;
   text-overflow: ellipsis;
-  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.query-model-select option {
+  background-color: #ffffff;
+  color: #1f2937;
 }
 
 .query-permission-select {
   max-width: 150px;
-  color: #4f76d6;
-  background-color: #eef3fd;
-  border-color: #d8e3fb;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%234f76d6' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
 }
 
 .query-model-select:hover {
   background-color: #eef1f5;
-  border-color: #d3d9e2;
-  color: #3a4456;
-}
-
-.query-permission-select:hover {
-  background-color: #e3ecfc;
-  border-color: #c4d6f9;
-  color: #3d63c4;
+  color: #4a5568;
 }
 
 .query-model-select:focus-visible {
-  border-color: #b9c6e8;
   box-shadow: 0 0 0 2px rgba(79, 118, 214, 0.15);
 }
 


### PR DESCRIPTION
## Summary
Replaced native HTML `<select>` elements in the composer toolbar with custom button-based dropdown components to enable full styling control across all browsers. Native select elements ignore most CSS styling for their popup menus, limiting design consistency.

## Key Changes
- **Styles** (`styles.js`):
  - Removed `.query-model-select` and `.query-permission-select` native select styles
  - Added new custom dropdown component styles:
    - `.query-dropdown` - container with position management
    - `.query-dropdown-trigger` - styled button replacing select element
    - `.query-dropdown-caret` - animated chevron icon
    - `.query-dropdown-menu` - positioned popup menu with shadow
    - `.query-dropdown-item` - individual menu items with hover/active states
  - Implemented smooth transitions and hover effects for better UX

- **Component** (`WidgetChat.vue`):
  - Converted permission mode selector from `<select>` to custom dropdown with button trigger
  - Converted model selector from `<select>` to custom dropdown with button trigger
  - Added state management for dropdown open/closed states (`permissionMenuOpen`, `modelMenuOpen`)
  - Implemented toggle functions and selection handlers for both dropdowns
  - Added outside-click detection to close dropdowns when clicking elsewhere
  - Added computed property `permissionModeLabel` to display current permission mode label

- **Tests** (`WidgetChat.spec.js`):
  - Added `choosePermissionMode()` helper function to interact with new permission dropdown in tests
  - Updated existing tests to use new helper instead of direct `setValue()` calls

## Implementation Details
- Dropdowns use Vue refs for DOM access and outside-click detection
- Menu positioning uses `position: absolute` with `bottom: calc(100% + 6px)` for upward expansion
- Model dropdown menu aligns right (`query-dropdown-menu-right`) while permission dropdown aligns left
- Active menu items are highlighted with blue background and bold text
- Caret icon rotates 180° when dropdown is open
- Both dropdowns close when the other opens (mutually exclusive)

https://claude.ai/code/session_017A6V77ah8f15QdpdXdSQ8W