### PR TITLE
fix(dataagent): pin Claude Agent SDK safe bundle

### DIFF
--- a/dataagent/dataagent-backend/requirements.txt
+++ b/dataagent/dataagent-backend/requirements.txt
@@ -1,5 +1,5 @@
 alembic>=1.13.0
-claude-agent-sdk==0.2.96
+claude-agent-sdk==0.2.114
 fastapi>=0.110.0
 httpx>=0.27.0
 uvicorn[standard]>=0.27.0

--- a/dataagent/dataagent-backend/tests/test_dataagent_requirements.py
+++ b/dataagent/dataagent-backend/tests/test_dataagent_requirements.py
@@ -4,9 +4,18 @@ from pathlib import Path
 
 
 REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
+CLAUDE_AGENT_SDK_VERSION = "0.2.114"
 
 
 def test_dataagent_runtime_preinstalls_pytest_for_skill_validation():
     requirements = REQUIREMENTS.read_text(encoding="utf-8").splitlines()
 
     assert any(line.strip().startswith("pytest") for line in requirements)
+
+
+def test_dataagent_runtime_pins_claude_agent_sdk_to_safe_cli_bundle():
+    requirements = REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+
+    assert f"claude-agent-sdk=={CLAUDE_AGENT_SDK_VERSION}" in {
+        line.strip() for line in requirements
+    }


### PR DESCRIPTION
## Summary
- Pin the DataAgent release package to `claude-agent-sdk==0.2.114` so the bundled Claude CLI is updated to 2.1.205 and avoids the 2.1.91-2.1.196 risk range.
- Add a requirements regression test that prevents the DataAgent release dependency from drifting back to the unsafe pin.

## What Changed

### Behavior Changes
- DataAgent backend and sandbox runner images will install `claude-agent-sdk==0.2.114` during Docker builds via `dataagent/dataagent-backend/requirements.txt`.

### Key Files
- `dataagent/dataagent-backend/requirements.txt`: updates the SDK pin from `0.2.96` to `0.2.114`.
- `dataagent/dataagent-backend/tests/test_dataagent_requirements.py`: asserts the safe SDK pin remains in the release requirements.

## Validation
- Command: `dataagent/dataagent-backend/.venv-py313/bin/python -m pytest dataagent/dataagent-backend/tests/test_dataagent_requirements.py`
  Result: pass, 2 tests passed.
- Command: PyPI metadata lookup for `claude-agent-sdk/0.2.114`
  Result: pass, version exists with Linux manylinux wheels and Python `>=3.10`.

## Risks
- Main regression risk: `claude-agent-sdk` API behavior may differ between `0.2.96` and `0.2.114`, though this change is scoped to the release dependency pin.

## Rollback
- Revert this PR to restore the previous `claude-agent-sdk==0.2.96` pin.

## Checklist
- [x] No secrets/credentials committed.
- [x] Compatibility impact reviewed.
- [x] Docs/config updates completed when needed.
