### PR TITLE
feat(dataagent-auth): align OAuth providers with Superset

### DIFF
--- a/dataagent/dataagent-backend/api/auth_routes.py
+++ b/dataagent/dataagent-backend/api/auth_routes.py
@@ -79,10 +79,17 @@ def _clear_session_cookie(response: Response) -> None:
 async def auth_config():
     cfg = get_auth_settings()
     if not cfg.enabled:
-        return {"enabled": False, "provider_name": "", "local_login_enabled": False, "oauth_login_enabled": False}
+        return {
+            "enabled": False,
+            "provider_name": "",
+            "provider_icon": "",
+            "local_login_enabled": False,
+            "oauth_login_enabled": False,
+        }
     return {
         "enabled": True,
         "provider_name": cfg.oauth.provider_name if cfg.oauth_login_enabled else "",
+        "provider_icon": cfg.oauth.icon if cfg.oauth_login_enabled else "",
         "local_login_enabled": cfg.local_login_enabled,
         "oauth_login_enabled": cfg.oauth_login_enabled,
     }

--- a/dataagent/dataagent-backend/core/auth.py
+++ b/dataagent/dataagent-backend/core/auth.py
@@ -1,7 +1,7 @@
 """DataAgent 外置配置加载 + 认证核心（会话 JWT、身份解析与管理员门禁）。
 
 配置来自 env ``DATAAGENT_CONFIG`` 指向的宿主机挂载 Python 文件
-（Superset ``superset_config.py`` 模式）。除认证（AUTH_* / OAUTH / LOCAL_ADMINS /
+（Superset ``superset_config.py`` 模式）。除认证（AUTH_* / OAUTH_PROVIDERS / LOCAL_ADMINS /
 ADMIN_USERS）外，也可通过 ``DATAAGENT_SETTINGS`` 字典覆盖运行时 Settings
 （config.py 中的字段，如超时/并发档位），main 启动时统一应用。
 
@@ -57,6 +57,7 @@ class AuthConfigError(RuntimeError):
 @dataclass
 class OAuthSettings:
     provider_name: str = "SSO"
+    icon: str = ""
     client_id: str = ""
     client_secret: str = ""
     authorize_url: str = ""
@@ -152,34 +153,68 @@ def _parse_local_admins(raw: Any) -> list[dict[str, str]]:
     return admins
 
 
-def _parse_oauth(raw: Any) -> OAuthSettings:
+def _parse_oauth_providers(raw: Any) -> OAuthSettings:
     if raw is None:
         return OAuthSettings()
-    if not isinstance(raw, dict):
-        raise AuthConfigError("OAUTH 必须是 dict")
-    known = {f for f in OAuthSettings.__dataclass_fields__}
-    values = {k: v for k, v in raw.items() if k in known}
-    oauth = OAuthSettings(**{k: str(v) for k, v in values.items()})
-    if any(raw.get(k) for k in ("client_id", "authorize_url", "token_url")) and not oauth.configured:
-        raise AuthConfigError("OAUTH 配置不完整：client_id / authorize_url / token_url 必须同时提供")
-    if oauth.configured:
-        # callback 实际必用的字段也纳入启动期校验，避免"能启动、登录页有 OAuth
-        # 按钮、回调必失败"的上线即不可用状态。
-        missing = [name for name in ("userinfo_url", "redirect_uri") if not getattr(oauth, name)]
-        if missing:
-            raise AuthConfigError(f"OAUTH 配置不完整：缺少回调必需字段 {missing}")
+    if not isinstance(raw, list):
+        raise AuthConfigError("OAUTH_PROVIDERS 必须是 provider dict 列表")
+    if not raw:
+        return OAuthSettings()
+    if len(raw) != 1:
+        raise AuthConfigError("OAUTH_PROVIDERS 本期仅支持单 Provider，必须恰好配置一项")
+    provider = raw[0]
+    if not isinstance(provider, dict):
+        raise AuthConfigError("OAUTH_PROVIDERS 条目必须是 dict")
+    remote_app = provider.get("remote_app")
+    if remote_app is None:
+        remote_app = {}
+    if not isinstance(remote_app, dict):
+        raise AuthConfigError("OAUTH_PROVIDERS.remote_app 必须是 dict")
+    client_kwargs = remote_app.get("client_kwargs")
+    if client_kwargs is None:
+        client_kwargs = {}
+    if not isinstance(client_kwargs, dict):
+        raise AuthConfigError("OAUTH_PROVIDERS.remote_app.client_kwargs 必须是 dict")
+    oauth = OAuthSettings(
+        provider_name=str(provider.get("name") or "").strip(),
+        icon=str(provider.get("icon") or "").strip(),
+        client_id=str(remote_app.get("client_id") or ""),
+        client_secret=str(remote_app.get("client_secret") or ""),
+        authorize_url=str(remote_app.get("authorize_url") or ""),
+        token_url=str(remote_app.get("access_token_url") or ""),
+        scopes=str(client_kwargs.get("scope") or "openid profile"),
+        redirect_uri=str(remote_app.get("redirect_uri") or ""),
+        userinfo_url=str(provider.get("userinfo_url") or ""),
+        user_id_field=str(provider.get("user_id_field") or "sub"),
+        username_field=str(provider.get("username_field") or "preferred_username"),
+        post_login_redirect=str(provider.get("post_login_redirect") or "/"),
+    )
+    if not oauth.provider_name:
+        raise AuthConfigError("OAUTH_PROVIDERS 条目缺少 name")
+    if not oauth.configured:
+        raise AuthConfigError(
+            "OAUTH_PROVIDERS.remote_app 配置不完整："
+            "client_id / authorize_url / access_token_url 必须同时提供"
+        )
+    # callback 实际必用的字段也纳入启动期校验，避免"能启动、登录页有 OAuth
+    # 按钮、回调必失败"的上线即不可用状态。
+    missing = [name for name in ("userinfo_url", "redirect_uri") if not getattr(oauth, name)]
+    if missing:
+        raise AuthConfigError(f"OAUTH_PROVIDERS 配置不完整：缺少回调必需字段 {missing}")
     return oauth
 
 
 def _build_settings(module: Any, config_path: str) -> AuthSettings:
     enabled = bool(getattr(module, "AUTH_ENABLED", False))
+    if getattr(module, "OAUTH", None):
+        raise AuthConfigError("OAUTH 扁平配置已不支持，请迁移为单项 OAUTH_PROVIDERS")
     settings = AuthSettings(
         enabled=enabled,
         session_ttl_seconds=int(getattr(module, "SESSION_TTL_SECONDS", 28800)),
         cookie_name=str(getattr(module, "COOKIE_NAME", "da_session") or "da_session"),
         cookie_secure=bool(getattr(module, "COOKIE_SECURE", False)),
         cookie_samesite=str(getattr(module, "COOKIE_SAMESITE", "lax") or "lax").lower(),
-        oauth=_parse_oauth(getattr(module, "OAUTH", None)),
+        oauth=_parse_oauth_providers(getattr(module, "OAUTH_PROVIDERS", None)),
         local_admins=_parse_local_admins(getattr(module, "LOCAL_ADMINS", None)),
         admin_users=[str(x).strip() for x in (getattr(module, "ADMIN_USERS", None) or []) if str(x).strip()],
         oauth_userinfo_mapper=getattr(module, "OAUTH_USERINFO_MAPPER", None),
@@ -206,7 +241,9 @@ def _build_settings(module: Any, config_path: str) -> AuthSettings:
     if enabled:
         settings.secret_key = _validate_secret_key(getattr(module, "SECRET_KEY", ""))
         if not settings.local_login_enabled and not settings.oauth_login_enabled:
-            raise AuthConfigError("AUTH_ENABLED=True 但 LOCAL_ADMINS 与 OAUTH 均未配置，无任何可用登录方式")
+            raise AuthConfigError(
+                "AUTH_ENABLED=True 但 LOCAL_ADMINS 与 OAUTH_PROVIDERS 均未配置，无任何可用登录方式"
+            )
     return settings
 
 

--- a/dataagent/dataagent-backend/tests/test_auth_config.py
+++ b/dataagent/dataagent-backend/tests/test_auth_config.py
@@ -303,6 +303,25 @@ def test_shipped_base_config_does_not_swallow_nested_import_error(monkeypatch, t
         init_auth()
 
 
+def test_shipped_override_example_is_safe_when_copied_unchanged(tmp_path):
+    """Example defaults to auth off with no half-configured OAuth provider."""
+    import shutil
+
+    shipped = (
+        Path(__file__).resolve().parents[3]
+        / "deploy"
+        / "docker"
+        / "dataagent"
+        / "dataagent_config_docker.py.example"
+    )
+    target = tmp_path / "auth_config.py"
+    shutil.copyfile(shipped, target)
+
+    settings = load_auth_settings(str(target))
+    assert settings.enabled is False
+    assert settings.oauth_login_enabled is False
+
+
 def test_shipped_deploy_base_config_is_disabled_by_default(monkeypatch, _clean_override_module):
     shipped = Path(__file__).resolve().parents[3] / "deploy" / "docker" / "dataagent" / "dataagent_config.py"
     assert shipped.is_file(), shipped
@@ -366,21 +385,106 @@ def test_userinfo_mapper_is_captured(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize("missing_field", ["userinfo_url", "redirect_uri"])
 def test_oauth_missing_callback_required_field_fails_startup(tmp_path, missing_field):
-    oauth = {
-        "provider_name": "SSO",
-        "client_id": "cid",
-        "client_secret": "secret",
-        "authorize_url": "https://sso.example.com/authorize",
-        "token_url": "https://sso.example.com/token",
+    oauth_provider = {
+        "name": "SSO",
+        "icon": "fa-github",
+        "remote_app": {
+            "client_id": "cid",
+            "client_secret": "secret",
+            "authorize_url": "https://sso.example.com/authorize",
+            "access_token_url": "https://sso.example.com/token",
+            "redirect_uri": "https://app.example.com/cb",
+        },
         "userinfo_url": "https://sso.example.com/userinfo",
-        "redirect_uri": "https://app.example.com/cb",
     }
-    oauth[missing_field] = ""
+    if missing_field == "redirect_uri":
+        oauth_provider["remote_app"][missing_field] = ""
+    else:
+        oauth_provider[missing_field] = ""
     path = write_config(
         tmp_path,
-        f"AUTH_ENABLED = True\nSECRET_KEY = {VALID_SECRET!r}\nOAUTH = {oauth!r}\n",
+        f"AUTH_ENABLED = True\nSECRET_KEY = {VALID_SECRET!r}\n"
+        f"OAUTH_PROVIDERS = {[oauth_provider]!r}\n",
     )
     with pytest.raises(AuthConfigError):
+        load_auth_settings(path)
+
+
+def test_oauth_providers_maps_superset_shape(tmp_path):
+    provider = {
+        "name": "GitHub",
+        "icon": "fa-github",
+        "token_key": "access_token",
+        "remote_app": {
+            "client_id": "cid",
+            "client_secret": "secret",
+            "authorize_url": "https://github.com/login/oauth/authorize",
+            "access_token_url": "https://github.com/login/oauth/access_token",
+            "client_kwargs": {"scope": "read:user user:email"},
+            "redirect_uri": "https://app.example.com/callback",
+            "response_type": "code",
+            "grant_type": "authorization_code",
+        },
+        "userinfo_url": "https://api.github.com/user",
+        "user_id_field": "id",
+        "username_field": "login",
+    }
+    path = write_config(tmp_path, f"OAUTH_PROVIDERS = {[provider]!r}\n")
+    oauth = load_auth_settings(path).oauth
+    assert oauth.provider_name == "GitHub"
+    assert oauth.icon == "fa-github"
+    assert oauth.token_url == provider["remote_app"]["access_token_url"]
+    assert oauth.scopes == "read:user user:email"
+    assert oauth.user_id_field == "id"
+
+
+@pytest.mark.parametrize(
+    "providers",
+    [
+        {"name": "not-a-list"},
+        ({"name": "tuple-is-not-a-list"},),
+        [{"name": "one"}, {"name": "two"}],
+        ["not-a-dict"],
+    ],
+)
+def test_oauth_providers_rejects_unsupported_shapes(tmp_path, providers):
+    path = write_config(tmp_path, f"OAUTH_PROVIDERS = {providers!r}\n")
+    with pytest.raises(AuthConfigError):
+        load_auth_settings(path)
+
+
+def test_nonempty_oauth_provider_cannot_silently_disable_itself(tmp_path):
+    path = write_config(tmp_path, "OAUTH_PROVIDERS = [{'name': 'half-configured'}]\n")
+    with pytest.raises(AuthConfigError, match="remote_app"):
+        load_auth_settings(path)
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        {"name": "bad-remote", "remote_app": []},
+        {
+            "name": "bad-client-kwargs",
+            "remote_app": {
+                "client_id": "cid",
+                "authorize_url": "https://sso.example.com/authorize",
+                "access_token_url": "https://sso.example.com/token",
+                "redirect_uri": "https://app.example.com/callback",
+                "client_kwargs": [],
+            },
+            "userinfo_url": "https://sso.example.com/userinfo",
+        },
+    ],
+)
+def test_oauth_provider_rejects_falsey_non_dict_nested_config(tmp_path, provider):
+    path = write_config(tmp_path, f"OAUTH_PROVIDERS = {[provider]!r}\n")
+    with pytest.raises(AuthConfigError, match="dict"):
+        load_auth_settings(path)
+
+
+def test_legacy_flat_oauth_fails_with_migration_required(tmp_path):
+    path = write_config(tmp_path, "OAUTH = {'provider_name': 'legacy'}\n")
+    with pytest.raises(AuthConfigError, match="OAUTH_PROVIDERS"):
         load_auth_settings(path)
 
 

--- a/dataagent/dataagent-backend/tests/test_auth_routes.py
+++ b/dataagent/dataagent-backend/tests/test_auth_routes.py
@@ -49,19 +49,22 @@ def enable_auth(
     oauth_block = ""
     if oauth:
         oauth_block = """
