### PR TITLE
fix(intelligent-query): stop hand-written chart_spec tags leaking as literal text

### DIFF
--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -50,6 +50,7 @@
   ```
   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|area|scatter|combo|radar|funnel|gauge|pie|table> --input '<sql_execution JSON>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>] [--stack]
   ```
+- 严禁在回答文本中手写 `<chart_spec>`/`</chart_spec>` 标签、```chart 代码块或凭记忆拼写 `chart_spec` 契约 JSON；回答中出现的 `chart_spec` JSON 只能是本轮 `build_chart_spec.py` 实际运行后 stdout 的原样内容，不加任何标签或代码块包裹；
 - 图表只能由 `build_chart_spec.py` 产出的 `chart_spec` JSON 契约表达：严禁用 Markdown 图片语法（`![](...)`）、图片链接、`chart_spec://`、`sandbox:`、`attachment:` 等任何伪 URL 或静态图片地址来"渲染"图表；后端与脚本从不生成 PNG/SVG/图片 URL，前端是唯一渲染器，写出图片链接只会让用户看到裂图。需要图表时，直接把脚本输出的完整 `chart_spec` JSON 放进回答（或保留为工具输出），不要再额外包一层图片或链接；
 - 图表契约必须基于真实且完整的查询结果构建，不得捏造、抽样或只截取前 N 个数据点；若 SQL 结果已被 `has_more`、`truncated_by_size` 或 `result_truncated` 标记为不完整，不得生成图表，必须先改写 SQL 聚合/过滤到完整有界结果；
 - 图表类型与数据结构匹配：趋势用折线图（强调累积量用面积图 area）、占比用饼图、排行/对比用柱状图（多分组堆叠加 `--stack`）、明细用表格；相关性用散点图 scatter、量级+比率混合对比用组合双轴 combo、少数对象多指标对比用雷达图 radar、阶段转化用漏斗图 funnel、单一关键指标用仪表盘 gauge；

--- a/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
+++ b/dataagent/dataagent-backend/prompts/data_agent_system_prompt.md
@@ -50,7 +50,7 @@
   ```
   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type <bar|line|area|scatter|combo|radar|funnel|gauge|pie|table> --input '<sql_execution JSON>' [--title "<标题>"] [--x-field <维度字段>] [--y-field <度量字段>] [--stack]
   ```
-- 严禁在回答文本中手写 `<chart_spec>`/`</chart_spec>` 标签、```chart 代码块或凭记忆拼写 `chart_spec` 契约 JSON；回答中出现的 `chart_spec` JSON 只能是本轮 `build_chart_spec.py` 实际运行后 stdout 的原样内容，不加任何标签或代码块包裹；
+- 严禁在回答文本中手写 `<chart_spec>`/`</chart_spec>` 标签、```chart 代码块、`type=bar` 之类自创的图表配置代码块，或凭记忆拼写 `chart_spec` 契约 JSON；回答中出现的 `chart_spec` JSON 只能是本轮 `build_chart_spec.py` 实际运行后 stdout 的原样内容，不加任何标签或代码块包裹；
 - 图表只能由 `build_chart_spec.py` 产出的 `chart_spec` JSON 契约表达：严禁用 Markdown 图片语法（`![](...)`）、图片链接、`chart_spec://`、`sandbox:`、`attachment:` 等任何伪 URL 或静态图片地址来"渲染"图表；后端与脚本从不生成 PNG/SVG/图片 URL，前端是唯一渲染器，写出图片链接只会让用户看到裂图。需要图表时，直接把脚本输出的完整 `chart_spec` JSON 放进回答（或保留为工具输出），不要再额外包一层图片或链接；
 - 图表契约必须基于真实且完整的查询结果构建，不得捏造、抽样或只截取前 N 个数据点；若 SQL 结果已被 `has_more`、`truncated_by_size` 或 `result_truncated` 标记为不完整，不得生成图表，必须先改写 SQL 聚合/过滤到完整有界结果；
 - 图表类型与数据结构匹配：趋势用折线图（强调累积量用面积图 area）、占比用饼图、排行/对比用柱状图（多分组堆叠加 `--stack`）、明细用表格；相关性用散点图 scatter、量级+比率混合对比用组合双轴 combo、少数对象多指标对比用雷达图 radar、阶段转化用漏斗图 funnel、单一关键指标用仪表盘 gauge；

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -312,6 +312,77 @@ describe('chartSpec', () => {
     expect(stripChartSpecsFromText(message)).toContain('"foo":"bar"')
   })
 
