### PR TITLE
fix(dataagent): identify failing reference SQL

### DIFF
--- a/tests/test_dataagent_deepeval_evals.py
+++ b/tests/test_dataagent_deepeval_evals.py
@@ -663,7 +663,17 @@ def test_deepeval_reference_query_transport_failure_has_specific_reason(monkeypa
         runner._execute_reference_query("http://dataagent", case, "topic_1")
     except runner.InfrastructureAbort as exc:
         assert str(exc).startswith("reference_sql_failed:")
+        assert "case_id=ODW_SAMPLE_001" in str(exc)
+        assert "database=opendataworks" in str(exc)
+        assert "engine=mysql" in str(exc)
+        assert 'sql="SELECT 1"' in str(exc)
         assert "HTTP 503" in str(exc)
+        assert exc.details["error_code"] == "reference_sql_failed"
+        assert exc.details["case_id"] == "ODW_SAMPLE_001"
+        assert exc.details["database"] == "opendataworks"
+        assert exc.details["engine"] == "mysql"
+        assert exc.details["sql"] == "SELECT 1"
+        assert exc.details["cause"] == "HTTP 503 query/execute: SQL execution channel is not configured"
     else:
         raise AssertionError("reference query transport failure must abort evaluation infrastructure")
 

--- a/tests/test_dataagent_eval_engine_contract.py
+++ b/tests/test_dataagent_eval_engine_contract.py
@@ -357,3 +357,46 @@ def test_three_engines_derive_expected_empty_from_reference_truth():
 
         nonempty_reference = {"applicable": True, "rows": [{"table_name": "orders"}], "row_count": 1}
         assert module._case_with_reference_empty_policy(case, nonempty_reference) is case, engine
+
+
+def test_three_engines_report_reference_sql_case_and_statement_on_backend_failure(monkeypatch):
+    modules = {name: _load(name, path) for name, path in RUNNERS.items()}
+    sql = "SELECT cmp_name, system_name FROM public.dim_tech_public_env_cmp_df"
+    case = {
+        "case_id": "ARCH_DIAGNOSTIC_001",
+        "expected_result": {
+            "reference_query": {
+                "sql": sql,
+                "database": "public",
+                "engine": "doris",
+                "limit": 100,
+            }
+        },
+    }
+
+    for engine, module in modules.items():
+        monkeypatch.setattr(
+            module,
+            "dataagent_http_json",
+            lambda *_args, **_kwargs: {
+                "rows": [],
+                "result_state": "failed",
+                "error": "Unknown column 'system_name'",
+            },
+        )
+        try:
+            module._execute_reference_query("http://dataagent", case, "topic_1")
+        except module.InfrastructureAbort as exc:
+            message = str(exc)
+            assert message.startswith("reference_sql_failed:"), engine
+            assert "case_id=ARCH_DIAGNOSTIC_001" in message, engine
+            assert "database=public" in message, engine
+            assert "engine=doris" in message, engine
+            assert f'sql={json.dumps(sql, ensure_ascii=False)}' in message, engine
+            assert "Unknown column 'system_name'" in message, engine
+            assert exc.details["error_code"] == "reference_sql_failed", engine
+            assert exc.details["case_id"] == "ARCH_DIAGNOSTIC_001", engine
+            assert exc.details["sql"] == sql, engine
+            assert exc.details["cause"].endswith("Unknown column 'system_name'"), engine
+        else:
+            raise AssertionError(f"{engine}: failed reference SQL must abort with diagnostics")

--- a/tests/test_run_dataagent_evals.py
+++ b/tests/test_run_dataagent_evals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import threading
@@ -546,9 +547,65 @@ def test_reference_query_transport_failure_has_specific_reason(monkeypatch):
         runner._execute_reference_query("http://dataagent", case, "topic_1")
     except runner.InfrastructureAbort as exc:
         assert str(exc).startswith("reference_sql_failed:")
+        assert "case_id=ODW_SAMPLE_001" in str(exc)
+        assert "database=opendataworks" in str(exc)
+        assert "engine=mysql" in str(exc)
+        assert 'sql="SELECT 1"' in str(exc)
         assert "HTTP 503" in str(exc)
+        assert exc.details == {
+            "error_code": "reference_sql_failed",
+            "case_id": "ODW_SAMPLE_001",
+            "database": "opendataworks",
+            "engine": "mysql",
+            "sql": "SELECT 1",
+            "sql_sha256": hashlib.sha256(b"SELECT 1").hexdigest(),
+            "cause": "HTTP 503 query/execute: SQL execution channel is not configured",
+        }
     else:
         raise AssertionError("reference query transport failure must abort evaluation infrastructure")
+
+
+def test_reference_query_failure_is_persisted_with_structured_context(tmp_path, monkeypatch):
+    runner = _load_runner()
+    dataset = _write_dataset(tmp_path / "cases.jsonl")
+    sql = "SELECT system_name FROM public.dim_tech_public_env_cmp_df"
+    details = {
+        "error_code": "reference_sql_failed",
+        "case_id": "ODW_SAMPLE_001",
+        "database": "public",
+        "engine": "doris",
+        "sql": sql,
+        "sql_sha256": hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+        "cause": "Unknown column 'system_name'",
+    }
+
+    monkeypatch.setattr(runner, "preflight", lambda *_args, **_kwargs: {"auth": {"auth_enabled": False}})
+
+    def fail_cases(*_args, **_kwargs):
+        raise runner.InfrastructureAbort(
+            "reference_sql_failed: case_id=ODW_SAMPLE_001; cause=Unknown column 'system_name'",
+            details=details,
+        )
+
+    monkeypatch.setattr(runner, "_run_cases", fail_cases)
+    code = runner.main(
+        [
+            "--base-url", "http://dataagent",
+            "--dataset", str(dataset),
+            "--output-dir", str(tmp_path / "report"),
+            "--agent-id", "agent_eval",
+            "--judge-base-url", "http://judge",
+            "--judge-token", "judge-token",
+            "--judge-model", "judge-model",
+        ]
+    )
+
+    assert code == 2
+    summary = json.loads((tmp_path / "report" / "summary.json").read_text(encoding="utf-8"))
+    assert summary["run_status"] == "infra_failed"
+    assert summary["infrastructure_details"] == details
+    assert "case_id=ODW_SAMPLE_001" in summary["infrastructure_error"]
+    assert sql == summary["infrastructure_details"]["sql"]
 
 
 def test_run_case_fails_when_auto_rule_check_fails(monkeypatch):

--- a/tools/dataagent-evals/builtin/README.md
+++ b/tools/dataagent-evals/builtin/README.md
@@ -59,3 +59,9 @@ is enabled, pass an administrator JWT only through
 - `report.html`
 - `dataset-snapshot.jsonl`
 - `raw/<case_id>.json`
+
+When reference SQL fails, exit code 2 is preserved and the terminal error names
+the `case_id`, database, engine, SQL hash, full SQL, and backend cause.
+`summary.json.infrastructure_details` exposes the same fields as structured
+data: `error_code`, `case_id`, `database`, `engine`, `sql`, `sql_sha256`, and
+`cause`.

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -84,9 +84,16 @@ class EvalRunnerError(Exception):
 
 
 class InfrastructureAbort(EvalRunnerError):
-    def __init__(self, message: str, *, partial_results: list[dict[str, Any]] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        partial_results: list[dict[str, Any]] | None = None,
+        details: dict[str, Any] | None = None,
+    ):
         super().__init__(message, exit_code=2)
         self.partial_results = partial_results or []
+        self.details = details or {}
 
 
 class JudgeConfig:
@@ -1467,6 +1474,32 @@ def _canonical_rows(rows: list[dict[str, Any]], *, tolerance: float = 0.0) -> li
     return sorted(normalized)
 
 
+def _reference_sql_failure(
+    case: dict[str, Any],
+    reference: dict[str, Any],
+    sql: str,
+    *,
+    error_code: str,
+    cause: str,
+    partial_results: list[dict[str, Any]] | None = None,
+) -> InfrastructureAbort:
+    details = {
+        "error_code": error_code,
+        "case_id": str(case.get("case_id") or "unknown"),
+        "database": str(reference.get("database") or ""),
+        "engine": str(reference.get("engine") or ""),
+        "sql": sql,
+        "sql_sha256": hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+        "cause": str(cause or "unknown reference SQL failure"),
+    }
+    message = (
+        f"{error_code}: case_id={details['case_id']}, database={details['database'] or 'N/A'}, "
+        f"engine={details['engine'] or 'N/A'}, sql_sha256={details['sql_sha256']}, "
+        f"sql={json.dumps(sql, ensure_ascii=False)}; cause={details['cause']}"
+    )
+    return InfrastructureAbort(message, partial_results=partial_results, details=details)
+
+
 def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str) -> dict[str, Any]:
     expected_result = case.get("expected_result") if isinstance(case.get("expected_result"), dict) else {}
     reference = expected_result.get("reference_query") if isinstance(expected_result.get("reference_query"), dict) else None