-OAUTH = {
-    "provider_name": "SSO",
-    "client_id": "cid",
-    "client_secret": "secret",
-    "authorize_url": "https://sso.example.com/authorize",
-    "token_url": "https://sso.example.com/token",
+OAUTH_PROVIDERS = [{
+    "name": "SSO",
+    "icon": "fa-github",
+    "remote_app": {
+        "client_id": "cid",
+        "client_secret": "secret",
+        "authorize_url": "https://sso.example.com/authorize",
+        "access_token_url": "https://sso.example.com/token",
+        "client_kwargs": {"scope": "openid profile"},
+        "redirect_uri": "https://app.example.com/api/v1/nl2sql/auth/oauth/callback",
+    },
     "userinfo_url": "https://sso.example.com/userinfo",
-    "scopes": "openid profile",
-    "redirect_uri": "https://app.example.com/api/v1/nl2sql/auth/oauth/callback",
     "user_id_field": "sub",
     "username_field": "preferred_username",
     "post_login_redirect": "/intelligent-query/chat",
-}
+}]
 """
     config_file = tmp_path / "auth_config.py"
     config_file.write_text(
@@ -87,6 +90,7 @@ def test_auth_config_reports_disabled_when_env_unset():
     assert response.json() == {
         "enabled": False,
         "provider_name": "",
+        "provider_icon": "",
         "local_login_enabled": False,
         "oauth_login_enabled": False,
     }
@@ -98,6 +102,15 @@ def test_login_endpoints_are_404_when_disabled():
     assert client.get("/api/v1/nl2sql/auth/me").status_code == 404
     assert client.post("/api/v1/nl2sql/auth/logout").status_code == 404
     assert client.get("/api/v1/nl2sql/auth/oauth/authorize").status_code == 404
+
+
+def test_auth_config_exposes_oauth_provider_name_and_icon(monkeypatch, tmp_path):
+    enable_auth(monkeypatch, tmp_path, oauth=True)
+    response = TestClient(app).get("/api/v1/nl2sql/auth/config")
+    assert response.status_code == 200
+    assert response.json()["provider_name"] == "SSO"
+    assert response.json()["provider_icon"] == "fa-github"
+    assert response.json()["oauth_login_enabled"] is True
 
 
 def test_local_login_sets_httponly_cookie_and_me_roundtrip(monkeypatch, tmp_path):
@@ -151,6 +164,8 @@ def test_oauth_authorize_redirects_with_state(monkeypatch, tmp_path):
     query = parse_qs(location.query)
     assert query["client_id"] == ["cid"]
     assert query["response_type"] == ["code"]
+    assert query["scope"] == ["openid profile"]
+    assert query["redirect_uri"] == ["https://app.example.com/api/v1/nl2sql/auth/oauth/callback"]
     state = query["state"][0]
     payload = auth.verify_oauth_state(state)
     assert payload is not None
@@ -297,16 +312,18 @@ AUTH_ENABLED = True
 SECRET_KEY = {VALID_SECRET!r}
 LOCAL_ADMINS = [{{"username": "admin", "password_bcrypt": {password_hash!r}}}]
 ADMIN_USERS = ["SSO:1024"]
-OAUTH = {{
-    "provider_name": "SSO",
-    "client_id": "cid",
-    "client_secret": "secret",
-    "authorize_url": "https://sso.example.com/authorize",
-    "token_url": "https://sso.example.com/token",
+OAUTH_PROVIDERS = [{{
+    "name": "SSO",
+    "remote_app": {{
+        "client_id": "cid",
+        "client_secret": "secret",
+        "authorize_url": "https://sso.example.com/authorize",
+        "access_token_url": "https://sso.example.com/token",
+        "redirect_uri": "https://app.example.com/cb",
+    }},
     "userinfo_url": "https://sso.example.com/userinfo",
-    "redirect_uri": "https://app.example.com/cb",
     "post_login_redirect": "/intelligent-query/chat",
-}}
+}}]
 {mapper_body}
 """,
         encoding="utf-8",

