### PR TITLE
build: pin nginx runtime to 1.30.3-alpine

### DIFF
--- a/dataagent/dataagent-frontend/Dockerfile
+++ b/dataagent/dataagent-frontend/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 COPY dataagent/dataagent-frontend ./
 RUN npm run build && npm run build:widget
 
-FROM nginx:alpine
+FROM nginx:1.30.3-alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY dataagent/dataagent-frontend/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docs/design/2026-07-17-nginx-base-image-pin-design.md
+++ b/docs/design/2026-07-17-nginx-base-image-pin-design.md
@@ -1,0 +1,51 @@
+# Nginx 基础镜像固定设计
+
+## Summary
+
+将 OpenDataWorks 两个前端运行时基础镜像从浮动的 `nginx:alpine` 固定为 `nginx:1.30.3-alpine`，在保持 Alpine 小体积的同时，避免普通业务提交重建镜像时隐式更换 Nginx 主版本。
+
+## Current State
+
+- `frontend/Dockerfile` 使用 `nginx:alpine`。
+- `dataagent/dataagent-frontend/Dockerfile` 使用 `nginx:alpine`。
+- GitHub Actions 在 `main` 提交后重建并覆盖两个镜像的 `latest` tag。
+- `nginx:alpine` 是浮动 tag，业务代码未改动 Dockerfile 时，重建仍可能引入新的 Nginx 或 Alpine 版本。
+
+## Problem
+
+浮动基础镜像使不同时间的同一业务提交无法保证生成相同的运行时基线，增加了问题定位和回滚成本。
+
+## Goals
+
+- 统一主前端和 DataAgent 前端的 Nginx 基线。
+- 固定 Nginx 补丁版本为 `1.30.3`。
+- 保留 Alpine 变体，不显著增加镜像体积。
+- 不改变现有 Nginx 路由、端口、健康检查和发布 tag 规则。
+
+## Non-Goals
+
+- 本轮不调整 `opendataagent/web` 的独立镜像基线。
+- 本轮不修改 PID 目录或容器安全策略。
+- 基础镜像固定不解决特定宿主机上的 `pwrite EPERM`，该问题仍需在容器运行时层处理。
+
+## Solution
+
+修改两个运行时 stage：
+
+```dockerfile
+FROM nginx:1.30.3-alpine
+```
+
+使用带补丁版本的 tag，而不使用仍会跟随稳定分支漂移的 `stable-alpine`。
+
+## Tradeoffs
+
+- 收益：构建基线更稳定，回归和回滚更可预测。
+- 代价：后续 Nginx 安全补丁需通过显式 PR 升级，不再由浮动 tag 自动带入。
+- 镜像仍使用 Alpine 变体，小体积目标不变。
+
+## Affected Areas
+
+- `frontend/Dockerfile`
+- `dataagent/dataagent-frontend/Dockerfile`
+- GitHub Actions 生成的两个前端镜像