@@ -1474,7 +1507,13 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
         return {"applicable": False, "passed": None, "rows": None}
     sql = str(reference.get("sql") or "").strip()
     if not re.match(r"(?is)^\s*(?:select|with)\b", sql) or re.search(r"(?is)\b(?:insert|update|delete|drop|alter|truncate|create|grant|revoke)\b", sql):
-        raise InfrastructureAbort("reference_sql_invalid: only read-only SELECT/CTE SQL is allowed")
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_invalid",
+            cause="only read-only SELECT/CTE SQL is allowed",
+        )
     payload = {
         "sql": sql,
         "database": str(reference.get("database") or "").strip(),
@@ -1490,17 +1529,34 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
             payload,
             timeout=payload["timeout_seconds"] + 15,
         )
-    except InfrastructureAbort:
-        raise
+    except InfrastructureAbort as exc:
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+            partial_results=exc.partial_results,
+        ) from exc
     except EvalRunnerError as exc:
-        raise InfrastructureAbort(f"reference_sql_failed: {exc}") from exc
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+        ) from exc
     rows = response.get("rows") if isinstance(response.get("rows"), list) else None
     result_state = str(response.get("result_state") or "success").lower()
     if rows is None or result_state not in {"success", "empty", "empty_result"}:
         detail = str(response.get("error") or response.get("message") or "").strip()
         suffix = f", detail={detail}" if detail else ""