--- a/dataagent/dataagent-frontend/package-lock.json
+++ b/dataagent/dataagent-frontend/package-lock.json
@@ -21,6 +21,7 @@
         "dayjs": "^1.11.10",
         "echarts": "^5.4.3",
         "element-plus": "^2.5.0",
+        "font-awesome": "^4.7.0",
         "marked": "^17.0.4",
         "pinia": "^2.1.7",
         "vue": "^3.4.0",
@@ -2477,6 +2478,15 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "license": "(OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=0.10.3"
       }
     },
     "node_modules/foreground-child": {
@@ -6018,6 +6028,11 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg=="
     },
     "foreground-child": {
       "version": "3.3.1",

--- a/dataagent/dataagent-frontend/package.json
+++ b/dataagent/dataagent-frontend/package.json
@@ -29,6 +29,7 @@
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",
     "element-plus": "^2.5.0",
+    "font-awesome": "^4.7.0",
     "marked": "^17.0.4",
     "pinia": "^2.1.7",
     "vue": "^3.4.0",

--- a/dataagent/dataagent-frontend/src/demo/mockServer.js
+++ b/dataagent/dataagent-frontend/src/demo/mockServer.js
@@ -2554,6 +2554,7 @@ export const demoAdapter = async (config) => {
     return createResponse(config, {
       enabled: false,
       provider_name: '',
+      provider_icon: '',
       local_login_enabled: false,
       oauth_login_enabled: false
     })

--- a/dataagent/dataagent-frontend/src/main.js
+++ b/dataagent/dataagent-frontend/src/main.js
@@ -4,6 +4,7 @@ import router from './router'
 import App from './App.vue'
 import { setDataagentUnauthorizedHandler } from './api/dataagent'
 import './styles/variables.css'
+import 'font-awesome/css/font-awesome.min.css'
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/dataagent/dataagent-frontend/src/stores/__tests__/auth.spec.js
+++ b/dataagent/dataagent-frontend/src/stores/__tests__/auth.spec.js
@@ -56,6 +56,7 @@ describe('useAuthStore', () => {
     authApiMock.getAuthConfig.mockResolvedValue({
       enabled: true,
       provider_name: 'SSO',
+      provider_icon: 'fa-github',
       local_login_enabled: true,
       oauth_login_enabled: true
     })
@@ -67,6 +68,8 @@ describe('useAuthStore', () => {
     expect(store.isAuthenticated).toBe(true)
     expect(store.isAdmin).toBe(false)
     expect(store.currentUser.username).toBe('alice')
+    expect(store.providerName).toBe('SSO')
+    expect(store.providerIcon).toBe('fa-github')
   })
 
   it('swallows the me() 401 and reports unauthenticated', async () => {

--- a/dataagent/dataagent-frontend/src/stores/auth.js
+++ b/dataagent/dataagent-frontend/src/stores/auth.js
@@ -18,6 +18,7 @@ export const useAuthStore = defineStore('auth', {
     // 无登录页、无守卫、管理功能照旧可用。
     enabled: false,
     providerName: '',
+    providerIcon: '',
     localLoginEnabled: false,
     oauthLoginEnabled: false,
     currentUser: null,
@@ -37,6 +38,7 @@ export const useAuthStore = defineStore('auth', {
         const config = await authApi.getAuthConfig()
         this.enabled = Boolean(config?.enabled)
         this.providerName = String(config?.provider_name || '')
+        this.providerIcon = String(config?.provider_icon || '')
         this.localLoginEnabled = Boolean(config?.local_login_enabled)
         this.oauthLoginEnabled = Boolean(config?.oauth_login_enabled)
       } catch (_error) {

--- a/dataagent/dataagent-frontend/src/views/LoginView.vue
+++ b/dataagent/dataagent-frontend/src/views/LoginView.vue
@@ -51,6 +51,7 @@
         class="login-button oauth-button"
         @click="handleOauthLogin"
       >
+        <i v-if="authStore.providerIcon" class="fa" :class="authStore.providerIcon" aria-hidden="true" />
         通过 {{ authStore.providerName || 'SSO' }} 登录
       </el-button>
     </el-card>
@@ -151,5 +152,9 @@ function handleOauthLogin() {
 
 .oauth-button {
   margin-top: 4px;
+}
+
+.oauth-button i {
+  margin-right: 8px;
 }
 </style>

--- a/dataagent/dataagent-frontend/src/views/__tests__/LoginView.spec.js
+++ b/dataagent/dataagent-frontend/src/views/__tests__/LoginView.spec.js
@@ -1,0 +1,52 @@
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerReplace = vi.hoisted(() => vi.fn())
+const authState = vi.hoisted(() => ({
+  enabled: true,
+  currentUser: null,
+  localLoginEnabled: false,
+  oauthLoginEnabled: true,
+  providerName: 'GitHub',
+  providerIcon: 'fa-github',
+  bootstrap: vi.fn(async () => {}),
+  loginLocal: vi.fn(),
+  oauthAuthorizeUrl: vi.fn(() => '/api/v1/nl2sql/auth/oauth/authorize')
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ replace: routerReplace })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  sanitizeRedirectPath: () => '/intelligent-query/chat',
+  useAuthStore: () => authState
+}))
+
+import LoginView from '../LoginView.vue'
+
+const stubs = {
+  'el-card': { template: '<div><slot /></div>' },
+  'el-alert': { template: '<div />' },
+  'el-form': { template: '<form><slot /></form>' },
+  'el-form-item': { template: '<div><slot /></div>' },
+  'el-input': { template: '<input />' },
+  'el-divider': { template: '<div><slot /></div>' },
+  'el-button': { template: '<button @click="$emit(\'click\')"><slot /></button>' }
+}
+
+describe('LoginView OAuth provider', () => {
+  beforeEach(() => {
+    routerReplace.mockReset()
+    authState.bootstrap.mockClear()
+  })
+
+  it('renders a Superset-style Font Awesome icon class next to the provider name', async () => {
+    const wrapper = shallowMount(LoginView, { global: { stubs } })
+    await flushPromises()
+
+    expect(wrapper.find('.oauth-button .fa.fa-github').exists()).toBe(true)
+    expect(wrapper.find('.oauth-button').text()).toContain('GitHub')
+  })
+})

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -268,7 +268,9 @@ DataAgent（智能问数）支持可选的 OAuth2 + 本地管理员登录，以�
 启用步骤：
 
 1. `cd deploy/docker/dataagent && cp dataagent_config_docker.py.example dataagent_config_docker.py`
-2. 按注释填写 `SECRET_KEY`（`secrets.token_urlsafe(32)` 生成）、`LOCAL_ADMINS`（bcrypt 哈希）、`OAUTH`、`ADMIN_USERS`（`provider:sub` 稳定标识），置 `AUTH_ENABLED = True`。
+2. 按注释填写 `SECRET_KEY`（`secrets.token_urlsafe(32)` 生成）、`LOCAL_ADMINS`（bcrypt 哈希）、单项 `OAUTH_PROVIDERS`（Superset/FAB `remote_app` 形态，`icon` 支持 Font Awesome 4 class）、`ADMIN_USERS`（`provider:sub` 稳定标识），置 `AUTH_ENABLED = True`。
+   早期版本的扁平 `OAUTH` 不再接受；检测到非空旧配置时服务会
+   fail-closed 启动失败并提示迁移，避免静默丢失 OAuth 登录。
 3. 重启 `dataagent-backend`。无需修改 compose。需要自定义扩展模块（如自研 SSO 适配）时，直接把 `.py` 放进同目录并在覆盖文件里 import（目录在 `sys.path` 上）。
 
 语义与回滚（fail-closed）：

--- a/deploy/docker/dataagent/custom_sso_user_mapper.py.example
+++ b/deploy/docker/dataagent/custom_sso_user_mapper.py.example
@@ -1,7 +1,7 @@
 """自定义 SSO userinfo 映射示例（Superset custom_sso_security_manager 对应物）。
 
 当 IdP 的 userinfo 响应不是标准 OIDC 平铺结构（嵌套 payload、自定义字段名、
-需要按组/角色字段决定管理员）时，用本钩子完全接管解析，替代 OAUTH 里的
+需要按组/角色字段决定管理员）时，用本钩子完全接管解析，替代 OAUTH_PROVIDERS 里的
 user_id_field / username_field 平铺取值。
 
 使用方式：

--- a/deploy/docker/dataagent/dataagent_config.py
+++ b/deploy/docker/dataagent/dataagent_config.py
@@ -7,7 +7,7 @@
 `superset_config.py` 一样加载同目录下的用户扩展模块。
 
 可配置内容：
-- 认证：`AUTH_ENABLED` / `SECRET_KEY` / `LOCAL_ADMINS` / `OAUTH` / `ADMIN_USERS`
+- 认证：`AUTH_ENABLED` / `SECRET_KEY` / `LOCAL_ADMINS` / `OAUTH_PROVIDERS` / `ADMIN_USERS`
   / `OAUTH_USERINFO_MAPPER`（非标准 IdP 的 userinfo 映射钩子，见
   custom_sso_user_mapper.py.example）。
 - 其他运行时配置：`DATAAGENT_SETTINGS = {"<config.py Settings 字段>": 值}`，
@@ -44,7 +44,7 @@ COOKIE_SECURE = False
 COOKIE_SAMESITE = "lax"
 
 LOCAL_ADMINS = []
-OAUTH = {}
+OAUTH_PROVIDERS = []
 ADMIN_USERS = []
 
 # 非认证的运行时 Settings 覆盖（config.py 字段），默认不覆盖任何值。

--- a/deploy/docker/dataagent/dataagent_config_docker.py.example
+++ b/deploy/docker/dataagent/dataagent_config_docker.py.example
@@ -7,7 +7,7 @@
 """
 
 # ---------------------------------------------------------------------------
-# 认证总开关。置 True 前先完成 SECRET_KEY 与至少一种登录方式（LOCAL_ADMINS / OAUTH）。
+# 认证总开关。置 True 前先完成 SECRET_KEY 与至少一种登录方式（LOCAL_ADMINS / OAUTH_PROVIDERS）。
 # ---------------------------------------------------------------------------
 AUTH_ENABLED = False
 
@@ -35,27 +35,40 @@ LOCAL_ADMINS = [
 ]
 
 # ---------------------------------------------------------------------------
-# OAuth2 授权码模式（通用 OIDC Provider）。三项核心（client_id / authorize_url /
-# token_url）齐全才视为已配置；留空则登录页只提供本地密码登录。
+# OAuth2 授权码模式（通用 OIDC Provider）。外形与 Superset/FAB 的
+# OAUTH_PROVIDERS 一致；本期仅支持单 Provider，配置多项会启动失败。
+# remote_app 内三项核心（client_id / authorize_url / access_token_url）
+# 齐全才视为已配置；保持下方空列表则登录页只提供本地密码登录。
+# 要启用 OAuth，将下方 provider 模板取消注释并填入真实值。
 # ---------------------------------------------------------------------------
-OAUTH = {
-    # 登录按钮显示名，同时作为用户稳定标识的 provider 前缀（见 ADMIN_USERS）。
-    "provider_name": "SSO",
-    "client_id": "",
-    "client_secret": "",
-    "authorize_url": "https://sso.example.com/oauth/authorize",
-    "token_url": "https://sso.example.com/oauth/token",
-    "userinfo_url": "https://sso.example.com/oauth/userinfo",
-    "scopes": "openid profile",
-    # 必须与 IdP 侧注册的回调一致：
-    #   https://<dataagent-host>/api/v1/nl2sql/auth/oauth/callback
-    "redirect_uri": "",
-    # userinfo 响应里的用户唯一标识与显示名字段（标准平铺 payload 时用）。
-    "user_id_field": "sub",
-    "username_field": "preferred_username",
-    # 登录成功后的回跳路径（仅接受同源应用内路径）。
-    "post_login_redirect": "/",
-}
+OAUTH_PROVIDERS = [
+    # {
+    #     # Provider 键和登录按钮显示名，也作为用户稳定标识前缀。
+    #     "name": "SSO",
+    #     # Font Awesome 4 class，如 fa-github / fa-google；留空则不显示图标。
+    #     "icon": "fa-github",
+    #     # token_key 为 FAB/Superset 兼容字段；DataAgent 直接解析 access_token。
+    #     "token_key": "access_token",
+    #     "remote_app": {
+    #         "client_id": "your-client-id",
+    #         "client_secret": "your-client-secret",
+    #         "authorize_url": "https://sso.example.com/oauth/authorize",
+    #         "access_token_url": "https://sso.example.com/oauth/token",
+    #         "client_kwargs": {"scope": "openid profile"},
+    #         # 必须与 IdP 侧注册的回调一致：
+    #         #   https://<dataagent-host>/api/v1/nl2sql/auth/oauth/callback
+    #         "redirect_uri": "https://<dataagent-host>/api/v1/nl2sql/auth/oauth/callback",
+    #         # DataAgent 传输层固定使用 code / authorization_code，无需配置。
+    #     },
+    #     # 以下是 DataAgent 扩展字段：按需拉取 userinfo 并映射用户。
+    #     "userinfo_url": "https://sso.example.com/oauth/userinfo",
+    #     # userinfo 响应里的用户唯一标识与显示名字段（标准平铺 payload 时用）。
+    #     "user_id_field": "sub",
+    #     "username_field": "preferred_username",
+    #     # 登录成功后的回跳路径（仅接受同源应用内路径）。
+    #     "post_login_redirect": "/",
+    # }
+]
 
 # ---------------------------------------------------------------------------
 # 非标准 IdP 的 userinfo 映射钩子（可选，Superset custom_sso_security_manager

--- a/docs/design/2026-07-01-dataagent-auth-design.md
+++ b/docs/design/2026-07-01-dataagent-auth-design.md
@@ -36,6 +36,8 @@ DataAgent 后端（FastAPI :8900）目前完全无认证：
 - 不与主门户 `odw-auth` / `odw_session` 集成（预留：Cookie 名避让、契约互不干扰）。
 - 不做细粒度 RBAC（仅 `admin` / `user`）。
 - v1 不做本地登录失败锁定（记录失败日志）。
+- 本期不支持多 OAuth Provider；但外置配置使用 Superset/FAB 的
+  `OAUTH_PROVIDERS` 列表外形，启动期强制列表最多一项。
 
 ## 3. 核心语义（评审后固化）
 
@@ -70,6 +72,24 @@ dataagent-frontend 独立 SPA 的所有 API client 显式携带 `X-ODW-Client: d
 
 - 本地管理员：配置脚本 `LOCAL_ADMINS=[{username, password_bcrypt}]`，bcrypt 校验，OAuth 不可用时仍可登录。
 - OAuth 提名：`ADMIN_USERS` 条目匹配 `"<provider>:<sub>"`（稳定标识）；**不用 username 提权**（可变、不保证唯一），username 仅做展示。
+
+### 3.4.1 OAuth Provider 配置契约
+
+- 配置键为 `OAUTH_PROVIDERS=[{...}]`，与 Superset/FAB 的列表和
+  `remote_app` 外形对齐；空列表表示不启用 OAuth，多于一项直接
+  fail-closed 启动失败。
+- 旧的非空扁平 `OAUTH` 不保留兼容分支；加载时立即报迁移错误，
+  避免已配 OAuth 被静默忽略后仅剩本地登录。
+- 通用字段映射：`name` 映射 provider 键/登录按钮显示名，
+  `icon` 是 Font Awesome 4 class（如 `fa-github`），
+  `remote_app.client_id/client_secret/authorize_url/access_token_url/redirect_uri`
+  及 `remote_app.client_kwargs.scope` 用于授权码传输。
+- `response_type=code` 和 `grant_type=authorization_code` 由 DataAgent 传输层固定；
+  `token_key` 可为 Superset 配置迁移保留，DataAgent 仍从标准
+  `access_token` 字段解析令牌。
+- `userinfo_url` / `user_id_field` / `username_field` /
+  `post_login_redirect` 为 DataAgent 扩展字段，保持现有按需 userinfo
+  拉取、身份映射和安全回跳语义。
 
 ### 3.5 可见性谓词矩阵
 
@@ -114,7 +134,7 @@ ALTER TABLE da_agent_topic
 
 | 方法 | 路径 | 说明 |
 |---|---|---|
-| GET | `/config` | 公开：`{enabled, provider_name, local_login_enabled}` |
+| GET | `/config` | 公开：`{enabled, provider_name, provider_icon, local_login_enabled, oauth_login_enabled}` |
 | POST | `/login` | 本地管理员密码登录，成功 Set-Cookie `da_session` |
 | GET | `/oauth/authorize` | 读配置拼授权 URL + state cookie，302 |
 | GET | `/oauth/callback` | code→token→userinfo→按 `ADMIN_USERS` 定角色→Set-Cookie→302 |
@@ -136,7 +156,8 @@ ALTER TABLE da_agent_topic
 - `authApi`（config/login/me/logout/authorize URL）；`X-ODW-Client: dataagent` 只在 SPA 调用点注入。
 - 两个 client（`nl2sql.js` 工厂 + `dataagent.js`）统一 `onUnauthorized` 钩子 → `/login?redirect=`（消毒后）。
 - Pinia `stores/auth.js`：`bootstrap()`、`isAuthenticated`、`isAdmin`（auth 关闭时为 true）、`loginLocal`、`logout`。
-- `LoginView.vue`：密码表单 + 条件 OAuth 按钮；redirect 消毒。
+- `LoginView.vue`：密码表单 + 条件 OAuth 按钮；OAuth 按钮用
+  Font Awesome 4 渲染 `provider_icon`（空值则仅文字）；redirect 消毒。
 - 路由守卫（仅 auth 启用时生效）+ 管理页路由/菜单按 `isAdmin` 拦截/隐藏。
 - `NL2SqlChatV2.vue` 的 `sourceMode` 增加 `'all'`（仅 admin），显示来源徽标 + 归属人。
 - 文件下载/预览事件代理（3.6）。
@@ -147,7 +168,7 @@ ALTER TABLE da_agent_topic
 - `deploy/docker/dataagent/` 目录由 compose 整体挂载进 dataagent-backend（`/app/docker/dataagent:ro`），env 默认指定 `DATAAGENT_CONFIG=/app/docker/dataagent/dataagent_config.py`；加载器把该目录加入 `sys.path`。
 - 目录内容：
   - `dataagent_config.py`：仓库自带基础配置，默认 `AUTH_ENABLED=False`（挂载即"显式关闭"态，行为与现状一致）；文件末尾 `from dataagent_config_docker import *` 加载同目录用户覆盖（不存在则跳过，Superset `superset_config_docker.py` 同款机制）。除认证外也可用 `DATAAGENT_SETTINGS = {"<config.py Settings 字段>": 值}` 覆盖运行时配置（启动期校验字段名，未知字段 fail-closed）。
-  - `dataagent_config_docker.py.example`：用户覆盖示例（SECRET_KEY/bcrypt 生成提示、通用 OIDC 样例、`provider:sub` 提名写法、`DATAAGENT_SETTINGS` 样例）；用户拷贝为 `dataagent_config_docker.py` 填写。
+  - `dataagent_config_docker.py.example`：用户覆盖示例（SECRET_KEY/bcrypt 生成提示、Superset/FAB 形态的单项 `OAUTH_PROVIDERS` 通用 OIDC 样例、Font Awesome icon、`provider:sub` 提名写法、`DATAAGENT_SETTINGS` 样例）；用户拷贝为 `dataagent_config_docker.py` 填写。
   - `custom_sso_user_mapper.py.example`：`OAUTH_USERINFO_MAPPER` 钩子示例（Superset `custom_sso_security_manager.py` 的 `oauth_user_info` 对应物）——非标准 IdP（嵌套 payload / 组角色提权）时完全接管 userinfo 解析；钩子返回 `role` 优先于 `ADMIN_USERS`；钩子运行期异常只使该次登录失败，不影响服务。
   - `.gitignore`：忽略一切用户文件（覆盖配置、自定义扩展模块如自研 SSO 适配），只保留自带文件与 `.example`。
 - `deploy/docker/nginx/`：两个前端 nginx 配置的宿主机副本 + compose 中注释式挂载；默认仍用镜像内构建版本（单一主路径），需要宿主机管理时取消注释。

--- a/docs/plans/2026-07-01-dataagent-auth-plan.md
+++ b/docs/plans/2026-07-01-dataagent-auth-plan.md
@@ -18,6 +18,9 @@
 - [x] T8 `api/admin_routes.py`：settings_router 挂 router 级 `dependencies=[Depends(require_admin)]`；`/api/v1/dataagent` 拆公开只读（3 个 agents GET）与 admin router（构造时显式 `dependencies=[Depends(require_admin)]`）；`/agents/capabilities` 先于 `/agents/{agent_id}` 注册；新增 `GET /api/v1/nl2sql-admin/topics`。
 - [x] T9 `deploy/docker/dataagent/`（Superset docker/pythonpath_dev 同款目录模式）：自带基础配置 `dataagent_config.py`（默认关闭 + 末尾加载用户覆盖，兼容承载非认证的 `DATAAGENT_SETTINGS` 运行时覆盖）、`dataagent_config_docker.py.example`、`custom_sso_user_mapper.py.example`（OAUTH_USERINFO_MAPPER 钩子示例）、目录 `.gitignore`；`core/auth.py` 加载器把配置目录加入 `sys.path` 以支持同目录用户扩展模块。
 - [x] T10 compose prod/dev + `.env.example` + `deploy/README.md`：`./docker/dataagent` 目录默认挂载 + env 默认指定基础配置（显式关闭态，行为不变）；`deploy/docker/nginx/` 前端 nginx 配置宿主机副本 + 注释式挂载；fail-closed 与回滚说明。
+- [x] T11 OAuth 配置契约优化：扁平 `OAUTH` 切换为 Superset/FAB
+  形态 `OAUTH_PROVIDERS`，启动期限制单 Provider，映射 `remote_app`
+  字段并保留 DataAgent userinfo 扩展字段。
 
 ### 前端（dataagent/dataagent-frontend/）
 
@@ -29,6 +32,8 @@
 - [x] F5/F6 双 client 401 → `/login?redirect=`；侧栏用户名/退出；菜单 isAdmin 隐藏。
 - [x] F7 `sourceMode: 'all'`（admin）→ `listAdminTopics()`。
 - [x] F8 mockServer `GET /api/v1/nl2sql/auth/config` → `{enabled:false}`。
+- [x] F9 引入 Font Awesome 4.7，`/auth/config` 下发 `provider_icon`，
+  `LoginView.vue` 按配置 class 渲染 OAuth 按钮图标。
 
 ### 测试
 
@@ -36,12 +41,31 @@
 - [x] `tests/test_auth_routes.py`：login/me/logout、Set-Cookie HttpOnly/SameSite/Secure 断言、authorize 302+state、mock httpx callback、provider:sub 提名、username 不提权。
 - [x] 扩展 `test_topic_task_store.py`、`test_widget_runtime_routes.py`（widget 优先、无标记带 cookie 仍匿名、dataagent 标记解析身份）、`test_admin_routes.py`（关闭开放回归、启用 401/200、agents GET 公开、capabilities 遮蔽回归、/topics 契约）。
 - [x] 前端 vitest：守卫/isAdmin、auth store、双 client 401、widget 无标记、Blob 链路、沙箱断言、rel path 转义、redirect 消毒、mock auth config。
+- [x] `OAUTH_PROVIDERS` 回归：Superset 形态字段映射、单 Provider
+  限制、callback 必需字段校验、`provider_icon` API/store 传递。
 
 ## 验证
 
 1. `.venv-py313`（或本环境等价 venv）聚焦 pytest；`nvm use` 后 vitest + `npm run build` + `build:widget`。
 2. 本地 MySQL + Redis 可用时：`alembic upgrade head`；冒烟 A（auth 关回归：topics 全链路、widget、admin 开放、`/auth/config` enabled=false）；冒烟 B（auth 开：fail-closed 启动失败验证、登录归属、匿名隔离、文件 Blob、admin 全源、settings 401、widget/门户嵌入不变）；4b 回滚回归（移除 env → 旧谓词）。
 3. 环境不可用的层面（真实 IdP OAuth 端到端、docker 双层 nginx cookie 链路）在交付说明中显式列出。
+
+### 2026-07-16 后续优化验证记录
+
+- 后端：`dataagent/dataagent-backend/.venv-py313`（Python 3.13）运行
+  auth/config/admin/topic/widget 联动回归，112 项全部通过。
+- 前端：按 `.nvmrc` 使用 Node 20.19.0；Vitest 全量 348 项通过，
+  `npm run build` 与 `npm run build:widget` 通过；主 SPA 产物包含
+  `fa-github` CSS 规则和 Font Awesome webfont 资源。
+- 真实 HTTP 冒烟：MySQL `127.0.0.1:3306`（Podman 已有
+  `data-portal-mysql`，业务 schema `opendataworks`，会话 schema `dataagent`）；
+  Redis `127.0.0.1:6379`（Podman `odw-local-redis`，验证期间启动、完成后停止）；
+  Uvicorn 用上述 `.venv-py313` 启动。`GET /api/v1/nl2sql/auth/config` 正确返回
+  `GitHub` / `fa-github`，本地管理员 login + `/api/v1/nl2sql/auth/me` 通过，
+  `/api/v1/nl2sql/auth/oauth/authorize` 正确 302 到 `remote_app` 配置的 URL，且 scope /
+  redirect_uri 与配置一致。
+- 未使用真实 provider 凭证，因此 IdP 交互、code 换 token 及真实
+  userinfo callback 仍是手工对接项；本次没有触发真实模型执行。
 
 ## Rollout / Backout
 
@@ -51,6 +75,6 @@
 ## 手工 Runbook（真实 IdP 对接，环境内无法自动验证）
 
 1. 在 IdP 注册应用，取得 client_id/secret，回调地址 `https://<dataagent-host>/api/v1/nl2sql/auth/oauth/callback`。
-2. 填入配置脚本 `OAUTH` 段；`AUTH_ENABLED=True`；重启。
+2. 填入配置脚本的单项 `OAUTH_PROVIDERS` 段；`AUTH_ENABLED=True`；重启。
 3. 浏览器访问独立站点 → 跳登录页 → OAuth 按钮 → IdP 登录 → 回跳后 `GET /api/v1/nl2sql/auth/me` 确认身份与角色。
 4. 用 `ADMIN_USERS=["<provider>:<sub>"]` 提名一名管理员，重登后确认 `role=admin` 与全量会话视图。


### PR DESCRIPTION
## Summary

- Align DataAgent OAuth configuration with the Superset/FAB `OAUTH_PROVIDERS` shape while retaining the current single-provider runtime.
- Render the configured provider icon on the Vue login button with Font Awesome 4 compatibility for values such as `fa-github`.

## What Changed

### Behavior Changes

- Replaces the flat `OAUTH` input with a strict single-entry `OAUTH_PROVIDERS` list and maps `remote_app` URLs, credentials, redirect URI, and scope.
- Fails closed for legacy flat configuration, multiple providers, incomplete providers, or invalid nested shapes instead of silently disabling OAuth.
- Adds `provider_icon` to the public auth capability response and carries it through the Pinia store to `LoginView.vue`.
- Adds Font Awesome 4.7 assets so Superset-style icon classes render correctly.
- Updates Docker examples, deployment guidance, design documentation, and the implementation plan for the new contract.

### Compatibility Impact

- Existing non-empty flat `OAUTH` configuration must be migrated to `OAUTH_PROVIDERS`; startup now returns an explicit migration error.
- Empty `OAUTH_PROVIDERS` remains the supported way to run local-login-only authentication.

## Validation

- `.venv-py313/bin/python -m pytest tests/test_auth_config.py tests/test_auth_routes.py tests/test_admin_routes.py tests/test_topic_task_store.py tests/test_widget_runtime_routes.py -q` — 112 passed.
- `npm --prefix dataagent/dataagent-frontend test` with Node 20.19.0 — 348 passed.
- `npm --prefix dataagent/dataagent-frontend run build` — passed; output contains Font Awesome CSS and webfont assets.
- `npm --prefix dataagent/dataagent-frontend run build:widget` — passed.
- Real Uvicorn HTTP smoke with local Podman MySQL and Redis — auth config, local login, `/me`, and OAuth authorize redirect passed.
- Real IdP code/token/userinfo exchange was not executed because provider credentials were not available.

## Risks

- Main risk: deployments still using the merged PR #400 flat `OAUTH` example will fail startup until migrated; this is deliberate fail-closed behavior and is documented in the deployment guide.

## Rollback

- Revert this PR and restore the prior flat `OAUTH` configuration, or keep auth explicitly disabled while migrating the external config.

## Checklist

- [x] No secrets or credentials introduced.
- [x] Compatibility impact reviewed and documented.
- [x] Documentation and deployment examples updated.
- [x] Backend, frontend, build, and local HTTP smoke verification completed.
