### PR TITLE
fix: preserve widget context for file downloads

### DIFF
--- a/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -101,6 +101,34 @@ describe('createNl2SqlApiClient', () => {
     )
   })
 
+  it('fetches file blobs with widget context headers', async () => {
+    const headers = {
+      'X-ODW-Client': 'widget',
+      'X-ODW-Website-Id': 'demo',
+      'X-ODW-User-Id': 'user-123'
+    }
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(new Blob(['file-content']))
+    })
+
+    try {
+      const client = createNl2SqlApiClient({
+        baseURL: 'https://odw.example.com',
+        defaultHeaders: headers
+      })
+
+      await client.topicApi.fetchFileBlob('topic-widget', 'output/report.csv')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://odw.example.com/api/v1/nl2sql/topics/topic-widget/files/output/report.csv',
+        { credentials: 'include', headers }
+      )
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
   it('exposes safe runtime config through the unified runtime API', () => {
     const client = createNl2SqlApiClient()
 

--- a/dataagent/dataagent-frontend/src/api/nl2sql.js
+++ b/dataagent/dataagent-frontend/src/api/nl2sql.js
@@ -185,8 +185,8 @@ export function createNl2SqlApiClient(options = {}) {
       }
       return response.text()
     },
-    // 登录态下浏览器裸链接导航带不上自定义标记头，SPA 的文件下载/预览
-    // 统一改走 fetch → Blob（见设计文档 3.6）。widget 仍用 fileUrl 裸链接。
+    // 浏览器裸链接导航带不上 SPA/dataagent/widget 的自定义上下文头，文件
+    // 下载统一改走 fetch -> Blob，由各聊天界面触发浏览器保存。
     async fetchFileBlob(topicId, relPath) {
       const response = await fetch(this.fileUrl(topicId, relPath), {
         credentials: 'include',

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -53,7 +53,11 @@
       <div v-if="copyNotice" class="query-copy-toast" role="status">{{ copyNotice }}</div>
 
       <div ref="messagesEl" class="query-messages" @scroll="onMessagesScroll">
-        <div class="query-messages-inner" :class="{ 'is-empty': !messages.length }">
+        <div
+          class="query-messages-inner"
+          :class="{ 'is-empty': !messages.length }"
+          @click="handleWorkspaceFileClick"
+        >
           <div v-if="errorText" class="query-error-card query-error-banner">
             <span class="query-error-label">错误</span>
             <span>{{ errorText }}</span>
@@ -165,8 +169,8 @@
                     v-for="file in msg.attachments"
                     :key="file.rel_path"
                     class="query-msg-attachment"
-                    :href="attachmentDownloadUrl(file)"
-                    download
+                    :href="resolveWorkspaceFileHref(file.rel_path)"
+                    :data-file-name="file.name"
                     :title="'下载 ' + file.name"
                   >
                     <svg class="query-msg-attachment-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /></svg>
@@ -558,13 +562,44 @@ const uid = () => `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
 // uses (copy/preview); rendering splits it into text/chart segments instead.
 const cleanTextForDisplay = (content) => stripChartSpecsFromText(String(content || '')).trim()
 
-// Message markdown: workspace-relative file links the agent emits
-// (`output/...`, `uploads/...`) become download URLs for the active topic.
+const WORKSPACE_FILE_FRAGMENT = '#odw-file='
+
+// Message markdown and attachment cards use a self-describing fragment. The
+// message container intercepts it and downloads with the widget context headers.
 const renderMarkdown = (text) => renderMarkdownBase(text, { resolveFileHref: resolveWorkspaceFileHref })
 const resolveWorkspaceFileHref = (relPath) => (
-  topicId.value ? api.topicApi.fileUrl(topicId.value, relPath, { download: true }) : ''
+  topicId.value ? `${WORKSPACE_FILE_FRAGMENT}${encodeURIComponent(String(relPath || ''))}` : ''
 )
-const attachmentDownloadUrl = (file) => api.topicApi.fileUrl(topicId.value, file.rel_path, { download: true })
+
+const downloadWorkspaceFile = async (relPath, fileName = '') => {
+  if (!topicId.value || !relPath) return
+  try {
+    const blob = await api.topicApi.fetchFileBlob(topicId.value, relPath)
+    const objectUrl = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = objectUrl
+    anchor.download = fileName || String(relPath).split('/').pop() || 'download'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(objectUrl)
+  } catch (error) {
+    errorText.value = `下载失败: ${error?.message || error}`
+  }
+}
+
+const handleWorkspaceFileClick = (event) => {
+  const anchor = event.target?.closest?.('a[href*="#odw-file="]')
+  if (!anchor) return
+  const href = anchor.getAttribute('href') || ''
+  const index = href.indexOf(WORKSPACE_FILE_FRAGMENT)
+  if (index < 0) return
+  event.preventDefault()
+  let relPath = href.slice(index + WORKSPACE_FILE_FRAGMENT.length)
+  try { relPath = decodeURIComponent(relPath) } catch { /* keep raw */ }
+  void downloadWorkspaceFile(relPath, anchor.dataset.fileName || '')
+}
+
 const formatBytes = (size) => {
   const n = Number(size) || 0
   if (n < 1024) return `${n} B`

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -5,6 +5,9 @@ import { nextTick, reactive } from 'vue'
 import WidgetChat from '../WidgetChat.vue'
 import widgetChatSource from '../WidgetChat.vue?raw'
 
+const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL')
+const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL')
+
 // ECharts touches the canvas API, which jsdom doesn't fully implement. The chart
 // promotion tests only care about which container the chart lands in, so stub the
 // renderer to keep the conclusion-area direct chart from emitting canvas errors.
@@ -46,7 +49,8 @@ const apiMocks = vi.hoisted(() => ({
     getTopicMessages: vi.fn(),
     deleteTopic: vi.fn(),
     updateTopic: vi.fn(),
-    updateMessageFeedback: vi.fn()
+    updateMessageFeedback: vi.fn(),
+    fetchFileBlob: vi.fn()
   },
   taskApi: {
     deliverMessage: vi.fn(),
@@ -151,6 +155,7 @@ describe('WidgetChat history conversations', () => {
     apiMocks.topicApi.deleteTopic.mockResolvedValue({ status: 'ok' })
     apiMocks.topicApi.updateTopic.mockImplementation(async (topicId, payload) => topic(topicId, '已更新会话', payload))
     apiMocks.topicApi.updateMessageFeedback.mockImplementation(async (_topicId, messageId, feedback) => ({ message_id: messageId, feedback }))
+    apiMocks.topicApi.fetchFileBlob.mockResolvedValue(new Blob(['file-content']))
     apiMocks.taskApi.deliverMessage.mockResolvedValue({ task_id: 'task-1' })
     apiMocks.taskApi.getTask.mockResolvedValue({ task_status: 'finished' })
     apiMocks.taskApi.streamSdkEvents.mockResolvedValue()
@@ -159,6 +164,10 @@ describe('WidgetChat history conversations', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    if (createObjectURLDescriptor) Object.defineProperty(URL, 'createObjectURL', createObjectURLDescriptor)
+    else Reflect.deleteProperty(URL, 'createObjectURL')
+    if (revokeObjectURLDescriptor) Object.defineProperty(URL, 'revokeObjectURL', revokeObjectURLDescriptor)
+    else Reflect.deleteProperty(URL, 'revokeObjectURL')
   })
 
   it('renders inline with portal-style layout, model info, suggestions, and no delete actions', async () => {
@@ -302,6 +311,50 @@ describe('WidgetChat history conversations', () => {
     await wrapper.get('[data-testid="feedback-dislike-msg-topic-2"]').trigger('click')
     expect(apiMocks.topicApi.updateMessageFeedback).toHaveBeenCalledWith('topic-2', 'msg-topic-2', 'dislike')
     expect(wrapper.get('[data-testid="feedback-dislike-msg-topic-2"]').classes()).toContain('active')
+  })
+
+  it('downloads widget attachments and markdown files through the header-aware API client', async () => {
+    apiMocks.topicApi.getTopicMessages.mockImplementation(async (topicId) => ({
+      topic_id: topicId,
+      total: 1,
+      items: [
+        {
+          message_id: `msg-${topicId}`,
+          sender_type: 'assistant',
+          content: '[下载明细](output/detail.csv)',
+          status: 'success',
+          seq_id: 1,
+          attachments: [
+            { name: '销售报表.xlsx', rel_path: 'output/销售报表.xlsx', size: 12, kind: 'output' }
+          ]
+        }
+      ]
+    }))
+    const createObjectURL = vi.fn().mockReturnValue('blob:widget-download')
+    const revokeObjectURL = vi.fn()
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+    await wrapper.get('[data-testid="history-topic-topic-2"]').trigger('click')
+    await flushPromises()
+
+    const attachment = wrapper.get('.query-msg-attachment')
+    expect(attachment.attributes('href')).toBe('#odw-file=output%2F%E9%94%80%E5%94%AE%E6%8A%A5%E8%A1%A8.xlsx')
+    await attachment.trigger('click')
+    await flushPromises()
+    expect(apiMocks.topicApi.fetchFileBlob).toHaveBeenCalledWith('topic-2', 'output/销售报表.xlsx')
+
+    const markdownLink = wrapper.get('.query-main-text a')
+    expect(markdownLink.attributes('href')).toBe('#odw-file=output%2Fdetail.csv')
+    await markdownLink.trigger('click')
+    await flushPromises()
+    expect(apiMocks.topicApi.fetchFileBlob).toHaveBeenCalledWith('topic-2', 'output/detail.csv')
+    expect(createObjectURL).toHaveBeenCalledTimes(2)
+    expect(anchorClick).toHaveBeenCalledTimes(2)
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2)
   })
 
   it('falls back when the widget clipboard API rejects and shows copy feedback', async () => {


### PR DESCRIPTION
## Summary

- route widget attachment and Markdown file clicks through the header-aware Blob download path
- preserve widget website/user context so backend topic authorization succeeds
- add regression coverage for widget downloads and custom request headers

## Root cause

Widget file links used direct browser navigation. That navigation could not include the widget context headers, so the backend resolved the request as portal traffic and returned `Topic not found` for the widget-owned topic.

## Validation

- `npm --prefix dataagent/dataagent-frontend test -- src/widget/__tests__/WidgetChat.spec.js src/api/__tests__/nl2sqlClient.spec.js` (39 tests passed)
- `npm --prefix dataagent/dataagent-frontend run build:widget`
- `git diff --check`