-        raise InfrastructureAbort(
-            f"reference_sql_failed: result_state={result_state}, rows_present={rows is not None}{suffix}"
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=f"result_state={result_state}, rows_present={rows is not None}{suffix}",
         )
     return {"applicable": True, "passed": None, "rows": rows, "row_count": len(rows), "database": payload["database"]}
 
@@ -2134,7 +2190,14 @@ def main(argv: list[str] | None = None) -> int:
         except InfrastructureAbort as exc:
             results = exc.partial_results
             summary = build_summary(results, dataset_stats) if results else build_summary([], dataset_stats, dry_run=True)
-            summary.update({"dry_run": False, "run_status": "infra_failed", "passed": False, "recommendation": "基础设施失败", "infrastructure_error": str(exc)})
+            summary.update({
+                "dry_run": False,
+                "run_status": "infra_failed",
+                "passed": False,
+                "recommendation": "基础设施失败",
+                "infrastructure_error": str(exc),
+                "infrastructure_details": exc.details or None,
+            })
             write_outputs(output_dir, results, summary)
             _report_to_endpoint(report_endpoint, summary, results, started_at=run_started_at)
             print(str(exc), file=sys.stderr)

--- a/tools/dataagent-evals/deepeval/README.md
+++ b/tools/dataagent-evals/deepeval/README.md
@@ -79,3 +79,7 @@ The output layout matches the builtin evaluation runner:
 - `report.html`
 - `dataset-snapshot.jsonl`
 - `raw/<case_id>.json`
+
+Reference-SQL infrastructure failures include the failing `case_id`, database,
+engine, SQL hash, full SQL, and backend cause in both the terminal message and
+`summary.json.infrastructure_details`.