--- a/docs/plans/2026-07-17-nginx-base-image-pin-plan.md
+++ b/docs/plans/2026-07-17-nginx-base-image-pin-plan.md
@@ -1,0 +1,45 @@
+# Nginx 基础镜像固定实施计划
+
+## Goal
+
+将 OpenDataWorks 主前端和 DataAgent 前端的 Nginx 运行时基线固定为 `nginx:1.30.3-alpine`。
+
+## Scope
+
+- 修改 `frontend/Dockerfile`。
+- 修改 `dataagent/dataagent-frontend/Dockerfile`。
+- 保持现有 Nginx 配置、构建产物路径、端口和 CMD 不变。
+- 不修改 `opendataagent/web/Dockerfile`。
+
+## Execution Steps
+
+1. 在 Docker Hub 官方 Nginx 镜像中确认 `1.30.3-alpine` tag 和多架构支持。
+2. 将两个 Dockerfile 的 `FROM nginx:alpine` 替换为 `FROM nginx:1.30.3-alpine`。
+3. 检查差异范围和 Dockerfile stage 结构。
+4. 在本地容器运行时可用时构建两个镜像；否则交由 GitHub Actions 完成多架构构建验证。
+
+## Verification
+
+- `rg '^FROM nginx:' frontend/Dockerfile dataagent/dataagent-frontend/Dockerfile`
+- `git diff --check`
+- `docker build -t opendataworks-frontend:nginx-1.30.3 frontend`
+- `docker build -t opendataworks-dataagent-frontend:nginx-1.30.3 -f dataagent/dataagent-frontend/Dockerfile .`
+
+## Verification Results
+
+- Docker Hub 官方镜像中已确认 `nginx:1.30.3-alpine` tag 和多架构支持。
+- 使用 Podman 5.5.1（ARM64 Linux）完整构建两个镜像，前端构建均成功。
+- 两个镜像均已启动验证，`nginx -v` 返回 `nginx/1.30.3`，工作进程正常启动。
+- 本地未压缩镜像大小约为：主前端 63.1 MiB，DataAgent 前端 64.7 MiB。
+- 构建期间 npm audit 报告 20 个既有依赖漏洞；本次仅固定运行时基础镜像，未调整前端依赖。
+- Docker 26 目标机器上的 `pwrite /run/nginx.pid` 场景仍需实机验证；固定版本用于消除浮动基础镜像漂移，不代表宿主机运行时权限问题已修复。
+
+## Rollout
+
+- 合并到 `main` 后，现有 `docker-build.yml` 重建并推送两个前端镜像。
+- 在目标 Docker 26 机器上验证镜像启动、健康检查和反向代理路由。
+
+## Backout
+
+- 回退本次 Dockerfile 变更并重建镜像。
+- 临时回滚时使用已验证的旧业务镜像 tag 或 digest，不直接切回浮动基础镜像。

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN npm run build
 
 # 生产运行镜像 - 使用 nginx 提供静态文件
-FROM nginx:alpine
+FROM nginx:1.30.3-alpine
 
 # 复制构建产物到 nginx
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- Pin the main frontend and DataAgent frontend runtime images to the small Alpine-based Nginx 1.30.3 release.
- Replace the floating `nginx:alpine` tag so routine rebuilds do not silently change the Nginx major or minor baseline.

## What Changed

### Behavior Changes
- Both frontend runtime stages now use `nginx:1.30.3-alpine`.
- Existing Nginx configuration, ports, build output paths, and release tags remain unchanged.
- The independent `opendataagent/web` image remains on its existing base image.

### Key Files
- `frontend/Dockerfile`: pins the main frontend runtime image.
- `dataagent/dataagent-frontend/Dockerfile`: pins the DataAgent frontend runtime image.
- `docs/design/2026-07-17-nginx-base-image-pin-design.md`: records scope and tradeoffs.
- `docs/plans/2026-07-17-nginx-base-image-pin-plan.md`: records verification, rollout, and backout.

## Validation
- `git diff --check`: passed.
- `podman build -t opendataworks-frontend:nginx-1.30.3 .` from `frontend/`: passed.
- `podman build -t opendataworks-dataagent-frontend:nginx-1.30.3 -f dataagent/dataagent-frontend/Dockerfile .`: passed.
- `nginx -v` in both built images: returned `nginx/1.30.3`.
- Started both images with test upstream host aliases: both containers remained running and started Nginx workers successfully.
- Local ARM64 uncompressed sizes: main frontend 63.1 MiB; DataAgent frontend 64.7 MiB.

## Risks
- The Docker 26 host that reported `pwrite /run/nginx.pid` still requires deployment validation; pinning the image removes base-image drift but does not change host security policy.
- Nginx security updates now require an explicit image-version PR.

## Rollback
- Revert commit `13ddec8f` and rebuild, or redeploy the previously verified application-image tag or digest.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updated when required.
