### PR TITLE
Add evaluation management UI and persistence layer

### DIFF
--- a/dataagent/dataagent-backend/alembic/versions/20260721_000021_add_eval_tables.py
+++ b/dataagent/dataagent-backend/alembic/versions/20260721_000021_add_eval_tables.py
@@ -1,0 +1,128 @@
+"""add evaluation dataset and run tables
+
+Revision ID: 20260721_000021
+Revises: 20260720_000020
+Create Date: 2026-07-21 12:00:00
+"""
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "20260721_000021"
+down_revision = "20260720_000020"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str) -> bool:
+    return inspect(op.get_bind()).has_table(table_name)
+
+
+def upgrade() -> None:
+    if not _has_table("eval_dataset"):
+        op.execute(
+            """
+            CREATE TABLE eval_dataset (
+                dataset_id VARCHAR(128) NOT NULL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                category VARCHAR(128) NOT NULL DEFAULT '',
+                suite_tags JSON NULL,
+                case_count INT NOT NULL DEFAULT 0,
+                dataset_hash CHAR(64) NOT NULL DEFAULT '',
+                status VARCHAR(32) NOT NULL DEFAULT 'active',
+                created_by VARCHAR(255) NOT NULL DEFAULT '',
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_eval_dataset_status (status),
+                INDEX idx_eval_dataset_updated (updated_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            """
+        )
+
+    if not _has_table("eval_case"):
+        op.execute(
+            """
+            CREATE TABLE eval_case (
+                id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                dataset_id VARCHAR(128) NOT NULL,
+                case_id VARCHAR(255) NOT NULL,
+                case_type VARCHAR(64) NOT NULL DEFAULT '',
+                category VARCHAR(128) NOT NULL DEFAULT '',
+                suite_tags JSON NULL,
+                question TEXT NOT NULL DEFAULT '',
+                turns JSON NULL,
+                case_json LONGTEXT NOT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uk_eval_case_dataset_case (dataset_id, case_id),
+                INDEX idx_eval_case_dataset (dataset_id),
+                INDEX idx_eval_case_type (case_type)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            """
+        )
+
+    if not _has_table("eval_run"):
+        op.execute(
+            """
+            CREATE TABLE eval_run (
+                run_id VARCHAR(128) NOT NULL PRIMARY KEY,
+                dataset_id VARCHAR(128) NOT NULL DEFAULT '',
+                dataset_hash CHAR(64) NOT NULL DEFAULT '',
+                run_label VARCHAR(255) NOT NULL DEFAULT '',
+                environment_label VARCHAR(255) NOT NULL DEFAULT '',
+                evaluation_engine VARCHAR(64) NOT NULL DEFAULT '',
+                engine_version VARCHAR(64) NOT NULL DEFAULT '',
+                model VARCHAR(255) NOT NULL DEFAULT '',
+                judge_model VARCHAR(255) NOT NULL DEFAULT '',
+                judge_prompt_version VARCHAR(128) NOT NULL DEFAULT '',
+                metric_semantics_version VARCHAR(64) NOT NULL DEFAULT '',
+                concurrency INT NOT NULL DEFAULT 1,
+                run_status VARCHAR(64) NOT NULL DEFAULT '',
+                passed TINYINT(1) NOT NULL DEFAULT 0,
+                recommendation VARCHAR(128) NOT NULL DEFAULT '',
+                total_cases INT NOT NULL DEFAULT 0,
+                passed_cases INT NOT NULL DEFAULT 0,
+                failed_cases INT NOT NULL DEFAULT 0,
+                veto_count INT NOT NULL DEFAULT 0,
+                judge_failed_count INT NOT NULL DEFAULT 0,
+                average_score DECIMAL(6,4) NOT NULL DEFAULT 0,
+                metrics_json LONGTEXT NULL,
+                summary_json LONGTEXT NULL,
+                started_at DATETIME NULL,
+                ingested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                INDEX idx_eval_run_dataset (dataset_id),
+                INDEX idx_eval_run_engine (evaluation_engine),
+                INDEX idx_eval_run_started (started_at),
+                INDEX idx_eval_run_ingested (ingested_at)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            """
+        )
+
+    if not _has_table("eval_run_case"):
+        op.execute(
+            """
+            CREATE TABLE eval_run_case (
+                id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                run_id VARCHAR(128) NOT NULL,
+                case_id VARCHAR(255) NOT NULL,
+                category VARCHAR(128) NOT NULL DEFAULT '',
+                score DECIMAL(6,4) NOT NULL DEFAULT 0,
+                case_passed TINYINT(1) NOT NULL DEFAULT 0,
+                task_status VARCHAR(64) NOT NULL DEFAULT '',
+                hallucination TINYINT(1) NOT NULL DEFAULT 0,
+                dimension_scores_json JSON NULL,
+                case_json LONGTEXT NULL,
+                INDEX idx_eval_run_case_run (run_id),
+                INDEX idx_eval_run_case_case (case_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            """
+        )
+
+
+def downgrade() -> None:
+    for table in ("eval_run_case", "eval_run", "eval_case", "eval_dataset"):
+        if _has_table(table):
+            op.execute(f"DROP TABLE {table}")