--- a/tools/dataagent-evals/deepeval/run.py
+++ b/tools/dataagent-evals/deepeval/run.py
@@ -103,9 +103,16 @@ class EvalRunnerError(Exception):
 
 
 class InfrastructureAbort(EvalRunnerError):
-    def __init__(self, message: str, *, partial_results: list[dict[str, Any]] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        partial_results: list[dict[str, Any]] | None = None,
+        details: dict[str, Any] | None = None,
+    ):
         super().__init__(message, exit_code=2)
         self.partial_results = partial_results or []
+        self.details = details or {}
 
 
 @dataclass(frozen=True)
@@ -1144,6 +1151,32 @@ def _actual_query_row_sets(blocks: list[dict[str, Any]]) -> list[list[dict[str, 
     return row_sets
 
 
+def _reference_sql_failure(
+    case: dict[str, Any],
+    reference: dict[str, Any],
+    sql: str,
+    *,
+    error_code: str,
+    cause: str,
+    partial_results: list[dict[str, Any]] | None = None,
+) -> InfrastructureAbort:
+    details = {
+        "error_code": error_code,
+        "case_id": str(case.get("case_id") or "unknown"),
+        "database": str(reference.get("database") or ""),
+        "engine": str(reference.get("engine") or ""),
+        "sql": sql,
+        "sql_sha256": hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+        "cause": str(cause or "unknown reference SQL failure"),
+    }
+    message = (
+        f"{error_code}: case_id={details['case_id']}, database={details['database'] or 'N/A'}, "
+        f"engine={details['engine'] or 'N/A'}, sql_sha256={details['sql_sha256']}, "
+        f"sql={json.dumps(sql, ensure_ascii=False)}; cause={details['cause']}"
+    )
+    return InfrastructureAbort(message, partial_results=partial_results, details=details)
+
+
 def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str) -> dict[str, Any]:
     expected = case.get("expected_result") if isinstance(case.get("expected_result"), dict) else {}
     reference = expected.get("reference_query") if isinstance(expected.get("reference_query"), dict) else None
@@ -1151,24 +1184,47 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
         return {"applicable": False, "passed": None}
     sql = str(reference.get("sql") or "").strip()
     if not re.match(r"(?is)^\s*(?:select|with)\b", sql) or re.search(r"(?is)\b(?:insert|update|delete|drop|alter|truncate|create|grant|revoke)\b", sql):
-        raise InfrastructureAbort("reference_sql_invalid: only read-only SELECT/CTE SQL is allowed")
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_invalid",
+            cause="only read-only SELECT/CTE SQL is allowed",
+        )
     timeout = int(reference.get("timeout_seconds") or 60)
     try:
         response = dataagent_http_json("POST", f"{base_url}/api/v1/nl2sql/query/execute", {
             "sql": sql, "database": str(reference.get("database") or ""), "engine": reference.get("engine"),
             "limit": int(reference.get("limit") or 1000), "timeout_seconds": timeout, "topic_id": topic_id,
         }, timeout=timeout + 15)
-    except InfrastructureAbort:
-        raise
+    except InfrastructureAbort as exc:
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+            partial_results=exc.partial_results,
+        ) from exc
     except EvalRunnerError as exc:
-        raise InfrastructureAbort(f"reference_sql_failed: {exc}") from exc
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+        ) from exc
     rows = response.get("rows") if isinstance(response.get("rows"), list) else None
     result_state = str(response.get("result_state") or "success").lower()
     if rows is None or result_state not in {"success", "empty", "empty_result"}:
         detail = str(response.get("error") or response.get("message") or "").strip()
         suffix = f", detail={detail}" if detail else ""
-        raise InfrastructureAbort(
-            f"reference_sql_failed: result_state={result_state}, rows_present={rows is not None}{suffix}"
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=f"result_state={result_state}, rows_present={rows is not None}{suffix}",
         )
     return {"applicable": True, "passed": None, "rows": rows, "row_count": len(rows)}
 
@@ -2053,7 +2109,14 @@ def main(argv: list[str] | None = None) -> int:
         except InfrastructureAbort as exc:
             results = exc.partial_results
             summary = build_summary(results, dataset_stats) if results else build_summary([], dataset_stats, dry_run=True)
