### PR TITLE
refactor(dataagent-auth): remove post-login redirect config

### DIFF
--- a/dataagent/dataagent-backend/api/auth_routes.py
+++ b/dataagent/dataagent-backend/api/auth_routes.py
@@ -255,7 +255,7 @@ async def oauth_callback(request: Request):
 
     redirect_path = sanitize_redirect_path(
         state_payload.get("redirect"),
-        fallback=sanitize_redirect_path(cfg.oauth.post_login_redirect, fallback="/"),
+        fallback="/",
     )
     response = RedirectResponse(url=redirect_path, status_code=302)
     _set_session_cookie(response, issue_session_token(identity))

--- a/dataagent/dataagent-backend/core/auth.py
+++ b/dataagent/dataagent-backend/core/auth.py
@@ -67,7 +67,6 @@ class OAuthSettings:
     redirect_uri: str = ""
     user_id_field: str = "sub"
     username_field: str = "preferred_username"
-    post_login_redirect: str = "/"
 
     @property
     def configured(self) -> bool:
@@ -187,7 +186,6 @@ def _parse_oauth_providers(raw: Any) -> OAuthSettings:
         userinfo_url=str(provider.get("userinfo_url") or ""),
         user_id_field=str(provider.get("user_id_field") or "sub"),
         username_field=str(provider.get("username_field") or "preferred_username"),
-        post_login_redirect=str(provider.get("post_login_redirect") or "/"),
     )
     if not oauth.provider_name:
         raise AuthConfigError("OAUTH_PROVIDERS 条目缺少 name")

--- a/dataagent/dataagent-backend/tests/test_auth_routes.py
+++ b/dataagent/dataagent-backend/tests/test_auth_routes.py
@@ -63,7 +63,6 @@ OAUTH_PROVIDERS = [{
     "userinfo_url": "https://sso.example.com/userinfo",
     "user_id_field": "sub",
     "username_field": "preferred_username",
-    "post_login_redirect": "/intelligent-query/chat",
 }]
 """
     config_file = tmp_path / "auth_config.py"
@@ -290,10 +289,11 @@ def test_oauth_callback_rejects_bad_state(monkeypatch, tmp_path):
 def test_oauth_callback_falls_back_to_safe_redirect(monkeypatch, tmp_path):
     enable_auth(monkeypatch, tmp_path, oauth=True)
     client = TestClient(app)
-    # state 中的 redirect 不合法（协议相对 URL）→ 回落 post_login_redirect。
+    # state 中的 redirect 不合法（协议相对 URL）→ 回落根路径，
+    # 由前端 router 决定当前默认页，后端不绑定具体页面 URL。
     response = _oauth_callback(client, monkeypatch, userinfo={"sub": "42"}, redirect="//evil.com")
     assert response.status_code == 302
-    assert response.headers["location"] == "/intelligent-query/chat"
+    assert response.headers["location"] == "/"
 
 
 # ---------------------------------------------------------------------------
@@ -322,7 +322,6 @@ OAUTH_PROVIDERS = [{{
         "redirect_uri": "https://app.example.com/cb",
     }},
     "userinfo_url": "https://sso.example.com/userinfo",
-    "post_login_redirect": "/intelligent-query/chat",
 }}]
 {mapper_body}
 """,

--- a/deploy/docker/dataagent/dataagent_config_docker.py.example
+++ b/deploy/docker/dataagent/dataagent_config_docker.py.example
@@ -67,8 +67,6 @@ OAUTH_PROVIDERS = [
     #     # userinfo 响应里的用户唯一标识与显示名字段（标准平铺 payload 时用）。
     #     "user_id_field": "sub",
     #     "username_field": "preferred_username",
-    #     # 登录成功后的回跳路径（仅接受同源应用内路径）。
-    #     "post_login_redirect": "/",
     # }
 ]
 

--- a/docs/design/2026-07-01-dataagent-auth-design.md
+++ b/docs/design/2026-07-01-dataagent-auth-design.md
@@ -87,9 +87,11 @@ dataagent-frontend 独立 SPA 的所有 API client 显式携带 `X-ODW-Client: d
 - `response_type=code` 和 `grant_type=authorization_code` 由 DataAgent 传输层固定；
   `token_key` 可为 Superset 配置迁移保留，DataAgent 仍从标准
   `access_token` 字段解析令牌。
-- `userinfo_url` / `user_id_field` / `username_field` /
-  `post_login_redirect` 为 DataAgent 扩展字段，保持现有按需 userinfo
-  拉取、身份映射和安全回跳语义。
+- `userinfo_url` / `user_id_field` / `username_field` 为 DataAgent
+  扩展字段，保持现有按需 userinfo 拉取和身份映射语义。
+- OAuth state 中的 redirect 缺失或不安全时固定回退到 `/`，
+  再由前端 router 选择当前默认页；不再提供 `post_login_redirect`
+  配置，避免认证后端绑定可变的页面路径。
 
 ### 3.5 可见性谓词矩阵
 


### PR DESCRIPTION
## Summary

- Remove the low-value `post_login_redirect` OAuth provider setting introduced in #401.
- Fall back to `/` when the OAuth state redirect is missing or unsafe, allowing the SPA router to choose the current default page.

## What Changed

- Removes `post_login_redirect` from `OAuthSettings` and `OAUTH_PROVIDERS` parsing.
- Changes the callback safety fallback from a configured page path to `/`.
- Removes the field from the Docker configuration example and updates the auth design.
- Updates the callback regression test to assert the root fallback.

## Validation

- `.venv-py313/bin/python -m pytest tests/test_auth_config.py tests/test_auth_routes.py -q` — 65 passed.
- `git diff --check` — passed.

## Risks

- Existing configurations containing `post_login_redirect` are harmlessly ignored; valid state redirects continue to work unchanged.

## Rollback

- Revert this PR to restore the configurable fallback.

## Checklist

- [x] No secrets or credentials introduced.
- [x] Compatibility impact reviewed.
- [x] Configuration example and design documentation updated.