+  it('drops a chart_spec tag pair whose body is malformed instead of leaking it as text', () => {
+    const message = `结论如下：发布次数整体上升。
+<chart_spec>
+{'kind': 'chart_spec', 'chart_type': 'line', 'dataset': [
+</chart_spec>
+以上为本次结论。`
+
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripped).toContain('结论如下：发布次数整体上升。')
+    expect(stripped).toContain('以上为本次结论。')
+    expect(stripped).not.toContain('<chart_spec>')
+    expect(stripped).not.toContain("'kind'")
+  })
+
+  it('drops a chart_spec tag pair whose body is not the contract shape', () => {
+    const message = '结论：\n<chart_spec>\n{"xAxis":{"type":"category"},"series":[{"type":"bar","data":[1,2]}]}\n</chart_spec>\n完。'
+
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripped).toContain('结论：')
+    expect(stripped).toContain('完。')
+    expect(stripped).not.toContain('chart_spec')
+    expect(stripped).not.toContain('xAxis')
+  })
+
+  it('renders a chart from a tag with attributes when the body is a valid spec', () => {
+    const message = '结论：\n<chart_spec type="line">\n{"kind":"chart_spec","version":1,"chart_type":"line","title":"趋势","x_field":"stat_day","series":[{"name":"次数","field":"cnt","type":"line"}],"dataset":[{"stat_day":"2026-03-10","cnt":3}],"error":null}\n</chart_spec>'
+
+    const specs = extractChartSpecsFromText(message)
+
+    expect(specs).toHaveLength(1)
+    expect(specs[0].chart_type).toBe('line')
+    expect(stripChartSpecsFromText(message)).not.toContain('<chart_spec')
+  })
+
+  it('drops an empty chart_spec tag pair', () => {
+    const message = '结论如下。\n<chart_spec></chart_spec>\n完。'
+
+    const segments = splitChartSpecText(message)
+
+    expect(segments.every((seg) => seg.type === 'text')).toBe(true)
+    expect(stripChartSpecsFromText(message)).not.toContain('chart_spec')
+    expect(stripChartSpecsFromText(message)).toContain('结论如下。')
+    expect(stripChartSpecsFromText(message)).toContain('完。')
+  })
+
+  it('drops an orphan chart_spec tag token without claiming surrounding prose', () => {
+    const message = '前文保留。</chart_spec>后文也保留。'
+
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(stripped).toContain('前文保留。')
+    expect(stripped).toContain('后文也保留。')
+    expect(stripped).not.toContain('chart_spec')
+  })
+
+  it('drops an unclosed opening tag token while streaming and promotes the JSON once balanced', () => {
+    const streaming = '结论：\n<chart_spec>\n{"kind":"chart_spec","version":1,"chart_type":"line","dataset":[{"stat_day":"2026-03-10"'
+    expect(extractChartSpecsFromText(streaming)).toHaveLength(0)
+    expect(stripChartSpecsFromText(streaming)).not.toContain('<chart_spec>')
+
+    const balanced = '结论：\n<chart_spec>\n{"kind":"chart_spec","version":1,"chart_type":"line","title":"趋势","x_field":"stat_day","series":[{"name":"次数","field":"cnt","type":"line"}],"dataset":[{"stat_day":"2026-03-10","cnt":3}],"error":null}'
+    const specs = extractChartSpecsFromText(balanced)
+    expect(specs).toHaveLength(1)
+    expect(specs[0].chart_type).toBe('line')
+    expect(stripChartSpecsFromText(balanced)).not.toContain('<chart_spec>')
+  })
+
   it('builds an area chart with filled line series', () => {
     const renderModel = buildChartRenderModel({
       kind: 'chart_spec',

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -312,6 +312,41 @@ describe('chartSpec', () => {
     expect(stripChartSpecsFromText(message)).toContain('"foo":"bar"')
   })
 
+  it('drops a chart fence with a hand-rolled type=bar config instead of leaking it as a code block', () => {
+    const message = '结论如下。\n```chart\ntype=bar\nx=layer\ny=table_cnt\n```\n完。'
+
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripped).toContain('结论如下。')
+    expect(stripped).toContain('完。')
+    expect(stripped).not.toContain('type=bar')
+    expect(stripped).not.toContain('```')
+  })
+
+  it('drops a json fence carrying a non-contract chart config with "type": "bar"', () => {
+    const message = '结论：\n```json\n{\n  "type": "bar",\n  "data": [1, 2]\n}\n```\n完。'
+
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripped).toContain('结论：')
+    expect(stripped).toContain('完。')
+    expect(stripped).not.toContain('"type"')
+  })
+
+  it('renders a chart from a fence wrapping an attributed tag pair without leftover fence markers', () => {
+    const message = '结论：\n```xml\n<chart_spec type="line">\n{"kind":"chart_spec","version":1,"chart_type":"line","title":"趋势","x_field":"stat_day","series":[{"name":"次数","field":"cnt","type":"line"}],"dataset":[{"stat_day":"2026-03-10","cnt":3}],"error":null}\n</chart_spec>\n```'
+
+    const specs = extractChartSpecsFromText(message)
+    const stripped = stripChartSpecsFromText(message)
+
+    expect(specs).toHaveLength(1)
+    expect(specs[0].chart_type).toBe('line')
+    expect(stripped).not.toContain('```')
+    expect(stripped).not.toContain('chart_spec')
+  })
+
   it('drops a chart_spec tag pair whose body is malformed instead of leaking it as text', () => {
     const message = `结论如下：发布次数整体上升。
 <chart_spec>

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/chartSpec.spec.js
@@ -324,15 +324,28 @@ describe('chartSpec', () => {
     expect(stripped).not.toContain('```')
   })
 
-  it('drops a json fence carrying a non-contract chart config with "type": "bar"', () => {
+  it('keeps a json fence without explicit chart_spec markers untouched even when it looks chart-ish', () => {
     const message = '结论：\n```json\n{\n  "type": "bar",\n  "data": [1, 2]\n}\n```\n完。'
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripChartSpecsFromText(message)).toContain('"type": "bar"')
+  })
+
+  it('keeps a fence that merely mentions the chart script command untouched', () => {
+    const message = '需要图表时执行：\n```bash\n"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/build_chart_spec.py" --chart-type bar --input \'...\'\n```\n以上。'
 
     const stripped = stripChartSpecsFromText(message)
 
     expect(extractChartSpecsFromText(message)).toHaveLength(0)
-    expect(stripped).toContain('结论：')
-    expect(stripped).toContain('完。')
-    expect(stripped).not.toContain('"type"')
+    expect(stripped).toContain('build_chart_spec.py')
+    expect(stripped).toContain('以上。')
+  })
+
+  it('keeps a config-style fence with a type=line entry untouched', () => {
+    const message = '配置示例：\n```ini\n[render]\ntype=line\nwidth=800\n```'
+
+    expect(extractChartSpecsFromText(message)).toHaveLength(0)
+    expect(stripChartSpecsFromText(message)).toContain('type=line')
   })
 
   it('renders a chart from a fence wrapping an attributed tag pair without leftover fence markers', () => {

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -536,19 +536,24 @@ export const buildChartOption = (specInput) => {
 // separately via brace scanning below.
 const CHART_SPEC_FENCE_PATTERN = /```([^\n`]*)\n?([\s\S]*?)```/g
 
-// A hand-rolled chart config line (`type=bar`, `"chart_type": "line"`, ...)
-// marks a fence as chart-intended even when its body is not contract JSON.
-const CHART_FENCE_TYPE_LINE = /^\s*["']?(?:chart[_-]?type|type)["']?\s*[:=]\s*["']?(?:bar|line|pie|area|scatter|combo|radar|funnel|gauge|table)\b/im
+// The contract-JSON marker, stricter than a bare `chart_spec` mention so a
+// fence that merely talks about the contract (e.g. a build_chart_spec.py
+// command template) is never claimed.
+const CHART_SPEC_KIND_MARK = /"kind"\s*[:：]\s*"chart_spec"/
 
 // Chart-intended fences are claimed even when their body fails to parse, so a
 // bypassing model's made-up chart block is dropped instead of leaking as a code
-// block. Other fences (sql, plain json examples) are claimed only on a
-// successful parse, as before.
-const fenceLooksChartIntended = (info, body) => (
-  /^chart/i.test(String(info || '').trim()) ||
-  `${info}\n${body}`.includes('chart_spec') ||
-  CHART_FENCE_TYPE_LINE.test(String(body || ''))
-)
+// block. Intent requires an explicit signal — a chart* info string, an embedded
+// <chart_spec> tag, or the contract kind marker; anything less keeps the fence
+// untouched (false negatives are preferred over eating legit code blocks).
+const fenceLooksChartIntended = (info, body) => {
+  const text = `${info}\n${body}`
+  return (
+    /^chart/i.test(String(info || '').trim()) ||
+    text.includes('<chart_spec') ||
+    CHART_SPEC_KIND_MARK.test(text)
+  )
+}
 
 // A hand-written <chart_spec> pair is claimed whether or not its body parses:
 // a model bypassing build_chart_spec.py often writes malformed or non-contract

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -535,9 +535,18 @@ export const buildChartOption = (specInput) => {
 // ({ "kind": "chart_spec", ... } written inline without any wrapper) is handled
 // separately via brace scanning below.
 const CHART_SPEC_FENCE_PATTERNS = [
-  /```(?:chart|json)?\s*([\s\S]*?)```/gi,
-  /<chart_spec>\s*([\s\S]*?)<\/chart_spec>/gi
+  /```(?:chart|json)?\s*([\s\S]*?)```/gi
 ]
+
+// A hand-written <chart_spec> pair is claimed whether or not its body parses:
+// a model bypassing build_chart_spec.py often writes malformed or non-contract
+// JSON, and leaving the raw tag in place would leak it to the user as literal
+// text. Attributes on the opening tag and whitespace in the close are tolerated.
+const CHART_SPEC_TAG_PATTERN = /<chart_spec\b[^>]*>\s*([\s\S]*?)<\/chart_spec\s*>/gi
+
+// A lone opening/closing tag with no matching pair is dropped as a bare token,
+// never claiming the prose around it.
+const CHART_SPEC_ORPHAN_TAG_PATTERN = /<\/?chart_spec\b[^>]*>/gi
 
 // A model sometimes hallucinates a chart as a markdown image/link pointing at a
 // fake `chart_spec://` URL (full-width colon included), which marked turns into a
@@ -608,6 +617,19 @@ const collectChartSpecRanges = (source) => {
     })
   }
 
+  // Tag pairs always claim their span: a parse failure (empty body, malformed or
+  // non-contract JSON) yields spec === null so the splitter drops the whole range
+  // instead of leaking the literal tag + JSON into the rendered answer.
+  CHART_SPEC_TAG_PATTERN.lastIndex = 0
+  let tagMatch
+  while ((tagMatch = CHART_SPEC_TAG_PATTERN.exec(source)) !== null) {
+    ranges.push({
+      start: tagMatch.index,
+      end: tagMatch.index + tagMatch[0].length,
+      spec: parseChartSpec(tagMatch[1])
+    })
+  }
+
   for (const pattern of CHART_SPEC_FENCE_PATTERNS) {
     pattern.lastIndex = 0
     let match
@@ -636,6 +658,16 @@ const collectChartSpecRanges = (source) => {
       }
     }
     searchFrom = hit + marker.length
+  }
+
+  // Orphan open/close tags left over after pair/JSON claiming (an unclosed tag
+  // ahead of streaming JSON, or a stray </chart_spec>) are dropped as bare
+  // tokens so they never show as literal text.
+  CHART_SPEC_ORPHAN_TAG_PATTERN.lastIndex = 0
+  let orphanMatch
+  while ((orphanMatch = CHART_SPEC_ORPHAN_TAG_PATTERN.exec(source)) !== null) {
+    if (isClaimed(orphanMatch.index)) continue
+    ranges.push({ start: orphanMatch.index, end: orphanMatch.index + orphanMatch[0].length, spec: null })
   }
 
   const sorted = ranges.sort((a, b) => a.start - b.start || b.end - a.end)

--- a/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/chartSpec.js
@@ -534,9 +534,21 @@ export const buildChartOption = (specInput) => {
 // a ```chart / ```json fence, or an <chart_spec> tag. The raw-object form
 // ({ "kind": "chart_spec", ... } written inline without any wrapper) is handled
 // separately via brace scanning below.
-const CHART_SPEC_FENCE_PATTERNS = [
-  /```(?:chart|json)?\s*([\s\S]*?)```/gi
-]
+const CHART_SPEC_FENCE_PATTERN = /```([^\n`]*)\n?([\s\S]*?)```/g
+
+// A hand-rolled chart config line (`type=bar`, `"chart_type": "line"`, ...)
+// marks a fence as chart-intended even when its body is not contract JSON.
+const CHART_FENCE_TYPE_LINE = /^\s*["']?(?:chart[_-]?type|type)["']?\s*[:=]\s*["']?(?:bar|line|pie|area|scatter|combo|radar|funnel|gauge|table)\b/im
+
+// Chart-intended fences are claimed even when their body fails to parse, so a
+// bypassing model's made-up chart block is dropped instead of leaking as a code
+// block. Other fences (sql, plain json examples) are claimed only on a
+// successful parse, as before.
+const fenceLooksChartIntended = (info, body) => (
+  /^chart/i.test(String(info || '').trim()) ||
+  `${info}\n${body}`.includes('chart_spec') ||
+  CHART_FENCE_TYPE_LINE.test(String(body || ''))
+)
 
 // A hand-written <chart_spec> pair is claimed whether or not its body parses:
 // a model bypassing build_chart_spec.py often writes malformed or non-contract
@@ -630,12 +642,16 @@ const collectChartSpecRanges = (source) => {
     })
   }
 
-  for (const pattern of CHART_SPEC_FENCE_PATTERNS) {
-    pattern.lastIndex = 0
-    let match
-    while ((match = pattern.exec(source)) !== null) {
-      const spec = parseChartSpec(match[1])
-      if (spec) ranges.push({ start: match.index, end: match.index + match[0].length, spec })
+  CHART_SPEC_FENCE_PATTERN.lastIndex = 0
+  let fenceMatch
+  while ((fenceMatch = CHART_SPEC_FENCE_PATTERN.exec(source)) !== null) {
+    const infoText = fenceMatch[1] || ''
+    const bodyText = fenceMatch[2] || ''
+    // The info fallback keeps single-line fences (```{...}```) parseable, where
+    // the whole body lands in the info capture.
+    const spec = parseChartSpec(bodyText) || parseChartSpec(infoText)
+    if (spec || fenceLooksChartIntended(infoText, bodyText)) {
+      ranges.push({ start: fenceMatch.index, end: fenceMatch.index + fenceMatch[0].length, spec })
     }
   }
 


### PR DESCRIPTION
The conclusion renderer only claimed a <chart_spec> range when its body
parsed as a valid contract, so a model that bypassed build_chart_spec.py
with malformed / non-contract JSON, an attributed tag, or an empty pair
left the raw tag and JSON visible as escaped literal text.

- Always claim closed <chart_spec> pairs (attributes tolerated); a failed
  parse yields spec:null so the splitter drops the whole range, matching
  the existing chart_spec:// pseudo-URL convention.
- Drop orphan open/close tag tokens without claiming surrounding prose.
- Harden the system prompt: chart_spec JSON in prose may only be the
  verbatim stdout of build_chart_spec.py, never hand-written tags/fences.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JXojLNR86QLCBvkT6XWfxm