### PR TITLE
feat: control widget anonymous access

### DIFF
--- a/dataagent/dataagent-backend/api/routes.py
+++ b/dataagent/dataagent-backend/api/routes.py
@@ -191,8 +191,6 @@ def _request_context(request: Request) -> dict[str, str]:
     visitor_id = _clean_header(request.headers.get("X-ODW-Visitor-Id"), 128)
     if not website_id:
         raise HTTPException(status_code=400, detail="X-ODW-Website-Id is required")
-    if not external_user_id and not visitor_id:
-        raise HTTPException(status_code=400, detail="X-ODW-User-Id or X-ODW-Visitor-Id is required")
 
     matched_site = None
     for site in _allowed_widget_sites():
@@ -212,6 +210,15 @@ def _request_context(request: Request) -> dict[str, str]:
     if not _origin_allowed(req_origin, allowed_origins):
         logger.warning(f"Widget origin rejected: origin={req_origin!r} allowed={allowed_origins!r}")
         raise HTTPException(status_code=403, detail="Widget origin is not allowed")
+
+    if not external_user_id and (not visitor_id or matched_site.get("allow_anonymous") is not True):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "code": "WIDGET_LOGIN_REQUIRED",
+                "message": "请先登录后使用智能问数",
+            },
+        )
 
     return {
         "source": "widget",

--- a/dataagent/dataagent-backend/core/skill_admin_service.py
+++ b/dataagent/dataagent-backend/core/skill_admin_service.py
@@ -210,6 +210,7 @@ def _normalize_widget_allowed_sites(raw: Any) -> list[dict[str, Any]]:
             "allowed_origins": origin_list,
             "project_name": str(item.get("project_name") or "").strip()[:128],
             "project_color": str(item.get("project_color") or "").strip()[:32],
+            "allow_anonymous": item.get("allow_anonymous") is True,
         })
     return normalized
 

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -262,6 +262,7 @@ class WidgetAllowedSite(BaseModel):
     allowed_origins: List[str] = Field(default_factory=list)
     project_name: str = ""
     project_color: str = ""
+    allow_anonymous: bool = False
 
 
 class AdminSettingsResponse(BaseModel):

--- a/dataagent/dataagent-backend/tests/test_skill_admin_service.py
+++ b/dataagent/dataagent-backend/tests/test_skill_admin_service.py
@@ -230,6 +230,7 @@ def test_normalize_widget_allowed_sites_from_json_string():
             "allowed_origins": ["https://a.com"],
             "project_name": "Demo",
             "project_color": "#4A90A4",
+            "allow_anonymous": False,
         }
     ]
 
@@ -247,6 +248,7 @@ def test_normalize_widget_allowed_sites_drops_invalid_and_duplicate_entries():
 
     assert [item["website_id"] for item in sites] == ["dup"]
     assert sites[0]["allowed_origins"] == []
+    assert sites[0]["allow_anonymous"] is False
 
 
 def test_merge_settings_payload_carries_widget_allowed_sites_from_patch():
@@ -257,7 +259,12 @@ def test_merge_settings_payload_carries_widget_allowed_sites_from_patch():
         },
         {
             "widget_allowed_sites": [
-                {"website_id": "new", "allowed_origins": ["https://b.com"], "project_color": "#000"}
+                {
+                    "website_id": "new",
+                    "allowed_origins": ["https://b.com"],
+                    "project_color": "#000",
+                    "allow_anonymous": True,
+                }
             ]
         },
     )
@@ -268,6 +275,7 @@ def test_merge_settings_payload_carries_widget_allowed_sites_from_patch():
             "allowed_origins": ["https://b.com"],
             "project_name": "",
             "project_color": "#000",
+            "allow_anonymous": True,
         }
     ]
 
@@ -287,6 +295,7 @@ def test_merge_settings_payload_preserves_widget_allowed_sites_without_patch():
             "allowed_origins": ["*"],
             "project_name": "",
             "project_color": "",
+            "allow_anonymous": False,
         }
     ]
 

--- a/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
+++ b/dataagent/dataagent-backend/tests/test_widget_runtime_routes.py
@@ -114,7 +114,7 @@ def install_fake_store(monkeypatch):
     return store
 
 
-def install_widget_settings(monkeypatch):
+def install_widget_settings(monkeypatch, *, allow_anonymous=False):
     monkeypatch.setattr(
         routes,
         "get_settings",
@@ -139,6 +139,7 @@ def install_widget_settings(monkeypatch):
                     "allowed_origins": ["https://host.example.com"],
                     "project_name": "Demo",
                     "project_color": "#4A90A4",
+                    "allow_anonymous": allow_anonymous,
                 }
             ]
         },
@@ -260,7 +261,7 @@ def test_widget_topic_create_uses_requested_agent_snapshot(monkeypatch):
 
 
 def test_widget_requests_fall_back_to_visitor_context_without_user_id(monkeypatch):
-    install_widget_settings(monkeypatch)
+    install_widget_settings(monkeypatch, allow_anonymous=True)
     install_agent_profile(monkeypatch)
     store = install_fake_store(monkeypatch)
     client = TestClient(app)
