### PR TITLE
docs: provide default DataAgent admin example

### DIFF
--- a/deploy/docker/dataagent/dataagent_config_docker.py.example
+++ b/deploy/docker/dataagent/dataagent_config_docker.py.example
@@ -27,11 +27,13 @@ COOKIE_SECURE = False
 COOKIE_SAMESITE = "lax"
 
 # ---------------------------------------------------------------------------
-# 本地管理员账号（OAuth 不可用时仍可登录）。password_bcrypt 生成方式：
+# 本地管理员账号（OAuth 不可用时仍可登录）。
+# 默认账号：admin / admin123；password_bcrypt 是 admin123 的 bcrypt 哈希。
+# 如需改密码，可替换下面的哈希，生成方式：
 #   python -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt()).decode())"
 # ---------------------------------------------------------------------------
 LOCAL_ADMINS = [
-    # {"username": "admin", "password_bcrypt": "$2b$12$..."},
+    {"username": "admin", "password_bcrypt": "$2a$10$UH1EXFfUxjTSk75341ddU./2/w63hc0GkmC31RlKgUmiU3eh3iK0i"},
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Populate the DataAgent docker override example with a default local admin entry.
- Document that the included bcrypt hash corresponds to admin/admin123 so enabling auth does not require manually generating a hash first.

## Validation
- `dataagent/dataagent-backend/.venv-py313/bin/python - <<'PY' ... bcrypt.checkpw(b'admin123', hash_value) ... PY` -> passed

## Risk / Rollback
- Risk is limited to the example config file; runtime auth logic is unchanged.
- Rollback by reverting this commit or replacing the example LOCAL_ADMINS entry with a commented placeholder.