### PR TITLE
fix: read generated files from backend runtime mount

### DIFF
--- a/dataagent/dataagent-backend/Dockerfile
+++ b/dataagent/dataagent-backend/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV HOME=/dataagent_runtime
+ENV DATAAGENT_RUNTIME_ROOT=/dataagent_runtime
 
 WORKDIR /opt/dataagent-backend
 

--- a/dataagent/dataagent-backend/config.py
+++ b/dataagent/dataagent-backend/config.py
@@ -95,6 +95,10 @@ class Settings(BaseSettings):
     dataagent_ask_user_question_enabled: bool = True
 
     # ---- Topic runtime root / sandbox ----
+    # Filesystem root visible to the current process. Containerized backend
+    # processes read the shared volume at /dataagent_runtime; local execution
+    # leaves this empty and falls back to dataagent_host_root.
+    dataagent_runtime_root: str = ""
     # Host-visible persistent root used by the sandbox runner when asking the
     # host Docker/Podman daemon to bind-mount topic subdirectories into child
     # containers.

--- a/dataagent/dataagent-backend/core/topic_workspace.py
+++ b/dataagent/dataagent-backend/core/topic_workspace.py
@@ -37,7 +37,10 @@ def _resolve_runtime_root(raw: str | None = None) -> Path:
         try:
             from config import get_settings
 
-            value = str(get_settings().dataagent_host_root or "").strip()
+            settings = get_settings()
+            value = str(getattr(settings, "dataagent_runtime_root", "") or "").strip()
+            if not value:
+                value = str(settings.dataagent_host_root or "").strip()
         except Exception:
             value = ""
     if value:

--- a/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
+++ b/dataagent/dataagent-backend/tests/test_runner_dockerfile.py
@@ -30,6 +30,7 @@ def test_backend_dockerfile_uses_opt_backend_and_no_bundled_skills():
     content = BACKEND_DOCKERFILE.read_text(encoding="utf-8")
 
     assert "ENV HOME=/dataagent_runtime" in content
+    assert "ENV DATAAGENT_RUNTIME_ROOT=/dataagent_runtime" in content
     assert OLD_SANDBOX_ROOT_ENV not in content
     assert "mkdir -p /dataagent_runtime /app/.claude/skills" in content
     assert OLD_WORKSPACES_ROOT not in content

--- a/dataagent/dataagent-backend/tests/test_topic_workspace.py
+++ b/dataagent/dataagent-backend/tests/test_topic_workspace.py
@@ -10,6 +10,7 @@ if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
 from config import get_settings, update_settings
