### PR TITLE
fix(widget): reset composer height after send

### DIFF
--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -913,6 +913,13 @@ const onComposerInput = () => {
   resizeTextarea()
 }
 
+// Sending clears inputText programmatically, which does not fire the textarea's
+// input event. Re-measure after Vue flushes the empty value so a multiline
+// question cannot leave the composer stuck at its previous height.
+watch(inputText, (value) => {
+  if (!value) nextTick(() => resizeTextarea())
+})
+
 // Enter 发送，Shift + Enter 换行;输入法组合输入期间的回车用于确认候选词,不发送。
 const onComposerKeydown = (event) => {
   if (slash.handleKeydown(event)) return

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -798,6 +798,28 @@ describe('WidgetChat history conversations', () => {
     }))
   })
 
+  it('resets the textarea height after sending a multiline question', async () => {
+    const { wrapper } = mountChat({ config: { displayMode: 'inline' } })
+    await flushPromises()
+
+    const textarea = wrapper.get('textarea')
+    let scrollHeight = 96
+    Object.defineProperty(textarea.element, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    await textarea.setValue('第一行\n第二行\n第三行')
+    expect(textarea.element.style.height).toBe('96px')
+
+    scrollHeight = 30
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(textarea.element.value).toBe('')
+    expect(textarea.element.style.height).toBe('30px')
+  })
+
   it('queues outbound messages until runtime config is ready', async () => {
     let resolveConfig
     apiMocks.runtimeApi.getConfig.mockReturnValue(new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Reset the widget composer to its normal one-line height after a question is sent.
- Re-measure the textarea after Vue clears the bound input value programmatically.

## What Changed

### Behavior Changes
- Multiline questions no longer leave the empty composer at the previous expanded height.
- Closing and reopening the widget is no longer required to restore the input height.

### Key Files
- `dataagent/dataagent-frontend/src/widget/WidgetChat.vue`: watches for the cleared input value and resizes after the DOM update.
- `dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js`: covers the expanded-input send and reset flow.


## Validation
- [x] `npm test -- --run src/widget/__tests__/WidgetChat.spec.js` — 28 tests passed.
- [x] `npm run build:widget` — production widget bundle built successfully.
- [x] `git diff --check` — no whitespace errors.

## Risks
- Main regression risk: textarea height calculation timing; the regression test verifies the resize happens after Vue renders the cleared value.

## Rollback
- Revert this PR to restore the previous composer resize behavior.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed; no public API or configuration changes.
- [x] Documentation/config updates are not required for this localized UI fix.
