### PR TITLE
fix(dataagent): make eval expected-vs-actual self-contained and show reference data diff

### DIFF
--- a/dataagent/dataagent-frontend/src/views/evaluation/EvaluationRunDetailView.vue
+++ b/dataagent/dataagent-frontend/src/views/evaluation/EvaluationRunDetailView.vue
@@ -207,8 +207,8 @@
               </template>
             </el-table-column>
           </el-table>
-          <div v-if="!expectedCaseDef" class="case-detail-dialog__muted case-detail-dialog__note">
-            未能关联到评测集用例定义（运行未关联数据集或用例已删除），预期列仅显示运行内可得信息。
+          <div v-if="!expCase" class="case-detail-dialog__muted case-detail-dialog__note">
+            该运行结果未内嵌用例定义，且未能从评测集反查到（评测集未导入或用例已删除）。用新版 runner 重新评测，或在「评测集管理」导入对应 JSONL 后即可看到完整预期。
           </div>
         </div>
 
@@ -491,16 +491,25 @@ const ruleChecks = computed(() => {
 
 const expectedCaseDef = ref(null)
 
+// 优先使用 run 结果内嵌的原始用例定义；旧 run 没有时回退到按数据集反查的定义。
+const expCase = computed(() => {
+  const embedded = caseJson.value?.case_definition
+  if (embedded && typeof embedded === 'object') return embedded
+  return expectedCaseDef.value
+})
+
 const joinList = (v, sep = '、') => (Array.isArray(v) && v.length ? v.map(String).join(sep) : '')
 const truncate = (s, n) => {
   const text = String(s || '')
   return text.length > n ? `${text.slice(0, n)}…` : text
 }
+const fmtRows = (rows) =>
+  Array.isArray(rows) && rows.length ? rows.map((r) => JSON.stringify(r)).join('\n') : ''
 
 const comparisonRows = computed(() => {
   const cj = caseJson.value
   if (!cj) return []
-  const exp = expectedCaseDef.value || {}
+  const exp = expCase.value || {}
   const gates = ruleCheckInfo.value.hard_gates || {}
   const dims = judgeInfo.value.dimension_scores || {}
   const rows = []
@@ -560,18 +569,44 @@ const comparisonRows = computed(() => {
   const result = exp.expected_result || {}
   const refQuery = result.reference_query || {}
   const refActual = cj.reference_data_accuracy || {}
+  const refSql = refQuery.sql || refActual.sql || ''
+  const expectedSample = fmtRows(refActual.expected_sample)
   const resultExpected = [
     joinList(result.required_columns) ? `必需列: ${joinList(result.required_columns)}` : '',
-    refQuery.sql ? `参考 SQL: ${truncate(refQuery.sql, 200)}` : '',
+    refSql ? `参考 SQL: ${truncate(refSql, 300)}` : '',
+    refActual.expected_row_count !== undefined ? `参考结果 ${refActual.expected_row_count} 行` : '',
+    expectedSample ? `参考结果:\n${truncate(expectedSample, 500)}` : '',
     result.allow_empty !== undefined ? `允许空结果: ${result.allow_empty ? '是' : '否'}` : ''
   ].filter(Boolean).join('\n')
   if (resultExpected || refActual.applicable) {
+    const actualSamples = Array.isArray(refActual.actual_samples) ? refActual.actual_samples : []
+    const actualSampleText = actualSamples
+      .map((sampleRows, i) => {
+        const body = fmtRows(sampleRows) || '(空结果)'
+        return actualSamples.length > 1 ? `候选结果 ${i + 1}:\n${body}` : body
+      })
+      .join('\n')
+    const actualParts = []
+    if (refActual.applicable) {
+      actualParts.push(
+        `参考数据对比: ${refActual.passed ? '一致' : '不一致'}`
+        + (refActual.comparison_mode ? `（模式: ${refActual.comparison_mode}）` : '')
+      )
+      if (refActual.passed === false && refActual.candidate_result_count !== undefined) {
+        actualParts.push(`Agent 共产生 ${refActual.candidate_result_count} 个查询结果集，均不匹配参考结果`)
+      }
+      if (actualSampleText) {
+        actualParts.push(`实际结果:\n${truncate(actualSampleText, 600)}`)
+      } else if (refActual.candidate_result_count === 0) {
+        actualParts.push('Agent 未产生可对比的查询结果')
+      }
+    } else {
+      actualParts.push('无参考数据对比')
+    }
     rows.push({
       group: '数据结果',
       expected: resultExpected,
-      actual: refActual.applicable
-        ? `参考数据对比: ${refActual.passed ? '一致' : '不一致'}${refActual.reason ? `（${refActual.reason}）` : ''}`
-        : '无参考数据对比',
+      actual: actualParts.join('\n'),
       ok: refActual.applicable ? Boolean(refActual.passed) : null
     })
   }

--- a/tools/dataagent-evals/builtin/run.py
+++ b/tools/dataagent-evals/builtin/run.py
@@ -1558,7 +1558,7 @@ def _execute_reference_query(base_url: str, case: dict[str, Any], topic_id: str)
             error_code="reference_sql_failed",
             cause=f"result_state={result_state}, rows_present={rows is not None}{suffix}",
         )
-    return {"applicable": True, "passed": None, "rows": rows, "row_count": len(rows), "database": payload["database"]}
+    return {"applicable": True, "passed": None, "rows": rows, "row_count": len(rows), "database": payload["database"], "sql": sql}
 
 
 def _compare_reference(reference: dict[str, Any], actual_row_sets: list[list[dict[str, Any]]], case: dict[str, Any]) -> dict[str, Any]:
@@ -1583,12 +1583,20 @@ def _compare_reference(reference: dict[str, Any], actual_row_sets: list[list[dic
         return _canonical_rows(expected_rows, tolerance=tolerance) == _canonical_rows(actual_rows, tolerance=tolerance)
 
     matched_rows = next((rows for rows in actual_row_sets if matches(rows)), None)
+    sample_limit = 20
+    if matched_rows is not None:
+        actual_samples = [matched_rows[:sample_limit]]
+    else:
+        actual_samples = [rows[:sample_limit] for rows in actual_row_sets[:3]]
     return {
         **reference,
         "passed": matched_rows is not None,
         "comparison_mode": mode,
         "actual_row_count": None if matched_rows is None else len(matched_rows),
         "candidate_result_count": len(actual_row_sets),
+        "expected_row_count": len(expected_rows),
+        "expected_sample": expected_rows[:sample_limit],
+        "actual_samples": actual_samples,
     }
 
 
@@ -1751,6 +1759,7 @@ def run_case(base_url: str, case: dict[str, Any], args: argparse.Namespace, judg
         "category": case.get("category"),
         "question": _case_question(case),
         "turns": _case_turns(case),
+        "case_definition": case,
         "agent_id": str(args.agent_id or "").strip(),
         "topic_id": topic_id,
         "task_id": str(task.get("task_id") or task_id),


### PR DESCRIPTION
## Summary
- The expected column in the eval case detail dialog was empty whenever the run's dataset had never been imported into the UI — the dataset-hash reverse lookup found nothing, so the case definition fetch 404'd
- A reference-data mismatch only showed "不一致" with no way to see why, because the runner stripped the reference rows at persist time and never stored the agent's actual rows
- Runner now embeds the full original case definition (`case_definition`) in each per-case result, so expected semantics/tools/SQL/answer points render without any dataset link; the dataset lookup remains as a fallback for old runs
- Reference comparison now persists the reference SQL, expected row count, a truncated expected row sample, and truncated samples of the agent's candidate result sets (matched set when passed, up to 3 candidates when failed)
- The 数据结果 comparison row shows reference SQL + reference rows on the expected side, and match verdict, comparison mode, candidate count, and actual rows on the actual side

## Test plan
- [x] `python -m pytest dataagent/dataagent-backend/tests/test_eval_contract.py` — 6/6 passed
- [x] `py_compile` on `run.py`
- [x] `nvm use && npm run build` (dataagent-frontend) — build passes
- [ ] The new `case_definition` / reference sample fields require a fresh eval run with the updated runner; historical runs fall back to dataset lookup / show no reference sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012erxzgmrHhkteTswJgoA4b)_