--- a/dataagent/dataagent-backend/api/eval_routes.py
+++ b/dataagent/dataagent-backend/api/eval_routes.py
@@ -1,0 +1,262 @@
+"""Evaluation management API — dataset CRUD, JSONL import/export, run ingestion, trends."""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi.responses import Response
+
+from core.auth import require_admin
+from core.eval_contract import canonical_bytes, dataset_hash, parse_jsonl, validate
+from core.eval_dataset_service import export_dataset, import_dataset, refresh_dataset_hash
+from core.eval_store import get_eval_store
+from models.schemas import (
+    EvalCaseDetail,
+    EvalCaseSummary,
+    EvalCaseUpsertRequest,
+    EvalCasesReplaceRequest,
+    EvalDatasetCreateRequest,
+    EvalDatasetSummary,
+    EvalDatasetUpdateRequest,
+    EvalImportResponse,
+    EvalRunCaseDetail,
+    EvalRunCaseSummary,
+    EvalRunDetail,
+    EvalRunIngestRequest,
+    EvalRunSummary,
+    EvalTrendPoint,
+)
+
+router = APIRouter(prefix="/api/v1/nl2sql-eval", dependencies=[Depends(require_admin)])
+
+
+# ---- Datasets ----
+
+@router.get("/datasets", response_model=list[EvalDatasetSummary])
+async def list_datasets(status: str = Query("", description="Filter by status")):
+    return get_eval_store().list_datasets(status=status)
+
+
+@router.post("/datasets", response_model=EvalDatasetSummary, status_code=201)
+async def create_dataset(request: EvalDatasetCreateRequest):
+    store = get_eval_store()
+    import uuid
+    dataset_id = f"ds-{uuid.uuid4().hex[:12]}"
+    return store.create_dataset(
+        dataset_id=dataset_id,
+        name=request.name,
+        description=request.description,
+        category=request.category,
+        suite_tags=request.suite_tags,
+    )
+
+
+@router.get("/datasets/{dataset_id}", response_model=EvalDatasetSummary)
+async def get_dataset(dataset_id: str):
+    ds = get_eval_store().get_dataset(dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="dataset not found")
+    return ds
+
+
+@router.put("/datasets/{dataset_id}", response_model=EvalDatasetSummary)
+async def update_dataset(dataset_id: str, request: EvalDatasetUpdateRequest):
+    store = get_eval_store()
+    if not store.get_dataset(dataset_id):
+        raise HTTPException(status_code=404, detail="dataset not found")
+    patch = {k: v for k, v in request.model_dump().items() if v is not None}
+    return store.update_dataset(dataset_id, patch)
+
+
+@router.delete("/datasets/{dataset_id}", status_code=204)
+async def delete_dataset(dataset_id: str):
+    if not get_eval_store().delete_dataset(dataset_id):
+        raise HTTPException(status_code=404, detail="dataset not found")
+
+
+# ---- Dataset import/export ----
+
+@router.post("/datasets/imports", response_model=EvalImportResponse)
+async def import_dataset_jsonl(file: UploadFile = File(...)):
+    content = await file.read()
+    name = (file.filename or "imported").removesuffix(".jsonl").removesuffix(".json")
+    try:
+        ds = import_dataset(name, content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return EvalImportResponse(
+        dataset_id=ds["dataset_id"],
+        name=ds["name"],
+        case_count=ds.get("case_count", 0),
+        dataset_hash=ds.get("dataset_hash", ""),
+    )
+
+
+@router.get("/datasets/{dataset_id}/export")
+async def export_dataset_jsonl(dataset_id: str):
+    try:
+        filename, data = export_dataset(dataset_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return Response(
+        content=data,
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# ---- Cases ----
+
+@router.get("/datasets/{dataset_id}/cases", response_model=list[EvalCaseSummary])
+async def list_cases(dataset_id: str):
+    store = get_eval_store()
+    if not store.get_dataset(dataset_id):
+        raise HTTPException(status_code=404, detail="dataset not found")
+    return store.list_cases(dataset_id)
+
+
+@router.get("/datasets/{dataset_id}/cases/{case_id}", response_model=EvalCaseDetail)
+async def get_case(dataset_id: str, case_id: str):
+    row = get_eval_store().get_case(dataset_id, case_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="case not found")
+    if isinstance(row.get("case_json"), str):
+        try:
+            row["case_json"] = json.loads(row["case_json"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return row
+
+
+@router.put("/datasets/{dataset_id}/cases", response_model=EvalDatasetSummary)
+async def replace_cases(dataset_id: str, request: EvalCasesReplaceRequest):
+    store = get_eval_store()
+    ds = store.get_dataset(dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="dataset not found")
+    result = validate(request.cases)
+    if not result["valid"]:
+        raise HTTPException(status_code=400, detail="; ".join(result["errors"][:20]))
+    store.replace_cases(dataset_id, request.cases, result["dataset_hash"])
+    return store.get_dataset(dataset_id)
+
+
+@router.put("/datasets/{dataset_id}/cases/{case_id}", response_model=EvalCaseDetail)
+async def upsert_case(dataset_id: str, case_id: str, request: EvalCaseUpsertRequest):
+    store = get_eval_store()
+    ds = store.get_dataset(dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="dataset not found")
+    case = request.case_json
+    if str(case.get("case_id") or "") != case_id:
+        raise HTTPException(status_code=400, detail="case_id in path and body must match")
+    all_cases = store.get_case_full_json(dataset_id)
+    existing_ids = {str(c.get("case_id") or "") for c in all_cases}
+    merged = [c for c in all_cases if str(c.get("case_id") or "") != case_id] + [case]
+    h = dataset_hash(merged)
+    result = store.upsert_case(dataset_id, case, h, len(merged))
+    if isinstance(result.get("case_json"), str):
+        try:
+            result["case_json"] = json.loads(result["case_json"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return result
+
+
+@router.delete("/datasets/{dataset_id}/cases/{case_id}", status_code=204)
+async def delete_case(dataset_id: str, case_id: str):
+    store = get_eval_store()
+    ds = store.get_dataset(dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="dataset not found")
+    all_cases = store.get_case_full_json(dataset_id)
+    remaining = [c for c in all_cases if str(c.get("case_id") or "") != case_id]
+    h = dataset_hash(remaining)
+    if not store.delete_case(dataset_id, case_id, h, len(remaining)):
+        raise HTTPException(status_code=404, detail="case not found")
+
+
+# ---- Runs ----
+
+@router.post("/runs", response_model=EvalRunSummary, status_code=201)
+async def ingest_run(request: EvalRunIngestRequest):
+    store = get_eval_store()
+    run = store.ingest_run(
+        request.summary,
+        request.cases,
+        run_id=request.run_id or "",
+        started_at=request.started_at or "",
+    )
+    return run
+
+
+@router.get("/runs", response_model=list[EvalRunSummary])
+async def list_runs(
+    dataset_id: str = Query(""),
+    evaluation_engine: str = Query(""),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    return get_eval_store().list_runs(
+        dataset_id=dataset_id,
+        evaluation_engine=evaluation_engine,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/runs/{run_id}", response_model=EvalRunDetail)
+async def get_run(run_id: str):
+    run = get_eval_store().get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="run not found")
+    for key in ("metrics_json", "summary_json"):
+        if isinstance(run.get(key), str):
+            try:
+                run[key] = json.loads(run[key])
+            except (json.JSONDecodeError, TypeError):
+                pass
+    return run
+
+
+@router.get("/runs/{run_id}/cases", response_model=list[EvalRunCaseSummary])
+async def list_run_cases(run_id: str):
+    if not get_eval_store().get_run(run_id):
+        raise HTTPException(status_code=404, detail="run not found")
+    rows = get_eval_store().list_run_cases(run_id)
+    for row in rows:
+        if isinstance(row.get("dimension_scores_json"), str):
+            try:
+                row["dimension_scores_json"] = json.loads(row["dimension_scores_json"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+    return rows
+
+
+@router.get("/runs/{run_id}/cases/{case_id}", response_model=EvalRunCaseDetail)
+async def get_run_case(run_id: str, case_id: str):
+    row = get_eval_store().get_run_case_detail(run_id, case_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="run case not found")
+    for key in ("dimension_scores_json", "case_json"):
+        if isinstance(row.get(key), str):
+            try:
+                row[key] = json.loads(row[key])
+            except (json.JSONDecodeError, TypeError):
+                pass
+    return row
+
+
+# ---- Trends ----
+
+@router.get("/trends", response_model=list[EvalTrendPoint])
+async def get_trends(
+    dataset_id: str = Query(""),
+    evaluation_engine: str = Query(""),
+    limit: int = Query(50, ge=1, le=200),
+):
+    return get_eval_store().trend_series(
+        dataset_id=dataset_id,
+        evaluation_engine=evaluation_engine,
+        limit=limit,
+    )

--- a/dataagent/dataagent-backend/api/eval_routes.py
+++ b/dataagent/dataagent-backend/api/eval_routes.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 import json
+import uuid
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 
 from core.auth import require_admin
 from core.eval_contract import canonical_bytes, dataset_hash, parse_jsonl, validate
-from core.eval_dataset_service import export_dataset, import_dataset, refresh_dataset_hash
+from core.eval_dataset_service import export_dataset, import_dataset
 from core.eval_store import get_eval_store
 from models.schemas import (
     EvalCaseDetail,
@@ -40,7 +42,6 @@ async def list_datasets(status: str = Query("", description="Filter by status"))
 @router.post("/datasets", response_model=EvalDatasetSummary, status_code=201)
 async def create_dataset(request: EvalDatasetCreateRequest):
     store = get_eval_store()
-    import uuid
     dataset_id = f"ds-{uuid.uuid4().hex[:12]}"
     return store.create_dataset(
         dataset_id=dataset_id,
@@ -98,10 +99,12 @@ async def export_dataset_jsonl(dataset_id: str):
         filename, data = export_dataset(dataset_id)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    ascii_name = filename.encode("ascii", "replace").decode("ascii")
+    disposition = f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{quote(filename)}"
     return Response(
         content=data,
         media_type="application/x-ndjson",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": disposition},
     )
 
 
@@ -151,8 +154,19 @@ async def upsert_case(dataset_id: str, case_id: str, request: EvalCaseUpsertRequ
     if str(case.get("case_id") or "") != case_id:
         raise HTTPException(status_code=400, detail="case_id in path and body must match")
     all_cases = store.get_case_full_json(dataset_id)
-    existing_ids = {str(c.get("case_id") or "") for c in all_cases}
-    merged = [c for c in all_cases if str(c.get("case_id") or "") != case_id] + [case]
+    replaced = False
+    merged = []
+    for c in all_cases:
+        if str(c.get("case_id") or "") == case_id:
+            merged.append(case)
+            replaced = True
+        else:
+            merged.append(c)
+    if not replaced:
+        merged.append(case)
+    validation = validate(merged)
+    if not validation["valid"]:
+        raise HTTPException(status_code=400, detail="; ".join(validation["errors"][:20]))
     h = dataset_hash(merged)
     result = store.upsert_case(dataset_id, case, h, len(merged))
     if isinstance(result.get("case_json"), str):

--- a/dataagent/dataagent-backend/core/eval_contract.py
+++ b/dataagent/dataagent-backend/core/eval_contract.py
@@ -1,0 +1,89 @@
+"""Evaluation V2 dataset contract — validation and canonical serialization.
+
+Mirrors ``tools/dataagent-evals/dataset/manage.py`` (WEIGHTS, REQUIRED,
+validate, canonical_bytes). The two implementations are kept in sync by a
+regression test that asserts byte-level equality on the smoke dataset.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+WEIGHTS = {
+    "intent": 1,
+    "ontology_entity": 1,
+    "relation_scope": 1,
+    "sql_or_tool_call": 2,
+    "result_consistency": 2,
+    "reasoning": 2,
+    "answer_quality": 1,
+}
+
+REQUIRED = {
+    "schema_version", "case_id", "category", "case_type", "suite_tags",
+    "expected_semantics", "expected_time", "expected_tools", "expected_sql",
+    "expected_result", "expected_answer", "limits", "scoring", "veto_rules",
+}
+
+
+def canonical_bytes(rows: list[dict[str, Any]]) -> bytes:
+    return b"".join(
+        (json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+        for row in rows
+    )
+
+
+def dataset_hash(rows: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(canonical_bytes(rows)).hexdigest()
+
+
+def validate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, row in enumerate(rows, 1):
+        case_id = str(row.get("case_id") or f"line-{index}")
+        missing = sorted(REQUIRED - set(row))
+        if missing:
+            errors.append(f"{case_id}: missing {','.join(missing)}")
+        if row.get("schema_version") != 2:
+            errors.append(f"{case_id}: schema_version must be 2")
+        if case_id in seen:
+            errors.append(f"{case_id}: duplicate case_id")
+        seen.add(case_id)
+        if not str(row.get("question") or "").strip() and not row.get("turns"):
+            errors.append(f"{case_id}: question or turns is required")
+        scoring = row.get("scoring") if isinstance(row.get("scoring"), dict) else {}
+        for key, maximum in WEIGHTS.items():
+            if scoring.get(key) != maximum:
+                errors.append(f"{case_id}: scoring.{key} must equal {maximum}")
+        dimension_sum = sum(float(scoring.get(key, -1000)) for key in WEIGHTS)
+        if dimension_sum != float(scoring.get("total_score", -1)) or dimension_sum != 10:
+            errors.append(f"{case_id}: scoring total must equal dimension sum 10")
+        tools = row.get("expected_tools") if isinstance(row.get("expected_tools"), dict) else {}
+        if int(tools.get("min_calls") or 0) > int(tools.get("max_calls") or 0):
+            errors.append(f"{case_id}: expected_tools min_calls exceeds max_calls")
+    return {
+        "schema_version": 2,
+        "case_count": len(rows),
+        "case_ids": [str(row.get("case_id") or "") for row in rows],
+        "dataset_hash": dataset_hash(rows),
+        "valid": not errors,
+        "errors": errors,
+    }
+
+
+def parse_jsonl(data: bytes) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line_no, line in enumerate(data.decode("utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"line {line_no}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise ValueError(f"line {line_no}: expected JSON object")
+        rows.append(row)
+    return rows

--- a/dataagent/dataagent-backend/core/eval_dataset_service.py
+++ b/dataagent/dataagent-backend/core/eval_dataset_service.py
@@ -1,0 +1,61 @@
+"""Evaluation dataset import/export service.
+
+Uses ``eval_contract`` for validation and canonical serialization (matching
+the ``tools/dataagent-evals/dataset/manage.py`` contract byte-for-byte).
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from core.eval_contract import canonical_bytes, dataset_hash, parse_jsonl, validate
+from core.eval_store import get_eval_store
+
+
+def import_dataset(name: str, data: bytes, *, created_by: str = "") -> dict[str, Any]:
+    """Parse JSONL bytes, validate, persist dataset + cases. Returns dataset row."""
+    rows = parse_jsonl(data)
+    if not rows:
+        raise ValueError("empty dataset")
+    result = validate(rows)
+    if not result["valid"]:
+        raise ValueError("; ".join(result["errors"][:20]))
+
+    dataset_id = f"ds-{uuid.uuid4().hex[:12]}"
+    store = get_eval_store()
+    ds = store.create_dataset(
+        dataset_id=dataset_id,
+        name=name,
+        case_count=result["case_count"],
+        dataset_hash=result["dataset_hash"],
+        created_by=created_by,
+    )
+    store.replace_cases(dataset_id, rows, result["dataset_hash"])
+    return ds
+
+
+def export_dataset(dataset_id: str) -> tuple[str, bytes]:
+    """Return ``(filename, jsonl_bytes)`` for download."""
+    store = get_eval_store()
+    ds = store.get_dataset(dataset_id)
+    if not ds:
+        raise ValueError(f"dataset not found: {dataset_id}")
+    rows = store.get_case_full_json(dataset_id)
+    data = canonical_bytes(rows)
+    safe_name = str(ds.get("name") or dataset_id).replace("/", "_").replace(" ", "_")
+    return f"{safe_name}.jsonl", data
+
+
+def refresh_dataset_hash(dataset_id: str) -> str:
+    """Recompute hash from current DB cases and update the dataset row."""
+    store = get_eval_store()
+    rows = store.get_case_full_json(dataset_id)
+    h = dataset_hash(rows)
+    with store._conn() as conn:
+        store._refresh_dataset_stats(conn, dataset_id, h, len(rows))
+    return h
+
+
+def validate_cases(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Thin wrapper exposing contract validation to routes."""
+    return validate(rows)

--- a/dataagent/dataagent-backend/core/eval_store.py
+++ b/dataagent/dataagent-backend/core/eval_store.py
@@ -1,0 +1,438 @@
+"""Evaluation dataset & run persistence — reads/writes to the ``dataagent`` schema."""
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import logging
+import uuid
+from contextlib import contextmanager
+from typing import Any
+
+import pymysql
+import pymysql.cursors
+
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 200
+
+
+def _now_str() -> str:
+    return dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+
+
+class EvalStore:
+
+    def _connect(self):
+        cfg = get_settings()
+        return pymysql.connect(
+            host=cfg.mysql_host,
+            port=cfg.mysql_port,
+            user=cfg.mysql_user,
+            password=cfg.mysql_password,
+            database=cfg.session_mysql_database,
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor,
+            autocommit=False,
+        )
+
+    @contextmanager
+    def _conn(self):
+        conn = self._connect()
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # ---- datasets ----
+
+    def list_datasets(self, *, status: str = "") -> list[dict[str, Any]]:
+        sql = "SELECT * FROM eval_dataset"
+        params: list[Any] = []
+        if status:
+            sql += " WHERE status = %s"
+            params.append(status)
+        sql += " ORDER BY updated_at DESC"
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                return cur.fetchall()
+
+    def get_dataset(self, dataset_id: str) -> dict[str, Any] | None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM eval_dataset WHERE dataset_id = %s", (dataset_id,))
+                return cur.fetchone()
+
+    def create_dataset(self, dataset_id: str, name: str, *, description: str = "",
+                       category: str = "", suite_tags: list[str] | None = None,
+                       case_count: int = 0, dataset_hash: str = "",
+                       created_by: str = "") -> dict[str, Any]:
+        now = _now_str()
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO eval_dataset
+                       (dataset_id, name, description, category, suite_tags,
+                        case_count, dataset_hash, created_by, created_at, updated_at)
+                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                    (dataset_id, name, description, category,
+                     json.dumps(suite_tags or [], ensure_ascii=False),
+                     case_count, dataset_hash, created_by, now, now),
+                )
+        return self.get_dataset(dataset_id)  # type: ignore[return-value]
+
+    def update_dataset(self, dataset_id: str, patch: dict[str, Any]) -> dict[str, Any] | None:
+        allowed = {"name", "description", "category", "suite_tags", "status"}
+        sets: list[str] = []
+        params: list[Any] = []
+        for key in allowed:
+            if key in patch:
+                value = patch[key]
+                if key == "suite_tags":
+                    value = json.dumps(value or [], ensure_ascii=False)
+                sets.append(f"{key} = %s")
+                params.append(value)
+        if not sets:
+            return self.get_dataset(dataset_id)
+        params.append(dataset_id)
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"UPDATE eval_dataset SET {', '.join(sets)} WHERE dataset_id = %s", params)
+        return self.get_dataset(dataset_id)
+
+    def delete_dataset(self, dataset_id: str) -> bool:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM eval_case WHERE dataset_id = %s", (dataset_id,))
+                cur.execute("DELETE FROM eval_dataset WHERE dataset_id = %s", (dataset_id,))
+                return cur.rowcount > 0
+
+    def _refresh_dataset_stats(self, conn, dataset_id: str, dataset_hash: str, case_count: int) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE eval_dataset SET case_count = %s, dataset_hash = %s WHERE dataset_id = %s",
+                (case_count, dataset_hash, dataset_id),
+            )
+
+    # ---- cases ----
+
+    def list_cases(self, dataset_id: str) -> list[dict[str, Any]]:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, dataset_id, case_id, case_type, category, suite_tags, question, updated_at "
+                    "FROM eval_case WHERE dataset_id = %s ORDER BY id",
+                    (dataset_id,),
+                )
+                return cur.fetchall()
+
+    def get_case(self, dataset_id: str, case_id: str) -> dict[str, Any] | None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM eval_case WHERE dataset_id = %s AND case_id = %s",
+                    (dataset_id, case_id),
+                )
+                return cur.fetchone()
+
+    def get_case_full_json(self, dataset_id: str) -> list[dict[str, Any]]:
+        """Return full case_json for all cases in a dataset, ordered deterministically."""
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT case_json FROM eval_case WHERE dataset_id = %s ORDER BY id",
+                    (dataset_id,),
+                )
+                rows = cur.fetchall()
+        result = []
+        for row in rows:
+            try:
+                result.append(json.loads(row["case_json"]))
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return result
+
+    def replace_cases(self, dataset_id: str, cases: list[dict[str, Any]], dataset_hash: str) -> int:
+        """Delete all existing cases and insert new ones; refresh dataset stats."""
+        now = _now_str()
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM eval_case WHERE dataset_id = %s", (dataset_id,))
+                for i in range(0, len(cases), _BATCH_SIZE):
+                    batch = cases[i:i + _BATCH_SIZE]
+                    cur.executemany(
+                        """INSERT INTO eval_case
+                           (dataset_id, case_id, case_type, category, suite_tags,
+                            question, turns, case_json, created_at, updated_at)
+                           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                        [
+                            (
+                                dataset_id,
+                                str(c.get("case_id") or ""),
+                                str(c.get("case_type") or ""),
+                                str(c.get("category") or ""),
+                                json.dumps(c.get("suite_tags") or [], ensure_ascii=False),
+                                str(c.get("question") or ""),
+                                json.dumps(c.get("turns"), ensure_ascii=False) if c.get("turns") else None,
+                                json.dumps(c, ensure_ascii=False, sort_keys=True),
+                                now, now,
+                            )
+                            for c in batch
+                        ],
+                    )
+            self._refresh_dataset_stats(conn, dataset_id, dataset_hash, len(cases))
+        return len(cases)
+
+    def upsert_case(self, dataset_id: str, case: dict[str, Any], dataset_hash: str, case_count: int) -> dict[str, Any]:
+        """Insert or update a single case; caller provides pre-computed hash/count."""
+        now = _now_str()
+        case_id = str(case.get("case_id") or "")
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO eval_case
+                       (dataset_id, case_id, case_type, category, suite_tags,
+                        question, turns, case_json, created_at, updated_at)
+                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                       ON DUPLICATE KEY UPDATE
+                        case_type=VALUES(case_type), category=VALUES(category),
+                        suite_tags=VALUES(suite_tags), question=VALUES(question),
+                        turns=VALUES(turns), case_json=VALUES(case_json), updated_at=VALUES(updated_at)""",
+                    (
+                        dataset_id, case_id,
+                        str(case.get("case_type") or ""),
+                        str(case.get("category") or ""),
+                        json.dumps(case.get("suite_tags") or [], ensure_ascii=False),
+                        str(case.get("question") or ""),
+                        json.dumps(case.get("turns"), ensure_ascii=False) if case.get("turns") else None,
+                        json.dumps(case, ensure_ascii=False, sort_keys=True),
+                        now, now,
+                    ),
+                )
+            self._refresh_dataset_stats(conn, dataset_id, dataset_hash, case_count)
+        return self.get_case(dataset_id, case_id)  # type: ignore[return-value]
+
+    def delete_case(self, dataset_id: str, case_id: str, dataset_hash: str, case_count: int) -> bool:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM eval_case WHERE dataset_id = %s AND case_id = %s",
+                    (dataset_id, case_id),
+                )
+                deleted = cur.rowcount > 0
+            if deleted:
+                self._refresh_dataset_stats(conn, dataset_id, dataset_hash, case_count)
+        return deleted
+
+    # ---- runs (ingestion) ----
+
+    def _run_id_from_summary(self, summary: dict[str, Any]) -> str:
+        raw = json.dumps(summary, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(raw).hexdigest()[:24]
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM eval_run WHERE run_id = %s", (run_id,))
+                return cur.fetchone()
+
+    def ingest_run(self, summary: dict[str, Any], cases: list[dict[str, Any]],
+                   *, run_id: str = "", started_at: str = "") -> dict[str, Any]:
+        """Idempotent ingestion of a run. Returns existing row on duplicate run_id."""
+        if not run_id:
+            run_id = self._run_id_from_summary(summary)
+
+        existing = self.get_run(run_id)
+        if existing:
+            return existing
+
+        metrics = summary.get("metrics") or {}
+        avg_score = 0.0
+        raw_avg = metrics.get("average_score")
+        if isinstance(raw_avg, (int, float)):
+            avg_score = float(raw_avg)
+
+        resolved_started: str | None = None
+        if started_at:
+            resolved_started = started_at
+        else:
+            label = str(summary.get("run_label") or "").strip()
+            if label:
+                try:
+                    dt.datetime.strptime(label, "%Y%m%d-%H%M%S")
+                    resolved_started = f"{label[:4]}-{label[4:6]}-{label[6:8]} {label[9:11]}:{label[11:13]}:{label[13:15]}"
+                except (ValueError, IndexError):
+                    pass
+
+        now = _now_str()
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO eval_run
+                       (run_id, dataset_id, dataset_hash, run_label, environment_label,
+                        evaluation_engine, engine_version, model, judge_model,
+                        judge_prompt_version, metric_semantics_version, concurrency,
+                        run_status, passed, recommendation,
+                        total_cases, passed_cases, failed_cases, veto_count, judge_failed_count,
+                        average_score, metrics_json, summary_json, started_at, ingested_at)
+                       VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                    (
+                        run_id,
+                        str(summary.get("dataset_id") or ""),
+                        str(summary.get("dataset_hash") or ""),
+                        str(summary.get("run_label") or ""),
+                        str(summary.get("environment_label") or ""),
+                        str(summary.get("evaluation_engine") or ""),
+                        str(summary.get("engine_version") or ""),
+                        str(summary.get("model") or ""),
+                        str(summary.get("judge_model") or ""),
+                        str(summary.get("judge_prompt_version") or ""),
+                        str(summary.get("metric_semantics_version") or ""),
+                        int(summary.get("concurrency") or 1),
+                        str(summary.get("run_status") or ""),
+                        1 if summary.get("passed") else 0,
+                        str(summary.get("recommendation") or ""),
+                        int(summary.get("total_cases") or 0),
+                        int(summary.get("passed_cases") or 0),
+                        int(summary.get("failed_cases") or 0),
+                        int(summary.get("veto_count") or 0),
+                        int(summary.get("judge_failed_count") or 0),
+                        avg_score,
+                        json.dumps(metrics, ensure_ascii=False),
+                        json.dumps(summary, ensure_ascii=False),
+                        resolved_started,
+                        now,
+                    ),
+                )
+                for i in range(0, len(cases), _BATCH_SIZE):
+                    batch = cases[i:i + _BATCH_SIZE]
+                    cur.executemany(
+                        """INSERT INTO eval_run_case
+                           (run_id, case_id, category, score, case_passed,
+                            task_status, hallucination, dimension_scores_json, case_json)
+                           VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                        [
+                            (
+                                run_id,
+                                str(c.get("case_id") or ""),
+                                str(c.get("category") or ""),
+                                float((c.get("judge") or {}).get("score") or 0),
+                                1 if c.get("case_passed") else 0,
+                                str(c.get("task_status") or ""),
+                                1 if (c.get("judge") or {}).get("hallucination") else 0,
+                                json.dumps((c.get("judge") or {}).get("dimension_scores") or {}, ensure_ascii=False),
+                                json.dumps(c, ensure_ascii=False),
+                            )
+                            for c in batch
+                        ],
+                    )
+        return self.get_run(run_id)  # type: ignore[return-value]
+
+    # ---- run queries ----
+
+    def list_runs(self, *, dataset_id: str = "", evaluation_engine: str = "",
+                  limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+        sql = """SELECT run_id, dataset_id, dataset_hash, run_label, environment_label,
+                        evaluation_engine, engine_version, model, judge_model,
+                        run_status, passed, recommendation,
+                        total_cases, passed_cases, failed_cases, average_score,
+                        started_at, ingested_at
+                 FROM eval_run WHERE 1=1"""
+        params: list[Any] = []
+        if dataset_id:
+            sql += " AND dataset_id = %s"
+            params.append(dataset_id)
+        if evaluation_engine:
+            sql += " AND evaluation_engine = %s"
+            params.append(evaluation_engine)
+        sql += " ORDER BY COALESCE(started_at, ingested_at) DESC LIMIT %s OFFSET %s"
+        params.extend([limit, offset])
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                return cur.fetchall()
+
+    def list_run_cases(self, run_id: str) -> list[dict[str, Any]]:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """SELECT id, run_id, case_id, category, score, case_passed,
+                              task_status, hallucination, dimension_scores_json
+                       FROM eval_run_case WHERE run_id = %s ORDER BY id""",
+                    (run_id,),
+                )
+                return cur.fetchall()
+
+    def get_run_case_detail(self, run_id: str, case_id: str) -> dict[str, Any] | None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM eval_run_case WHERE run_id = %s AND case_id = %s",
+                    (run_id, case_id),
+                )
+                return cur.fetchone()
+
+    def trend_series(self, *, dataset_id: str = "", evaluation_engine: str = "",
+                     limit: int = 50) -> list[dict[str, Any]]:
+        """Return time-ordered run summaries for trend charts."""
+        sql = """SELECT run_id, run_label, evaluation_engine, model,
+                        average_score, passed, total_cases, passed_cases, failed_cases,
+                        metrics_json, started_at, ingested_at
+                 FROM eval_run WHERE run_status = 'completed'"""
+        params: list[Any] = []
+        if dataset_id:
+            sql += " AND dataset_id = %s"
+            params.append(dataset_id)
+        if evaluation_engine:
+            sql += " AND evaluation_engine = %s"
+            params.append(evaluation_engine)
+        sql += " ORDER BY COALESCE(started_at, ingested_at) ASC LIMIT %s"
+        params.append(limit)
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                rows = cur.fetchall()
+        for row in rows:
+            raw = row.pop("metrics_json", None)
+            if raw:
+                try:
+                    metrics = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    metrics = {}
+            else:
+                metrics = {}
+            row["intent_accuracy"] = _ratio_value(metrics, "intent_accuracy")
+            row["ontology_accuracy"] = _ratio_value(metrics, "ontology_accuracy")
+            row["hallucination_rate"] = float(metrics.get("hallucination_rate") or 0)
+            row["result_consistency_rate"] = _ratio_value(metrics, "result_consistency_rate")
+            row["data_accuracy"] = _ratio_value(metrics, "data_accuracy")
+            row["effective_pass_rate"] = _ratio_value(metrics, "effective_pass_rate")
+            row["time"] = str(row.get("started_at") or row.get("ingested_at") or "")
+        return rows
+
+
+def _ratio_value(metrics: dict, key: str) -> float | None:
+    raw = metrics.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        v = raw.get("value")
+        return float(v) if v is not None else None
+    return float(raw)
+
+
+_instance: EvalStore | None = None
+
+
+def get_eval_store() -> EvalStore:
+    global _instance
+    if _instance is None:
+        _instance = EvalStore()
+    return _instance

--- a/dataagent/dataagent-backend/core/eval_store.py
+++ b/dataagent/dataagent-backend/core/eval_store.py
@@ -114,6 +114,16 @@ class EvalStore:
                 cur.execute("DELETE FROM eval_dataset WHERE dataset_id = %s", (dataset_id,))
                 return cur.rowcount > 0
 
+    def _find_dataset_by_hash(self, ds_hash: str) -> str | None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT dataset_id FROM eval_dataset WHERE dataset_hash = %s LIMIT 1",
+                    (ds_hash,),
+                )
+                row = cur.fetchone()
+                return row["dataset_id"] if row else None
+
     def _refresh_dataset_stats(self, conn, dataset_id: str, dataset_hash: str, case_count: int) -> None:
         with conn.cursor() as cur:
             cur.execute(
@@ -253,6 +263,14 @@ class EvalStore:
         if existing:
             return existing
 
+        raw_dataset_id = str(summary.get("dataset_id") or "")
+        if raw_dataset_id and not self.get_dataset(raw_dataset_id):
+            ds_hash = str(summary.get("dataset_hash") or "")
+            if ds_hash:
+                matched = self._find_dataset_by_hash(ds_hash)
+                if matched:
+                    raw_dataset_id = matched
+
         metrics = summary.get("metrics") or {}
         avg_score = 0.0
         raw_avg = metrics.get("average_score")
@@ -285,7 +303,7 @@ class EvalStore:
                        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
                     (
                         run_id,
-                        str(summary.get("dataset_id") or ""),
+                        raw_dataset_id,
                         str(summary.get("dataset_hash") or ""),
                         str(summary.get("run_label") or ""),
                         str(summary.get("environment_label") or ""),

--- a/dataagent/dataagent-backend/main.py
+++ b/dataagent/dataagent-backend/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.admin_routes import router as admin_router
 from api.auth_routes import oauth_callback_router, router as auth_router
+from api.eval_routes import router as eval_router
 from api.routes import router
 from config import get_settings, update_settings
 from core.auth import init_auth
@@ -47,6 +48,7 @@ app.include_router(auth_router)
 app.include_router(oauth_callback_router)
 app.include_router(router)
 app.include_router(admin_router)
+app.include_router(eval_router)
 
 
 @app.get("/")

--- a/dataagent/dataagent-backend/models/schemas.py
+++ b/dataagent/dataagent-backend/models/schemas.py
@@ -791,3 +791,176 @@ class WidgetEventIngestResponse(BaseModel):
 
 
 TableMeta.model_rebuild()
+
+
+# ---- Evaluation ----
+
+class EvalDatasetSummary(BaseModel):
+    dataset_id: str
+    name: str
+    description: str = ""
+    category: str = ""
+    suite_tags: Any = Field(default_factory=list)
+    case_count: int = 0
+    dataset_hash: str = ""
+    status: str = "active"
+    created_by: str = ""
+    created_at: Any = None
+    updated_at: Any = None
+
+
+class EvalDatasetCreateRequest(BaseModel):
+    name: str
+    description: str = ""
+    category: str = ""
+    suite_tags: List[str] = Field(default_factory=list)
+
+
+class EvalDatasetUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    suite_tags: Optional[List[str]] = None
+    status: Optional[str] = None
+
+
+class EvalCaseSummary(BaseModel):
+    id: int = 0
+    dataset_id: str = ""
+    case_id: str = ""
+    case_type: str = ""
+    category: str = ""
+    suite_tags: Any = Field(default_factory=list)
+    question: str = ""
+    updated_at: Any = None
+
+
+class EvalCaseDetail(BaseModel):
+    id: int = 0
+    dataset_id: str = ""
+    case_id: str = ""
+    case_type: str = ""
+    category: str = ""
+    suite_tags: Any = Field(default_factory=list)
+    question: str = ""
+    turns: Any = None
+    case_json: Any = None
+    updated_at: Any = None
+
+
+class EvalCaseUpsertRequest(BaseModel):
+    case_json: Dict[str, Any]
+
+
+class EvalCasesReplaceRequest(BaseModel):
+    cases: List[Dict[str, Any]]
+
+
+class EvalImportResponse(BaseModel):
+    dataset_id: str
+    name: str
+    case_count: int = 0
+    dataset_hash: str = ""
+    errors: List[str] = Field(default_factory=list)
+
+
+class EvalRunSummary(BaseModel):
+    run_id: str
+    dataset_id: str = ""
+    dataset_hash: str = ""
+    run_label: str = ""
+    environment_label: str = ""
+    evaluation_engine: str = ""
+    engine_version: str = ""
+    model: str = ""
+    judge_model: str = ""
+    run_status: str = ""
+    passed: bool = False
+    recommendation: str = ""
+    total_cases: int = 0
+    passed_cases: int = 0
+    failed_cases: int = 0
+    average_score: float = 0.0
+    started_at: Any = None
+    ingested_at: Any = None
+
+
+class EvalRunDetail(BaseModel):
+    run_id: str
+    dataset_id: str = ""
+    dataset_hash: str = ""
+    run_label: str = ""
+    environment_label: str = ""
+    evaluation_engine: str = ""
+    engine_version: str = ""
+    model: str = ""
+    judge_model: str = ""
+    judge_prompt_version: str = ""
+    metric_semantics_version: str = ""
+    concurrency: int = 1
+    run_status: str = ""
+    passed: bool = False
+    recommendation: str = ""
+    total_cases: int = 0
+    passed_cases: int = 0
+    failed_cases: int = 0
+    veto_count: int = 0
+    judge_failed_count: int = 0
+    average_score: float = 0.0
+    metrics_json: Any = None
+    summary_json: Any = None
+    started_at: Any = None
+    ingested_at: Any = None
+
+
+class EvalRunIngestRequest(BaseModel):
+    run_id: Optional[str] = None
+    started_at: Optional[str] = None
+    summary: Dict[str, Any]
+    cases: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class EvalRunCaseSummary(BaseModel):
+    id: int = 0
+    run_id: str = ""
+    case_id: str = ""
+    category: str = ""
+    score: float = 0.0
+    case_passed: bool = False
+    task_status: str = ""
+    hallucination: bool = False
+    dimension_scores_json: Any = None
+
+
+class EvalRunCaseDetail(BaseModel):
+    id: int = 0
+    run_id: str = ""
+    case_id: str = ""
+    category: str = ""
+    score: float = 0.0
+    case_passed: bool = False
+    task_status: str = ""
+    hallucination: bool = False
+    dimension_scores_json: Any = None
+    case_json: Any = None
+
+
+class EvalTrendPoint(BaseModel):
+    run_id: str = ""
+    run_label: str = ""
+    evaluation_engine: str = ""
+    model: str = ""
+    average_score: float = 0.0
+    passed: bool = False
+    total_cases: int = 0
+    passed_cases: int = 0
+    failed_cases: int = 0
+    intent_accuracy: Optional[float] = None
+    ontology_accuracy: Optional[float] = None
+    hallucination_rate: float = 0.0
+    result_consistency_rate: Optional[float] = None
+    data_accuracy: Optional[float] = None
+    effective_pass_rate: Optional[float] = None
+    time: str = ""
+    started_at: Any = None
+    ingested_at: Any = None

--- a/dataagent/dataagent-backend/tests/test_eval_contract.py
+++ b/dataagent/dataagent-backend/tests/test_eval_contract.py
@@ -1,0 +1,86 @@
+"""Contract regression test — eval_contract.py vs manage.py must stay byte-identical."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parents[1]
+SMOKE_JSONL = REPO_ROOT / "tools" / "dataagent-evals" / "dataset" / "examples" / "opendataworks-business-knowledge-smoke-v2.jsonl"
+MANAGE_PY = REPO_ROOT / "tools" / "dataagent-evals" / "dataset"
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def _load_manage():
+    """Import manage.py from the evals dataset directory."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("manage", MANAGE_PY / "manage.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_smoke_rows():
+    data = SMOKE_JSONL.read_bytes()
+    rows = []
+    for line in data.decode("utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def test_canonical_bytes_identical():
+    from core.eval_contract import canonical_bytes as backend_canonical
+    manage = _load_manage()
+    rows = _load_smoke_rows()
+    assert backend_canonical(rows) == manage.canonical_bytes(rows)
+
+
+def test_validate_identical():
+    from core.eval_contract import validate as backend_validate
+    manage = _load_manage()
+    rows = _load_smoke_rows()
+    result_backend = backend_validate(rows)
+    result_manage = manage.validate(rows)
+    assert result_backend["valid"] == result_manage["valid"]
+    assert result_backend["case_count"] == result_manage["case_count"]
+    assert result_backend["case_ids"] == result_manage["case_ids"]
+    assert result_backend["dataset_hash"] == result_manage["dataset_hash"]
+    assert result_backend["errors"] == result_manage["errors"]
+
+
+def test_dataset_hash_identical():
+    from core.eval_contract import dataset_hash as backend_hash
+    manage = _load_manage()
+    rows = _load_smoke_rows()
+    assert backend_hash(rows) == manage.canonical_bytes(rows).__class__.__name__ or True
+    import hashlib
+    expected = hashlib.sha256(manage.canonical_bytes(rows)).hexdigest()
+    assert backend_hash(rows) == expected
+
+
+def test_parse_jsonl_roundtrip():
+    from core.eval_contract import parse_jsonl
+    data = SMOKE_JSONL.read_bytes()
+    rows = parse_jsonl(data)
+    assert len(rows) > 0
+    for row in rows:
+        assert isinstance(row, dict)
+        assert row.get("schema_version") == 2
+
+
+def test_parse_jsonl_bad_json():
+    from core.eval_contract import parse_jsonl
+    import pytest
+    with pytest.raises(ValueError, match="line 1"):
+        parse_jsonl(b"not valid json\n")
+
+
+def test_parse_jsonl_not_object():
+    from core.eval_contract import parse_jsonl
+    import pytest
+    with pytest.raises(ValueError, match="expected JSON object"):
+        parse_jsonl(b'[1, 2, 3]\n')

--- a/dataagent/dataagent-frontend/src/api/dataagent.js
+++ b/dataagent/dataagent-frontend/src/api/dataagent.js
@@ -144,5 +144,95 @@ export const dataagentApi = {
 
   getWidgetTopicMessages(topicId, params = {}) {
     return dataagentRequest.get(`/v1/nl2sql-admin/widget-topics/${encodeURIComponent(topicId)}/messages`, { params })
+  },
+
+  // ---- Evaluation datasets ----
+
+  listEvalDatasets(params = {}) {
+    return dataagentRequest.get('/v1/nl2sql-eval/datasets', { params })
+  },
+
+  getEvalDataset(datasetId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}`)
+  },
+
+  createEvalDataset(data) {
+    return dataagentRequest.post('/v1/nl2sql-eval/datasets', data)
+  },
+
+  updateEvalDataset(datasetId, data) {
+    return dataagentRequest.put(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}`, data)
+  },
+
+  deleteEvalDataset(datasetId) {
+    return dataagentRequest.delete(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}`)
+  },
+
+  importEvalDataset(file) {
+    const formData = new FormData()
+    formData.append('file', file)
+    return dataagentRequest.post('/v1/nl2sql-eval/datasets/imports', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 300000
+    })
+  },
+
+  exportEvalDataset(datasetId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/export`, {
+      responseType: 'blob'
+    })
+  },
+
+  // ---- Evaluation cases ----
+
+  listEvalCases(datasetId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/cases`)
+  },
+
+  getEvalCase(datasetId, caseId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/cases/${encodeURIComponent(caseId)}`)
+  },
+
+  upsertEvalCase(datasetId, caseId, caseJson) {
+    return dataagentRequest.put(
+      `/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/cases/${encodeURIComponent(caseId)}`,
+      { case_json: caseJson }
+    )
+  },
+
+  deleteEvalCase(datasetId, caseId) {
+    return dataagentRequest.delete(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/cases/${encodeURIComponent(caseId)}`)
+  },
+
+  replaceEvalCases(datasetId, cases) {
+    return dataagentRequest.put(`/v1/nl2sql-eval/datasets/${encodeURIComponent(datasetId)}/cases`, { cases })
+  },
+
+  // ---- Evaluation runs ----
+
+  listEvalRuns(params = {}) {
+    return dataagentRequest.get('/v1/nl2sql-eval/runs', { params })
+  },
+
+  getEvalRun(runId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/runs/${encodeURIComponent(runId)}`)
+  },
+
+  listEvalRunCases(runId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/runs/${encodeURIComponent(runId)}/cases`)
+  },
+
+  getEvalRunCase(runId, caseId) {
+    return dataagentRequest.get(`/v1/nl2sql-eval/runs/${encodeURIComponent(runId)}/cases/${encodeURIComponent(caseId)}`)
+  },
+
+  ingestEvalRun(data) {
+    return dataagentRequest.post('/v1/nl2sql-eval/runs', data)
+  },
+
+  // ---- Evaluation trends ----
+
+  getEvalTrends(params = {}) {
+    return dataagentRequest.get('/v1/nl2sql-eval/trends', { params })
   }
 }

--- a/dataagent/dataagent-frontend/src/router/index.js
+++ b/dataagent/dataagent-frontend/src/router/index.js
@@ -125,6 +125,30 @@ export const routes = [
         name: 'IntelligentQueryWidget',
         component: () => import('@/views/settings/WidgetAccessConfig.vue'),
         meta: { tab: 'widget', title: 'Widget 接入', adminOnly: true }
+      },
+      {
+        path: 'evaluations',
+        name: 'EvaluationSets',
+        component: () => import('@/views/evaluation/EvaluationSetsView.vue'),
+        meta: { tab: 'evaluations', title: '评测集', adminOnly: true }
+      },
+      {
+        path: 'evaluations/:datasetId',
+        name: 'EvaluationSetDetail',
+        component: () => import('@/views/evaluation/EvaluationSetDetailView.vue'),
+        meta: { tab: 'evaluations', title: '评测集详情', adminOnly: true }
+      },
+      {
+        path: 'evaluation-results',
+        name: 'EvaluationResults',
+        component: () => import('@/views/evaluation/EvaluationResultsView.vue'),
+        meta: { tab: 'eval-results', title: '评测结果', adminOnly: true }
+      },
+      {
+        path: 'evaluation-results/:runId',
+        name: 'EvaluationRunDetail',
+        component: () => import('@/views/evaluation/EvaluationRunDetailView.vue'),
+        meta: { tab: 'eval-results', title: '评测运行详情', adminOnly: true }
       }
     ]
   },

--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationResultsView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationResultsView.vue
@@ -1,0 +1,386 @@
+<template>
+  <div class="eval-results">
+    <div class="eval-results__toolbar">
+      <div>
+        <div class="eval-results__title">评测结果</div>
+        <div class="eval-results__subtitle">查看评测运行记录与趋势</div>
+      </div>
+      <div class="eval-results__filters">
+        <el-select v-model="filterDatasetId" clearable placeholder="按评测集筛选" class="eval-results__select">
+          <el-option
+            v-for="ds in datasets"
+            :key="ds.dataset_id"
+            :label="ds.name"
+            :value="ds.dataset_id"
+          />
+        </el-select>
+        <el-select v-model="filterEngine" clearable placeholder="按引擎筛选" class="eval-results__select-sm">
+          <el-option label="builtin" value="builtin" />
+          <el-option label="deepeval" value="deepeval" />
+          <el-option label="opik" value="opik" />
+        </el-select>
+      </div>
+    </div>
+
+    <div class="eval-results__trend-section">
+      <div class="eval-results__trend-header">
+        <div class="eval-results__trend-title">趋势</div>
+      </div>
+      <div v-loading="trendLoading" class="eval-results__trend-chart">
+        <div v-if="trendData.length" ref="chartRef" class="eval-results__chart-canvas" />
+        <el-empty v-else description="暂无趋势数据" :image-size="80" />
+      </div>
+    </div>
+
+    <div class="eval-results__run-section">
+      <div class="eval-results__run-title">运行记录</div>
+      <el-table
+        v-loading="runsLoading"
+        :data="runs"
+        stripe
+        class="eval-results__table"
+      >
+        <el-table-column prop="run_label" label="运行标签" min-width="160" show-overflow-tooltip>
+          <template #default="{ row }">
+            <el-link type="primary" @click="openRunDetail(row)">{{ row.run_label || row.run_id.slice(0, 12) }}</el-link>
+          </template>
+        </el-table-column>
+        <el-table-column prop="evaluation_engine" label="引擎" width="100" />
+        <el-table-column prop="model" label="模型" width="160" show-overflow-tooltip />
+        <el-table-column label="通过" width="70" align="center">
+          <template #default="{ row }">
+            <el-tag size="small" :type="row.passed ? 'success' : 'danger'">
+              {{ row.passed ? '是' : '否' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="平均分" width="90" align="center">
+          <template #default="{ row }">{{ formatScore(row.average_score) }}</template>
+        </el-table-column>
+        <el-table-column label="用例" width="120" align="center">
+          <template #default="{ row }">
+            <span class="eval-results__pass-count">{{ row.passed_cases }}</span> /
+            <span>{{ row.total_cases }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="run_status" label="状态" width="80" />
+        <el-table-column label="运行时间" width="170">
+          <template #default="{ row }">{{ formatTime(row.started_at || row.ingested_at) }}</template>
+        </el-table-column>
+        <el-table-column label="操作" width="80" fixed="right">
+          <template #default="{ row }">
+            <el-button text type="primary" @click="openRunDetail(row)">详情</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-empty
+        v-if="!runsLoading && !runs.length"
+        description="暂无运行记录"
+        :image-size="100"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import dayjs from 'dayjs'
+import * as echarts from 'echarts/core'
+import { use } from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import {
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  TooltipComponent
+} from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
+import { dataagentApi } from '@/api/dataagent'
+import { withAgentContext } from '@/router/agentContext'
+
+use([CanvasRenderer, LineChart, GridComponent, TooltipComponent, LegendComponent, TitleComponent])
+
+const route = useRoute()
+const router = useRouter()
+
+const datasets = ref([])
+const runs = ref([])
+const trendData = ref([])
+const runsLoading = ref(false)
+const trendLoading = ref(false)
+const filterDatasetId = ref('')
+const filterEngine = ref('')
+
+const chartRef = ref(null)
+let chartInstance = null
+let resizeObserver = null
+
+const formatTime = (val) => val ? dayjs(val).format('YYYY-MM-DD HH:mm:ss') : '-'
+const formatScore = (val) => typeof val === 'number' ? val.toFixed(2) : '-'
+
+const notifyError = (error, fallback) => {
+  if (!error?.__odwNotified) ElMessage.error(error?.message || fallback)
+}
+
+const loadDatasets = async () => {
+  try {
+    datasets.value = await dataagentApi.listEvalDatasets()
+  } catch { /* ignore */ }
+}
+
+const loadRuns = async () => {
+  runsLoading.value = true
+  try {
+    runs.value = await dataagentApi.listEvalRuns({
+      dataset_id: filterDatasetId.value || undefined,
+      evaluation_engine: filterEngine.value || undefined,
+      limit: 100
+    })
+  } catch (e) {
+    runs.value = []
+    notifyError(e, '加载运行记录失败')
+  } finally {
+    runsLoading.value = false
+  }
+}
+
+const loadTrends = async () => {
+  trendLoading.value = true
+  try {
+    trendData.value = await dataagentApi.getEvalTrends({
+      dataset_id: filterDatasetId.value || undefined,
+      evaluation_engine: filterEngine.value || undefined,
+      limit: 50
+    })
+  } catch (e) {
+    trendData.value = []
+    notifyError(e, '加载趋势数据失败')
+  } finally {
+    trendLoading.value = false
+  }
+}
+
+const buildChartOption = () => {
+  if (!trendData.value.length) return null
+
+  const xLabels = trendData.value.map((p) => {
+    if (p.started_at) return dayjs(p.started_at).format('MM-DD HH:mm')
+    return p.run_label || p.run_id?.slice(0, 8) || ''
+  })
+
+  const series = [
+    {
+      name: '平均分',
+      type: 'line',
+      data: trendData.value.map((p) => p.average_score ?? null),
+      smooth: true,
+      connectNulls: true
+    },
+    {
+      name: '意图准确率',
+      type: 'line',
+      data: trendData.value.map((p) => p.intent_accuracy ?? null),
+      smooth: true,
+      connectNulls: true
+    },
+    {
+      name: '实体准确率',
+      type: 'line',
+      data: trendData.value.map((p) => p.ontology_accuracy ?? null),
+      smooth: true,
+      connectNulls: true
+    },
+    {
+      name: '幻觉率',
+      type: 'line',
+      data: trendData.value.map((p) => p.hallucination_rate ?? null),
+      smooth: true,
+      connectNulls: true
+    },
+    {
+      name: '结果一致率',
+      type: 'line',
+      data: trendData.value.map((p) => p.result_consistency_rate ?? null),
+      smooth: true,
+      connectNulls: true
+    },
+    {
+      name: '有效通过率',
+      type: 'line',
+      data: trendData.value.map((p) => p.effective_pass_rate ?? null),
+      smooth: true,
+      connectNulls: true
+    }
+  ].filter((s) => s.data.some((v) => v !== null && v !== undefined))
+
+  return {
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 50, right: 20, top: 40, bottom: 40 },
+    xAxis: { type: 'category', data: xLabels, axisLabel: { rotate: 30 } },
+    yAxis: { type: 'value', min: 0 },
+    series
+  }
+}
+
+const disposeChart = () => {
+  if (resizeObserver) {
+    resizeObserver.disconnect()
+    resizeObserver = null
+  }
+  if (chartInstance) {
+    chartInstance.dispose()
+    chartInstance = null
+  }
+}
+
+const renderChart = async () => {
+  await nextTick()
+  const container = chartRef.value
+  if (!container) return
+  const option = buildChartOption()
+  if (!option) {
+    disposeChart()
+    return
+  }
+  if (!chartInstance) {
+    chartInstance = echarts.init(container)
+    resizeObserver = new ResizeObserver(() => chartInstance?.resize())
+    resizeObserver.observe(container)
+  }
+  chartInstance.clear()
+  chartInstance.setOption(option, { notMerge: true })
+  chartInstance.resize()
+}
+
+const openRunDetail = (run) => {
+  router.push(withAgentContext({
+    name: 'EvaluationRunDetail',
+    params: { runId: run.run_id }
+  }, route.query))
+}
+
+watch([filterDatasetId, filterEngine], () => {
+  loadRuns()
+  loadTrends()
+})
+
+watch(trendData, () => renderChart(), { deep: true })
+
+onMounted(async () => {
+  await loadDatasets()
+  await Promise.all([loadRuns(), loadTrends()])
+})
+
+onBeforeUnmount(() => disposeChart())
+</script>
+
+<style scoped>
+.eval-results {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.eval-results__toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.eval-results__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eval-results__subtitle {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.eval-results__filters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.eval-results__select {
+  width: 200px;
+}
+
+.eval-results__select-sm {
+  width: 140px;
+}
+
+.eval-results__trend-section {
+  background: #fff;
+  border: 1px solid #dbe2ea;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.eval-results__trend-header {
+  margin-bottom: 12px;
+}
+
+.eval-results__trend-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eval-results__trend-chart {
+  min-height: 320px;
+}
+
+.eval-results__chart-canvas {
+  width: 100%;
+  height: 320px;
+}
+
+.eval-results__run-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.eval-results__run-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eval-results__table {
+  min-width: 0;
+}
+
+.eval-results__pass-count {
+  color: #22c55e;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .eval-results__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-results__filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-results__select,
+  .eval-results__select-sm {
+    width: 100%;
+  }
+}
+</style>

--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationRunDetailView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationRunDetailView.vue
@@ -1,0 +1,474 @@
+<template>
+  <div class="run-detail">
+    <div class="run-detail__topbar">
+      <button type="button" class="run-detail__back" @click="goBack">&larr; 评测结果</button>
+      <span class="run-detail__slash">/</span>
+      <span class="run-detail__name">{{ run?.run_label || runId }}</span>
+    </div>
+
+    <div v-if="run" class="run-detail__summary">
+      <div class="run-detail__cards">
+        <div class="metric-card">
+          <div class="metric-card__label">平均分</div>
+          <div class="metric-card__value">{{ formatScore(run.average_score) }}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">通过</div>
+          <div class="metric-card__value" :class="run.passed ? 'metric-card__value--pass' : 'metric-card__value--fail'">
+            {{ run.passed ? '通过' : '未通过' }}
+          </div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">用例通过</div>
+          <div class="metric-card__value">{{ run.passed_cases }} / {{ run.total_cases }}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">幻觉用例</div>
+          <div class="metric-card__value">{{ run.veto_count || 0 }}</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__label">评判失败</div>
+          <div class="metric-card__value">{{ run.judge_failed_count || 0 }}</div>
+        </div>
+      </div>
+
+      <el-descriptions :column="3" border size="small" class="run-detail__info">
+        <el-descriptions-item label="引擎">{{ run.evaluation_engine }}</el-descriptions-item>
+        <el-descriptions-item label="引擎版本">{{ run.engine_version || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="模型">{{ run.model || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="评判模型">{{ run.judge_model || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="评判 Prompt">{{ run.judge_prompt_version || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="指标语义版本">{{ run.metric_semantics_version || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="状态">{{ run.run_status || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="建议">{{ run.recommendation || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="并发">{{ run.concurrency || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="数据集 ID">{{ run.dataset_id || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="数据集 Hash">
+          <span class="run-detail__hash">{{ run.dataset_hash ? run.dataset_hash.slice(0, 16) + '…' : '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="运行时间">{{ formatTime(run.started_at) }}</el-descriptions-item>
+        <el-descriptions-item label="入库时间">{{ formatTime(run.ingested_at) }}</el-descriptions-item>
+        <el-descriptions-item label="Run ID" :span="2">
+          <span class="run-detail__hash">{{ run.run_id }}</span>
+        </el-descriptions-item>
+      </el-descriptions>
+
+      <div v-if="metricsEntries.length" class="run-detail__metrics-section">
+        <div class="run-detail__section-title">指标详情</div>
+        <el-table :data="metricsEntries" size="small" stripe>
+          <el-table-column prop="key" label="指标" min-width="200" />
+          <el-table-column label="值" min-width="200">
+            <template #default="{ row }">
+              <template v-if="row.isRatio">
+                {{ formatScore(row.value) }} ({{ row.numerator }}/{{ row.denominator }})
+              </template>
+              <template v-else>{{ row.display }}</template>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+    </div>
+
+    <div class="run-detail__case-section">
+      <div class="run-detail__case-header">
+        <div class="run-detail__section-title">用例结果 ({{ runCases.length }})</div>
+        <el-input
+          v-model="caseSearch"
+          clearable
+          placeholder="搜索 case_id"
+          class="run-detail__search"
+        />
+      </div>
+
+      <el-table
+        v-loading="casesLoading"
+        :data="filteredCases"
+        stripe
+        class="run-detail__table"
+      >
+        <el-table-column prop="case_id" label="Case ID" min-width="180" show-overflow-tooltip />
+        <el-table-column prop="category" label="类别" width="100" />
+        <el-table-column label="得分" width="80" align="center">
+          <template #default="{ row }">{{ formatScore(row.score) }}</template>
+        </el-table-column>
+        <el-table-column label="通过" width="70" align="center">
+          <template #default="{ row }">
+            <el-tag size="small" :type="row.case_passed ? 'success' : 'danger'">
+              {{ row.case_passed ? '是' : '否' }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="task_status" label="状态" width="100" />
+        <el-table-column label="幻觉" width="70" align="center">
+          <template #default="{ row }">
+            <el-tag v-if="row.hallucination" size="small" type="danger">是</el-tag>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="七维分" min-width="260">
+          <template #default="{ row }">
+            <template v-if="row.dimension_scores_json">
+              <span
+                v-for="(dim, idx) in dimensionList(row.dimension_scores_json)"
+                :key="idx"
+                class="run-detail__dim"
+              >
+                {{ dim.name }}:{{ dim.score }}
+              </span>
+            </template>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="80" fixed="right">
+          <template #default="{ row }">
+            <el-button text type="primary" @click="openCaseDetail(row)">详情</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
+
+    <el-dialog
+      v-model="caseDialogVisible"
+      :title="`用例详情 - ${caseDetail?.case_id || ''}`"
+      width="76%"
+      :close-on-click-modal="true"
+      destroy-on-close
+    >
+      <div v-if="caseDetail" class="case-detail-dialog">
+        <el-descriptions :column="3" border size="small">
+          <el-descriptions-item label="Case ID">{{ caseDetail.case_id }}</el-descriptions-item>
+          <el-descriptions-item label="得分">{{ formatScore(caseDetail.score) }}</el-descriptions-item>
+          <el-descriptions-item label="通过">
+            <el-tag size="small" :type="caseDetail.case_passed ? 'success' : 'danger'">
+              {{ caseDetail.case_passed ? '是' : '否' }}
+            </el-tag>
+          </el-descriptions-item>
+          <el-descriptions-item label="状态">{{ caseDetail.task_status || '-' }}</el-descriptions-item>
+          <el-descriptions-item label="幻觉">{{ caseDetail.hallucination ? '是' : '否' }}</el-descriptions-item>
+          <el-descriptions-item label="类别">{{ caseDetail.category || '-' }}</el-descriptions-item>
+        </el-descriptions>
+
+        <div v-if="caseDetail.dimension_scores_json" class="case-detail-dialog__dims">
+          <div class="run-detail__section-title">维度评分</div>
+          <el-table :data="dimensionList(caseDetail.dimension_scores_json)" size="small" stripe>
+            <el-table-column prop="name" label="维度" />
+            <el-table-column prop="score" label="得分" width="80" align="center" />
+            <el-table-column prop="weight" label="权重" width="80" align="center" />
+            <el-table-column prop="rationale" label="理由" min-width="300" show-overflow-tooltip />
+          </el-table>
+        </div>
+
+        <div v-if="caseDetail.case_json" class="case-detail-dialog__json">
+          <div class="run-detail__section-title">完整用例数据</div>
+          <div class="case-detail-dialog__editor">
+            <TextCodeEditor
+              :model-value="formatJson(caseDetail.case_json)"
+              read-only
+            />
+          </div>
+        </div>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import dayjs from 'dayjs'
+import { dataagentApi } from '@/api/dataagent'
+import { withAgentContext } from '@/router/agentContext'
+import TextCodeEditor from '@/components/TextCodeEditor.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const runId = computed(() => String(route.params.runId || ''))
+
+const run = ref(null)
+const runCases = ref([])
+const casesLoading = ref(false)
+const caseSearch = ref('')
+const caseDialogVisible = ref(false)
+const caseDetail = ref(null)
+
+const formatTime = (val) => val ? dayjs(val).format('YYYY-MM-DD HH:mm:ss') : '-'
+const formatScore = (val) => typeof val === 'number' ? val.toFixed(2) : '-'
+
+const formatJson = (val) => {
+  if (typeof val === 'string') {
+    try { return JSON.stringify(JSON.parse(val), null, 2) } catch { return val }
+  }
+  if (val && typeof val === 'object') return JSON.stringify(val, null, 2)
+  return String(val || '')
+}
+
+const notifyError = (error, fallback) => {
+  if (!error?.__odwNotified) ElMessage.error(error?.message || fallback)
+}
+
+const goBack = () => {
+  router.push(withAgentContext({ name: 'EvaluationResults' }, route.query))
+}
+
+const metricsEntries = computed(() => {
+  if (!run.value?.metrics_json || typeof run.value.metrics_json !== 'object') return []
+  const entries = []
+  const walk = (obj, prefix) => {
+    for (const [k, v] of Object.entries(obj)) {
+      const key = prefix ? `${prefix}.${k}` : k
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        if ('value' in v && 'numerator' in v && 'denominator' in v) {
+          entries.push({ key, value: v.value, numerator: v.numerator, denominator: v.denominator, isRatio: true, display: '' })
+        } else {
+          walk(v, key)
+        }
+      } else {
+        entries.push({ key, value: v, isRatio: false, display: Array.isArray(v) ? JSON.stringify(v) : String(v ?? '-') })
+      }
+    }
+  }
+  walk(run.value.metrics_json, '')
+  return entries
+})
+
+const DIMENSION_NAMES = {
+  intent: '意图理解',
+  ontology_entity: '实体识别',
+  relation_scope: '关系范围',
+  sql_or_tool_call: 'SQL/工具',
+  result_consistency: '结果一致',
+  reasoning: '推理过程',
+  answer_quality: '回答质量'
+}
+
+const dimensionList = (dimJson) => {
+  if (!dimJson || typeof dimJson !== 'object') return []
+  return Object.entries(dimJson).map(([key, val]) => ({
+    name: DIMENSION_NAMES[key] || key,
+    score: typeof val === 'object' ? (val.score ?? '-') : val,
+    weight: typeof val === 'object' ? (val.weight ?? '-') : '-',
+    rationale: typeof val === 'object' ? (val.rationale || '') : ''
+  }))
+}
+
+const filteredCases = computed(() => {
+  const kw = String(caseSearch.value || '').trim().toLowerCase()
+  if (!kw) return runCases.value
+  return runCases.value.filter((c) => String(c.case_id || '').toLowerCase().includes(kw))
+})
+
+const loadRun = async () => {
+  try {
+    run.value = await dataagentApi.getEvalRun(runId.value)
+  } catch (e) {
+    run.value = null
+    notifyError(e, '加载运行详情失败')
+  }
+}
+
+const loadRunCases = async () => {
+  casesLoading.value = true
+  try {
+    runCases.value = await dataagentApi.listEvalRunCases(runId.value)
+  } catch (e) {
+    runCases.value = []
+    notifyError(e, '加载用例结果失败')
+  } finally {
+    casesLoading.value = false
+  }
+}
+
+const openCaseDetail = async (row) => {
+  try {
+    caseDetail.value = await dataagentApi.getEvalRunCase(runId.value, row.case_id)
+    caseDialogVisible.value = true
+  } catch (e) {
+    notifyError(e, '加载用例详情失败')
+  }
+}
+
+watch(runId, () => {
+  if (runId.value) {
+    loadRun()
+    loadRunCases()
+  }
+})
+
+onMounted(() => {
+  if (runId.value) {
+    loadRun()
+    loadRunCases()
+  }
+})
+</script>
+
+<style scoped>
+.run-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.run-detail__topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+}
+
+.run-detail__back {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #2563eb;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.run-detail__back:hover {
+  color: #1d4ed8;
+}
+
+.run-detail__slash {
+  color: #94a3b8;
+}
+
+.run-detail__name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+  min-width: 0;
+  word-break: break-all;
+}
+
+.run-detail__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.run-detail__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.metric-card {
+  background: #fff;
+  border: 1px solid #dbe2ea;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.metric-card__label {
+  font-size: 13px;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.metric-card__value {
+  font-size: 22px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.metric-card__value--pass {
+  color: #22c55e;
+}
+
+.metric-card__value--fail {
+  color: #ef4444;
+}
+
+.run-detail__info {
+  background: #fff;
+  border-radius: 8px;
+}
+
+.run-detail__hash {
+  font-family: monospace;
+  font-size: 12px;
+  color: #64748b;
+  word-break: break-all;
+}
+
+.run-detail__section-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 8px;
+}
+
+.run-detail__metrics-section {
+  background: #fff;
+  border: 1px solid #dbe2ea;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.run-detail__case-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.run-detail__case-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.run-detail__search {
+  width: 220px;
+}
+
+.run-detail__table {
+  min-width: 0;
+}
+
+.run-detail__dim {
+  display: inline-block;
+  margin-right: 8px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.case-detail-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.case-detail-dialog__dims {
+  margin-top: 8px;
+}
+
+.case-detail-dialog__json {
+  margin-top: 8px;
+}
+
+.case-detail-dialog__editor {
+  height: 360px;
+}
+
+@media (max-width: 768px) {
+  .run-detail__cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .run-detail__case-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .run-detail__search {
+    width: 100%;
+  }
+}
+</style>

--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetDetailView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetDetailView.vue
@@ -195,7 +195,24 @@ const openCaseEditor = async (caseRow) => {
       question: '',
       category: '',
       suite_tags: [],
-      expected: {}
+      expected_semantics: { intent: '', entities: [], conditions: [] },
+      expected_time: { range: '', granularity: '' },
+      expected_tools: { min_calls: 1, max_calls: 3 },
+      expected_sql: { keywords: [], tables: [] },
+      expected_result: { row_count: null, columns: [] },
+      expected_answer: { must_contain: [], must_not_contain: [] },
+      limits: { max_turns: 5, timeout_seconds: 120 },
+      scoring: {
+        intent: 1,
+        ontology_entity: 1,
+        relation_scope: 1,
+        sql_or_tool_call: 2,
+        result_consistency: 2,
+        reasoning: 2,
+        answer_quality: 1,
+        total_score: 10
+      },
+      veto_rules: { hallucination_fails: true }
     }, null, 2)
   }
   editorVisible.value = true

--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetDetailView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetDetailView.vue
@@ -1,0 +1,393 @@
+<template>
+  <div class="eval-detail">
+    <div class="eval-detail__topbar">
+      <button type="button" class="eval-detail__back" @click="goBack">&larr; 评测集列表</button>
+      <span class="eval-detail__slash">/</span>
+      <span class="eval-detail__name">{{ dataset?.name || datasetId }}</span>
+    </div>
+
+    <div v-if="dataset" class="eval-detail__meta">
+      <el-descriptions :column="3" border size="small">
+        <el-descriptions-item label="名称">{{ dataset.name }}</el-descriptions-item>
+        <el-descriptions-item label="类别">{{ dataset.category || '-' }}</el-descriptions-item>
+        <el-descriptions-item label="状态">
+          <el-tag size="small" :type="dataset.status === 'active' ? 'success' : 'info'">
+            {{ dataset.status === 'active' ? '活跃' : '归档' }}
+          </el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="用例数">{{ dataset.case_count }}</el-descriptions-item>
+        <el-descriptions-item label="Hash">
+          <span class="eval-detail__hash">{{ dataset.dataset_hash ? dataset.dataset_hash.slice(0, 16) + '…' : '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="更新时间">{{ formatTime(dataset.updated_at) }}</el-descriptions-item>
+        <el-descriptions-item v-if="dataset.description" label="描述" :span="3">{{ dataset.description }}</el-descriptions-item>
+      </el-descriptions>
+    </div>
+
+    <div class="eval-detail__case-toolbar">
+      <div class="eval-detail__case-title">用例列表 ({{ cases.length }})</div>
+      <div class="eval-detail__case-actions">
+        <el-input
+          v-model="searchKeyword"
+          clearable
+          placeholder="搜索 case_id 或 question"
+          class="eval-detail__search"
+        />
+        <el-button type="primary" @click="openCaseEditor(null)">新建用例</el-button>
+      </div>
+    </div>
+
+    <el-table
+      v-loading="casesLoading"
+      :data="filteredCases"
+      stripe
+      class="eval-detail__table"
+    >
+      <el-table-column prop="case_id" label="Case ID" width="200" show-overflow-tooltip />
+      <el-table-column prop="case_type" label="类型" width="100" />
+      <el-table-column prop="category" label="类别" width="100" show-overflow-tooltip />
+      <el-table-column prop="question" label="问题" min-width="280" show-overflow-tooltip />
+      <el-table-column label="标签" width="160">
+        <template #default="{ row }">
+          <el-tag
+            v-for="tag in parseTags(row.suite_tags)"
+            :key="tag"
+            size="small"
+            effect="plain"
+            class="eval-detail__tag"
+          >
+            {{ tag }}
+          </el-tag>
+          <span v-if="!parseTags(row.suite_tags).length">-</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="140" fixed="right">
+        <template #default="{ row }">
+          <el-button text type="primary" @click="openCaseEditor(row)">编辑</el-button>
+          <el-button text type="danger" @click="confirmDeleteCase(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-empty
+      v-if="!casesLoading && !filteredCases.length"
+      :description="searchKeyword ? '没有匹配的用例' : '暂无用例'"
+      :image-size="100"
+    />
+
+    <el-dialog
+      v-model="editorVisible"
+      :title="editingCase ? `编辑用例 ${editingCase.case_id}` : '新建用例'"
+      width="76%"
+      :close-on-click-modal="false"
+      destroy-on-close
+    >
+      <div class="case-editor">
+        <div class="case-editor__hint">
+          编辑完整的 V2 评测用例 JSON，需包含 <code>case_id</code>、<code>schema_version</code> 等必要字段。
+        </div>
+        <div class="case-editor__area">
+          <TextCodeEditor
+            v-model="editorContent"
+            placeholder='{"schema_version": 2, "case_id": "...", "question": "...", "case_type": "single_turn", ...}'
+          />
+        </div>
+        <div v-if="editorError" class="case-editor__error">{{ editorError }}</div>
+      </div>
+      <template #footer>
+        <el-button @click="editorVisible = false">取消</el-button>
+        <el-button type="primary" :loading="editorSaving" @click="saveCase">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import dayjs from 'dayjs'
+import { dataagentApi } from '@/api/dataagent'
+import { withAgentContext } from '@/router/agentContext'
+import TextCodeEditor from '@/components/TextCodeEditor.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const datasetId = computed(() => String(route.params.datasetId || ''))
+
+const dataset = ref(null)
+const cases = ref([])
+const casesLoading = ref(false)
+const searchKeyword = ref('')
+
+const editorVisible = ref(false)
+const editingCase = ref(null)
+const editorContent = ref('')
+const editorError = ref('')
+const editorSaving = ref(false)
+
+const parseTags = (tags) => {
+  if (Array.isArray(tags)) return tags
+  if (typeof tags === 'string') {
+    try { return JSON.parse(tags) } catch { return [] }
+  }
+  return []
+}
+
+const filteredCases = computed(() => {
+  const kw = String(searchKeyword.value || '').trim().toLowerCase()
+  if (!kw) return cases.value
+  return cases.value.filter((c) =>
+    String(c.case_id || '').toLowerCase().includes(kw) ||
+    String(c.question || '').toLowerCase().includes(kw)
+  )
+})
+
+const formatTime = (val) => val ? dayjs(val).format('YYYY-MM-DD HH:mm:ss') : '-'
+
+const notifyError = (error, fallback) => {
+  if (!error?.__odwNotified) ElMessage.error(error?.message || fallback)
+}
+
+const goBack = () => {
+  router.push(withAgentContext({ name: 'EvaluationSets' }, route.query))
+}
+
+const loadDataset = async () => {
+  try {
+    dataset.value = await dataagentApi.getEvalDataset(datasetId.value)
+  } catch (e) {
+    dataset.value = null
+    notifyError(e, '加载评测集失败')
+  }
+}
+
+const loadCases = async () => {
+  casesLoading.value = true
+  try {
+    cases.value = await dataagentApi.listEvalCases(datasetId.value)
+  } catch (e) {
+    cases.value = []
+    notifyError(e, '加载用例失败')
+  } finally {
+    casesLoading.value = false
+  }
+}
+
+const openCaseEditor = async (caseRow) => {
+  editorError.value = ''
+  editingCase.value = caseRow
+  if (caseRow) {
+    try {
+      const detail = await dataagentApi.getEvalCase(datasetId.value, caseRow.case_id)
+      const json = typeof detail.case_json === 'string' ? JSON.parse(detail.case_json) : detail.case_json
+      editorContent.value = JSON.stringify(json, null, 2)
+    } catch (e) {
+      editorContent.value = ''
+      notifyError(e, '加载用例详情失败')
+    }
+  } else {
+    editorContent.value = JSON.stringify({
+      schema_version: 2,
+      case_id: '',
+      case_type: 'single_turn',
+      question: '',
+      category: '',
+      suite_tags: [],
+      expected: {}
+    }, null, 2)
+  }
+  editorVisible.value = true
+}
+
+const saveCase = async () => {
+  editorError.value = ''
+  let parsed
+  try {
+    parsed = JSON.parse(editorContent.value)
+  } catch {
+    editorError.value = 'JSON 格式错误，请检查'
+    return
+  }
+  const caseId = String(parsed.case_id || '').trim()
+  if (!caseId) {
+    editorError.value = '缺少 case_id 字段'
+    return
+  }
+  editorSaving.value = true
+  try {
+    await dataagentApi.upsertEvalCase(datasetId.value, caseId, parsed)
+    ElMessage.success('用例已保存')
+    editorVisible.value = false
+    await loadDataset()
+    await loadCases()
+  } catch (e) {
+    notifyError(e, '保存用例失败')
+  } finally {
+    editorSaving.value = false
+  }
+}
+
+const confirmDeleteCase = async (caseRow) => {
+  try {
+    await ElMessageBox.confirm(
+      `确认删除用例「${caseRow.case_id}」？`,
+      '删除用例',
+      { type: 'warning', confirmButtonText: '确认删除', cancelButtonText: '取消' }
+    )
+  } catch { return }
+  try {
+    await dataagentApi.deleteEvalCase(datasetId.value, caseRow.case_id)
+    ElMessage.success('用例已删除')
+    await loadDataset()
+    await loadCases()
+  } catch (e) {
+    notifyError(e, '删除用例失败')
+  }
+}
+
+watch(datasetId, () => {
+  if (datasetId.value) {
+    loadDataset()
+    loadCases()
+  }
+})
+
+onMounted(() => {
+  if (datasetId.value) {
+    loadDataset()
+    loadCases()
+  }
+})
+</script>
+
+<style scoped>
+.eval-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.eval-detail__topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+}
+
+.eval-detail__back {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #2563eb;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.eval-detail__back:hover {
+  color: #1d4ed8;
+}
+
+.eval-detail__slash {
+  color: #94a3b8;
+}
+
+.eval-detail__name {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+  min-width: 0;
+  word-break: break-all;
+}
+
+.eval-detail__meta {
+  background: #fff;
+  border: 1px solid #dbe2ea;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.eval-detail__hash {
+  font-family: monospace;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.eval-detail__case-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.eval-detail__case-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eval-detail__case-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.eval-detail__search {
+  width: 240px;
+}
+
+.eval-detail__table {
+  min-width: 0;
+}
+
+.eval-detail__tag {
+  margin-right: 4px;
+  margin-bottom: 2px;
+}
+
+.case-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.case-editor__hint {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.case-editor__hint code {
+  padding: 1px 4px;
+  background: #f1f5f9;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.case-editor__area {
+  height: 420px;
+}
+
+.case-editor__error {
+  color: #ef4444;
+  font-size: 13px;
+}
+
+@media (max-width: 768px) {
+  .eval-detail__case-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-detail__case-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-detail__search {
+    width: 100%;
+  }
+}
+</style>

--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetsView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetsView.vue
@@ -1,0 +1,363 @@
+<template>
+  <div class="eval-sets">
+    <div class="eval-sets__toolbar">
+      <div>
+        <div class="eval-sets__title">评测集</div>
+        <div class="eval-sets__subtitle">共 {{ datasets.length }} 个评测集</div>
+      </div>
+      <div class="eval-sets__actions">
+        <el-input
+          v-model="searchKeyword"
+          clearable
+          placeholder="搜索名称或类别"
+          class="eval-sets__search"
+        />
+        <el-upload
+          accept=".jsonl,.json"
+          :show-file-list="false"
+          :disabled="importLoading"
+          :before-upload="beforeUpload"
+          :http-request="handleImport"
+        >
+          <el-button type="primary" :loading="importLoading">导入 JSONL</el-button>
+        </el-upload>
+        <el-button type="primary" @click="openCreateDialog">新建评测集</el-button>
+      </div>
+    </div>
+
+    <el-table
+      v-loading="listLoading"
+      :data="filteredDatasets"
+      stripe
+      class="eval-sets__table"
+    >
+      <el-table-column prop="name" label="名称" min-width="180" show-overflow-tooltip>
+        <template #default="{ row }">
+          <el-link type="primary" @click="openDetail(row)">{{ row.name }}</el-link>
+        </template>
+      </el-table-column>
+      <el-table-column prop="category" label="类别" width="120" show-overflow-tooltip />
+      <el-table-column prop="case_count" label="用例数" width="90" align="center" />
+      <el-table-column prop="dataset_hash" label="Hash" width="140" show-overflow-tooltip>
+        <template #default="{ row }">
+          <span class="eval-sets__hash">{{ row.dataset_hash ? row.dataset_hash.slice(0, 12) + '…' : '-' }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="标签" min-width="160">
+        <template #default="{ row }">
+          <el-tag
+            v-for="tag in parseTags(row.suite_tags)"
+            :key="tag"
+            size="small"
+            effect="plain"
+            class="eval-sets__tag"
+          >
+            {{ tag }}
+          </el-tag>
+          <span v-if="!parseTags(row.suite_tags).length">-</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="状态" width="80" align="center">
+        <template #default="{ row }">
+          <el-tag size="small" :type="row.status === 'active' ? 'success' : 'info'">
+            {{ row.status === 'active' ? '活跃' : '归档' }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="更新时间" width="170">
+        <template #default="{ row }">{{ formatTime(row.updated_at) }}</template>
+      </el-table-column>
+      <el-table-column label="操作" width="200" fixed="right">
+        <template #default="{ row }">
+          <el-button text type="primary" @click="openDetail(row)">详情</el-button>
+          <el-button text type="primary" :loading="exportingId === row.dataset_id" @click="handleExport(row)">导出</el-button>
+          <el-button text type="primary" @click="openEditDialog(row)">编辑</el-button>
+          <el-button text type="danger" @click="confirmDelete(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-empty
+      v-if="!listLoading && !filteredDatasets.length"
+      :description="searchKeyword ? '没有匹配的评测集' : '暂无评测集，请导入或新建'"
+      :image-size="120"
+    />
+
+    <el-dialog
+      v-model="dialogVisible"
+      :title="editingDataset ? '编辑评测集' : '新建评测集'"
+      width="520px"
+      :close-on-click-modal="false"
+    >
+      <el-form :model="dialogForm" label-width="80px">
+        <el-form-item label="名称" required>
+          <el-input v-model="dialogForm.name" placeholder="评测集名称" maxlength="120" />
+        </el-form-item>
+        <el-form-item label="类别">
+          <el-input v-model="dialogForm.category" placeholder="如：business, smoke" maxlength="60" />
+        </el-form-item>
+        <el-form-item label="描述">
+          <el-input v-model="dialogForm.description" type="textarea" :rows="3" placeholder="评测集描述" maxlength="500" />
+        </el-form-item>
+        <el-form-item label="标签">
+          <el-select
+            v-model="dialogForm.suite_tags"
+            multiple
+            filterable
+            allow-create
+            default-first-option
+            placeholder="输入标签后回车"
+          />
+        </el-form-item>
+        <el-form-item v-if="editingDataset" label="状态">
+          <el-select v-model="dialogForm.status">
+            <el-option label="活跃" value="active" />
+            <el-option label="归档" value="archived" />
+          </el-select>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="dialogLoading" @click="submitDialog">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import dayjs from 'dayjs'
+import { dataagentApi } from '@/api/dataagent'
+import { withAgentContext } from '@/router/agentContext'
+
+const route = useRoute()
+const router = useRouter()
+
+const listLoading = ref(false)
+const importLoading = ref(false)
+const exportingId = ref('')
+const dialogVisible = ref(false)
+const dialogLoading = ref(false)
+const searchKeyword = ref('')
+const datasets = ref([])
+const editingDataset = ref(null)
+
+const dialogForm = ref({ name: '', description: '', category: '', suite_tags: [], status: 'active' })
+
+const parseTags = (tags) => {
+  if (Array.isArray(tags)) return tags
+  if (typeof tags === 'string') {
+    try { return JSON.parse(tags) } catch { return [] }
+  }
+  return []
+}
+
+const filteredDatasets = computed(() => {
+  const kw = String(searchKeyword.value || '').trim().toLowerCase()
+  if (!kw) return datasets.value
+  return datasets.value.filter((ds) =>
+    String(ds.name || '').toLowerCase().includes(kw) ||
+    String(ds.category || '').toLowerCase().includes(kw)
+  )
+})
+
+const formatTime = (val) => val ? dayjs(val).format('YYYY-MM-DD HH:mm:ss') : '-'
+
+const notifyError = (error, fallback) => {
+  if (!error?.__odwNotified) ElMessage.error(error?.message || fallback)
+}
+
+const loadDatasets = async () => {
+  listLoading.value = true
+  try {
+    datasets.value = await dataagentApi.listEvalDatasets()
+  } catch (e) {
+    datasets.value = []
+    notifyError(e, '加载评测集失败')
+  } finally {
+    listLoading.value = false
+  }
+}
+
+const openDetail = (ds) => {
+  router.push(withAgentContext({
+    name: 'EvaluationSetDetail',
+    params: { datasetId: ds.dataset_id }
+  }, route.query))
+}
+
+const openCreateDialog = () => {
+  editingDataset.value = null
+  dialogForm.value = { name: '', description: '', category: '', suite_tags: [], status: 'active' }
+  dialogVisible.value = true
+}
+
+const openEditDialog = (ds) => {
+  editingDataset.value = ds
+  dialogForm.value = {
+    name: ds.name || '',
+    description: ds.description || '',
+    category: ds.category || '',
+    suite_tags: parseTags(ds.suite_tags),
+    status: ds.status || 'active'
+  }
+  dialogVisible.value = true
+}
+
+const submitDialog = async () => {
+  if (!String(dialogForm.value.name).trim()) {
+    ElMessage.warning('请输入评测集名称')
+    return
+  }
+  dialogLoading.value = true
+  try {
+    if (editingDataset.value) {
+      await dataagentApi.updateEvalDataset(editingDataset.value.dataset_id, dialogForm.value)
+      ElMessage.success('评测集已更新')
+    } else {
+      await dataagentApi.createEvalDataset(dialogForm.value)
+      ElMessage.success('评测集已创建')
+    }
+    dialogVisible.value = false
+    await loadDatasets()
+  } catch (e) {
+    notifyError(e, '操作失败')
+  } finally {
+    dialogLoading.value = false
+  }
+}
+
+const confirmDelete = async (ds) => {
+  try {
+    await ElMessageBox.confirm(
+      `确认删除评测集「${ds.name}」？此操作不可恢复。`,
+      '删除评测集',
+      { type: 'warning', confirmButtonText: '确认删除', cancelButtonText: '取消' }
+    )
+  } catch { return }
+  try {
+    await dataagentApi.deleteEvalDataset(ds.dataset_id)
+    ElMessage.success('评测集已删除')
+    await loadDatasets()
+  } catch (e) {
+    notifyError(e, '删除失败')
+  }
+}
+
+const beforeUpload = (file) => {
+  const name = String(file?.name || '').toLowerCase()
+  if (!name.endsWith('.jsonl') && !name.endsWith('.json')) {
+    ElMessage.error('请上传 JSONL 格式文件')
+    return false
+  }
+  return true
+}
+
+const handleImport = async ({ file }) => {
+  importLoading.value = true
+  try {
+    const result = await dataagentApi.importEvalDataset(file)
+    ElMessage.success(`导入成功：${result.name}，共 ${result.case_count} 个用例`)
+    await loadDatasets()
+  } catch (e) {
+    notifyError(e, '导入失败')
+  } finally {
+    importLoading.value = false
+  }
+}
+
+const handleExport = async (ds) => {
+  if (exportingId.value) return
+  exportingId.value = ds.dataset_id
+  try {
+    const blob = await dataagentApi.exportEvalDataset(ds.dataset_id)
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${ds.name || ds.dataset_id}.jsonl`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(url)
+    ElMessage.success('导出成功')
+  } catch (e) {
+    notifyError(e, '导出失败')
+  } finally {
+    exportingId.value = ''
+  }
+}
+
+onMounted(() => { loadDatasets() })
+</script>
+
+<style scoped>
+.eval-sets {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.eval-sets__toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.eval-sets__title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.eval-sets__subtitle {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.eval-sets__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.eval-sets__search {
+  width: 220px;
+}
+
+.eval-sets__table {
+  min-width: 0;
+}
+
+.eval-sets__hash {
+  font-family: monospace;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.eval-sets__tag {
+  margin-right: 4px;
+  margin-bottom: 2px;
+}
+
+@media (max-width: 768px) {
+  .eval-sets__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-sets__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .eval-sets__search {
+    width: 100%;
+  }
+}
+</style>

--- a/dataagent/dataagent-frontend/src/views/intelligence/IntelligentQueryView.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/IntelligentQueryView.vue
@@ -35,6 +35,14 @@
             <el-icon><Monitor /></el-icon>
             <span>Widget 接入</span>
           </el-menu-item>
+          <el-menu-item index="evaluations">
+            <el-icon><DataBoard /></el-icon>
+            <span>评测集</span>
+          </el-menu-item>
+          <el-menu-item index="eval-results">
+            <el-icon><TrendCharts /></el-icon>
+            <span>评测结果</span>
+          </el-menu-item>
         </template>
       </el-menu>
       <div v-if="authStore.enabled && authStore.currentUser" class="intelligent-query-user">
@@ -61,7 +69,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Collection, Cpu, MagicStick, Monitor, User } from '@element-plus/icons-vue'
+import { Collection, Cpu, DataBoard, MagicStick, Monitor, TrendCharts, User } from '@element-plus/icons-vue'
 import { useAuthStore } from '@/stores/auth'
 import { withAgentContext } from '@/router/agentContext'
 
@@ -83,7 +91,9 @@ const MENU_TO_PATH = {
   skills: '/skills',
   agents: '/agents',
   models: '/models',
-  widget: '/widget-access'
+  widget: '/widget-access',
+  evaluations: '/evaluations',
+  'eval-results': '/evaluation-results'
 }
 
 const brandLogo = `${import.meta.env.BASE_URL}opendataworks-icon.svg`

--- a/docs/design/2026-07-21-dataagent-eval-management-ui-design.md
+++ b/docs/design/2026-07-21-dataagent-eval-management-ui-design.md
@@ -1,0 +1,116 @@
+# DataAgent Evaluation Management UI — Design
+
+**Date**: 2026-07-21
+**Status**: Implemented
+**Scope**: `dataagent/dataagent-backend`, `dataagent/dataagent-frontend`, `tools/dataagent-evals/builtin`
+
+## Current State
+
+DataAgent has a mature, file-based evaluation system:
+
+- **Datasets**: JSONL files (`schema_version: 2`) stored in `tools/dataagent-evals/dataset/`, managed by `manage.py` with canonical serialization and SHA-256 hashing.
+- **Runners**: Three independent engines (`builtin`, `deepeval`, `opik`) under `tools/dataagent-evals/`, each producing `summary.json` + `cases.jsonl` + `report.html`.
+- **Trends**: `tools/dataagent-evals/history/report.py` normalizes run directories into offline HTML reports.
+- **7-dimension scoring**: intent, ontology_entity, relation_scope, sql_or_tool_call, result_consistency, reasoning, answer_quality; total = 10 points.
+
+All management, result viewing, and trending is offline/CLI-only. There is no persistent database storage for evaluation data, and no web UI for any evaluation workflow.
+
+## Problem
+
+- Evaluation datasets can only be managed by editing JSONL files locally — no web-based CRUD, search, or validation.
+- Evaluation results are scattered across run directories with no persistent, queryable store.
+- Trend analysis requires running offline scripts; no live dashboard exists.
+- Sharing evaluation state across team members requires file sharing rather than a centralized service.
+
+## Scope
+
+**In scope (this change)**:
+- Database persistence for evaluation datasets, cases, runs, and run results.
+- Web UI for dataset CRUD (create, read, update, delete), JSONL import/export, and case editing.
+- Web UI for viewing evaluation runs, run details, per-case results, and trend charts.
+- Ingestion API for runners to report results to the database.
+- Optional `--report-endpoint` flag on the builtin runner for automatic result upload.
+
+**Out of scope**:
+- Triggering evaluation runs from the UI (runners remain independent CLI tools).
+- Multi-tenant or RBAC beyond the existing `require_admin` guard.
+- Runner modifications beyond the optional `--report-endpoint`.
+
+## Solution
+
+### Architecture
+
+```
+dataagent-frontend (Vue 3 / Element Plus / ECharts)
+  └─ Evaluation management pages (admin-only)
+       │ axios → dataagentApi (X-ODW-Client: dataagent)
+       ▼
+dataagent-backend (FastAPI)
+  ├─ api/eval_routes.py     APIRouter prefix=/api/v1/nl2sql-eval
+  ├─ core/eval_store.py     PyMySQL CRUD (session_mysql_database)
+  ├─ core/eval_contract.py  V2 schema validation (mirrors manage.py)
+  ├─ core/eval_dataset_service.py  Import/export orchestration
+  └─ models/schemas.py      Pydantic response models
+       │
+       ▼
+MySQL: existing `dataagent` schema, new eval_* tables (Alembic migration)
+```
+
+### Data Model
+
+Four new tables in the existing `dataagent` schema:
+
+1. **`eval_dataset`** — Dataset metadata (name, description, category, tags, case_count, SHA-256 hash, status).
+2. **`eval_case`** — Individual test cases; `case_json LONGTEXT` stores the complete V2 case for lossless JSONL round-trip.
+3. **`eval_run`** — One evaluation run; stores summary metrics, model/engine info, pass/fail, timing. `run_id` defaults to sha256 of summary for idempotent ingestion.
+4. **`eval_run_case`** — Per-case results within a run; score, pass/fail, hallucination flag, 7-dimension scores, full case JSON.
+
+### Contract Duplication
+
+The backend cannot import `tools/dataagent-evals/dataset/manage.py` at runtime (Docker image only contains `dataagent/dataagent-backend`). Instead, `core/eval_contract.py` reimplements the same contract (WEIGHTS, REQUIRED, validate, canonical_bytes). A regression test imports both implementations and asserts byte-level equality on the smoke dataset.
+
+### Ingestion
+
+Runners produce `summary.json` + `cases.jsonl`. The `POST /runs` endpoint accepts these as JSON body. Ingestion is idempotent: duplicate `run_id` returns the existing record without re-inserting. `started_at` uses a three-level fallback: explicit parameter → parsed from `run_label` (`%Y%m%d-%H%M%S`) → `ingested_at`.
+
+### Frontend
+
+Four new views under `src/views/evaluation/`:
+- **EvaluationSetsView**: Dataset table with CRUD, search, JSONL import (el-upload), export (blob download).
+- **EvaluationSetDetailView**: Case list with search, inline JSON editor (CodeMirror via TextCodeEditor) for creating/editing V2 cases.
+- **EvaluationResultsView**: Run list with filters (dataset, engine) + ECharts trend line chart (average_score, accuracies, hallucination_rate over time).
+- **EvaluationRunDetailView**: Summary metric cards, detailed descriptions table, metrics tree, per-case results table with expandable 7-dimension scores and full JSON viewer.
+
+All routes are `adminOnly`, consistent with existing admin pages.
+
+## Interfaces
+
+### API Routes (`/api/v1/nl2sql-eval`, all `require_admin`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /datasets | List datasets |
+| POST | /datasets | Create dataset |
+| GET/PUT/DELETE | /datasets/{id} | Dataset CRUD |
+| POST | /datasets/imports | Import JSONL |
+| GET | /datasets/{id}/export | Export JSONL |
+| GET | /datasets/{id}/cases | List cases |
+| GET/PUT/DELETE | /datasets/{id}/cases/{case_id} | Case CRUD |
+| PUT | /datasets/{id}/cases | Bulk replace cases |
+| POST | /runs | Ingest run |
+| GET | /runs | List runs |
+| GET | /runs/{run_id} | Run detail |
+| GET | /runs/{run_id}/cases | Run case list |
+| GET | /runs/{run_id}/cases/{case_id} | Run case detail |
+| GET | /trends | Trend series |
+
+### Dataset Hash Refresh
+
+Any case mutation (upsert, delete, replace) triggers `canonical_bytes` recomputation of `dataset_hash` and `case_count` on `eval_dataset`, keeping metadata consistent with actual content.
+
+## Tradeoffs
+
+1. **Contract duplication vs runtime import**: Duplication adds maintenance cost but avoids Docker build complexity and keeps the runner independent. Regression test mitigates drift risk.
+2. **Storing full case_json in DB**: Increases storage but enables lossless JSONL export round-trips without lossy reconstruction from normalized columns.
+3. **Ingestion API vs direct DB writes from runners**: Keeps runners stateless and deployment-agnostic; adds an HTTP call but preserves the "three engines are independent" philosophy.
+4. **No UI-triggered evaluation**: Keeps MVP scope manageable; runners remain CLI tools with their own configuration and credentials.

--- a/docs/design/2026-07-21-dataagent-eval-management-ui-design.md
+++ b/docs/design/2026-07-21-dataagent-eval-management-ui-design.md
@@ -108,9 +108,18 @@ All routes are `adminOnly`, consistent with existing admin pages.
 
 Any case mutation (upsert, delete, replace) triggers `canonical_bytes` recomputation of `dataset_hash` and `case_count` on `eval_dataset`, keeping metadata consistent with actual content.
 
+### Dataset ID Resolution on Ingestion
+
+Runner `summary.dataset_id` is the JSONL **filename stem** (e.g. `opendataworks-business-knowledge-smoke-v2`), not a UI-generated `ds-*` UUID. On ingestion, if the submitted `dataset_id` does not match any `eval_dataset.dataset_id`, the system performs a reverse lookup by `dataset_hash`: when the runner's `dataset_hash` matches an existing dataset's hash, `dataset_id` is overwritten with the UI dataset's ID. This enables "filter runs by dataset" to work across both UI-managed and CLI-managed datasets. When no hash match is found, the original `dataset_id` is preserved as-is (soft association).
+
+### Case Upsert Validation
+
+Single-case upsert (`PUT /datasets/{id}/cases/{case_id}`) runs the full V2 `validate()` on the merged case list before persisting, consistent with bulk `replace_cases`. This prevents invalid cases from entering the database via the primary UI editing path. The merged list preserves the original insertion order (in-place replacement) so that `dataset_hash` matches the export order (`ORDER BY id`).
+
 ## Tradeoffs
 
-1. **Contract duplication vs runtime import**: Duplication adds maintenance cost but avoids Docker build complexity and keeps the runner independent. Regression test mitigates drift risk.
+1. **Contract duplication vs runtime import**: Duplication adds maintenance cost but avoids Docker build complexity and keeps the runner independent. Regression test (`tests/test_eval_contract.py`) mitigates drift risk.
 2. **Storing full case_json in DB**: Increases storage but enables lossless JSONL export round-trips without lossy reconstruction from normalized columns.
 3. **Ingestion API vs direct DB writes from runners**: Keeps runners stateless and deployment-agnostic; adds an HTTP call but preserves the "three engines are independent" philosophy.
 4. **No UI-triggered evaluation**: Keeps MVP scope manageable; runners remain CLI tools with their own configuration and credentials.
+5. **No explicit request body size limit on ingestion**: The `POST /runs` endpoint does not enforce an application-level body size limit. Large runs (many cases) are bounded by the upstream reverse proxy and uvicorn's default limits. This is acceptable for the current single-tenant deployment; a future multi-tenant scenario may need explicit limits.

--- a/docs/plans/2026-07-21-dataagent-eval-management-ui-plan.md
+++ b/docs/plans/2026-07-21-dataagent-eval-management-ui-plan.md
@@ -1,0 +1,74 @@
+# DataAgent Evaluation Management UI — Plan
+
+**Date**: 2026-07-21
+**Design**: `docs/design/2026-07-21-dataagent-eval-management-ui-design.md`
+**Branch**: `claude/evaluation-set-management-ui-gr7aru`
+
+## Tasks
+
+### 1. Database Migration
+- **File**: `dataagent/dataagent-backend/alembic/versions/20260721_000021_add_eval_tables.py`
+- Create `eval_dataset`, `eval_case`, `eval_run`, `eval_run_case` tables
+- `down_revision = "20260720_000020"` (current head)
+- Uses `_has_table()` guard pattern from existing migrations
+
+### 2. Backend Core Modules
+- **`core/eval_contract.py`**: V2 schema validation mirroring `manage.py` (WEIGHTS, REQUIRED, validate, canonical_bytes, parse_jsonl)
+- **`core/eval_store.py`**: EvalStore class with `_conn()` context manager (mirrors `topic_task_store` pattern); dataset/case/run CRUD; idempotent ingestion; trend series
+- **`core/eval_dataset_service.py`**: Import (parse + validate + create), export (canonical_bytes), hash refresh
+
+### 3. Backend API Layer
+- **`api/eval_routes.py`**: APIRouter `prefix=/api/v1/nl2sql-eval`, `dependencies=[Depends(require_admin)]`; dataset CRUD + import/export + case CRUD + run ingestion + trends
+- **`models/schemas.py`**: Append Pydantic models (EvalDatasetSummary, EvalCaseSummary, EvalRunSummary, EvalTrendPoint, etc.)
+- **`main.py`**: Wire `eval_router`
+
+### 4. Runner Integration
+- **`tools/dataagent-evals/builtin/run.py`**: Add `--report-endpoint` / `DATAAGENT_EVAL_REPORT_ENDPOINT` arg; stdlib urllib POST on completion; best-effort (failure warns only)
+
+### 5. Frontend
+- **`src/api/dataagent.js`**: Add 15 eval API methods to `dataagentApi`
+- **`src/router/index.js`**: Add 4 child routes (evaluations, evaluations/:datasetId, evaluation-results, evaluation-results/:runId)
+- **`src/views/intelligence/IntelligentQueryView.vue`**: Add sidebar menu items + icon imports
+- **`src/views/evaluation/EvaluationSetsView.vue`**: Dataset list with CRUD, import, export
+- **`src/views/evaluation/EvaluationSetDetailView.vue`**: Case list with CodeMirror JSON editor
+- **`src/views/evaluation/EvaluationResultsView.vue`**: Run list + ECharts trend chart
+- **`src/views/evaluation/EvaluationRunDetailView.vue`**: Run summary + per-case table + detail dialog
+
+### 6. Documentation
+- `docs/design/2026-07-21-dataagent-eval-management-ui-design.md`
+- `docs/plans/2026-07-21-dataagent-eval-management-ui-plan.md`
+
+## Touched Files
+
+| File | Action |
+|------|--------|
+| `dataagent/dataagent-backend/alembic/versions/20260721_000021_add_eval_tables.py` | New |
+| `dataagent/dataagent-backend/core/eval_contract.py` | New |
+| `dataagent/dataagent-backend/core/eval_store.py` | New |
+| `dataagent/dataagent-backend/core/eval_dataset_service.py` | New |
+| `dataagent/dataagent-backend/api/eval_routes.py` | New |
+| `dataagent/dataagent-backend/models/schemas.py` | Modified (appended eval models) |
+| `dataagent/dataagent-backend/main.py` | Modified (wired eval_router) |
+| `tools/dataagent-evals/builtin/run.py` | Modified (added --report-endpoint) |
+| `dataagent/dataagent-frontend/src/api/dataagent.js` | Modified (added eval API methods) |
+| `dataagent/dataagent-frontend/src/router/index.js` | Modified (added eval routes) |
+| `dataagent/dataagent-frontend/src/views/intelligence/IntelligentQueryView.vue` | Modified (added menu items) |
+| `dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetsView.vue` | New |
+| `dataagent/dataagent-frontend/src/views/evaluation/EvaluationSetDetailView.vue` | New |
+| `dataagent/dataagent-frontend/src/views/evaluation/EvaluationResultsView.vue` | New |
+| `dataagent/dataagent-frontend/src/views/evaluation/EvaluationRunDetailView.vue` | New |
+| `docs/design/2026-07-21-dataagent-eval-management-ui-design.md` | New |
+| `docs/plans/2026-07-21-dataagent-eval-management-ui-plan.md` | New |
+
+## Verification
+
+- **Frontend build**: `npm --prefix dataagent/dataagent-frontend run build` passes
+- **Backend contract test**: `eval_contract` validate/canonical_bytes matches `manage.py` on smoke dataset
+- **Backend syntax**: All new Python files parse without errors
+- **End-to-end smoke** (when local MySQL + backend available): Import JSONL → list datasets → export → byte equality; ingest run → list runs → trend data
+
+## Rollback
+
+- Drop migration: `alembic downgrade 20260720_000020` removes all eval_* tables
+- Frontend routes are lazy-loaded and admin-gated; removing the router entries restores previous state
+- Runner `--report-endpoint` is opt-in with no default; removing the flag has zero impact on existing workflows

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -376,8 +376,11 @@ def preflight(base_url: str, auth_token: str = "") -> dict[str, Any]:
         if not _DATAAGENT_AUTH_TOKEN:
             raise InfrastructureAbort("dataagent_auth_token_missing: DATAAGENT_EVAL_AUTH_TOKEN is required")
         identity = dataagent_http_json("GET", f"{base_url}/api/v1/nl2sql/auth/me", timeout=15)
+        if isinstance(identity.get("data"), dict):
+            identity = identity["data"]
+        role = str(identity.get("role") or "").lower()
         roles = identity.get("roles") if isinstance(identity.get("roles"), list) else []
-        is_admin = bool(identity.get("is_admin")) or "admin" in {str(role).lower() for role in roles}
+        is_admin = role == "admin" or bool(identity.get("is_admin")) or "admin" in {str(r).lower() for r in roles}
         if not is_admin:
             raise InfrastructureAbort("dataagent_auth_not_admin: evaluation requires an administrator session")
     return {"auth": {"auth_enabled": auth_enabled, "identity_role": "admin" if identity else None}, "health": health, "runtime_config": runtime_config}

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -168,6 +168,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--history-root", default=os.environ.get("DATAAGENT_EVAL_HISTORY_ROOT", ""))
     parser.add_argument("--agent-snapshot-path", default=os.environ.get("DATAAGENT_EVAL_AGENT_SNAPSHOT_PATH", ""))
     parser.add_argument("--auth-token", default=os.environ.get("DATAAGENT_EVAL_AUTH_TOKEN", ""), help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--report-endpoint",
+        default=os.environ.get("DATAAGENT_EVAL_REPORT_ENDPOINT", ""),
+        help="Optional URL to POST summary+cases for DB ingestion (e.g. http://host:8900/api/v1/nl2sql-eval/runs).",
+    )
     return parser.parse_args(argv)
 
 
@@ -2013,6 +2018,31 @@ def render_report(summary: dict[str, Any], results: list[dict[str, Any]]) -> str
     return "\n".join(lines)
 
 
+def _report_to_endpoint(endpoint: str, summary: dict[str, Any], results: list[dict[str, Any]],
+                        started_at: str = "") -> None:
+    """Best-effort POST of run results to the eval ingestion API."""
+    if not endpoint:
+        return
+    payload = json.dumps({
+        "summary": summary,
+        "cases": results,
+        "started_at": started_at,
+    }, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    if _DATAAGENT_AUTH_TOKEN:
+        req.add_header("Authorization", f"Bearer {_DATAAGENT_AUTH_TOKEN}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            print(f"report uploaded to {endpoint}: {resp.status}")
+    except Exception as exc:
+        print(f"WARNING: report upload to {endpoint} failed: {exc}", file=sys.stderr)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.concurrency < 1:
@@ -2032,8 +2062,11 @@ def main(argv: list[str] | None = None) -> int:
     if not output_dir.is_absolute():
         output_dir = root / output_dir
 
+    report_endpoint = str(getattr(args, "report_endpoint", "") or "").strip()
+
     try:
         cases, dataset_stats = load_dataset(dataset_path, args.case_ids)
+        run_started_at = dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
         dataset_stats.update({
             "run_label": str(args.run_label or "") or _timestamp(),
             "environment_label": str(args.environment_label or "local"),
@@ -2062,10 +2095,12 @@ def main(argv: list[str] | None = None) -> int:
             summary = build_summary(results, dataset_stats) if results else build_summary([], dataset_stats, dry_run=True)
             summary.update({"dry_run": False, "run_status": "infra_failed", "passed": False, "recommendation": "基础设施失败", "infrastructure_error": str(exc)})
             write_outputs(output_dir, results, summary)
+            _report_to_endpoint(report_endpoint, summary, results, started_at=run_started_at)
             print(str(exc), file=sys.stderr)
             return 2
         summary = build_summary(results, dataset_stats)
         write_outputs(output_dir, results, summary)
+        _report_to_endpoint(report_endpoint, summary, results, started_at=run_started_at)
         print(f"eval outputs written to: {output_dir}")
         return 0 if summary.get("passed") else 1
     except EvalRunnerError as exc:


### PR DESCRIPTION
## Summary

Implements a complete evaluation management system with persistent database storage and web UI for managing evaluation datasets, cases, and runs. This enables centralized, queryable evaluation workflows replacing the previous file-based, CLI-only approach.

## Key Changes

### Backend Infrastructure
- **Database schema** (`alembic/versions/20260721_000021_add_eval_tables.py`): New tables for `eval_dataset`, `eval_case`, `eval_run`, and `eval_run_case` with proper indexing and constraints
- **Persistence layer** (`core/eval_store.py`): `EvalStore` class providing CRUD operations for datasets, cases, and runs with transaction management and batch operations
- **Contract validation** (`core/eval_contract.py`): V2 schema validation and canonical serialization mirroring `tools/dataagent-evals/dataset/manage.py` for byte-identical hashing
- **Import/export service** (`core/eval_dataset_service.py`): Dataset import from JSONL with validation, and export with canonical serialization
- **API routes** (`api/eval_routes.py`): RESTful endpoints for dataset CRUD, case management, run ingestion, and trend queries

### Frontend UI
- **Evaluation Sets view** (`EvaluationSetsView.vue`): List, search, create, edit, delete, import/export datasets with metadata management
- **Set detail view** (`EvaluationSetDetailView.vue`): Case management with inline editor, search, and CRUD operations
- **Evaluation Results view** (`EvaluationResultsView.vue`): Run history with trend chart visualization and filtering by dataset/engine
- **Run detail view** (`EvaluationRunDetailView.vue`): Comprehensive run analysis with metrics, per-case results, dimension scores, and case detail modal
- **API client** (`src/api/dataagent.js`): Complete evaluation API integration

### Integration
- **Router configuration** (`src/router/index.js`): New evaluation management routes under `/evaluations` path
- **Navigation** (`IntelligentQueryView.vue`): Menu item for evaluation management
- **Backend setup** (`main.py`): Registered eval routes in FastAPI application
- **Eval runner** (`tools/dataagent-evals/builtin/run.py`): Added `--report-endpoint` flag for run result ingestion

### Data Models
- **Schemas** (`models/schemas.py`): Added 20+ Pydantic models for evaluation domain (datasets, cases, runs, trends)

## Notable Implementation Details

- **Contract regression test** (`tests/test_eval_contract.py`): Ensures backend validation stays byte-identical with `manage.py` for dataset hashing
- **Idempotent ingestion**: Run ingestion handles duplicate submissions gracefully
- **Batch operations**: Case replacement uses configurable batch size (200) for performance
- **Trend series**: Normalized run data for time-series visualization
- **7-dimension scoring**: Full support for intent, ontology_entity, relation_scope, sql_or_tool_call, result_consistency, reasoning, answer_quality metrics
- **Design documentation** (`docs/design/2026-07-21-dataagent-eval-management-ui-design.md`): Comprehensive design rationale and scope

https://claude.ai/code/session_012erxzgmrHhkteTswJgoA4b