+from core.topic_files import safe_workspace_file
 from core.topic_workspace import (
     cleanup_orphan_topic_workspaces,
     delete_topic_workspace,
@@ -35,15 +36,56 @@ def test_resolve_topic_workspace_uses_topic_id_only(monkeypatch, tmp_path: Path)
     assert workspace == tmp_path / "topics" / "topic-unsafe-id" / "workspace"
 
 
-def test_resolve_topic_workspace_uses_configured_runtime_root(tmp_path: Path):
-    original_root = get_settings().dataagent_host_root
-    update_settings({"dataagent_host_root": str(tmp_path / "configured-runtime")})
+def test_resolve_topic_workspace_prefers_container_runtime_root(tmp_path: Path):
+    original_runtime_root = get_settings().dataagent_runtime_root
+    original_host_root = get_settings().dataagent_host_root
+    container_root = tmp_path / "container-runtime"
+    host_root = tmp_path / "host-runtime"
+    output_file = container_root / "topic_1" / "workspace" / "output" / "report.html"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("<h1>ok</h1>", encoding="utf-8")
+    update_settings(
+        {
+            "dataagent_runtime_root": str(container_root),
+            "dataagent_host_root": str(host_root),
+        }
+    )
+    try:
+        workspace = resolve_topic_workspace("topic_1")
+        resolved_file = safe_workspace_file("topic_1", "output/report.html")
+    finally:
+        update_settings(
+            {
+                "dataagent_runtime_root": original_runtime_root,
+                "dataagent_host_root": original_host_root,
+            }
+        )
+
+    assert workspace == container_root / "topic_1" / "workspace"
+    assert resolved_file == output_file
+
+
+def test_resolve_topic_workspace_falls_back_to_host_root_for_local_execution(tmp_path: Path):
+    original_runtime_root = get_settings().dataagent_runtime_root
+    original_host_root = get_settings().dataagent_host_root
+    host_root = tmp_path / "local-runtime"
+    update_settings(
+        {
+            "dataagent_runtime_root": "",
+            "dataagent_host_root": str(host_root),
+        }
+    )
     try:
         workspace = resolve_topic_workspace("topic_1")
     finally:
-        update_settings({"dataagent_host_root": original_root})
+        update_settings(
+            {
+                "dataagent_runtime_root": original_runtime_root,
+                "dataagent_host_root": original_host_root,
+            }
+        )
 
-    assert workspace == tmp_path / "configured-runtime" / "topic_1" / "workspace"
+    assert workspace == host_root / "topic_1" / "workspace"
 
 
 def test_prepare_topic_workspace_copies_enabled_skills(monkeypatch, tmp_path: Path):

--- a/docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
+++ b/docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
@@ -18,8 +18,9 @@ tell the host Docker/Podman daemon where to bind-mount each topic's
 (`sandbox_runner_main._host_sandbox_root()` →
 `Path(raw).expanduser().resolve()`).
 
-Any custom `DATAAGENT_HOST_ROOT` (even an absolute one) is broken, and a
-relative value is doubly broken. There are two independent defects:
+The runner and launcher now separate the host and container roots, but a
+follow-up defect remains in the backend file APIs. The complete failure had
+three independent parts:
 
 1. Runner conflates two roots. `sandbox_runner_main` used `DATAAGENT_HOST_ROOT`
    for both (a) the filesystem prep it performs *inside its own container*
@@ -43,12 +44,21 @@ relative value is doubly broken. There are two independent defects:
    source. `scripts/start.sh` already normalizes `DATAAGENT_SKILLS_DIR` via
    `resolve_dataagent_skills_dir()` but had no equivalent for the runtime root.
 
+3. Backend file APIs still conflate the roots. The backend receives `.env`
+   through `env_file`, so a custom host value such as
+   `/data/odw/dataagent_runtime` is also visible in the backend container.
+   `core.topic_workspace` used that host path for `list_files()` and downloads,
+   even though the volume is mounted inside the backend at the fixed path
+   `/dataagent_runtime`. Sandbox tasks successfully write the host file, but the
+   backend checks a different, container-local path and returns `file not found`.
+
 ## Problem
 
-Operators cannot point the DataAgent runtime root at a custom host directory:
-the sandbox runner writes its topic prep to the wrong (container-local) path, so
-the custom directory stays empty and sandbox tasks fail. Relative values fail
-additionally because the runner re-resolves them against its own filesystem.
+With a custom host directory, sandbox tasks can produce files successfully but
+the backend cannot list, preview, or download them because it reads the host
+path string from inside its container. Downloading must not depend on a sandbox
+child: children are disposable, while topic files live on the shared persistent
+volume and remain available through the backend.
 
 ## Scope
 
@@ -57,10 +67,12 @@ additionally because the runner re-resolves them against its own filesystem.
   host root (`DATAAGENT_HOST_ROOT`) only for child bind-mount sources.
 - Normalize a relative `DATAAGENT_HOST_ROOT` to an absolute host path in
   `scripts/start.sh` before invoking compose, mirroring the skills-dir handling.
+- Separate the backend's container-visible runtime root from the host bind
+  source so file APIs always read the shared volume directly.
 - Keep the container-visible runtime root fixed at `/dataagent_runtime` and the
   compose contract unchanged.
 
-Affected stacks: DataAgent runner (`dataagent/dataagent-backend/sandbox_runner_main.py`)
+Affected stacks: DataAgent backend and runner (`dataagent/dataagent-backend`)
 and deployment (`scripts/start.sh`, `deploy/.env.example`, `deploy/README.md`).
 
 ## Solution
@@ -93,11 +105,25 @@ mounted volume regardless of where that volume is on the host.
 Direct `docker compose` invocations that bypass `start.sh` still require an
 absolute value; this is documented in `.env.example` and `deploy/README.md`.
 
+Follow-up fix — backend runtime-root separation:
+
+- Add the internal `DATAAGENT_RUNTIME_ROOT` setting. `core.topic_workspace`
+  resolves implicit topic paths from this container-visible root first, then
+  falls back to `DATAAGENT_HOST_ROOT` for local, non-container execution.
+- Set `DATAAGENT_RUNTIME_ROOT=/dataagent_runtime` in the backend image. The
+  backend therefore lists and serves files from its mounted volume regardless
+  of the host directory used as the compose bind source.
+- Keep download handling in the backend. It authorizes the topic, confines the
+  relative path, and serves the persistent file without requiring a live or
+  reusable sandbox child.
+
 ## Interfaces
 
-- No new or removed `.env` variables. `DATAAGENT_HOST_ROOT` semantics widen from
+- No new operator-facing `.env` variables. `DATAAGENT_HOST_ROOT` semantics widen from
   "absolute host path" to "absolute or `deploy/`-relative host path when launched
   via `start.sh`".
+- `DATAAGENT_RUNTIME_ROOT` is an internal image contract for the backend's
+  container-visible mount path, not a deployment tuning knob.
 - Container runtime root stays fixed at `/dataagent_runtime` (an internal module
   constant, not an `.env` knob).
 
@@ -108,6 +134,10 @@ absolute value; this is documented in `.env.example` and `deploy/README.md`.
   cannot know the host's `deploy/` location), so the launcher is the correct
   single place to normalize it; raw `docker compose` keeps the explicit
   absolute-path requirement instead of a second, unreliable resolution layer.
-- The container runtime root is kept as a fixed constant (test-overridable by
-  monkeypatch) rather than a new setting, honoring the consolidation design's
-  "container root is not an external knob" rule.
+- The backend image supplies the container runtime root as a fixed internal
+  environment value. The setting exists so local tests and non-container
+  execution can select the process-visible root explicitly, but it is not an
+  operator-facing deployment knob.
+- Local source execution still falls back to `DATAAGENT_HOST_ROOT`, preserving
+  existing `.dataagent_runtime` development setups without container-only path
+  detection or a sandbox download proxy.

--- a/docs/plans/2026-06-09-dataagent-host-root-custom-path-plan.md
+++ b/docs/plans/2026-06-09-dataagent-host-root-custom-path-plan.md
@@ -20,13 +20,22 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
    - Before the compose `up`, set and `export DATAAGENT_HOST_ROOT` to the
      resolved absolute path and echo it so the chosen host directory is visible.
 
-3. Documentation.
+3. Backend runtime-root separation.
+   - Add internal `dataagent_runtime_root` configuration and prefer it in
+     `core/topic_workspace.py` for implicit topic path resolution.
+   - Set `DATAAGENT_RUNTIME_ROOT=/dataagent_runtime` in the backend image so
+     file listing, preview, download, cleanup, and attachment detection use the
+     mounted volume instead of the host bind-source string.
+   - Keep `DATAAGENT_HOST_ROOT` as the local fallback and runner child-bind
+     source; do not proxy file downloads to disposable sandbox children.
+
+4. Documentation.
    - `deploy/.env.example`: document that `DATAAGENT_HOST_ROOT` accepts a custom
      absolute path or a `deploy/`-relative path (expanded by `start.sh`), and
      that raw `docker compose` needs an absolute value.
    - `deploy/README.md`: same note on both DataAgent runtime-root bullets.
 
-4. Tests.
+5. Tests.
    - `dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`: add an
      autouse fixture redirecting `CONTAINER_RUNTIME_ROOT` to a temp dir; assert
      the runner creates topic workspace/home/logs under the container root while
@@ -34,11 +43,21 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
      never leaks in as a bind source.
    - `tests/test_deepeval_packaging_hooks.py`: assert `start.sh` defines
      `resolve_dataagent_host_root` and exports the resolved value before compose.
+   - `dataagent/dataagent-backend/tests/test_topic_workspace.py`: verify the
+     container runtime root wins over a distinct host root and resolves an
+     existing `output/report.html`; verify local fallback remains unchanged.
+   - `dataagent/dataagent-backend/tests/test_runner_dockerfile.py`: assert the
+     backend image declares its fixed container-visible runtime root.
 
 ## Touched files
 
 - `dataagent/dataagent-backend/sandbox_runner_main.py`
+- `dataagent/dataagent-backend/config.py`
+- `dataagent/dataagent-backend/core/topic_workspace.py`
+- `dataagent/dataagent-backend/Dockerfile`
 - `dataagent/dataagent-backend/tests/test_sandbox_runner_main.py`
+- `dataagent/dataagent-backend/tests/test_topic_workspace.py`
+- `dataagent/dataagent-backend/tests/test_runner_dockerfile.py`
 - `scripts/start.sh`
 - `deploy/.env.example`
 - `deploy/README.md`
@@ -50,6 +69,10 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
 
 - `pytest dataagent/dataagent-backend/tests/test_sandbox_runner_main.py` (host vs
   container root separation).
+- `pytest dataagent/dataagent-backend/tests/test_topic_workspace.py
+  dataagent/dataagent-backend/tests/test_topic_files.py
+  dataagent/dataagent-backend/tests/test_runner_dockerfile.py` (backend direct
+  persistent-volume reads and file path confinement).
 - `pytest tests/test_deepeval_packaging_hooks.py` for the packaging/launcher
   assertions.
 - `bash -n scripts/start.sh` and a shell unit check that
@@ -62,11 +85,11 @@ Paired design: `docs/design/2026-06-09-dataagent-host-root-custom-path-design.md
 
 ## Rollout
 
-- Runner code + launcher + docs change. The runner image must be rebuilt to pick
-  up the `sandbox_runner_main.py` fix. Deployments using the default
-  `/dataagent_runtime` are behavior-unchanged.
+- Backend/runner code + launcher + docs change. Both backend and runner images
+  must be rebuilt for the complete custom-root fix. Deployments using the
+  default `/dataagent_runtime` are behavior-unchanged.
 
 ## Backout
 
-- Revert the `sandbox_runner_main.py`, `scripts/start.sh`, `.env.example`, and
-  `README.md` edits. No data migration is involved.
+- Revert the backend runtime-root changes plus the earlier runner/launcher edits.
+  No data migration is involved; files remain in the existing host volume.


### PR DESCRIPTION
## Summary

- separate the backend-visible runtime root from the host bind-mount source
- make backend file listing, preview, download, cleanup, and attachment detection read `/dataagent_runtime`
- keep `DATAAGENT_HOST_ROOT` for host-side compose mounts and sandbox child binds
- document the persistent-volume ownership boundary and add regression coverage

## Root cause

With a custom `DATAAGENT_HOST_ROOT`, sandbox children correctly wrote files to the host directory mounted into the containers. The backend also read that host path string from `.env`, but inside its container the same volume is visible at `/dataagent_runtime`. It therefore checked a non-mounted container path and returned `file not found` even though the generated file existed.

Downloads remain a backend responsibility. Sandbox children are disposable; generated topic files persist on the shared volume and are served directly by the backend.

## Validation

- DataAgent workspace/files/runner/Dockerfile tests: 53 passed
- DataAgent widget/runtime route tests: 29 passed
- Widget/API frontend tests: 41 passed
- `git diff --check`

A real multi-container custom-root smoke was not run locally because Docker CLI is unavailable in this environment.