-            summary.update({"dry_run": False, "run_status": "infra_failed", "passed": False, "recommendation": "基础设施失败", "infrastructure_error": str(exc)})
+            summary.update({
+                "dry_run": False,
+                "run_status": "infra_failed",
+                "passed": False,
+                "recommendation": "基础设施失败",
+                "infrastructure_error": str(exc),
+                "infrastructure_details": exc.details or None,
+            })
             write_outputs(output_dir, results, summary)
             print(str(exc), file=sys.stderr)
             return 2

--- a/tools/dataagent-evals/opik/README.md
+++ b/tools/dataagent-evals/opik/README.md
@@ -41,3 +41,7 @@ The runner also writes the standard `run.json`, `summary.json`, `cases.jsonl`,
 `report.md`, `report.html`, raw evidence, and dataset snapshot. Exit codes are
 0 for passing, 1 for quality-gate failure, and 2 for authentication, Opik, or
 other evaluation-infrastructure failure.
+
+For reference-SQL failures, the terminal error and local
+`summary.json.infrastructure_details` identify the failing `case_id`, database,
+engine, SQL hash, full SQL, and backend cause before the runner exits 2.

--- a/tools/dataagent-evals/opik/run.py
+++ b/tools/dataagent-evals/opik/run.py
@@ -100,9 +100,16 @@ class EvalRunnerError(Exception):
 
 
 class InfrastructureAbort(EvalRunnerError):
-    def __init__(self, message: str, *, partial_results: list[dict[str, Any]] | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        partial_results: list[dict[str, Any]] | None = None,
+        details: dict[str, Any] | None = None,
+    ):
         super().__init__(message, exit_code=2)
         self.partial_results = partial_results or []
+        self.details = details or {}
 
 
 class JudgeConfig:
@@ -1454,6 +1461,32 @@ def _canonical_rows(rows: list[dict[str, Any]], *, tolerance: float = 0.0) -> li
     return sorted(normalized)
 
 
+def _reference_sql_failure(
+    case: dict[str, Any],
+    reference: dict[str, Any],
+    sql: str,
+    *,
+    error_code: str,
+    cause: str,
+    partial_results: list[dict[str, Any]] | None = None,
+) -> InfrastructureAbort:
+    details = {
+        "error_code": error_code,
+        "case_id": str(case.get("case_id") or "unknown"),
+        "database": str(reference.get("database") or ""),
+        "engine": str(reference.get("engine") or ""),
+        "sql": sql,
+        "sql_sha256": hashlib.sha256(sql.encode("utf-8")).hexdigest(),
+        "cause": str(cause or "unknown reference SQL failure"),
+    }
+    message = (
+        f"{error_code}: case_id={details['case_id']}, database={details['database'] or 'N/A'}, "
+        f"engine={details['engine'] or 'N/A'}, sql_sha256={details['sql_sha256']}, "
+        f"sql={json.dumps(sql, ensure_ascii=False)}; cause={details['cause']}"
+    )
+    return InfrastructureAbort(message, partial_results=partial_results, details=details)
+
+
 def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str) -> dict[str, Any]:
     expected_result = case.get("expected_result") if isinstance(case.get("expected_result"), dict) else {}
     reference = expected_result.get("reference_query") if isinstance(expected_result.get("reference_query"), dict) else None
@@ -1461,7 +1494,13 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
         return {"applicable": False, "passed": None, "rows": None}
     sql = str(reference.get("sql") or "").strip()
     if not re.match(r"(?is)^\s*(?:select|with)\b", sql) or re.search(r"(?is)\b(?:insert|update|delete|drop|alter|truncate|create|grant|revoke)\b", sql):
-        raise InfrastructureAbort("reference_sql_invalid: only read-only SELECT/CTE SQL is allowed")
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_invalid",
+            cause="only read-only SELECT/CTE SQL is allowed",
+        )
     payload = {
         "sql": sql,
         "database": str(reference.get("database") or "").strip(),
@@ -1477,17 +1516,34 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
             payload,
             timeout=payload["timeout_seconds"] + 15,
         )
