### PR TITLE
Preserve workflow binding in agent-driven task updates

### DIFF
--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTaskService.java
@@ -40,6 +40,19 @@ public class BackendAgentTaskService implements AgentTaskService {
     public Object updateTask(Long taskId, AgentTaskUpsertRequest request, String operator) {
         DataTask task = toTask(request);
         task.setId(taskId);
+        // DataTask.workflowId is a relation-management field, not a persisted
+        // column: DataTaskService.update() treats a null value as "detach the
+        // task from its workflow". The agent write contract only documents task
+        // fields (see opendataworks-data-dev skill), so agent payloads never
+        // include workflowId; without this, every agent-driven update silently
+        // dropped the task's workflow binding. Preserve the current binding
+        // unless the caller explicitly sets workflowId (including to null).
+        if (!request.getTask().containsKey("workflowId")) {
+            DataTask existing = dataTaskService.getById(taskId);
+            if (existing != null) {
+                task.setWorkflowId(existing.getWorkflowId());
+            }
+        }
         validateDataScope(task);
         applyAuditDefaults(task, operator, false);
         return dataTaskService.update(task, nullSafe(request.getInputTableIds()), nullSafe(request.getOutputTableIds()));

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTaskServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTaskServiceTest.java
@@ -1,17 +1,26 @@
 package com.onedata.portal.agentapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentTaskUpsertRequest;
 import com.onedata.portal.agentapi.service.BackendAgentTaskService;
 import com.onedata.portal.entity.DataTask;
 import com.onedata.portal.exception.BusinessException;
 import com.onedata.portal.service.DataTaskService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,5 +51,38 @@ class BackendAgentTaskServiceTest {
         when(dataTaskService.getById(999L)).thenReturn(null);
 
         assertThrows(BusinessException.class, () -> service().getTask(999L));
+    }
+
+    @Test
+    void updateTaskPreservesExistingWorkflowBindingWhenOmitted() {
+        DataTask existing = new DataTask();
+        existing.setId(7L);
+        existing.setWorkflowId(42L);
+        when(dataTaskService.getById(7L)).thenReturn(existing);
+
+        Map<String, Object> taskFields = new LinkedHashMap<>();
+        taskFields.put("taskName", "renamed-task");
+        AgentTaskUpsertRequest request = new AgentTaskUpsertRequest();
+        request.setTask(taskFields);
+
+        service().updateTask(7L, request, "agent-operator");
+
+        ArgumentCaptor<DataTask> captor = ArgumentCaptor.forClass(DataTask.class);
+        verify(dataTaskService).update(captor.capture(), any(), any());
+        assertEquals(42L, captor.getValue().getWorkflowId());
+    }
+
+    @Test
+    void updateTaskHonorsExplicitWorkflowIdWhenProvided() {
+        Map<String, Object> taskFields = new LinkedHashMap<>();
+        taskFields.put("workflowId", null);
+        AgentTaskUpsertRequest request = new AgentTaskUpsertRequest();
+        request.setTask(taskFields);
+
+        service().updateTask(7L, request, "agent-operator");
+
+        ArgumentCaptor<DataTask> captor = ArgumentCaptor.forClass(DataTask.class);
+        verify(dataTaskService).update(captor.capture(), any(), any());
+        assertNull(captor.getValue().getWorkflowId());
     }
 }


### PR DESCRIPTION
## Summary
Fixed a bug where agent-driven task updates were silently dropping the task's workflow binding. The agent API contract doesn't include `workflowId` in payloads, but the update logic was treating missing `workflowId` as an explicit null, causing unintended detachment from workflows.

## Changes
- **BackendAgentTaskService.updateTask()**: Added logic to preserve the existing `workflowId` when it's not explicitly provided in the request. The fix checks if `workflowId` is present in the request payload; if absent, it fetches the existing task and retains its current workflow binding.
- **BackendAgentTaskServiceTest**: Added two test cases:
  - `updateTaskPreservesExistingWorkflowBindingWhenOmitted()`: Verifies that workflow binding is preserved when `workflowId` is not in the request
  - `updateTaskHonorsExplicitWorkflowIdWhenProvided()`: Verifies that explicit `workflowId` values (including null) are still honored when provided

## Implementation Details
The fix distinguishes between "field not provided" (preserve existing) and "field explicitly set to null" (detach from workflow) by checking `request.getTask().containsKey("workflowId")`. This respects the agent write contract which only documents task fields and never includes `workflowId`.

https://claude.ai/code/session_01W15Rp5zHrRvsHwz8w5J9ev