@@ -277,6 +278,38 @@ def test_widget_requests_fall_back_to_visitor_context_without_user_id(monkeypatc
     assert context["website_id"] == "demo"
     assert context["external_user_id"] == ""
     assert context["visitor_id"] == "visitor-abc"
+
+
+def test_widget_requests_reject_visitor_when_anonymous_access_is_disabled(monkeypatch):
+    install_widget_settings(monkeypatch)
+    install_agent_profile(monkeypatch)
+    store = install_fake_store(monkeypatch)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/nl2sql/topics",
+        headers=widget_headers("", visitor_id="visitor-abc"),
+        json={"title": "匿名访客", "agent_id": "agent_widget"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == {
+        "code": "WIDGET_LOGIN_REQUIRED",
+        "message": "请先登录后使用智能问数",
+    }
+    assert store.calls == [("init_schema", None)]
+
+
+def test_widget_requests_without_identity_require_login(monkeypatch):
+    install_widget_settings(monkeypatch, allow_anonymous=True)
+    store = install_fake_store(monkeypatch)
+    client = TestClient(app)
+
+    response = client.get("/api/v1/nl2sql/topics", headers=widget_headers(""))
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "WIDGET_LOGIN_REQUIRED"
+    assert store.calls == [("init_schema", None)]
 
 
 def test_widget_origin_must_match_allowed_site(monkeypatch):

--- a/dataagent/dataagent-frontend/examples/widget/README.md
+++ b/dataagent/dataagent-frontend/examples/widget/README.md
@@ -2,6 +2,18 @@
 
 嵌入式智能问数组件，可通过单个 `<script>` 标签将 OpenDataWorks 的智能问数能力集成到任何网页中。
 
+本文档是 Widget 接入参数、身份策略和运行方式的权威说明。`docs/design/` 与 `docs/plans/` 下的文件仅记录内部设计和实施过程。
+
+## 接入前置配置
+
+嵌入脚本生效前，管理员需要先在 DataAgent 的 `/widget-access` 页面新增接入站点：
+
+1. `Website ID`：必须与嵌入脚本的 `data-website-id` 完全一致。
+2. `允许来源（Origin）`：填写宿主页面来源，例如 `https://portal.example.com`；`*` 仅建议用于本地演示。
+3. `匿名访问`：默认关闭。生产站点建议保持关闭，由宿主系统提供当前用户身份。
+
+未加入站点白名单或 Origin 不匹配时，后端返回 `403`，Widget 不允许访问智能问数接口。
+
 ## 快速开始
 
 在页面底部（`</body>` 前）添加以下脚本标签：
@@ -12,6 +24,8 @@
   data-website-id="your-website-id"
   data-agent-id="your-agent-id"
   data-api-base-url="http://localhost:8900"
+  data-user-id="current-user-id"
+  data-login-url="/login"
   defer
 ></script>
 ```
@@ -32,7 +46,42 @@ Widget 会自动初始化并在页面右下角显示一个悬浮按钮。
 | `data-project-name` | 否 | `'智能问数'` | 显示名称，出现在面板标题栏 |
 | `data-project-color` | 否 | `'#4A90A4'` | 主题色（十六进制），影响按钮、标题栏等元素的颜色 |
 | `data-container-id` | 否 | — | 内嵌模式下的容器元素 ID（仅内嵌模式必填） |
-| `data-user-id` | 否 | — | 可选的用户标识，用于关联会话和历史记录 |
+| `data-user-id` | 否 | — | 当前用户标识；未开启匿名访问时必须由宿主系统提供 |
+| `data-login-url` | 否 | — | 未提供用户身份时“前往登录”按钮的跳转地址 |
+| `data-allow-anonymous` | 否 | `'false'` | 是否允许客户端生成访客 ID；还需在管理端为该站点开启匿名访问 |
+
+## 身份与匿名访问
+
+匿名访问采用前后端双重开关，任何一侧未开启都不会放行匿名用户：
+
+| 用户 ID | 嵌入参数 `allowAnonymous` | 管理端允许匿名 | 结果 |
+|---------|--------------------------|----------------|------|
+| 已提供 | 任意 | 任意 | 按该外部用户加载会话和使用 Widget |
+| 未提供 | `false` 或未配置 | 任意 | 展示“请先登录”，不生成访客 ID |
+| 未提供 | `true` | 关闭 | 后端返回 `401/WIDGET_LOGIN_REQUIRED`，切换到登录状态 |
+| 未提供 | `true` | 开启 | 生成 `visitor_` 标识，按匿名访客使用 Widget |
+
+匿名访问默认关闭。未登录状态保留 Widget 入口、标题栏和关闭按钮，但隐藏历史会话、推荐问题和输入区，不加载会话或业务数据：
+
+- 配置 `data-login-url`：显示“前往登录”。
+- 未配置 `data-login-url`：显示“刷新页面”。
+- `sendMessage()`、`ask()`、新建会话和历史会话等公开 API 同样会被拦截。
+- 后端拒绝匿名身份时返回 HTTP `401`，错误码为 `WIDGET_LOGIN_REQUIRED`。
+
+宿主系统应在自身登录校验完成后注入 `data-user-id`，不要直接采用用户可修改的 URL 参数或表单值。当前 `X-ODW-User-Id` 是外部身份传递契约，不等同于密码或签名令牌。
+
+公开演示场景需要在管理端站点设置和嵌入脚本中同时开启匿名访问：
+
+```html
+<script
+  src="http://localhost:3001/widget/opendataworks-widget.bundle.js"
+  data-website-id="public-demo"
+  data-agent-id="demo"
+  data-api-base-url="http://localhost:8900"
+  data-allow-anonymous="true"
+  defer
+></script>
+```
 
 ## 显示模式
 
@@ -50,6 +99,8 @@ Widget 会自动初始化并在页面右下角显示一个悬浮按钮。
   data-position="bottom-right"
   data-project-name="智能助手"
   data-project-color="#6366f1"
+  data-user-id="current-user-id"
+  data-login-url="/login"
   defer
 ></script>
 ```
@@ -77,6 +128,8 @@ Widget 直接渲染到指定的 DOM 容器中，成为页面布局的一部分�
   data-container-id="widget-container"
   data-project-name="智能问数"
   data-project-color="#4A90A4"
+  data-user-id="current-user-id"
+  data-login-url="/login"
   defer
 ></script>
 ```
@@ -89,6 +142,26 @@ Widget 直接渲染到指定的 DOM 容器中，成为页面布局的一部分�
 ## JavaScript API
 
 Widget 加载后会在 `window` 上暴露 `OpenDataWorksWidget` 控制器对象。
+
+### 编程式安装
+
+不使用脚本 `data-*` 属性时，可以通过配置对象创建实例。属性名采用 camelCase：
+
+```javascript
+const widget = window.OpenDataWorksWidget.installWidget({
+  websiteId: 'my-site',
+  agentId: 'agent-001',
+  apiBaseUrl: 'http://localhost:8900',
+  userId: currentUser.id,
+  loginUrl: '/login',
+  allowAnonymous: false,
+  displayMode: 'floating',
+  projectName: '智能问数',
+  projectColor: '#4A90A4'
+});
+```
+
+编程式安装和 `data-*` 安装遵循相同的身份与匿名访问策略。
 
 ### 面板控制
 
@@ -150,6 +223,10 @@ widget.on('error', (error) => {
   console.error('发生错误:', error);
 });
 
+widget.on('login:required', () => {
+  console.log('Widget 等待宿主系统提供用户身份');
+});
+
 widget.on('ready', () => {
   console.log('Widget 已就绪');
 });
@@ -173,8 +250,8 @@ widget.destroy();
 ### 启动步骤
 
 ```bash
-# 1. 进入前端目录
-cd frontend
+# 1. 进入 DataAgent 前端目录
+cd dataagent/dataagent-frontend
 
 # 2. 确保使用正确的 Node 版本
 export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && nvm use
@@ -217,6 +294,15 @@ A: 检查浏览器控制台是否有加载错误，确认 script src 地址可�
 
 **Q: 点击发送消息没有响应？**
 A: 确认 `data-api-base-url` 和 `data-agent-id` 已正确配置，且后端服务正在运行。
+
+**Q: Widget 只显示“请先登录”？**
+A: 当前站点未提供 `data-user-id`。生产接入应在宿主登录完成后注入用户 ID；公开演示则需要同时开启管理端“匿名访问”和 `data-allow-anonymous="true"`。
+
+**Q: 已配置 `data-allow-anonymous="true"`，仍然要求登录？**
+A: 检查 `/widget-access` 中对应 `Website ID` 的匿名访问开关。客户端参数不能绕过后端站点策略。
+
+**Q: 返回 `403 Widget site/origin is not allowed`？**
+A: 检查管理端站点白名单中的 `Website ID` 和允许来源，确保与实际脚本参数及宿主页面 Origin 一致。
 
 **Q: 内嵌模式下 Widget 没有渲染？**
 A: 确保 `data-container-id` 指向的 DOM 元素已存在且具有明确的宽高。

--- a/dataagent/dataagent-frontend/examples/widget/api-demo.html
+++ b/dataagent/dataagent-frontend/examples/widget/api-demo.html
@@ -676,6 +676,7 @@
       script.setAttribute('data-project-name', '智能调试助手');
       script.setAttribute('data-project-color', '#6366f1');
       script.setAttribute('data-website-id', 'demo-api-test');
+      script.setAttribute('data-allow-anonymous', 'true');
       script.setAttribute('data-agent-id', 'demo');
       script.setAttribute('data-api-base-url', '');
       
@@ -716,6 +717,7 @@
     data-project-name="智能调试助手"
     data-project-color="#6366f1"
     data-website-id="demo-api-test"
+    data-allow-anonymous="true"
     data-agent-id="demo"
     data-api-base-url=""
     defer

--- a/dataagent/dataagent-frontend/examples/widget/floating.html
+++ b/dataagent/dataagent-frontend/examples/widget/floating.html
@@ -587,6 +587,7 @@
     data-project-name="智能助手"
     data-project-color="#6366f1"
     data-website-id="demo-floating"
+    data-allow-anonymous="true"
     data-agent-id="demo"
     data-api-base-url=""
     defer

--- a/dataagent/dataagent-frontend/examples/widget/inline.html
+++ b/dataagent/dataagent-frontend/examples/widget/inline.html
@@ -516,6 +516,7 @@ ORDER BY 1 DESC;</textarea>
     data-project-name="AI 智能助教"
     data-project-color="#0ea5e9"
     data-website-id="demo-inline"
+    data-allow-anonymous="true"
     data-agent-id="demo"
     data-api-base-url=""
     defer

--- a/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
+++ b/dataagent/dataagent-frontend/src/api/__tests__/nl2sqlClient.spec.js
@@ -222,8 +222,23 @@ describe('auth wiring', () => {
     // 每个 axios client 的 response 拦截器第二个参数是错误处理器。
     const rejectHandler = clients[0].interceptors.response.use.mock.calls[0][1]
 
-    await expect(rejectHandler({ response: { status: 401 }, message: 'x' })).rejects.toBeTruthy()
+    const loginError = {
+      response: {
+        status: 401,
+        data: {
+          detail: {
+            code: 'WIDGET_LOGIN_REQUIRED',
+            message: '请先登录后使用智能问数'
+          }
+        }
+      },
+      message: 'x'
+    }
+    await expect(rejectHandler(loginError)).rejects.toBe(loginError)
     expect(onUnauthorized).toHaveBeenCalledTimes(1)
+    expect(onUnauthorized).toHaveBeenCalledWith(loginError)
+    expect(loginError.code).toBe('WIDGET_LOGIN_REQUIRED')
+    expect(loginError.message).toBe('请先登录后使用智能问数')
 
     await expect(rejectHandler({ response: { status: 500 }, message: 'x' })).rejects.toBeTruthy()
     expect(onUnauthorized).toHaveBeenCalledTimes(1)

--- a/dataagent/dataagent-frontend/src/api/nl2sql.js
+++ b/dataagent/dataagent-frontend/src/api/nl2sql.js
@@ -102,12 +102,20 @@ function createAxiosClient(baseURL, prefix, timeout, defaultHeaders = {}, onUnau
   request.interceptors.response.use(
     (response) => unwrapResponse(response),
     (error) => {
-      // 认证 401 交给调用方（SPA 跳登录页）。widget 从不传 onUnauthorized，行为不变。
+      const responseDetail = error?.response?.data?.detail
+      const responseMessage = typeof responseDetail === 'object'
+        ? responseDetail?.message
+        : (responseDetail || error?.response?.data?.message)
+      const responseCode = typeof responseDetail === 'object'
+        ? responseDetail?.code
+        : error?.response?.data?.code
+      if (responseCode) error.code = String(responseCode)
+      error.message = String(responseMessage || error.message || '网络错误')
+
+      // 认证 401 交给调用方：SPA 可跳转登录页，Widget 切换到未登录状态。
       if (error?.response?.status === 401 && typeof onUnauthorized === 'function') {
         onUnauthorized(error)
       }
-      const responseMessage = error?.response?.data?.detail || error?.response?.data?.message
-      error.message = responseMessage || error.message || '网络错误'
       return Promise.reject(error)
     }
   )
@@ -119,7 +127,6 @@ export function createNl2SqlApiClient(options = {}) {
   const baseURL = normalizeBaseUrl(options.baseURL)
   const timeout = options.timeout || DEFAULT_TIMEOUT
   const defaultHeaders = options.defaultHeaders || options.headers || {}
-  // 401 钩子只在 SPA 调用点传入；widget 不传（保持匿名嵌入行为不变）。
   const onUnauthorized = typeof options.onUnauthorized === 'function' ? options.onUnauthorized : null
   const runtimeRequest = createAxiosClient(baseURL, RUNTIME_PREFIX, timeout, defaultHeaders, onUnauthorized)
   const adminRequest = createAxiosClient(baseURL, ADMIN_PREFIX, timeout, defaultHeaders, onUnauthorized)

--- a/dataagent/dataagent-frontend/src/demo/mockServer.js
+++ b/dataagent/dataagent-frontend/src/demo/mockServer.js
@@ -1112,12 +1112,14 @@ const demoProviderSettings = {
   widget_allowed_sites: [
     {
       website_id: 'mall-portal',
+      allow_anonymous: false,
       project_name: '商城官网',
       project_color: '#4A90A4',
       allowed_origins: ['https://mall.demo.example.com']
     },
     {
       website_id: 'ops-console',
+      allow_anonymous: false,
       project_name: '运营后台',
       project_color: '#7C5CFC',
       allowed_origins: ['https://ops.demo.example.com']

--- a/dataagent/dataagent-frontend/src/views/settings/WidgetAccessConfig.vue
+++ b/dataagent/dataagent-frontend/src/views/settings/WidgetAccessConfig.vue
@@ -71,6 +71,21 @@
           <el-form-item>
             <template #label>
               <span class="field-label">
+                匿名访问
+                <el-tooltip content="关闭后，接入方必须提供用户身份；未登录用户只能看到登录提示。" placement="top">
+                  <el-icon><QuestionFilled /></el-icon>
+                </el-tooltip>
+              </span>
+            </template>
+            <div class="anonymous-row">
+              <el-switch v-model="site.allow_anonymous" />
+              <span class="anonymous-state">{{ site.allow_anonymous ? '允许匿名访客使用' : '必须登录后使用' }}</span>
+            </div>
+          </el-form-item>
+
+          <el-form-item>
+            <template #label>
+              <span class="field-label">
                 允许来源（Origin）
                 <el-tooltip placement="top">
                   <template #content>
@@ -121,6 +136,7 @@ const normalizeSite = (raw = {}) => ({
   website_id: String(raw.website_id || ''),
   project_name: String(raw.project_name || ''),
   project_color: String(raw.project_color || ''),
+  allow_anonymous: raw.allow_anonymous === true,
   allowed_origins: Array.isArray(raw.allowed_origins) ? raw.allowed_origins.map((item) => String(item || '')) : []
 })
 
@@ -128,6 +144,7 @@ const toPayloadSite = (site) => ({
   website_id: String(site.website_id || '').trim(),
   project_name: String(site.project_name || '').trim(),
   project_color: String(site.project_color || '').trim(),
+  allow_anonymous: site.allow_anonymous === true,
   allowed_origins: (site.allowed_origins || [])
     .map((item) => String(item || '').trim())
     .filter((item, index, arr) => item && arr.indexOf(item) === index)
@@ -370,6 +387,17 @@ onMounted(loadSettings)
 
 .color-input {
   width: 160px;
+}
+
+.anonymous-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.anonymous-state {
+  font-size: 13px;
+  color: #53677e;
 }
 
 .origin-list {

--- a/dataagent/dataagent-frontend/src/views/settings/__tests__/WidgetAccessConfig.spec.js
+++ b/dataagent/dataagent-frontend/src/views/settings/__tests__/WidgetAccessConfig.spec.js
@@ -46,6 +46,11 @@ const stubs = {
     emits: ['update:modelValue'],
     template: '<span class="color-picker" />'
   },
+  'el-switch': {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<button class="switch" type="button" @click="$emit(\'update:modelValue\', !modelValue)" />'
+  },
   'el-tooltip': { template: '<span><slot /><slot name="content" /></span>' },
   'el-icon': { template: '<i><slot /></i>' },
   Check: { template: '<i />' },
@@ -69,7 +74,7 @@ describe('WidgetAccessConfig', () => {
   it('renders existing sites from settings', async () => {
     apiMocks.getSettings.mockResolvedValue({
       widget_allowed_sites: [
-        { website_id: 'demo', allowed_origins: ['https://a.com'], project_name: 'Demo', project_color: '#4A90A4' }
+        { website_id: 'demo', allowed_origins: ['https://a.com'], project_name: 'Demo', project_color: '#4A90A4', allow_anonymous: false }
       ]
     })
     const wrapper = mountConfig()
@@ -93,7 +98,7 @@ describe('WidgetAccessConfig', () => {
   it('adds a site and saves the normalized payload', async () => {
     apiMocks.getSettings.mockResolvedValue({ widget_allowed_sites: [] })
     apiMocks.updateSettings.mockResolvedValue({
-      widget_allowed_sites: [{ website_id: 'new-site', allowed_origins: ['https://b.com'], project_name: '', project_color: '' }]
+      widget_allowed_sites: [{ website_id: 'new-site', allowed_origins: ['https://b.com'], project_name: '', project_color: '', allow_anonymous: true }]
     })
     const wrapper = mountConfig()
     await flushPromises()
@@ -101,6 +106,7 @@ describe('WidgetAccessConfig', () => {
     wrapper.vm.addSite()
     await flushPromises()
     wrapper.vm.sites[0].website_id = 'new-site'
+    wrapper.vm.sites[0].allow_anonymous = true
     wrapper.vm.sites[0].allowed_origins = ['https://b.com', 'https://b.com', '']
     await flushPromises()
 
@@ -108,7 +114,7 @@ describe('WidgetAccessConfig', () => {
     await flushPromises()
 
     expect(apiMocks.updateSettings).toHaveBeenCalledWith({
-      widget_allowed_sites: [{ website_id: 'new-site', project_name: '', project_color: '', allowed_origins: ['https://b.com'] }]
+      widget_allowed_sites: [{ website_id: 'new-site', project_name: '', project_color: '', allow_anonymous: true, allowed_origins: ['https://b.com'] }]
     })
     expect(messageMocks.success).toHaveBeenCalled()
   })

--- a/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
+++ b/dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue
@@ -17,10 +17,10 @@
           <div class="odw-panel__title">{{ config.projectName }}</div>
         </div>
         <div class="odw-panel__actions">
-          <button class="odw-icon-button" type="button" aria-label="新建会话" title="新建会话" @click="newConversation">
+          <button v-if="!state.loginRequired" class="odw-icon-button" type="button" aria-label="新建会话" title="新建会话" @click="newConversation">
             <Plus class="odw-icon-svg" aria-hidden="true" />
           </button>
-          <button class="odw-icon-button odw-history-toggle" type="button" aria-label="历史会话" title="历史会话" @click="toggleHistory">
+          <button v-if="!state.loginRequired" class="odw-icon-button odw-history-toggle" type="button" aria-label="历史会话" title="历史会话" @click="toggleHistory">
             <svg class="odw-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M3 3v5h5" />
               <path d="M3.05 13A9 9 0 1 0 6 5.3L3 8" />
@@ -102,7 +102,7 @@ const {
 
 onMounted(() => {
   bind()
-  if (isInline.value) {
+  if (isInline.value && !props.state.loginRequired) {
     props.state.track?.('widget_open')
   }
 })
@@ -110,7 +110,7 @@ onBeforeUnmount(unbind)
 
 const open = () => {
   props.state.isOpen = true
-  props.state.track?.('widget_open')
+  if (!props.state.loginRequired) props.state.track?.('widget_open')
   props.emit('open')
 }
 
@@ -121,7 +121,7 @@ const openIfNotDragged = () => {
 
 const close = () => {
   props.state.isOpen = false
-  props.state.track?.('widget_close')
+  if (!props.state.loginRequired) props.state.track?.('widget_close')
   props.emit('close')
 }
 

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -7,9 +7,9 @@
       'is-history-open': historyVisible
     }"
   >
-    <div v-if="historyVisible" class="query-sidebar-backdrop" @click="closeHistory" />
+    <div v-if="historyVisible && !loginRequired" class="query-sidebar-backdrop" @click="closeHistory" />
 
-    <aside v-if="historyVisible" class="query-sidebar" aria-label="历史会话">
+    <aside v-if="historyVisible && !loginRequired" class="query-sidebar" aria-label="历史会话">
       <div class="query-sidebar-head">
         <button class="query-btn-new" type="button" data-testid="new-conversation" @click="newConversation">
           新建会话
@@ -50,9 +50,17 @@
     </aside>
 
     <main class="query-main">
-      <div v-if="copyNotice" class="query-copy-toast" role="status">{{ copyNotice }}</div>
+      <div v-if="loginRequired" class="query-login-required" data-testid="widget-login-required">
+        <Lock class="query-login-required-icon" aria-hidden="true" />
+        <div class="query-login-required-title">请先登录</div>
+        <div class="query-login-required-text">登录后即可使用智能问数</div>
+        <a v-if="loginUrl" class="query-login-required-action" :href="loginUrl">前往登录</a>
+        <button v-else class="query-login-required-action" type="button" @click="reloadPage">刷新页面</button>
+      </div>
 
-      <div ref="messagesEl" class="query-messages" @scroll="onMessagesScroll">
+      <div v-if="!loginRequired && copyNotice" class="query-copy-toast" role="status">{{ copyNotice }}</div>
+
+      <div v-if="!loginRequired" ref="messagesEl" class="query-messages" @scroll="onMessagesScroll">
         <div
           class="query-messages-inner"
           :class="{ 'is-empty': !messages.length }"
@@ -221,7 +229,7 @@
       </div>
 
       <!-- Composer bar -->
-      <form class="query-composer-bar" :class="{ 'is-landing': !messages.length }" @submit.prevent="send">
+      <form v-if="!loginRequired" class="query-composer-bar" :class="{ 'is-landing': !messages.length }" @submit.prevent="send">
         <div class="query-composer-wrap">
           <template v-if="!messages.length">
             <div v-if="!providers.length" class="query-config-empty">
@@ -345,6 +353,7 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, triggerRef, watch } from 'vue'
+import { Lock } from '@element-plus/icons-vue'
 import { createNl2SqlApiClient } from '@/api/nl2sql'
 import ToolOutputRenderer from '@/views/intelligence/ToolOutputRenderer.vue'
 import ChartSpecView from '@/views/intelligence/ChartSpecView.vue'
@@ -356,6 +365,7 @@ import { useNl2SqlChat } from '@/views/intelligence/useNl2SqlChat'
 import { useChatMessageActions } from '@/views/intelligence/useChatMessageActions'
 import SlashCommandMenu from '@/views/intelligence/SlashCommandMenu.vue'
 import { useSlashCommands, buildCommands } from '@/views/intelligence/useSlashCommands'
+import { isWidgetLoginRequired } from './config'
 
 const props = defineProps({
   config: {
@@ -370,10 +380,19 @@ const props = defineProps({
 
 const emit = defineEmits(['event', 'consumed-outbound'])
 
+const loginRequired = ref(isWidgetLoginRequired(props.config))
+const requireLogin = () => {
+  loginRequired.value = true
+  props.state.loginRequired = true
+  props.state.historyOpen = false
+  emit('event', { name: 'login:required' })
+}
+
 const api = createNl2SqlApiClient({
   baseURL: props.config.apiBaseUrl,
   timeout: 300000,
-  defaultHeaders: props.config.headers
+  defaultHeaders: props.config.headers,
+  onUnauthorized: requireLogin
 })
 provide('nl2sqlApi', api)
 
@@ -442,6 +461,8 @@ const copyNotice = ref('')
 
 const isInline = computed(() => props.config.displayMode === 'inline')
 const agentId = computed(() => String(props.config.agentId || '').trim())
+const loginUrl = computed(() => String(props.config.loginUrl || '').trim())
+const reloadPage = () => window.location.reload()
 
 // Shared NL2SQL conversation engine. The widget keeps its own demo/mock send,
 // tracking, outbound API, and shadow-DOM template; everything else is the engine.
@@ -486,6 +507,15 @@ watch(
     // A finished run may have reported new SDK slash commands (built-ins surface
     // only after the first run); refresh the authoritative list.
     if (previous && !value) void loadSlashCommands()
+  },
+  { immediate: true }
+)
+
+watch(
+  loginRequired,
+  (value) => {
+    props.state.loginRequired = value
+    if (value) props.state.historyOpen = false
   },
   { immediate: true }
 )
@@ -996,7 +1026,9 @@ watch(
 
 onMounted(async () => {
   document.addEventListener('click', handleToolbarDropdownOutsideClick, true)
+  if (loginRequired.value) return
   await loadConfig()
+  if (loginRequired.value) return
   if (agentId.value && agentId.value !== 'demo') {
     try {
       const agentProfile = await api.agentApi.getAgent(agentId.value)

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -170,6 +170,54 @@ describe('WidgetChat history conversations', () => {
     else Reflect.deleteProperty(URL, 'revokeObjectURL')
   })
 
+  it('shows the login-required state without loading data when anonymous access is disabled', async () => {
+    const { wrapper, state } = mountChat({
+      config: {
+        userId: '',
+        allowAnonymous: false,
+        loginUrl: '/login',
+        headers: {
+          'X-ODW-Client': 'widget',
+          'X-ODW-Website-Id': 'demo'
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="widget-login-required"]').text()).toContain('请先登录')
+    expect(wrapper.get('.query-login-required-action').attributes('href')).toBe('/login')
+    expect(wrapper.find('.query-composer-bar').exists()).toBe(false)
+    expect(wrapper.find('.query-sidebar').exists()).toBe(false)
+    expect(state.loginRequired).toBe(true)
+    expect(apiMocks.runtimeApi.getConfig).not.toHaveBeenCalled()
+    expect(apiMocks.topicApi.listTopics).not.toHaveBeenCalled()
+  })
+
+  it('switches to the login-required state when the backend rejects anonymous access', async () => {
+    const { wrapper, state } = mountChat({
+      config: {
+        userId: '',
+        allowAnonymous: true,
+        headers: {
+          'X-ODW-Client': 'widget',
+          'X-ODW-Website-Id': 'demo',
+          'X-ODW-Visitor-Id': 'visitor-test'
+        }
+      }
+    })
+
+    await flushPromises()
+    const clientOptions = apiMocks.createClient.mock.calls.at(-1)[0]
+    clientOptions.onUnauthorized({ code: 'WIDGET_LOGIN_REQUIRED' })
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="widget-login-required"]').exists()).toBe(true)
+    expect(wrapper.get('.query-login-required-action').text()).toBe('刷新页面')
+    expect(state.loginRequired).toBe(true)
+    expect(state.historyOpen).toBe(false)
+  })
+
   it('renders inline with portal-style layout, model info, suggestions, and no delete actions', async () => {
     const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
 

--- a/dataagent/dataagent-frontend/src/widget/__tests__/config.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/config.spec.js
@@ -31,14 +31,34 @@ describe('parseWidgetConfig', () => {
     expect(config.headers).not.toHaveProperty('X-ODW-Visitor-Id')
   })
 
-  it('uses a generated visitor id when no user id is available', () => {
+  it('does not generate a visitor id by default when no user id is available', () => {
     const script = document.createElement('script')
     script.dataset.websiteId = 'demo'
+    script.dataset.loginUrl = '/login'
     window.localStorage.clear()
 
     const config = parseWidgetConfig(script)
 
     expect(config.userId).toBe('')
+    expect(config.visitorId).toBe('')
+    expect(config.allowAnonymous).toBe(false)
+    expect(config.loginUrl).toBe('/login')
+    expect(config.headers).toMatchObject({
+      'X-ODW-Client': 'widget',
+      'X-ODW-Website-Id': 'demo'
+    })
+    expect(config.headers).not.toHaveProperty('X-ODW-Visitor-Id')
+  })
+
+  it('generates a visitor id only when anonymous access is explicitly enabled', () => {
+    const script = document.createElement('script')
+    script.dataset.websiteId = 'demo'
+    script.dataset.allowAnonymous = 'true'
+    window.localStorage.clear()
+
+    const config = parseWidgetConfig(script)
+
+    expect(config.allowAnonymous).toBe(true)
     expect(config.visitorId).toMatch(/^visitor_/)
     expect(config.headers).toMatchObject({
       'X-ODW-Client': 'widget',

--- a/dataagent/dataagent-frontend/src/widget/__tests__/entry.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/entry.spec.js
@@ -88,6 +88,7 @@ describe('installWidget', () => {
     script.dataset.websiteId = 'demo'
     script.dataset.agentId = 'demo'
     script.dataset.projectName = 'Demo'
+    script.dataset.allowAnonymous = 'true'
     document.body.appendChild(script)
 
     const controller = installWidget(script)
@@ -108,6 +109,7 @@ describe('installWidget', () => {
     script.dataset.websiteId = 'demo'
     script.dataset.agentId = 'demo'
     script.dataset.projectName = 'Demo'
+    script.dataset.allowAnonymous = 'true'
     document.body.appendChild(script)
 
     const controller = installWidget(script)
@@ -124,12 +126,32 @@ describe('installWidget', () => {
     expect(typeof window.OpenDataWorksWidget.ask).toBe('function')
   })
 
+  it('blocks public message and ask APIs while login is required', async () => {
+    const script = document.createElement('script')
+    script.dataset.websiteId = 'demo'
+    script.dataset.agentId = 'demo'
+    document.body.appendChild(script)
+
+    const controller = installWidget(script)
+    const loginRequired = vi.fn()
+    controller.on('login:required', loginRequired)
+
+    controller.sendMessage('blocked message')
+    controller.ask('blocked ask')
+    await nextTick()
+
+    expect(loginRequired).toHaveBeenCalledTimes(2)
+    expect(document.querySelector('[data-odw-ask-modal]')).toBeNull()
+    expect(document.querySelector('[data-odw-widget-root]').shadowRoot.textContent).not.toContain('blocked message')
+  })
+
   it('mounts inline widgets into the configured container without a launcher', () => {
     const target = document.createElement('div')
     target.id = 'odw-intelligent-query'
     document.body.appendChild(target)
     const script = document.createElement('script')
     script.dataset.websiteId = 'demo'
+    script.dataset.allowAnonymous = 'true'
     script.dataset.displayMode = 'inline'
     script.dataset.containerId = 'odw-intelligent-query'
     document.body.appendChild(script)

--- a/dataagent/dataagent-frontend/src/widget/config.js
+++ b/dataagent/dataagent-frontend/src/widget/config.js
@@ -14,6 +14,8 @@ const randomId = () => {
 
 const visitorStorageKey = (websiteId) => `odw_widget_visitor_id_${websiteId || 'default'}`
 
+export const parseBooleanFlag = (value) => value === true || String(value || '').trim().toLowerCase() === 'true'
+
 export function resolveCurrentScript() {
   if (typeof document === 'undefined') return null
   return document.currentScript || document.querySelector('script[data-website-id][src*="opendataworks-widget"]')
@@ -37,7 +39,9 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
   const websiteId = String(dataset.websiteId || '').trim()
   const userId = String(dataset.userId || '').trim()
   const agentId = String(dataset.agentId || '').trim()
-  const visitorId = userId ? '' : resolveVisitorId(websiteId)
+  const allowAnonymous = parseBooleanFlag(dataset.allowAnonymous)
+  const visitorId = userId || !allowAnonymous ? '' : resolveVisitorId(websiteId)
+  const loginUrl = String(dataset.loginUrl || '').trim()
   const apiBaseUrl = trimTrailingSlash(dataset.apiBaseUrl || (script?.src ? new URL(script.src, window.location.href).origin : ''))
   const projectName = String(dataset.projectName || DEFAULT_PROJECT_NAME).trim() || DEFAULT_PROJECT_NAME
   const projectColor = String(dataset.projectColor || DEFAULT_PROJECT_COLOR).trim() || DEFAULT_PROJECT_COLOR
@@ -51,7 +55,7 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
   }
   if (userId) {
     headers['X-ODW-User-Id'] = userId
-  } else {
+  } else if (visitorId) {
     headers['X-ODW-Visitor-Id'] = visitorId
   }
 
@@ -60,6 +64,8 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
     userId,
     agentId,
     visitorId,
+    allowAnonymous,
+    loginUrl,
     projectName,
     projectColor,
     apiBaseUrl,
@@ -68,4 +74,11 @@ export function parseWidgetConfig(script = resolveCurrentScript()) {
     containerId,
     headers
   }
+}
+
+export function isWidgetLoginRequired(config = {}) {
+  const websiteId = String(config.websiteId || config.headers?.['X-ODW-Website-Id'] || '').trim()
+  if (!websiteId) return false
+  const userId = String(config.userId || config.headers?.['X-ODW-User-Id'] || '').trim()
+  return !userId && config.allowAnonymous !== true
 }

--- a/dataagent/dataagent-frontend/src/widget/entry.js
+++ b/dataagent/dataagent-frontend/src/widget/entry.js
@@ -1,6 +1,6 @@
 import { createApp, reactive } from 'vue'
 import OpenDataWorksWidget from './OpenDataWorksWidget.vue'
-import { parseWidgetConfig, resolveCurrentScript, resolveVisitorId } from './config'
+import { isWidgetLoginRequired, parseBooleanFlag, parseWidgetConfig, resolveCurrentScript, resolveVisitorId } from './config'
 import { WIDGET_STYLES } from './styles'
 import { createWidgetTracker } from './tracking'
 
@@ -580,6 +580,8 @@ export function installWidget(scriptOrConfig = resolveCurrentScript()) {
     config.position = config.position || 'bottom-right'
     config.projectName = config.projectName || '智能问数'
     config.projectColor = config.projectColor || '#4A90A4'
+    config.allowAnonymous = parseBooleanFlag(config.allowAnonymous)
+    config.loginUrl = String(config.loginUrl || '').trim()
     if (!config.headers) {
       const websiteId = String(config.websiteId || '').trim()
       if (websiteId) {
@@ -587,7 +589,7 @@ export function installWidget(scriptOrConfig = resolveCurrentScript()) {
         config.headers = { 'X-ODW-Client': 'widget', 'X-ODW-Website-Id': websiteId }
         if (userId) {
           config.headers['X-ODW-User-Id'] = userId
-        } else {
+        } else if (config.allowAnonymous) {
           config.headers['X-ODW-Visitor-Id'] = config.visitorId || resolveVisitorId(websiteId)
         }
       } else {
@@ -624,9 +626,11 @@ export function installWidget(scriptOrConfig = resolveCurrentScript()) {
     headers: config.headers || {}
   })
 
+  const initialLoginRequired = isWidgetLoginRequired(config)
   const state = reactive({
     isOpen: config.displayMode === 'inline',
-    historyOpen: config.displayMode === 'inline' && parentWidth >= 600,
+    historyOpen: config.displayMode === 'inline' && parentWidth >= 600 && !initialLoginRequired,
+    loginRequired: initialLoginRequired,
     isBusy: false,
     outboundMessage: '',
     cancelSignal: 0,
@@ -673,13 +677,27 @@ export function installWidget(scriptOrConfig = resolveCurrentScript()) {
       const message = String(text || '').trim()
       if (!message) return
       state.isOpen = true
+      if (state.loginRequired) {
+        emit('login:required')
+        return
+      }
       scheduleOutboundMessage(state, message)
     },
     ask(text) {
+      if (state.loginRequired) {
+        state.isOpen = true
+        emit('login:required')
+        return
+      }
       openAskModal(text)
       emit('ask:open', { text: String(text || '').trim() })
     },
     openAskModal(text) {
+      if (state.loginRequired) {
+        state.isOpen = true
+        emit('login:required')
+        return
+      }
       openAskModal(text)
       emit('ask:open', { text: String(text || '').trim() })
     },
@@ -693,22 +711,26 @@ export function installWidget(scriptOrConfig = resolveCurrentScript()) {
     },
     openHistory() {
       state.isOpen = true
+      if (state.loginRequired) return
       state.historyOpen = true
       emit('history:open')
     },
     newConversation() {
       state.isOpen = true
+      if (state.loginRequired) return
       state.newConversationSignal += 1
       emit('conversation:new')
     },
     selectConversation(topicId) {
       state.isOpen = true
+      if (state.loginRequired) return
       state.requestedTopicId = String(topicId || '')
       state.selectConversationSignal += 1
       emit('conversation:select', { topicId: state.requestedTopicId })
     },
     deleteConversation(topicId) {
       state.isOpen = true
+      if (state.loginRequired) return
       state.deleteRequestedTopicId = String(topicId || '')
       state.deleteConversationSignal += 1
       emit('conversation:delete', { topicId: state.deleteRequestedTopicId })

--- a/dataagent/dataagent-frontend/src/widget/styles.js
+++ b/dataagent/dataagent-frontend/src/widget/styles.js
@@ -543,6 +543,59 @@ export const WIDGET_STYLES = `
   position: relative;
 }
 
+.query-login-required {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.query-login-required-icon {
+  width: 38px;
+  height: 38px;
+  margin-bottom: 18px;
+  color: var(--accent);
+}
+
+.query-login-required-title {
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.query-login-required-text {
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.query-login-required-action {
+  min-width: 104px;
+  margin-top: 22px;
+  padding: 9px 18px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.query-login-required-action:hover {
+  filter: brightness(0.94);
+}
+
 .query-messages {
   flex: 1;
   min-height: 0;

--- a/docs/design/2026-04-29-intelligent-query-widget-design.md
+++ b/docs/design/2026-04-29-intelligent-query-widget-design.md
@@ -56,7 +56,7 @@ In scope:
 Out of scope:
 
 - Main Java backend changes.
-- Public anonymous widget access.
+- Public anonymous widget access without explicit site opt-in. Anonymous access is disabled by default; the current integration contract is documented in `dataagent/dataagent-frontend/examples/widget/README.md`.
 - SSO or signed identity tokens.
 - Exposing Skills, model management, or portal navigation in the widget.
 
@@ -104,7 +104,7 @@ Widget calls add these headers:
 - `X-ODW-Client: widget`
 - `X-ODW-Website-Id: <website_id>`
 - `X-ODW-User-Id: <business_user_id>`
-- `X-ODW-Visitor-Id: <generated_visitor_id>` when no user id is provided
+- `X-ODW-Visitor-Id: <generated_visitor_id>` only when no user id is provided and anonymous access is explicitly enabled by both the embed configuration and the backend site policy
 
 Widget runtime payloads also include `agent_id` from the embedding script's `data-agent-id`. Widget topic creation requires this value so the selected DataAgent profile snapshot, including its `data_scope`, is stored on the topic. Widget topic listing and message delivery pass the same `agent_id` to keep history filtering and task validation aligned with the selected agent.
 
@@ -127,7 +127,7 @@ Direct user id headers provide internal product-level isolation, not cryptograph
 
 ### Allowed Sites
 
-DataAgent reads `WIDGET_ALLOWED_SITES_JSON`, for example:
+Allowed sites are managed from the DataAgent `/widget-access` page and persisted in `da_agent_settings.raw_json` as `widget_allowed_sites`, for example:
 
 ```json
 [
@@ -135,12 +135,13 @@ DataAgent reads `WIDGET_ALLOWED_SITES_JSON`, for example:
     "website_id": "your-project",
     "allowed_origins": ["https://app.example.com"],
     "project_name": "Your Project",
-    "project_color": "#4A90A4"
+    "project_color": "#4A90A4",
+    "allow_anonymous": false
   }
 ]
 ```
 
-Widget requests with an unknown `website_id` or disallowed `Origin` receive 403. Empty configuration allows no widget sites by default.
+Widget requests with an unknown `website_id` or disallowed `Origin` receive 403. Empty configuration allows no widget sites by default. Missing `allow_anonymous` is treated as `false`; anonymous use also requires `data-allow-anonymous="true"` in the embedding configuration. The complete setup and troubleshooting guide lives in `dataagent/dataagent-frontend/examples/widget/README.md`.
 
 ## Tradeoffs
 

--- a/docs/design/2026-05-29-widget-allowlist-settings-design.md
+++ b/docs/design/2026-05-29-widget-allowlist-settings-design.md
@@ -33,7 +33,8 @@ Widget 接入白名单（哪些站点 `website_id` + 允许来源 `Origin` 可�
 
 - `AdminSettingsResponse` 增加 `widget_allowed_sites: List[WidgetAllowedSite]`。
 - `AdminSettingsUpdateRequest` 增加可选 `widget_allowed_sites`。
-- `WidgetAllowedSite`：`website_id` / `allowed_origins[]` / `project_name` / `project_color`。
+- `WidgetAllowedSite`：`website_id` / `allowed_origins[]` / `project_name` / `project_color` / `allow_anonymous`。
+- `allow_anonymous` 缺失时按 `false` 处理；匿名访问的接入参数、后端校验和未登录 UI 以 `dataagent/dataagent-frontend/examples/widget/README.md` 为准。
 
 ### 运行时取数
 
@@ -44,7 +45,7 @@ Widget 接入白名单（哪些站点 `website_id` + 允许来源 `Origin` 可�
 ### 前端
 
 - `IntelligentQueryView.vue` 侧边栏新增独立菜单项「Widget 接入」（tab=`widget`）。
-- 新增 `views/settings/WidgetAccessConfig.vue`：站点卡片列表，支持新增/删除站点、编辑 `website_id`/项目名/主题色、动态增删允许来源；脏检查驱动保存；保存前校验 `website_id` 非空且不重复。
+- 新增 `views/settings/WidgetAccessConfig.vue`：站点卡片列表，支持新增/删除站点、编辑 `website_id`/项目名/主题色、配置匿名访问、动态增删允许来源；脏检查驱动保存；保存前校验 `website_id` 非空且不重复。
 
 ## 取舍
 

--- a/docs/design/2026-07-17-widget-anonymous-access-control-design.md
+++ b/docs/design/2026-07-17-widget-anonymous-access-control-design.md
@@ -1,0 +1,71 @@
+# Widget 匿名访问控制设计
+
+> 本文记录内部设计决策。接入方配置与使用说明以 `dataagent/dataagent-frontend/examples/widget/README.md` 为准。
+
+## 现状
+
+智能问数 Widget 在接入方未提供 `userId` 时，会在浏览器生成并持久化 `visitor_` 标识，请求携带 `X-ODW-Visitor-Id`。后端只校验 `website_id` 与 `Origin`，因此白名单内站点默认允许匿名访客创建会话、提问和读取该访客的历史记录。
+
+`visitor_` 只用于会话隔离，不是经过认证的用户身份。对于可访问业务数据的 Agent，默认匿名访问不符合最小授权原则。
+
+## 目标
+
+- Widget 匿名访问默认关闭，并可按 `website_id` 显式开启。
+- 匿名访问必须由后端站点策略强制执行，不能通过伪造访客请求绕过。
+- 未提供用户身份且未开启匿名时，不生成 `visitor_`，Widget 展示明确的登录状态，不加载会话或业务数据。
+- 保留公开演示等场景的匿名访问能力。
+
+## 方案
+
+### 站点策略
+
+在 `widget_allowed_sites` 的每个站点条目增加：
+
+```json
+{
+  "website_id": "portal-prod",
+  "allowed_origins": ["https://portal.example.com"],
+  "allow_anonymous": false
+}
+```
+
+缺失 `allow_anonymous` 时按 `false` 处理。现有站点配置升级后自动转为禁止匿名，不需要数据库迁移；字段继续存放在 `da_agent_settings.raw_json`。
+
+后端先校验站点和 Origin，再校验身份：
+
+- 有 `X-ODW-User-Id`：按现有外部用户上下文继续处理。
+- 无用户 ID、有访客 ID且站点 `allow_anonymous=true`：按匿名访客上下文处理。
+- 其他情况：返回 HTTP 401，`detail.code=WIDGET_LOGIN_REQUIRED`。
+
+### Widget 接入配置
+
+新增两个可选接入参数：
+
+- `data-allow-anonymous="true"` / `allowAnonymous: true`：允许客户端生成访客 ID。默认 `false`。
+- `data-login-url="..."` / `loginUrl: "..."`：未登录状态的跳转地址。
+
+匿名访问需要客户端参数与后端站点策略同时开启。客户端未开启时不生成或发送访客 ID；后端未开启时即使收到访客 ID也拒绝请求。
+
+### 未登录界面
+
+当 Widget 有 `websiteId`、没有用户身份且客户端未开启匿名，或后端返回 `WIDGET_LOGIN_REQUIRED` 时：
+
+- 悬浮入口和面板标题栏保留。
+- 隐藏新建会话、历史会话、消息列表、推荐问题和输入区。
+- 面板主体展示锁定图标、`请先登录` 和 `登录后即可使用智能问数`。
+- 配置 `loginUrl` 时显示 `前往登录`；未配置时显示 `刷新页面`。
+- 未登录期间不发送行为埋点或会话请求。
+
+登录由宿主业务系统完成。登录后宿主页面重新加载 Widget，并通过现有 `userId` 接入契约提供身份。
+
+## 兼容与边界
+
+- 主门户以无 `websiteId` 的 portal 模式加载 Widget，不受本策略影响。
+- 已有 `visitor_` 会话和管理端查询能力保留；关闭匿名后不再新增匿名会话。
+- 公开演示站点需要同时在管理设置中开启匿名，并在嵌入脚本中设置 `data-allow-anonymous="true"`。
+- 本次不改变 `X-ODW-User-Id` 的可信传递方式。外部身份签名或令牌校验需要与宿主认证系统单独设计。
+
+## 风险与回退
+
+- 现有未传用户 ID 的生产 Widget 会进入登录态，这是安全默认值带来的预期行为。
+- 如某站点确需恢复旧行为，可在站点设置开启匿名，并同步更新嵌入参数，无需回滚代码。

--- a/docs/plans/2026-07-17-widget-anonymous-access-control-plan.md
+++ b/docs/plans/2026-07-17-widget-anonymous-access-control-plan.md
@@ -1,0 +1,38 @@
+# Widget 匿名访问控制实施计划
+
+## 任务
+
+- [x] 扩展 `WidgetAllowedSite` 与设置归一化逻辑，新增默认关闭的 `allow_anonymous`。
+- [x] 在 Widget 接入设置页增加站点级匿名访问开关，并更新前端设置测试。
+- [x] 调整后端 Widget 请求上下文校验，拒绝未授权匿名请求并返回 `WIDGET_LOGIN_REQUIRED`。
+- [x] 扩展 Widget 脚本和 JavaScript 配置，默认不生成访客 ID，支持 `allowAnonymous` 与 `loginUrl`。
+- [x] 增加 Widget 未登录视图，隐藏会话操作和输入区，处理后端 401 登录错误。
+- [x] 更新接入文档与演示页面，明确匿名访问需要前后端双重开启。
+- [x] 运行 DataAgent 后端与 Widget 前端的针对性测试和构建。
+
+## 涉及文件
+
+- `dataagent/dataagent-backend/models/schemas.py`
+- `dataagent/dataagent-backend/core/skill_admin_service.py`
+- `dataagent/dataagent-backend/api/routes.py`
+- `dataagent/dataagent-backend/tests/test_skill_admin_service.py`
+- `dataagent/dataagent-backend/tests/test_widget_runtime_routes.py`
+- `dataagent/dataagent-frontend/src/views/settings/WidgetAccessConfig.vue`
+- `dataagent/dataagent-frontend/src/widget/config.js`
+- `dataagent/dataagent-frontend/src/widget/entry.js`
+- `dataagent/dataagent-frontend/src/widget/OpenDataWorksWidget.vue`
+- `dataagent/dataagent-frontend/src/widget/WidgetChat.vue`
+- `dataagent/dataagent-frontend/src/widget/styles.js`
+- 对应前端测试和 `examples/widget/` 接入文档
+
+## 验证
+
+- 后端：站点配置默认值、显式开启、匿名拒绝、匿名放行、已登录用户放行。
+- 前端：配置解析不生成访客 ID、显式匿名生成访客 ID、未登录视图及登录链接、后端 401 切换登录态。
+- 构建：按仓库 Node 基线运行 Widget 构建。
+
+## 发布与回退
+
+- 发布后检查现有 Widget 接入方是否传递用户 ID；公开演示站点需显式开启匿名。
+- 单站点应急回退通过设置 `allow_anonymous=true` 并增加客户端匿名参数完成。
+- 代码回退不涉及数据库结构变更；旧配置中的新增字段可被旧版本忽略。


### PR DESCRIPTION
## Summary
- disable anonymous Widget access by default and enforce a per-site backend policy
- show a dedicated login-required state with login URL and explicit anonymous embed configuration
- expose the anonymous-access switch in Widget settings and consolidate the integration guide

## Validation
- `.venv-py313/bin/python -m pytest -q tests/test_skill_admin_service.py tests/test_widget_runtime_routes.py` (57 passed)
- `npm test -- --run src/api/__tests__/nl2sqlClient.spec.js src/widget/__tests__/config.spec.js src/widget/__tests__/WidgetChat.spec.js src/widget/__tests__/entry.spec.js src/views/settings/__tests__/WidgetAccessConfig.spec.js` (60 passed)
- `npm run build:widget`
- real HTTP smoke: anonymous requests rejected with `WIDGET_LOGIN_REQUIRED`; authenticated list/create/delete returned 200
- Playwright desktop and mobile visual checks

## Risk
Existing Widget embeds without user information now show the login-required state unless anonymous access is enabled at both the site and embed levels.

## Rollback
Enable anonymous access for the site and set `data-allow-anonymous="true"`, or revert commit `01e62a12`.