-    except InfrastructureAbort:
-        raise
+    except InfrastructureAbort as exc:
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+            partial_results=exc.partial_results,
+        ) from exc
     except EvalRunnerError as exc:
-        raise InfrastructureAbort(f"reference_sql_failed: {exc}") from exc
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=str(exc),
+        ) from exc
     rows = response.get("rows") if isinstance(response.get("rows"), list) else None
     result_state = str(response.get("result_state") or "success").lower()
     if rows is None or result_state not in {"success", "empty", "empty_result"}:
         detail = str(response.get("error") or response.get("message") or "").strip()
         suffix = f", detail={detail}" if detail else ""
-        raise InfrastructureAbort(
-            f"reference_sql_failed: result_state={result_state}, rows_present={rows is not None}{suffix}"
+        raise _reference_sql_failure(
+            case,
+            reference,
+            sql,
+            error_code="reference_sql_failed",
+            cause=f"result_state={result_state}, rows_present={rows is not None}{suffix}",
         )
     return {"applicable": True, "passed": None, "rows": rows, "row_count": len(rows), "database": payload["database"]}
 
@@ -2255,7 +2311,14 @@ def main(argv: list[str] | None = None) -> int:
         except InfrastructureAbort as exc:
             results = exc.partial_results
             summary = build_summary(results, dataset_stats) if results else build_summary([], dataset_stats, dry_run=True)
-            summary.update({"dry_run": False, "run_status": "infra_failed", "passed": False, "recommendation": "基础设施失败", "infrastructure_error": str(exc)})
+            summary.update({
+                "dry_run": False,
+                "run_status": "infra_failed",
+                "passed": False,
+                "recommendation": "基础设施失败",
+                "infrastructure_error": str(exc),
+                "infrastructure_details": exc.details or None,
+            })
             write_outputs(output_dir, results, summary)
             print(str(exc), file=sys.stderr)
             return 2


### PR DESCRIPTION
## Summary
- Make reference-SQL failures immediately attributable to the failing evaluation case and SQL statement.
- Persist the same diagnostics as structured report data for offline and automated triage.

## What Changed

### Behavior Changes
- Reference-SQL validation, HTTP, authentication, and backend result failures now include `case_id`, database, engine, SHA-256 SQL fingerprint, full SQL, and the original cause.
- `summary.json.infrastructure_details` stores `error_code`, `case_id`, `database`, `engine`, `sql`, `sql_sha256`, and `cause` while preserving exit code 2 and partial reports.
- builtin, DeepEval, and Opik implement the output independently but conform to the same external diagnostics contract.

### Example
```text
reference_sql_failed: case_id=ARCH_DIAGNOSTIC_001, database=public, engine=doris,
sql_sha256=..., sql="SELECT cmp_name, system_name FROM ...";
cause=result_state=failed, detail=Unknown column 'system_name'
```

## Validation
- Command: `DATAAGENT_EVAL_DISABLE_NETWORK=1 dataagent/dataagent-backend/.venv-py313/bin/python -m pytest tests/test_run_dataagent_evals.py tests/test_dataagent_deepeval_evals.py tests/test_dataagent_eval_engine_contract.py -q`
  Result: pass, 67 tests passed.
- Command: `dataagent/dataagent-backend/.venv-py313/bin/python -m py_compile tools/dataagent-evals/builtin/run.py tools/dataagent-evals/deepeval/run.py tools/dataagent-evals/opik/run.py`
  Result: pass.
- Command: `git diff --check origin/main...HEAD`
  Result: pass.
- GitHub Actions is expected to remain blocked before runner assignment by the repository account billing/spending-limit issue observed on PR #421; no workflow step ran there.

## Risks
- Full private reference SQL is now present in local error reports by design; datasets and reports must continue to be handled as private evaluation artifacts.

## Rollback
- Revert commit `82c50f17` to restore the previous terse infrastructure errors.

## Checklist
- [x] No credentials or authorization tokens are included in diagnostics.
- [x] Exit-code and partial-report compatibility preserved.
- [x] Documentation and three-engine regression coverage updated.
