### PR TITLE
feat(dataagent): 引擎感知的建表规范与建表工具,补齐数据开发闭环

### DIFF
--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentTableController.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/controller/AgentTableController.java
@@ -1,0 +1,33 @@
+package com.onedata.portal.agentapi.controller;
+
+import com.onedata.portal.agentapi.dto.AgentTableCreateRequest;
+import com.onedata.portal.agentapi.service.AgentTableService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai/table")
+public class AgentTableController {
+
+    private final AgentTableService agentTableService;
+
+    @PostMapping("/preview")
+    public Object preview(
+            @Validated @RequestBody AgentTableCreateRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentTableService.previewCreateTable(request, operator);
+    }
+
+    @PostMapping
+    public Object create(
+            @Validated @RequestBody AgentTableCreateRequest request,
+            @RequestHeader(value = "X-Agent-Operator", required = false) String operator) {
+        return agentTableService.createTable(request, operator);
+    }
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentTableCreateRequest.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/dto/AgentTableCreateRequest.java
@@ -1,0 +1,89 @@
+package com.onedata.portal.agentapi.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+/**
+ * Agent-facing create-table payload. Field names mirror the platform
+ * {@code TableCreateRequest} so the backend implementation can map it directly.
+ * The target table name is generated from the naming components (layer /
+ * businessDomain / ...) by the platform, keeping agent-created tables consistent
+ * with tables created through the Data Studio UI. Executing the DDL (as opposed
+ * to previewing) requires {@code dorisClusterId}; the backend enforces this.
+ */
+@Data
+public class AgentTableCreateRequest {
+
+    private String layer;
+
+    private String businessDomain;
+
+    private String dataDomain;
+
+    private String customIdentifier;
+
+    private String statisticsCycle;
+
+    private String updateType;
+
+    @NotBlank(message = "dbName 不能为空")
+    private String dbName;
+
+    private String tableComment;
+
+    private String owner;
+
+    /** Doris table model: DUPLICATE (default / detail) / AGGREGATE / UNIQUE. */
+    private String tableModel;
+
+    private Integer bucketNum;
+
+    private Integer replicaNum;
+
+    private String partitionColumn;
+
+    private List<String> distributionColumns;
+
+    private List<String> keyColumns;
+
+    /** Target Doris cluster/datasource id. Required to execute the DDL. */
+    private Long dorisClusterId;
+
+    /** Whether to physically execute the CREATE TABLE on the engine. Defaults to true. */
+    private Boolean syncToDoris;
+
+    /** Advanced: a complete Doris CREATE TABLE DDL to use verbatim. */
+    private String dorisDdl;
+
+    @NotEmpty(message = "columns 不能为空")
+    private List<Column> columns;
+
+    /**
+     * Column definition. Field names mirror the platform {@code TableColumnRequest}.
+     */
+    @Data
+    public static class Column {
+
+        @NotBlank(message = "columnName 不能为空")
+        private String columnName;
+
+        @NotBlank(message = "dataType 不能为空")
+        private String dataType;
+
+        /** Type parameters, e.g. "64" for VARCHAR(64) or "18,2" for DECIMAL(18,2). */
+        private String typeParams;
+
+        private Boolean nullable;
+
+        private Boolean primaryKey;
+
+        private Boolean partitionColumn;
+
+        private String defaultValue;
+
+        private String comment;
+    }
+}

--- a/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentTableService.java
+++ b/backend-agent-api/src/main/java/com/onedata/portal/agentapi/service/AgentTableService.java
@@ -1,0 +1,17 @@
+package com.onedata.portal.agentapi.service;
+
+import com.onedata.portal.agentapi.dto.AgentTableCreateRequest;
+
+/**
+ * Agent-facing table-creation API. Implementations delegate to the platform's
+ * engine-aware table-create service so agent-created tables follow the same DDL
+ * conventions and metadata bookkeeping as tables created through the UI.
+ */
+public interface AgentTableService {
+
+    /** Preview only: generate the target table name and normalized DDL, no execution. */
+    Object previewCreateTable(AgentTableCreateRequest request, String operator);
+
+    /** Create the table: persist metadata and execute the DDL on the engine. */
+    Object createTable(AgentTableCreateRequest request, String operator);
+}

--- a/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTableService.java
+++ b/backend/src/main/java/com/onedata/portal/agentapi/service/BackendAgentTableService.java
@@ -1,0 +1,46 @@
+package com.onedata.portal.agentapi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentTableCreateRequest;
+import com.onedata.portal.agentapi.scope.AgentDataScopeContext;
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.service.TableCreateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Agent-facing table-creation API, delegating to the engine-aware
+ * {@link TableCreateService}. Preview generates the target table name and
+ * normalized DDL without side effects; create persists metadata and executes the
+ * DDL on the engine (Doris). The X-Agent-Operator identity is recorded as the
+ * table owner, and the target database is checked against the agent data scope.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BackendAgentTableService implements AgentTableService {
+
+    private final TableCreateService tableCreateService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Object previewCreateTable(AgentTableCreateRequest request, String operator) {
+        return tableCreateService.preview(toDomain(request, operator));
+    }
+
+    @Override
+    public Object createTable(AgentTableCreateRequest request, String operator) {
+        return tableCreateService.create(toDomain(request, operator));
+    }
+
+    private TableCreateRequest toDomain(AgentTableCreateRequest request, String operator) {
+        TableCreateRequest domain = objectMapper.convertValue(request, TableCreateRequest.class);
+        AgentDataScopeContext.requireDatabaseNameAllowedIfPresent(domain.getDbName());
+        if (StringUtils.hasText(operator) && !StringUtils.hasText(domain.getOwner())) {
+            domain.setOwner(operator);
+        }
+        return domain;
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/table/DorisTableEngineHandler.java
+++ b/backend/src/main/java/com/onedata/portal/service/table/DorisTableEngineHandler.java
@@ -84,9 +84,7 @@ public class DorisTableEngineHandler implements TableEngineHandler {
         ddl.append("PROPERTIES (\n");
         ddl.append("  \"replication_num\" = \"")
                 .append(request.getReplicaNum() != null ? request.getReplicaNum() : 3)
-                .append("\",\n");
-        ddl.append("  \"storage_format\" = \"V2\",\n");
-        ddl.append("  \"compression\" = \"LZ4\"\n");
+                .append("\"\n");
         ddl.append(");");
         return ddl.toString();
     }

--- a/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTableServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/agentapi/BackendAgentTableServiceTest.java
@@ -1,0 +1,93 @@
+package com.onedata.portal.agentapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.agentapi.dto.AgentTableCreateRequest;
+import com.onedata.portal.agentapi.service.BackendAgentTableService;
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.service.TableCreateService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class BackendAgentTableServiceTest {
+
+    @Mock
+    private TableCreateService tableCreateService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private BackendAgentTableService service() {
+        return new BackendAgentTableService(tableCreateService, objectMapper);
+    }
+
+    private AgentTableCreateRequest sampleRequest() {
+        AgentTableCreateRequest.Column col = new AgentTableCreateRequest.Column();
+        col.setColumnName("order_id");
+        col.setDataType("BIGINT");
+        col.setComment("订单ID");
+        AgentTableCreateRequest req = new AgentTableCreateRequest();
+        req.setDbName("dwd");
+        req.setLayer("dwd");
+        req.setTableModel("DUPLICATE");
+        req.setBucketNum(10);
+        req.setReplicaNum(3);
+        req.setKeyColumns(Arrays.asList("dt", "order_id"));
+        req.setDistributionColumns(Collections.singletonList("order_id"));
+        req.setDorisClusterId(5L);
+        req.setSyncToDoris(Boolean.TRUE);
+        req.setColumns(Collections.singletonList(col));
+        return req;
+    }
+
+    @Test
+    void createTableMapsAgentRequestToDomainAndDelegates() {
+        service().createTable(sampleRequest(), "agent-operator");
+
+        ArgumentCaptor<TableCreateRequest> captor = ArgumentCaptor.forClass(TableCreateRequest.class);
+        verify(tableCreateService).create(captor.capture());
+        TableCreateRequest domain = captor.getValue();
+
+        // Scalar fields map by name (AgentTableCreateRequest mirrors TableCreateRequest).
+        assertEquals("dwd", domain.getDbName());
+        assertEquals("DUPLICATE", domain.getTableModel());
+        assertEquals(Integer.valueOf(10), domain.getBucketNum());
+        assertEquals(Integer.valueOf(3), domain.getReplicaNum());
+        assertEquals(Arrays.asList("dt", "order_id"), domain.getKeyColumns());
+        assertEquals(Collections.singletonList("order_id"), domain.getDistributionColumns());
+        assertEquals(Long.valueOf(5L), domain.getDorisClusterId());
+        assertEquals(Boolean.TRUE, domain.getSyncToDoris());
+        // Operator becomes the table owner when none was provided.
+        assertEquals("agent-operator", domain.getOwner());
+        // Nested column list maps by field name (Column -> TableColumnRequest).
+        assertEquals(1, domain.getColumns().size());
+        assertEquals("order_id", domain.getColumns().get(0).getColumnName());
+        assertEquals("BIGINT", domain.getColumns().get(0).getDataType());
+        assertEquals("订单ID", domain.getColumns().get(0).getComment());
+    }
+
+    @Test
+    void previewCreateTableDelegatesToPreview() {
+        service().previewCreateTable(sampleRequest(), "agent-operator");
+        verify(tableCreateService).preview(any(TableCreateRequest.class));
+    }
+
+    @Test
+    void createTableKeepsExplicitOwner() {
+        AgentTableCreateRequest req = sampleRequest();
+        req.setOwner("alice");
+        service().createTable(req, "agent-operator");
+
+        ArgumentCaptor<TableCreateRequest> captor = ArgumentCaptor.forClass(TableCreateRequest.class);
+        verify(tableCreateService).create(captor.capture());
+        assertEquals("alice", captor.getValue().getOwner());
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/table/DorisTableEngineHandlerTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/table/DorisTableEngineHandlerTest.java
@@ -1,0 +1,53 @@
+package com.onedata.portal.service.table;
+
+import com.onedata.portal.dto.TableColumnRequest;
+import com.onedata.portal.dto.TableCreateRequest;
+import com.onedata.portal.service.DorisConnectionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class DorisTableEngineHandlerTest {
+
+    @Mock
+    private DorisConnectionService dorisConnectionService;
+
+    private TableCreateRequest sampleRequest() {
+        TableColumnRequest col = new TableColumnRequest();
+        col.setColumnName("order_id");
+        col.setDataType("BIGINT");
+        TableCreateRequest req = new TableCreateRequest();
+        req.setDbName("dwd");
+        req.setTableModel("DUPLICATE");
+        req.setReplicaNum(3);
+        req.setBucketNum(10);
+        req.setKeyColumns(Arrays.asList("dt", "order_id"));
+        req.setDistributionColumns(Collections.singletonList("order_id"));
+        req.setColumns(Collections.singletonList(col));
+        return req;
+    }
+
+    @Test
+    void buildCreateDdlOmitsStorageFormatAndCompression() {
+        String ddl = new DorisTableEngineHandler(dorisConnectionService)
+                .buildCreateDdl("dwd_user_order_di", sampleRequest());
+
+        // storage_format / compression are Doris defaults and are no longer emitted.
+        assertFalse(ddl.contains("storage_format"), ddl);
+        assertFalse(ddl.contains("compression"), ddl);
+        // PROPERTIES keeps only replication_num, and closes cleanly (no dangling comma).
+        assertTrue(ddl.contains("\"replication_num\" = \"3\""), ddl);
+        assertTrue(ddl.contains("\"replication_num\" = \"3\"\n)"), ddl);
+        // Core structure is unchanged.
+        assertTrue(ddl.contains("ENGINE=OLAP"), ddl);
+        assertTrue(ddl.contains("DISTRIBUTED BY HASH(`order_id`) BUCKETS 10"), ddl);
+    }
+}

--- a/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
@@ -40,23 +40,26 @@ tools: [Bash, Read]
 - 发布：`portal_preview_publish` →（确认）→ `portal_publish_workflow`。
 - 调度：`portal_upsert_schedule`、`portal_workflow_schedule_online`、`portal_workflow_schedule_offline`。
 
-字段契约见 `reference/10-task-fields.md`，生命周期与状态机见 `reference/20-workflow-lifecycle.md`，建表 DDL 规范见 `reference/40-ddl-standards.md`，命名/校验规则见 `assets/dev-policies.json`，引擎建表默认值见 `assets/engine-ddl-rules.json`，任务模板见 `assets/task-template.json`。
+字段契约见 `reference/10-task-fields.md`，生命周期与状态机见 `reference/20-workflow-lifecycle.md`，建表 DDL 规范见 `reference/40-ddl-standards.md`，常见加工场景模板见 `reference/50-sql-scenarios.md`，命名/校验规则见 `assets/dev-policies.json`，引擎建表默认值见 `assets/engine-ddl-rules.json`，任务模板见 `assets/task-template.json`。
 
 ## Playbook（核心规则）
 
 1. **SQL 生成 / 润色**
    - 生成前用 `portal_search_tables` / `portal_get_table_ddl` 核实库、表、字段，不臆造表名或字段。
    - 润色或落任务前，先 `portal_analyze_sql` 识别输入/输出表与操作类型；据此推荐 `inputTableIds` / `outputTableIds`。
+   - 常见加工场景(每日增量/全量快照/聚合/关联拉宽/upsert)可参照 `reference/50-sql-scenarios.md` 的模板起手，再按真实表结构改写。
    - 含写操作的 SQL（INSERT/UPDATE/INSERT OVERWRITE 等）只允许写进任务定义，**不要**用只读查询工具试跑。
 
 2. **建表（当需求需要新目标表时）**
+   - **新目标表一律走建表工具直接建表，不要为"建表"单独创建执行 DDL 的数据任务**;数据任务只承载 DML 加工逻辑。
    - 建表 DDL **必须匹配目标引擎规范**，严格遵循 `reference/40-ddl-standards.md`；默认值(分桶数、副本数、表模型等)取自 `assets/engine-ddl-rules.json`，与后端一致。
    - Doris:先判定表模型——明细层用 `DUPLICATE`(默认)，需去重/ upsert 用 `UNIQUE KEY(...)`，预聚合用 `AGGREGATE`；给出 KEY 列、分区列、分桶键与桶数、副本数。
    - 优先 `portal_preview_create_table` 传结构化字段，让后端产出规范化 DDL 与最终表名；把 DDL/表名/是否已存在展示给用户核对。
    - 确认后 `portal_create_table` 执行建表(高危，会触发确认卡；批准即执行)。建成的表再进入建任务环节维护血缘。
    - 后端建表当前仅执行 Doris；MySQL 等目标表按规范产出 DDL 供落任务或人工执行。
 
-3. **创建任务**
+3. **创建任务（DML 加工）**
+   - **落任务前 DML SQL 必须验证通过**:`portal_analyze_sql` 解析成功、输入/输出表可解析、无 error 级风险;必要时用 `portal_query_readonly` 只读抽样核对 SELECT 逻辑。**验证不通过不建任务、不加入计划**;含写操作的整段 SQL 不试跑,只落任务定义。
    - 一律以 draft 创建（`status: draft`）。
    - 必填字段参照 `reference/10-task-fields.md` 与 `assets/task-template.json`；命名遵循 `assets/dev-policies.json`。
    - 传入 analyze 得到的输入/输出表 ID，保持血缘完整。

--- a/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: opendataworks-data-dev
-description: "当请求需要在 OpenDataWorks 上进行数据开发时使用：生成/润色 SQL、创建数据任务、组装工作流、发布与上线、配置调度。依赖 portal MCP 的写工具与对话内权限确认。不用于纯问数、业务语义或本体建模。"
-compatibility: "需要可见的 portal MCP 写工具(portal_create_task/portal_create_workflow/portal_preview_publish/portal_publish_workflow 等)。高危操作(发布/上线)在 default/acceptEdits 权限模式下会触发对话内确认。"
+description: "当请求需要在 OpenDataWorks 上进行数据开发时使用：生成/润色 SQL、按引擎规范建表、创建数据任务、组装工作流、发布与上线、配置调度。依赖 portal MCP 的写工具与对话内权限确认。不用于纯问数、业务语义或本体建模。"
+compatibility: "需要可见的 portal MCP 写工具(portal_create_table/portal_create_task/portal_create_workflow/portal_preview_publish/portal_publish_workflow 等)。高危操作(建表/发布/上线)在 default/acceptEdits 权限模式下会触发对话内确认。"
 tools: [Bash, Read]
 ---
 
@@ -9,13 +9,14 @@ tools: [Bash, Read]
 
 数据开发 Skill。OpenDataWorks Data Development Skill。
 
-把"为某张表写一段 SQL → 建任务 → 加入工作流 → 发布 → 上线 → 配调度"的开发链路，通过 portal MCP 写工具安全地编排出来。SQL 就绪规则与平台事实由 `opendataworks-platform-tools` 提供；业务含义由语义技能提供；本技能只负责**开发动作的编排与安全发布流程**。
+把"为某张表写一段 SQL → 建目标表 → 建任务 → 加入工作流 → 发布 → 上线 → 配调度"的开发链路，通过 portal MCP 写工具安全地编排出来。SQL 就绪规则与平台事实由 `opendataworks-platform-tools` 提供；业务含义由语义技能提供；本技能只负责**开发动作的编排与安全发布流程**。
 
 ## 范围
 
 负责：
 
 - 生成与润色 SQL（先核实表结构与输入/输出表，再产出）。
+- 按目标引擎规范生成建表 DDL，并通过建表工具创建目标表(见 `reference/40-ddl-standards.md`)。
 - 创建/更新数据任务（draft 优先），维护输入/输出表血缘。
 - 组装工作流（绑定任务、设置依赖边）。
 - 发布(deploy)、上线/下线(online/offline)、调度配置与上线/下线。
@@ -33,12 +34,13 @@ tools: [Bash, Read]
 本技能以 portal MCP 写工具为主，配方见 `reference/30-tool-recipes.md`。关键工具：
 
 - 探查：`portal_search_tables`、`portal_get_table_ddl`、`portal_analyze_sql`（平台工具技能提供前两者）。
+- 建表：`portal_preview_create_table`(只读预览表名+DDL)、`portal_create_table`(执行建表，高危)。
 - 任务：`portal_create_task`、`portal_update_task`、`portal_get_task`、`portal_list_tasks`。
 - 工作流：`portal_create_workflow`、`portal_update_workflow`、`portal_get_workflow`、`portal_list_workflows`。
 - 发布：`portal_preview_publish` →（确认）→ `portal_publish_workflow`。
 - 调度：`portal_upsert_schedule`、`portal_workflow_schedule_online`、`portal_workflow_schedule_offline`。
 
-字段契约见 `reference/10-task-fields.md`，生命周期与状态机见 `reference/20-workflow-lifecycle.md`，命名/校验规则见 `assets/dev-policies.json`，任务模板见 `assets/task-template.json`。
+字段契约见 `reference/10-task-fields.md`，生命周期与状态机见 `reference/20-workflow-lifecycle.md`，建表 DDL 规范见 `reference/40-ddl-standards.md`，命名/校验规则见 `assets/dev-policies.json`，引擎建表默认值见 `assets/engine-ddl-rules.json`，任务模板见 `assets/task-template.json`。
 
 ## Playbook（核心规则）
 
@@ -47,29 +49,38 @@ tools: [Bash, Read]
    - 润色或落任务前，先 `portal_analyze_sql` 识别输入/输出表与操作类型；据此推荐 `inputTableIds` / `outputTableIds`。
    - 含写操作的 SQL（INSERT/UPDATE/INSERT OVERWRITE 等）只允许写进任务定义，**不要**用只读查询工具试跑。
 
-2. **创建任务**
+2. **建表（当需求需要新目标表时）**
+   - 建表 DDL **必须匹配目标引擎规范**，严格遵循 `reference/40-ddl-standards.md`；默认值(分桶数、副本数、表模型等)取自 `assets/engine-ddl-rules.json`，与后端一致。
+   - Doris:先判定表模型——明细层用 `DUPLICATE`(默认)，需去重/ upsert 用 `UNIQUE KEY(...)`，预聚合用 `AGGREGATE`；给出 KEY 列、分区列、分桶键与桶数、副本数。
+   - 优先 `portal_preview_create_table` 传结构化字段，让后端产出规范化 DDL 与最终表名；把 DDL/表名/是否已存在展示给用户核对。
+   - 确认后 `portal_create_table` 执行建表(高危，会触发确认卡；批准即执行)。建成的表再进入建任务环节维护血缘。
+   - 后端建表当前仅执行 Doris；MySQL 等目标表按规范产出 DDL 供落任务或人工执行。
+
+3. **创建任务**
    - 一律以 draft 创建（`status: draft`）。
    - 必填字段参照 `reference/10-task-fields.md` 与 `assets/task-template.json`；命名遵循 `assets/dev-policies.json`。
    - 传入 analyze 得到的输入/输出表 ID，保持血缘完整。
 
-3. **组装工作流**
+4. **组装工作流**
    - 绑定任务、设置依赖边后，向用户复述 DAG 结构（节点 + 依赖），口头确认无误再进入发布。
    - 工作流必须处于 draft 才能改结构。
 
-4. **发布与上线（高危，强制顺序）**
+5. **发布与上线（高危，强制顺序）**
    - 先 `portal_preview_publish`，把 `diffSummary` / `errors` / `warnings` 摘要展示给用户；存在 error 级 issue 时**禁止**继续，转为修复建议。
    - 调用 `portal_publish_workflow(operation="deploy", preview_token=<上一步返回>)`。`deploy`/`online` 必须携带 preview 返回的 `preview_token`。
    - deploy 成功后再 `portal_publish_workflow(operation="online", preview_token=...)` 上线。
    - 在 default / acceptEdits 权限模式下，发布/上线会触发对话内权限确认卡片；请把操作目标与差异摘要放进工具参数的 `title` / `summary`，便于用户判断。
 
-5. **调度**
+6. **调度**
    - `portal_upsert_schedule` 配置 cron/时区等；`portal_workflow_schedule_online`（需 preview_token，高危）启用；`portal_workflow_schedule_offline` 停用。
 
-6. **失败恢复**
+7. **失败恢复**
    - 发布失败时读取后端返回的报错与 `workflow_publish_record` 信息，判断是结构问题（回 draft 修改后重走预览）还是引擎问题（提示用户检查 DolphinScheduler 配置）；不要盲目重试同一请求。
+   - 建表失败时读取后端报错(如表已存在、字段/类型非法、集群不可达)，回到 DDL 规范修正后重新预览；不要盲目重试同一请求。
 
 ## 安全边界
 
 - 永远不要绕过 `portal_preview_publish` 直接发布/上线。
+- 建表前优先 `portal_preview_create_table` 预览并让用户核对表名与 DDL，再 `portal_create_table` 执行；建表是不可逆高危操作。
 - 不要把权限模式或确认流程当作可跳过的步骤——高危确认由运行时强制，模型无法绕过。
-- 写工具的可用性取决于会话权限模式：`plan` 模式下写工具不可用，只能产出方案。
+- 写工具的可用性取决于会话权限模式：`plan` 模式下写工具(含 `portal_create_table`)不可用，只能产出方案。

--- a/dataagent/.claude/skills/opendataworks-data-dev/assets/engine-ddl-rules.json
+++ b/dataagent/.claude/skills/opendataworks-data-dev/assets/engine-ddl-rules.json
@@ -14,10 +14,7 @@
       "prefer_multiple_of_be_nodes": true,
       "distribution_key": "high-cardinality, high-frequency equality/join column"
     },
-    "fixed_properties": {
-      "storage_format": "V2",
-      "compression": "LZ4"
-    },
+    "optional_properties_note": "storage_format/compression 用 Doris 默认即可,无需显式指定",
     "replication_property_names": ["replication_num", "replication_allocation"],
     "type_notes": {
       "no_unsigned": true,

--- a/dataagent/.claude/skills/opendataworks-data-dev/assets/engine-ddl-rules.json
+++ b/dataagent/.claude/skills/opendataworks-data-dev/assets/engine-ddl-rules.json
@@ -1,0 +1,37 @@
+{
+  "description": "引擎建表默认值与约束(供生成/校验建表 DDL 时取默认值)。与后端 TableCreateService/DorisTableEngineHandler 严格一致;详解见 reference/40-ddl-standards.md。",
+  "doris": {
+    "engine": "OLAP",
+    "default_table_model": "DUPLICATE",
+    "table_models": ["DUPLICATE", "AGGREGATE", "UNIQUE"],
+    "default_bucket_num": 10,
+    "default_replica_num": 3,
+    "replica_num_hint": { "local_or_test": 1, "production": 3 },
+    "bucket_sizing": {
+      "target_bytes_per_bucket": "1GB-10GB",
+      "partitioned_estimate_basis": "single_partition",
+      "min_buckets_small_table": 1,
+      "prefer_multiple_of_be_nodes": true,
+      "distribution_key": "high-cardinality, high-frequency equality/join column"
+    },
+    "fixed_properties": {
+      "storage_format": "V2",
+      "compression": "LZ4"
+    },
+    "replication_property_names": ["replication_num", "replication_allocation"],
+    "type_notes": {
+      "no_unsigned": true,
+      "big_integer": "LARGEINT",
+      "long_string": "STRING"
+    }
+  },
+  "mysql": {
+    "engine": "InnoDB",
+    "charset": "utf8mb4",
+    "collation": "utf8mb4_general_ci",
+    "auto_increment_type": "BIGINT UNSIGNED",
+    "supports_unsigned": true,
+    "execute_via_create_table_tool": false,
+    "note": "MySQL DDL 规范先行用于生成/校验与落任务 SQL;后端建表工具当前仅执行 Doris。"
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/30-tool-recipes.md
@@ -1,6 +1,6 @@
 # 工具配方（调用顺序与参数）
 
-全部为 portal MCP 工具。`default` 权限模式下所有写工具都会触发对话内确认；`acceptEdits` 下草稿写操作自动执行，高危工具（`portal_publish_workflow`、`portal_workflow_schedule_online`）仍触发确认；`bypassPermissions` 下写工具自动执行，但 deploy/online/schedule-online 仍必须提供后端 preview token。
+全部为 portal MCP 工具。`default` 权限模式下所有写工具都会触发对话内确认；`acceptEdits` 下草稿写操作自动执行，高危工具（`portal_create_table`、`portal_publish_workflow`、`portal_workflow_schedule_online`）仍触发确认；`bypassPermissions` 下写工具自动执行，但 deploy/online/schedule-online 仍必须提供后端 preview token。
 
 ## 1. 探查表与 SQL
 
@@ -11,7 +11,33 @@ portal_analyze_sql   {sql, database?, cluster_id?}
   -> 返回输入/输出表、操作类型、风险告警
 ```
 
-## 2. 创建任务（draft）
+## 2. 建表（新目标表）
+
+建表 DDL 规范见 `reference/40-ddl-standards.md`，默认值见 `assets/engine-ddl-rules.json`。先预览、核对，再执行。表名由分层等组件生成，不用手填 `tableName`。
+
+```
+# 需要目标 Doris 集群/数据源时，用 portal_resolve_datasource 得到 cluster_id
+portal_preview_create_table {
+  db_name, layer, business_domain?, data_domain?, custom_identifier?,
+  statistics_cycle?, update_type?, table_comment?,
+  table_model?:"DUPLICATE",            # 明细=DUPLICATE(默认)/去重=UNIQUE/聚合=AGGREGATE
+  key_columns?:[...], distribution_columns?:[...], bucket_num?:10, replica_num?:3,
+  partition_column?,
+  columns:[ { column_name, data_type, type_params?, nullable?, primary_key?,
+              partition_column?, default_value?, comment? }, ... ]
+}
+  -> 返回生成的表名 + 规范化 DDL；把表名/DDL 展示给用户核对
+
+# 用户确认后执行(高危,批准即建表)。执行必须带 doris_cluster_id。
+portal_create_table {
+  <同上字段>, doris_cluster_id,
+  title?:"新建表 <层>_<主题>", summary?:"<DDL 摘要/字段概览>"
+}
+```
+
+高级:可直接传 `doris_ddl` 提供完整 Doris CREATE TABLE(表名仍以生成结果为准,避免名称与 DDL 不一致)。建成后进入建任务环节维护血缘。
+
+## 3. 创建任务（draft）
 
 ```
 portal_create_task {
@@ -24,7 +50,7 @@ portal_create_task {
 ```
 更新：`portal_update_task {task_id, task, input_table_ids, output_table_ids}`（仅 draft）。
 
-## 3. 组装工作流（draft）
+## 4. 组装工作流（draft）
 
 ```
 portal_create_workflow { workflow: { workflowName, tasks:[...], edges:[...], globalParams? } }
@@ -32,7 +58,7 @@ portal_update_workflow { workflow_id, workflow: {...} }
 ```
 绑定后向用户复述 DAG，确认后进入发布。
 
-## 4. 发布与上线（强制顺序）
+## 5. 发布与上线（强制顺序）
 
 ```
 portal_preview_publish { workflow_id }
@@ -49,7 +75,7 @@ portal_publish_workflow { workflow_id, operation:"online", preview_token }
 ```
 下线：`portal_publish_workflow { workflow_id, operation:"offline" }`。
 
-## 5. 调度
+## 6. 调度
 
 ```
 portal_upsert_schedule { workflow_id, schedule: { scheduleCron, scheduleTimezone, ... } }
@@ -59,6 +85,7 @@ portal_workflow_schedule_offline { workflow_id }
 
 ## 失败恢复
 
+- `portal_create_table` 失败 → 读取报错(表已存在/字段或类型非法/集群不可达);回 `40-ddl-standards.md` 修正后重新预览,不要盲目重试同一请求。
 - `portal_publish_workflow` 失败 → 读取返回报错；结构问题回 draft 改后重走 preview；引擎问题提示检查 DolphinScheduler 配置。
 - preview 的 `errors` 非空 → 不发布，逐条转成修复建议。
 - preview_token 过期或工作流版本已变 → 重新 `portal_preview_publish` 取新 token。

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/40-ddl-standards.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/40-ddl-standards.md
@@ -1,0 +1,150 @@
+# 建表 DDL 规范（引擎感知）
+
+新建目标表的 DDL **必须匹配目标数据库引擎的建表规范**——不同引擎（Doris、MySQL 等）的
+建表语法与约定不同,不能用同一套 DDL。平台建表的权威实现是后端
+`TableCreateService` + `DorisTableEngineHandler`,本规范与其保持一致。
+
+**首选**:用 `portal_create_table` 传结构化字段,让后端产出并执行规范 DDL(见
+`reference/30-tool-recipes.md`)。**需要手写或核对 DDL 时**,严格遵循本规范。默认值见
+`assets/engine-ddl-rules.json`,与后端默认严格一致。
+
+## 通用规则
+
+- 命名遵循 `assets/dev-policies.json`:任务/表名 `^[a-z][a-z0-9_]{2,63}$`,层前缀
+  `ods/dwd/dws/dim/ads`;建议 `<层>_<主题>_<刷新方式>`(`di`=按日增量,`df`=按日全量)。
+- 每一列都写 `COMMENT`;显式声明 `NOT NULL` / `NULL`;需要默认值时显式写 `DEFAULT`。
+- 先用 `portal_get_table_ddl` / `portal_search_tables` 核实上游表与字段,再决定目标表字段
+  与类型,不臆造。
+- 避免使用引擎保留字作为库/表/列名。
+
+## Doris（ENGINE=OLAP）
+
+### 骨架（对齐后端 `DorisTableEngineHandler.buildCreateDdl`）
+
+```sql
+CREATE TABLE `db_name`.`table_name` (
+  `col_a` BIGINT NOT NULL COMMENT '...',
+  `col_b` VARCHAR(64) NULL COMMENT '...'
+) ENGINE=OLAP
+<表模型> KEY(`k1`, `k2`)
+COMMENT '表注释'
+PARTITION BY RANGE(`dt`) ()
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "3",
+  "storage_format" = "V2",
+  "compression" = "LZ4"
+);
+```
+
+### 表模型（三选一,建表即固定）
+
+| 模型 | 关键字 | 用途 |
+| --- | --- | --- |
+| **明细表** | `DUPLICATE KEY(...)`（默认） | 保留每行明细、不去重。ODS/DWD 明细层首选。 |
+| 聚合表 | `AGGREGATE KEY(...)` | 建表即固定聚合方式(SUM/REPLACE/…),写入自动预聚合;建后列变更受限。 |
+| 主键表 | `UNIQUE KEY(...)` | 按 KEY 去重/ upsert,同键覆盖。需要主键唯一或更新语义时用。 |
+
+- 未指定时后端默认 `DUPLICATE`。
+- **KEY 列(`keyColumns`)必须前置且顺序敏感**——它同时是排序键与前缀索引,把高频等值/
+  范围过滤列按选择性从高到低放前面。
+
+### 分区
+
+- 大表(尤其带时间维度)用 `PARTITION BY RANGE(<时间列>)` 按时间分区;分区列通常是
+  `dt`/`event_date` 等 DATE/DATETIME 列。
+- 可选动态分区,用 `PROPERTIES` 的 `dynamic_partition.*`(如 `dynamic_partition.enable`、
+  `dynamic_partition.time_unit`、`dynamic_partition.end`、`dynamic_partition.replication_num`)
+  自动滚动创建/回收分区。
+- 小维表/字典表可不分区。
+
+### 分桶(DISTRIBUTED BY)与分桶数量建议
+
+- `DISTRIBUTED BY HASH(<分桶键>) BUCKETS <n>`;后端默认 `n=10`。
+- 分桶键选**高基数、查询高频的等值列**(常为 join / 过滤键),避免用低基数或倾斜列,否则
+  数据分布不均、单 tablet 过大。
+- **分桶数量建议**:
+  - 目标单 bucket 数据量约 `1–10GB`。
+  - **非分区表**按全表体量估算桶数;**分区表**按**单个分区**体量估算(总桶数 = 分区数 × 每分区桶数)。
+  - 小表最少 `1–10` 桶即可,不要过度分桶(桶过多会放大元数据与调度开销)。
+  - 桶数一般取 BE 节点数的整数倍,便于均衡。
+
+### 副本数(replication_num)
+
+- 生产默认 `3`(高可用);本地/测试单 BE 环境用 `1`。
+- 后端 `buildCreateDdl` 写 `"replication_num" = "<n>"`;部分较新 Doris 集群用
+  `"replication_allocation" = "tag.location.default: <n>"` 表达副本,二者语义等价,平台解析
+  两种写法。
+
+### 固定 PROPERTIES
+
+- `"storage_format" = "V2"`、`"compression" = "LZ4"`(与后端建表一致,除非有明确理由不要改)。
+
+### 数据类型注意
+
+- **无 `UNSIGNED`**;超过 BIGINT 范围用 `LARGEINT`。
+- 时间用 `DATE` / `DATETIME`(无隐式默认,需要默认值显式写)。
+- `DECIMAL(p, s)` 显式精度;金额类避免用浮点。
+- 变长字符串 `VARCHAR(n)` 按**字节**计长;超长文本用 `STRING`。
+
+### 变更约束(供后续改表时参考)
+
+- `AGGREGATE` 表的字段变更需指定聚合方式,平台不支持在线自动同步这类变更。
+- Doris 不支持在线新增/修改主键(KEY)列。
+- 修改分桶数需已存在分桶键。
+
+### 完整示例（dwd 每日增量明细表）
+
+```sql
+CREATE TABLE `dwd`.`dwd_user_order_di` (
+  `dt` DATE NOT NULL COMMENT '分区日期',
+  `order_id` BIGINT NOT NULL COMMENT '订单ID',
+  `user_id` BIGINT NOT NULL COMMENT '用户ID',
+  `amount` DECIMAL(18, 2) NULL COMMENT '订单金额',
+  `status` VARCHAR(32) NULL COMMENT '订单状态'
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `order_id`)
+COMMENT '用户订单明细（每日增量）'
+PARTITION BY RANGE(`dt`) ()
+DISTRIBUTED BY HASH(`order_id`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "3",
+  "storage_format" = "V2",
+  "compression" = "LZ4"
+);
+```
+
+## MySQL（知识先行）
+
+> 后端建表工具当前仅执行 Doris DDL;MySQL 目标表的 DDL 规范用于**生成/核对 SQL、写入
+> 任务定义**,暂不经 `portal_create_table` 直接执行。
+
+### 规则
+
+- `ENGINE=InnoDB`、`DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`。
+- 显式 `PRIMARY KEY`;高频过滤/join 列建二级索引(`KEY idx_xxx (col)`),避免冗余索引。
+- 自增主键用 `BIGINT UNSIGNED AUTO_INCREMENT`。
+- 时间戳:业务时间用 `DATETIME`;记录行创建/更新时间可用 `TIMESTAMP DEFAULT CURRENT_TIMESTAMP`
+  (注意时区语义)。
+- 布尔用 `TINYINT(1)`;需要非负整数用 `UNSIGNED`(与 Doris 相反,MySQL 支持)。
+- 大文本用 `TEXT`/`LONGTEXT`,不要塞进 `VARCHAR`。
+
+### 完整示例
+
+```sql
+CREATE TABLE `ods_user_profile` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `user_id` BIGINT UNSIGNED NOT NULL COMMENT '用户ID',
+  `nickname` VARCHAR(64) NULL COMMENT '昵称',
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  PRIMARY KEY (`id`),
+  KEY `idx_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户档案';
+```
+
+## 与建表工具的关系
+
+- 优先 `portal_preview_create_table` 预览(后端按本规范生成表名 + 规范化 DDL)→ 确认 →
+  `portal_create_table` 执行(高危,批准即建表)。
+- 直接给 `dorisDdl` 时,DDL 内的表名需与按命名规范生成的表名一致,否则以结构化字段为准由
+  后端构建,避免名称与 DDL 不一致。

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/40-ddl-standards.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/40-ddl-standards.md
@@ -31,9 +31,7 @@ COMMENT '表注释'
 PARTITION BY RANGE(`dt`) ()
 DISTRIBUTED BY HASH(`k1`) BUCKETS 10
 PROPERTIES (
-  "replication_num" = "3",
-  "storage_format" = "V2",
-  "compression" = "LZ4"
+  "replication_num" = "3"
 );
 ```
 
@@ -76,9 +74,9 @@ PROPERTIES (
   `"replication_allocation" = "tag.location.default: <n>"` 表达副本,二者语义等价,平台解析
   两种写法。
 
-### 固定 PROPERTIES
+### PROPERTIES
 
-- `"storage_format" = "V2"`、`"compression" = "LZ4"`(与后端建表一致,除非有明确理由不要改)。
+- 一般只需 `"replication_num"`。`storage_format` / `compression` 用 Doris 默认即可,**无需显式写**。
 
 ### 数据类型注意
 
@@ -108,9 +106,7 @@ COMMENT '用户订单明细（每日增量）'
 PARTITION BY RANGE(`dt`) ()
 DISTRIBUTED BY HASH(`order_id`) BUCKETS 10
 PROPERTIES (
-  "replication_num" = "3",
-  "storage_format" = "V2",
-  "compression" = "LZ4"
+  "replication_num" = "3"
 );
 ```
 

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/50-sql-scenarios.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/50-sql-scenarios.md
@@ -4,24 +4,28 @@
 
 约定:分层 `ods/dwd/dws/dim/ads`;刷新 `di`=按日增量、`df`=按日全量;时间/分区占位(如 `${bizdate}`)按平台调度参数约定替换。目标表若不存在,先用 `portal_create_table` 建表(不要建"DDL 任务")。
 
-## 1. 每日增量加工（di,写入当日分区）
+**写入采用「先删再增」**:先删掉目标分区/当日数据,再 `INSERT INTO`,保证任务**可重跑幂等**、不重复累计。`DELETE` 条件建议落在 key 列(如 `dt`)上;整分区重刷也可用 `TRUNCATE TABLE t PARTITION(p)`。
+
+## 1. 每日增量加工（di,重刷当日）
 
 来源:上游明细/日志;目标:`dwd` 明细分区表。
 
 ```sql
-INSERT OVERWRITE TABLE `dwd`.`dwd_user_order_di` PARTITION (dt = '${bizdate}')
-SELECT o.order_id, o.user_id, o.amount, o.status
+DELETE FROM `dwd`.`dwd_user_order_di` WHERE dt = '${bizdate}';
+INSERT INTO `dwd`.`dwd_user_order_di`
+SELECT o.dt, o.order_id, o.user_id, o.amount, o.status
 FROM `ods`.`ods_order_log_di` o
 WHERE o.dt = '${bizdate}';
 ```
 
-## 2. 每日全量快照（df,重刷全表/当日快照)
+## 2. 每日全量快照（df,重刷当日快照)
 
-来源:业务全量表;目标:`dwd`/`dim` 全量表。
+来源:业务全量表;目标:`dim`/`dwd` 快照分区表。
 
 ```sql
-INSERT OVERWRITE TABLE `dim`.`dim_user_df` PARTITION (dt = '${bizdate}')
-SELECT u.user_id, u.nickname, u.city, u.reg_time
+DELETE FROM `dim`.`dim_user_df` WHERE dt = '${bizdate}';
+INSERT INTO `dim`.`dim_user_df`
+SELECT '${bizdate}' AS dt, u.user_id, u.nickname, u.city, u.reg_time
 FROM `ods`.`ods_user_df` u
 WHERE u.dt = '${bizdate}';
 ```
@@ -31,10 +35,12 @@ WHERE u.dt = '${bizdate}';
 来源:`dwd` 明细;目标:`dws` 轻度汇总表。
 
 ```sql
-INSERT OVERWRITE TABLE `dws`.`dws_user_order_1d` PARTITION (dt = '${bizdate}')
-SELECT user_id,
-       COUNT(1)        AS order_cnt,
-       SUM(amount)     AS order_amt
+DELETE FROM `dws`.`dws_user_order_1d` WHERE dt = '${bizdate}';
+INSERT INTO `dws`.`dws_user_order_1d`
+SELECT '${bizdate}' AS dt,
+       user_id,
+       COUNT(1)    AS order_cnt,
+       SUM(amount) AS order_amt
 FROM `dwd`.`dwd_user_order_di`
 WHERE dt = '${bizdate}'
 GROUP BY user_id;
@@ -45,8 +51,9 @@ GROUP BY user_id;
 来源:多张 `dwd`/`dim`;目标:宽表。
 
 ```sql
-INSERT OVERWRITE TABLE `dwd`.`dwd_order_wide_di` PARTITION (dt = '${bizdate}')
-SELECT o.order_id, o.user_id, u.city, o.amount
+DELETE FROM `dwd`.`dwd_order_wide_di` WHERE dt = '${bizdate}';
+INSERT INTO `dwd`.`dwd_order_wide_di`
+SELECT o.dt, o.order_id, o.user_id, u.city, o.amount
 FROM `dwd`.`dwd_user_order_di` o
 LEFT JOIN `dim`.`dim_user_df` u
   ON o.user_id = u.user_id AND u.dt = '${bizdate}'
@@ -55,7 +62,7 @@ WHERE o.dt = '${bizdate}';
 
 ## 5. 主键去重 / upsert(UNIQUE KEY 表)
 
-目标为 Doris `UNIQUE KEY` 表时,同键写入即覆盖,直接 INSERT 即可(无需自行去重逻辑)。
+目标为 Doris `UNIQUE KEY` 表时,同键写入即覆盖,**无需先删**,直接 INSERT。
 
 ```sql
 INSERT INTO `dwd`.`dwd_user_profile`  -- UNIQUE KEY(user_id)
@@ -64,8 +71,13 @@ FROM `ods`.`ods_user_profile_di`
 WHERE dt = '${bizdate}';
 ```
 
+## 说明
+
+- **先删再增 vs INSERT OVERWRITE**:Doris 2.0+ 也支持 `INSERT OVERWRITE TABLE ... PARTITION(...)`,与先删再增等效;这里默认用先删再增(全版本通用、语义直观)。
+- 若 SQL 节点仅执行单条语句,把 `DELETE` 放到前置/pre-SQL 步骤,或使用支持多语句的节点。
+
 ## 验证要点(落任务前)
 
 - `portal_analyze_sql` 解析成功,输入/输出表可解析、无 error 级风险。
 - 目标表已存在(否则先 `portal_create_table`);字段与来源可对齐。
-- SELECT 逻辑可用 `portal_query_readonly` 只读试跑抽样核对;**含写操作的整段 SQL 不试跑**,只落任务定义。
+- SELECT 逻辑可用 `portal_query_readonly` 只读试跑抽样核对;**含写操作(DELETE/INSERT)的语句不试跑**,只落任务定义。

--- a/dataagent/.claude/skills/opendataworks-data-dev/reference/50-sql-scenarios.md
+++ b/dataagent/.claude/skills/opendataworks-data-dev/reference/50-sql-scenarios.md
@@ -1,0 +1,71 @@
+# 场景 SQL 模板（数据加工）
+
+常见数据开发场景的 SQL 起手式。先用 `portal_search_tables` / `portal_get_table_ddl` 核实来源表与目标表结构,再套用模板;**所有 DML 落任务前必须经 `portal_analyze_sql` 验证通过**(见 SKILL.md 建任务步骤)。
+
+约定:分层 `ods/dwd/dws/dim/ads`;刷新 `di`=按日增量、`df`=按日全量;时间/分区占位(如 `${bizdate}`)按平台调度参数约定替换。目标表若不存在,先用 `portal_create_table` 建表(不要建"DDL 任务")。
+
+## 1. 每日增量加工（di,写入当日分区）
+
+来源:上游明细/日志;目标:`dwd` 明细分区表。
+
+```sql
+INSERT OVERWRITE TABLE `dwd`.`dwd_user_order_di` PARTITION (dt = '${bizdate}')
+SELECT o.order_id, o.user_id, o.amount, o.status
+FROM `ods`.`ods_order_log_di` o
+WHERE o.dt = '${bizdate}';
+```
+
+## 2. 每日全量快照（df,重刷全表/当日快照)
+
+来源:业务全量表;目标:`dwd`/`dim` 全量表。
+
+```sql
+INSERT OVERWRITE TABLE `dim`.`dim_user_df` PARTITION (dt = '${bizdate}')
+SELECT u.user_id, u.nickname, u.city, u.reg_time
+FROM `ods`.`ods_user_df` u
+WHERE u.dt = '${bizdate}';
+```
+
+## 3. 聚合汇总（dws,GROUP BY 指标）
+
+来源:`dwd` 明细;目标:`dws` 轻度汇总表。
+
+```sql
+INSERT OVERWRITE TABLE `dws`.`dws_user_order_1d` PARTITION (dt = '${bizdate}')
+SELECT user_id,
+       COUNT(1)        AS order_cnt,
+       SUM(amount)     AS order_amt
+FROM `dwd`.`dwd_user_order_di`
+WHERE dt = '${bizdate}'
+GROUP BY user_id;
+```
+
+## 4. 多表关联（join 拉宽）
+
+来源:多张 `dwd`/`dim`;目标:宽表。
+
+```sql
+INSERT OVERWRITE TABLE `dwd`.`dwd_order_wide_di` PARTITION (dt = '${bizdate}')
+SELECT o.order_id, o.user_id, u.city, o.amount
+FROM `dwd`.`dwd_user_order_di` o
+LEFT JOIN `dim`.`dim_user_df` u
+  ON o.user_id = u.user_id AND u.dt = '${bizdate}'
+WHERE o.dt = '${bizdate}';
+```
+
+## 5. 主键去重 / upsert(UNIQUE KEY 表)
+
+目标为 Doris `UNIQUE KEY` 表时,同键写入即覆盖,直接 INSERT 即可(无需自行去重逻辑)。
+
+```sql
+INSERT INTO `dwd`.`dwd_user_profile`  -- UNIQUE KEY(user_id)
+SELECT user_id, nickname, city, update_time
+FROM `ods`.`ods_user_profile_di`
+WHERE dt = '${bizdate}';
+```
+
+## 验证要点(落任务前)
+
+- `portal_analyze_sql` 解析成功,输入/输出表可解析、无 error 级风险。
+- 目标表已存在(否则先 `portal_create_table`);字段与来源可对齐。
+- SELECT 逻辑可用 `portal_query_readonly` 只读试跑抽样核对;**含写操作的整段 SQL 不试跑**,只落任务定义。

--- a/dataagent/dataagent-backend/core/permission_gate.py
+++ b/dataagent/dataagent-backend/core/permission_gate.py
@@ -23,6 +23,10 @@ HIGH_RISK_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "portal_publish_workflow",
         "portal_workflow_schedule_online",
+        # Executes real, irreversible CREATE TABLE DDL on the engine; confirm every
+        # time in default/acceptEdits, deny under plan. The read-only
+        # portal_preview_create_table is intentionally not a write tool.
+        "portal_create_table",
     }
 )
 

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -354,3 +354,21 @@ def test_data_dev_skill_documents_engine_aware_ddl_standards():
 
     # The create-table tool is referenced as the execution path.
     assert "portal_create_table" in snapshot
+
+
+def test_data_dev_skill_presets_scenarios_and_gates_dml_validation():
+    snapshot = _skill_text_snapshot(DATA_DEV_SKILL_ROOT)
+
+    # Preset scenario SQL templates exist and are wired into the skill.
+    assert (DATA_DEV_SKILL_ROOT / "reference" / "50-sql-scenarios.md").exists()
+    assert "50-sql-scenarios.md" in snapshot
+    for token in ("每日增量", "INSERT OVERWRITE", "GROUP BY"):
+        assert token in snapshot, token
+
+    # DDL builds the target table directly via the tool, never as a scheduled
+    # "DDL task"; data tasks only carry DML.
+    assert "单独创建执行 DDL 的数据任务" in snapshot
+
+    # DML must pass validation before it becomes a task / enters the plan.
+    assert "portal_analyze_sql" in snapshot
+    assert "验证不通过不建任务" in snapshot

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -347,8 +347,6 @@ def test_data_dev_skill_documents_engine_aware_ddl_standards():
     assert rules["doris"]["default_bucket_num"] == 10
     assert rules["doris"]["default_replica_num"] == 3
     assert rules["doris"]["default_table_model"] == "DUPLICATE"
-    assert rules["doris"]["fixed_properties"]["storage_format"] == "V2"
-    assert rules["doris"]["fixed_properties"]["compression"] == "LZ4"
     assert rules["mysql"]["engine"] == "InnoDB"
     assert rules["mysql"]["charset"] == "utf8mb4"
 
@@ -362,7 +360,8 @@ def test_data_dev_skill_presets_scenarios_and_gates_dml_validation():
     # Preset scenario SQL templates exist and are wired into the skill.
     assert (DATA_DEV_SKILL_ROOT / "reference" / "50-sql-scenarios.md").exists()
     assert "50-sql-scenarios.md" in snapshot
-    for token in ("每日增量", "INSERT OVERWRITE", "GROUP BY"):
+    # Writes use the delete-then-insert idiom (idempotent rerun), not INSERT OVERWRITE.
+    for token in ("每日增量", "DELETE FROM", "INSERT INTO", "GROUP BY"):
         assert token in snapshot, token
 
     # DDL builds the target table directly via the tool, never as a scheduled

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -10,6 +10,7 @@ SQL_SKILL_ROOT = SKILLS_ROOT / "dataagent-nl2sql"
 BUSINESS_SKILL_ROOT = SKILLS_ROOT / "opendataworks-business-knowledge"
 PLATFORM_TOOLS_SKILL_ROOT = SKILLS_ROOT / "opendataworks-platform-tools"
 ONTOLOGY_MODELING_SKILL_ROOT = SKILLS_ROOT / "ontology-modeling-assistant"
+DATA_DEV_SKILL_ROOT = SKILLS_ROOT / "opendataworks-data-dev"
 
 
 def _skill_text_snapshot(root: Path) -> str:
@@ -308,3 +309,48 @@ def test_ontology_modeling_skill_contains_modeling_assets_without_sql_execution_
     assert not (ONTOLOGY_MODELING_SKILL_ROOT / "bin").exists()
     assert "run_sql.py 是唯一推荐的 SQL 执行入口" not in snapshot
     assert "validate_sql.py 是唯一推荐的 SQL 验证入口" not in snapshot
+
+
+def test_data_dev_skill_documents_engine_aware_ddl_standards():
+    snapshot = _skill_text_snapshot(DATA_DEV_SKILL_ROOT)
+
+    # DDL standards reference exists and is wired into the skill.
+    assert (DATA_DEV_SKILL_ROOT / "reference" / "40-ddl-standards.md").exists()
+    assert "40-ddl-standards.md" in snapshot
+
+    # Engine-aware CREATE TABLE knowledge, aligned with the backend
+    # DorisTableEngineHandler.buildCreateDdl conventions.
+    doris_tokens = [
+        "ENGINE=OLAP",
+        "DUPLICATE",
+        "AGGREGATE",
+        "UNIQUE KEY",
+        "DISTRIBUTED BY HASH",
+        "BUCKETS",
+        "replication_num",
+        "PARTITION BY RANGE",
+        "分桶数量建议",
+        "明细表",
+    ]
+    for token in doris_tokens:
+        assert token in snapshot, token
+
+    # MySQL DDL standards (knowledge-first, not executed by the tool yet).
+    for token in ["InnoDB", "utf8mb4", "PRIMARY KEY"]:
+        assert token in snapshot, token
+
+    # Machine-readable engine defaults must match the backend defaults exactly
+    # (DorisTableEngineHandler: bucketNum default 10, replicaNum default 3).
+    rules = json.loads(
+        (DATA_DEV_SKILL_ROOT / "assets" / "engine-ddl-rules.json").read_text(encoding="utf-8")
+    )
+    assert rules["doris"]["default_bucket_num"] == 10
+    assert rules["doris"]["default_replica_num"] == 3
+    assert rules["doris"]["default_table_model"] == "DUPLICATE"
+    assert rules["doris"]["fixed_properties"]["storage_format"] == "V2"
+    assert rules["doris"]["fixed_properties"]["compression"] == "LZ4"
+    assert rules["mysql"]["engine"] == "InnoDB"
+    assert rules["mysql"]["charset"] == "utf8mb4"
+
+    # The create-table tool is referenced as the execution path.
+    assert "portal_create_table" in snapshot

--- a/dataagent/dataagent-backend/tests/test_permission_gate.py
+++ b/dataagent/dataagent-backend/tests/test_permission_gate.py
@@ -6,6 +6,8 @@ from core import permission_gate as pg
 PUBLISH = "mcp__portal__portal_publish_workflow"
 SCHED_ONLINE = "mcp__portal__portal_workflow_schedule_online"
 CREATE_TASK = "mcp__portal__portal_create_task"
+CREATE_TABLE = "mcp__portal__portal_create_table"
+PREVIEW_CREATE_TABLE = "mcp__portal__portal_preview_create_table"
 ANALYZE = "mcp__portal__portal_analyze_sql"
 READ = "mcp__portal__portal_search_tables"
 
@@ -74,6 +76,22 @@ def test_post_plan_mode_is_accept_edits() -> None:
     assert pg.post_plan_mode() == "acceptEdits"
     assert pg.requires_confirmation(CREATE_TASK, pg.post_plan_mode()) is False
     assert pg.requires_confirmation(PUBLISH, pg.post_plan_mode()) is True
+
+
+def test_create_table_is_high_risk_and_preview_is_read_only() -> None:
+    # portal_create_table executes irreversible CREATE TABLE DDL -> high-risk write:
+    # confirmed in default AND acceptEdits, denied under plan.
+    assert pg.is_write_tool(CREATE_TABLE)
+    assert pg.is_high_risk_tool(CREATE_TABLE)
+    assert pg.requires_confirmation(CREATE_TABLE, "default") is True
+    assert pg.requires_confirmation(CREATE_TABLE, "acceptEdits") is True
+    assert pg.requires_confirmation(CREATE_TABLE, "bypassPermissions") is False
+    assert pg.plan_denies_tool(CREATE_TABLE) is True
+    # The preview tool is read-only: not a write tool, never confirmed, allowed under plan.
+    assert not pg.is_write_tool(PREVIEW_CREATE_TABLE)
+    assert not pg.is_high_risk_tool(PREVIEW_CREATE_TABLE)
+    assert pg.requires_confirmation(PREVIEW_CREATE_TABLE, "default") is False
+    assert pg.plan_denies_tool(PREVIEW_CREATE_TABLE) is False
 
 
 def test_strip_card_annotations_drops_only_annotation_keys() -> None:

--- a/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
+++ b/dataagent/dataagent-frontend/src/widget/WidgetChat.vue
@@ -297,7 +297,6 @@
                 <button
                   type="button"
                   class="query-dropdown-trigger query-permission-select"
-                  :disabled="isBusy"
                   title="Session permission mode"
                   @click="togglePermissionMenu"
                 >
@@ -426,7 +425,8 @@ const permissionDropdownRef = ref(null)
 const modelDropdownRef = ref(null)
 
 const togglePermissionMenu = () => {
-  if (isBusy.value) return
+  // Permission mode is read at run start, so switching it while a run is busy
+  // only affects the next turn — allow it (parity with chat v2).
   modelMenuOpen.value = false
   permissionMenuOpen.value = !permissionMenuOpen.value
 }

--- a/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
+++ b/dataagent/dataagent-frontend/src/widget/__tests__/WidgetChat.spec.js
@@ -441,6 +441,18 @@ describe('WidgetChat history conversations', () => {
     expect(widgetChatSource).toContain('.query-message-footer:focus-within')
   })
 
+  it('keeps the permission-mode dropdown usable while a run is busy', () => {
+    // Permission mode is read at run start, so switching it mid-run only affects
+    // the next turn — the trigger must not be disabled by isBusy, and toggling it
+    // must not early-return while busy.
+    const trigger = widgetChatSource.match(
+      /query-permission-select"([\s\S]*?)@click="togglePermissionMenu"/
+    )
+    expect(trigger).not.toBeNull()
+    expect(trigger[1]).not.toContain(':disabled')
+    expect(widgetChatSource).toContain('Permission mode is read at run start')
+  })
+
   it('renders inline chart specs from assistant text without showing raw spec markup', async () => {
     const chartSpec = JSON.stringify({
       kind: 'chart_spec',

--- a/dataagent/portal-mcp/portal_mcp/app.py
+++ b/dataagent/portal-mcp/portal_mcp/app.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
@@ -81,6 +82,49 @@ class QueryReadonlyInput(BaseModel):
 # --- data development assistant: write tool inputs ---------------------------
 # Nested task/workflow/schedule payloads are forwarded as-is to the backend
 # agent API, which owns the authoritative field schema (mirrors the web DTOs).
+
+
+class CreateTableColumnInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid", str_strip_whitespace=True, alias_generator=to_camel, populate_by_name=True
+    )
+
+    column_name: str = Field(..., description="列名")
+    data_type: str = Field(..., description="数据类型,如 BIGINT/VARCHAR/DECIMAL/DATETIME/STRING")
+    type_params: str | None = Field(default=None, description="类型参数,如 '64'(VARCHAR)或 '18,2'(DECIMAL)")
+    nullable: bool | None = Field(default=None, description="是否可空,默认可空")
+    primary_key: bool | None = Field(default=None, description="是否为 KEY/主键列")
+    partition_column: bool | None = Field(default=None, description="是否为分区列")
+    default_value: str | None = Field(default=None, description="默认值")
+    comment: str | None = Field(default=None, description="列注释")
+
+
+class CreateTableInput(BaseModel):
+    """建表入参,对齐平台建表规范(见 opendataworks-data-dev 技能 reference/40-ddl-standards.md)。表名由分层等组件生成。"""
+
+    model_config = ConfigDict(
+        extra="forbid", str_strip_whitespace=True, alias_generator=to_camel, populate_by_name=True
+    )
+
+    db_name: str = Field(..., description="目标数据库名")
+    columns: list[CreateTableColumnInput] = Field(..., min_length=1, description="列定义(至少一列),每列建议带 comment")
+    layer: str | None = Field(default=None, description="数仓分层:ods/dwd/dws/dim/ads,用于生成表名")
+    business_domain: str | None = Field(default=None, description="业务域,用于生成表名")
+    data_domain: str | None = Field(default=None, description="数据域,用于生成表名")
+    custom_identifier: str | None = Field(default=None, description="自定义标识,用于生成表名")
+    statistics_cycle: str | None = Field(default=None, description="统计周期,用于生成表名")
+    update_type: str | None = Field(default=None, description="刷新方式,如 di(按日增量)/df(按日全量)")
+    table_comment: str | None = Field(default=None, description="表注释")
+    owner: str | None = Field(default=None, description="负责人,可选(默认取调用者身份)")
+    table_model: str | None = Field(default=None, description="Doris 表模型:DUPLICATE(默认/明细)/AGGREGATE/UNIQUE")
+    bucket_num: int | None = Field(default=None, ge=1, description="分桶数,默认 10")
+    replica_num: int | None = Field(default=None, ge=1, description="副本数,默认 3(本地/测试用 1)")
+    partition_column: str | None = Field(default=None, description="分区列(RANGE 分区)")
+    distribution_columns: list[str] | None = Field(default=None, description="分桶键(DISTRIBUTED BY HASH)")
+    key_columns: list[str] | None = Field(default=None, description="KEY 列(表模型 KEY(...),顺序敏感)")
+    doris_cluster_id: int | None = Field(default=None, description="目标 Doris 集群/数据源 ID;执行建表必填,预览可省")
+    sync_to_doris: bool | None = Field(default=None, description="是否在引擎执行建表;默认执行,置 false 仅登记元数据")
+    doris_ddl: str | None = Field(default=None, description="高级:直接提供完整 Doris CREATE TABLE DDL")
 
 
 class CreateTaskInput(BaseModel):
@@ -286,6 +330,22 @@ def build_mcp_server(service: PortalToolService) -> FastMCP:
         return await service.query_readonly(payload)
 
     # --- data development assistant: write tools -----------------------------
+
+    @mcp.tool(
+        name="portal_preview_create_table",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+    )
+    async def portal_preview_create_table(params: CreateTableInput) -> dict[str, Any]:
+        """Preview a new target table: returns the generated table name and normalized CREATE TABLE DDL without creating anything. Follow the data-dev skill DDL standards; use before portal_create_table."""
+        return await service.preview_create_table(params.model_dump(by_alias=True, exclude_none=True))
+
+    @mcp.tool(
+        name="portal_create_table",
+        annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+    )
+    async def portal_create_table(params: CreateTableInput) -> dict[str, Any]:
+        """Create a new target table: persist metadata and execute the DDL on the engine (Doris). High-risk and irreversible; requires dorisClusterId to execute. Preview first with portal_preview_create_table."""
+        return await service.create_table(params.model_dump(by_alias=True, exclude_none=True))
 
     @mcp.tool(
         name="portal_create_task",

--- a/dataagent/portal-mcp/portal_mcp/backend_client.py
+++ b/dataagent/portal-mcp/portal_mcp/backend_client.py
@@ -39,6 +39,12 @@ class BackendApiClient:
 
     # --- write surface (data development assistant) ---------------------------
 
+    async def preview_create_table(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/ai/table/preview", json=payload)
+
+    async def create_table(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/ai/table", json=payload)
+
     async def create_task(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._request("POST", "/v1/ai/task", json=payload)
 

--- a/dataagent/portal-mcp/portal_mcp/service.py
+++ b/dataagent/portal-mcp/portal_mcp/service.py
@@ -29,6 +29,12 @@ class PortalToolService:
 
     # --- write surface (data development assistant) ---------------------------
 
+    async def preview_create_table(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.preview_create_table(payload))
+
+    async def create_table(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._wrap(self.backend_client.create_table(payload))
+
     async def create_task(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._wrap(self.backend_client.create_task(payload))
 

--- a/dataagent/portal-mcp/tests/test_write_tools.py
+++ b/dataagent/portal-mcp/tests/test_write_tools.py
@@ -91,6 +91,8 @@ async def test_build_mcp_server_registers_write_tools():
     tools = await mcp.list_tools()
     names = {t.name for t in tools}
     for expected in {
+        "portal_preview_create_table",
+        "portal_create_table",
         "portal_create_task",
         "portal_update_task",
         "portal_get_task",
@@ -109,6 +111,56 @@ async def test_build_mcp_server_registers_write_tools():
         assert expected in names, f"missing tool {expected}"
     # read tools still present
     assert "portal_search_tables" in names
+
+
+def test_create_table_input_serializes_to_camel_case():
+    from portal_mcp.app import CreateTableInput
+
+    inp = CreateTableInput(
+        db_name="dwd",
+        layer="dwd",
+        update_type="di",
+        table_model="DUPLICATE",
+        bucket_num=10,
+        replica_num=3,
+        key_columns=["dt", "order_id"],
+        distribution_columns=["order_id"],
+        doris_cluster_id=5,
+        columns=[{"column_name": "order_id", "data_type": "BIGINT", "comment": "订单ID"}],
+    )
+    payload = inp.model_dump(by_alias=True, exclude_none=True)
+
+    # Backend (AgentTableCreateRequest / TableCreateRequest) expects camelCase.
+    assert payload["dbName"] == "dwd"
+    assert payload["bucketNum"] == 10
+    assert payload["replicaNum"] == 3
+    assert payload["keyColumns"] == ["dt", "order_id"]
+    assert payload["distributionColumns"] == ["order_id"]
+    assert payload["dorisClusterId"] == 5
+    assert payload["columns"][0]["columnName"] == "order_id"
+    assert payload["columns"][0]["dataType"] == "BIGINT"
+    # snake_case must not leak into the backend payload.
+    assert "db_name" not in payload
+    assert "column_name" not in payload["columns"][0]
+
+
+def test_create_table_requires_at_least_one_column():
+    from portal_mcp.app import CreateTableInput
+
+    with pytest.raises(ValidationError):
+        CreateTableInput(db_name="dwd", columns=[])
+
+
+@pytest.mark.anyio
+async def test_create_table_service_methods_delegate_to_backend():
+    backend = RecordingBackend()
+    service = PortalToolService(backend)
+
+    await service.preview_create_table({"dbName": "dwd", "columns": []})
+    await service.create_table({"dbName": "dwd", "columns": [], "dorisClusterId": 5})
+
+    names = [c[0] for c in backend.calls]
+    assert names == ["preview_create_table", "create_table"]
 
 
 def test_operator_contextvar_propagates_into_request_headers(monkeypatch):

--- a/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
+++ b/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
@@ -164,10 +164,10 @@
 - **场景 SQL 模板**:新增 `reference/50-sql-scenarios.md`(每日增量/全量快照/聚合/关联拉宽/
   UNIQUE upsert),写入采用**先删再增**(`DELETE ... WHERE dt` → `INSERT INTO`)以支持重跑幂等;
   `INSERT OVERWRITE ... PARTITION` 作为 Doris 2.0+ 的等效替代在说明中提及。
-- **DDL 精简**:规范与模板去掉 `storage_format=V2` / `compression=LZ4`(Doris 默认值,无需显式
-  写),PROPERTIES 一般只留 `replication_num`。注:后端 `DorisTableEngineHandler.buildCreateDdl`
-  仍会写这两项(引擎默认、无害),Data Studio UI 建表沿用之;仅技能侧指导做了精简,若需后端
-  建表模板也一并去掉,是一处独立的 Java 改动。
+- **DDL 精简**:去掉 `storage_format=V2` / `compression=LZ4`(Doris 默认值,无需显式写),
+  PROPERTIES 只留 `replication_num`。技能规范/模板与**后端建表模板同步精简**——
+  `DorisTableEngineHandler.buildCreateDdl` 不再输出这两项(并修正 `replication_num` 尾逗号),
+  故建表工具与 Data Studio UI 建表产出的 DDL 一致。
 - **前端(与 DDL 无关的并行 UX 修复)**:widget 权限模式下拉在 `isBusy` 时也可切换——
   权限模式于 run 起始快照,忙时切换只影响下一轮,与 chat v2 行为一致
   (`WidgetChat.vue` 去掉 `isBusy` 禁用)。

--- a/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
+++ b/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
@@ -162,7 +162,12 @@
   无 error 级风险),必要时 `portal_query_readonly` 只读抽样核对 SELECT,**验证通过才建任务/
   加入计划**;含写操作整段 SQL 不试跑。
 - **场景 SQL 模板**:新增 `reference/50-sql-scenarios.md`(每日增量/全量快照/聚合/关联拉宽/
-  UNIQUE upsert),作为加工 SQL 起手式。
+  UNIQUE upsert),写入采用**先删再增**(`DELETE ... WHERE dt` → `INSERT INTO`)以支持重跑幂等;
+  `INSERT OVERWRITE ... PARTITION` 作为 Doris 2.0+ 的等效替代在说明中提及。
+- **DDL 精简**:规范与模板去掉 `storage_format=V2` / `compression=LZ4`(Doris 默认值,无需显式
+  写),PROPERTIES 一般只留 `replication_num`。注:后端 `DorisTableEngineHandler.buildCreateDdl`
+  仍会写这两项(引擎默认、无害),Data Studio UI 建表沿用之;仅技能侧指导做了精简,若需后端
+  建表模板也一并去掉,是一处独立的 Java 改动。
 - **前端(与 DDL 无关的并行 UX 修复)**:widget 权限模式下拉在 `isBusy` 时也可切换——
   权限模式于 run 起始快照,忙时切换只影响下一轮,与 chat v2 行为一致
   (`WidgetChat.vue` 去掉 `isBusy` 禁用)。

--- a/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
+++ b/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
@@ -1,0 +1,155 @@
+# 数据开发 DDL 规范与建表工具 Design
+
+## Context
+
+数据开发全流程(`opendataworks-data-dev` 技能 + portal MCP 写工具)当前能完成
+「生成/润色 SQL → 建任务 → 组装工作流 → 发布/上线 → 配调度」,但**建表环节是断的**:
+
+- portal MCP **没有建表工具**(只有 create/update task、create/update workflow、
+  publish、schedule)。新表的建表 DDL 由模型凭通用知识自由生成,只能落进任务 SQL
+  或以文本交给用户手动执行。
+- `opendataworks-data-dev` 技能只有命名与校验规则(`assets/dev-policies.json`)和任务
+  字段(`reference/10-task-fields.md`),**没有任何引擎建表规范**。
+- 结果:模型生成的 DDL 常不满足目标引擎(尤以 **Doris** 为甚)的建表规范——缺
+  `DISTRIBUTED BY ... BUCKETS`、`replication_num`、表模型(Duplicate/Aggregate/Unique)、
+  分区等,与平台实际建表约定不一致。
+
+而平台后端**已有引擎感知的建表能力,且是建表约定的权威来源**:
+
+- `service/TableCreateService`
+  - `preview(request)`:生成表名 + 建表 DDL(只读,不执行)。
+  - `create(request)`(`@Transactional`):校验 → 构建 DDL(或用传入的 `dorisDdl`)→
+    写元数据 → 在引擎执行建表 → 记录版本。
+  - 当前**仅 Doris**:`tableEngineHandlerRegistry.require(DatasourceType.DORIS)`。
+- `service/table/TableEngineHandler`(引擎抽象)+ `DorisTableEngineHandler.buildCreateDdl()`
+  编码的 Doris 真实约定:
+  - `CREATE TABLE \`db\`.\`t\` (...) ENGINE=OLAP`
+  - 表模型 `DUPLICATE`(默认/明细)`/AGGREGATE/UNIQUE` + `KEY(col, ...)`,KEY 列前置
+  - `PARTITION BY RANGE(col) ()`
+  - `DISTRIBUTED BY HASH(col, ...) BUCKETS n`(`bucketNum` 默认 **10**)
+  - `PROPERTIES("replication_num"="3"(默认), "storage_format"="V2", "compression"="LZ4")`
+- `dto/TableCreateRequest`:结构化字段(表名由 layer/businessDomain/dataDomain/
+  customIdentifier/statisticsCycle/updateType 组件经 `TableNameGeneratorService` 生成;
+  columns、tableModel、keyColumns、distributionColumns、bucketNum、replicaNum、
+  partitionColumn、tableComment、dorisClusterId、syncToDoris、可选 dorisDdl)。
+- AI 面向端点层:portal-mcp 的 `backend_client.py` 统一走 `/v1/ai/*`(如 `/v1/ai/task`、
+  `/v1/ai/workflow`、`/v1/ai/metadata/ddl`)→ AI 控制器 → `agentapi/service/BackendAgent*Service`
+  桥 → 领域服务。
+
+## Problem
+
+两个独立缺口:
+
+1. **知识缺口**:模型没有引擎建表规范可依,生成 DDL 不合规(Doris 尤甚;MySQL 也需
+   规范约束)。
+2. **能力缺口**:即便 DDL 正确,数据开发会话也没有「执行建表」的受控工具,断了
+   「需求 → 建表 → 建任务 → 工作流 → 发布」的闭环。
+
+## Goal
+
+- **G1(第一优先)**:在 `opendataworks-data-dev` 技能内补一份**引擎感知的建表规范
+  reference(Doris + MySQL)**,对齐后端 `DorisTableEngineHandler` 的真实约定,作为模型
+  生成/校验 DDL 的单一依据。
+- **G2(第二优先)**:新增受控**建表工具 `portal_create_table`**,复用
+  `TableCreateService` 在目标引擎执行 DDL;经统一权限门确认(**批准即执行,无需附言**),
+  接入 data-dev 技能 playbook,补齐建表闭环。
+
+## Non-Goals
+
+- 不新增 MySQL 引擎的后端建表 handler。后端当前仅注册 Doris handler;`portal_create_table`
+  初版**仅 Doris 执行**。MySQL 的 DDL 规范先作为**知识指导**(用于生成/校验、落任务 SQL),
+  待后端补 MySQL handler 再放开工具执行。
+- 不改表名生成/校验链路(沿用 `TableNameGeneratorService` 与 `dev-policies.json`)。
+- 不改 plan/审批链路(沿用 `2026-06-26-widget-plan-mode-approval` 的 `can_use_tool` 门控);
+  建表工具复用现有确认卡机制。
+- 不引入独立技能。按用户确认,DDL 规范并入现有 data-dev 技能的 reference(零 DB 迁移)。
+
+## Design
+
+### G1 —— DDL 规范知识(并入 data-dev 技能)
+
+新增 `dataagent/.claude/skills/opendataworks-data-dev/reference/40-ddl-standards.md`,分引擎:
+
+- **通用**:命名沿用 `dev-policies.json`(层前缀 ods/dwd/dws/dim/ads);每列必须
+  `COMMENT`;显式 `NOT NULL`/`NULL`;默认值书写;时间/数值/字符串类型选择;避免保留字。
+- **Doris**(严格对齐 `buildCreateDdl`):
+  - `ENGINE=OLAP`;表模型选择:
+    - **明细表 = `DUPLICATE`**(默认,保留明细、不去重)
+    - 聚合 = `AGGREGATE`(建表即固定聚合方式,列变更受限)
+    - 主键去重/需 upsert = **`UNIQUE KEY(...)`**
+  - KEY 列(`keyColumns`)前置且顺序敏感,是前缀索引与排序键。
+  - `DISTRIBUTED BY HASH(高基数列) BUCKETS n` —— 见「分桶数量建议」。
+  - `replication_num`:本地/测试单副本 = `1`;生产默认 = `3`。
+  - 分区:`PARTITION BY RANGE(时间列)`,大表按时间分区;可选动态分区
+    `dynamic_partition.*`(与后端解析约定一致:`replication_allocation`/
+    `dynamic_partition.replication_allocation`)。
+  - 固定 `PROPERTIES`:`storage_format=V2`、`compression=LZ4`。
+  - 类型注意:无 `UNSIGNED`;超大整数用 `LARGEINT`;`DATETIME` 无隐式默认;`DECIMAL(p,s)`
+    精度显式;`VARCHAR(n)` 按字节;字符串大字段用 `STRING`。
+  - **分桶数量建议**:单 bucket 目标数据量约 `1–10GB`;非分区表按全表估算,分区表按
+    **单分区**估算;小表最少 `1–10` 桶,避免过度分桶;分桶键选高基数且查询高频的等值列
+    (常为 join/过滤键),避免数据倾斜。
+- **MySQL**(知识先行):`ENGINE=InnoDB`;`DEFAULT CHARSET=utf8mb4`;显式 `PRIMARY KEY`;
+  合理二级索引;`AUTO_INCREMENT`;`TIMESTAMP` vs `DATETIME` 语义;`UNSIGNED`、
+  `TINYINT(1)` 布尔约定;可选分区。
+
+新增 `dataagent/.claude/skills/opendataworks-data-dev/assets/engine-ddl-rules.json`:
+机器可读的默认值/约束,与后端默认严格一致,供模型快速取默认值——
+`doris`: `default_bucket_num=10`、`default_replica_num=3`、`table_models`、`fixed_properties`;
+`mysql`: `engine=InnoDB`、`charset=utf8mb4`。
+
+更新 `SKILL.md`:在「SQL 生成/润色」与「创建任务」之间加**建表**步骤,指向
+`reference/40-ddl-standards.md`;明确「新表先按引擎规范产出并核对 DDL,再经
+`portal_create_table` 执行或落入任务定义」。
+
+### G2 —— 建表工具 `portal_create_table`
+
+**后端**(复用 `TableCreateService`,不重复造 DDL):
+
+- 新增 `agentapi/service/BackendAgentTableService`(仿 `BackendAgentTaskService`),桥接
+  `TableCreateService.preview/create`,并接入 `AgentDataScope` 过滤与既有鉴权。
+- 在 AI 控制器层(与 `/v1/ai/task`、`/v1/ai/metadata/ddl` 同层)加端点:
+  - `POST /v1/ai/table/preview` → `TableCreateService.preview`(生成表名 + DDL,**只读**)
+  - `POST /v1/ai/table` → `TableCreateService.create`(**执行建表**)
+
+**portal-mcp**:
+
+- `backend_client.py` 增 `preview_create_table`/`create_table` 调用。
+- `app.py` 注册两个工具:
+  - `portal_preview_create_table`(只读预览:返回表名 + 规范化 DDL + 是否已存在)
+  - `portal_create_table`(执行建表)
+- 输入 schema 映射 `TableCreateRequest` 关键字段。**优先传结构化字段让后端构建规范 DDL**
+  (保证表名与 DDL 内表名一致);`dorisDdl` 作为高级可选项。`title`/`summary` 作为确认卡
+  注解(门控会 strip,不下发领域工具)。
+
+**权限门**(`core/permission_gate.py`):
+
+- `portal_create_table` 加入 `HIGH_RISK_TOOL_NAMES` —— 执行真实引擎 DDL、变更 schema、
+  不可逆,值得每次确认;`default`/`acceptEdits` 下均触发确认卡,`plan` 下 deny。
+  **批准即执行,无需附言**(符合用户诉求;沿用现有 allow/deny 决策链路,覆盖
+  批准/拒绝/取消/超时)。
+- `portal_preview_create_table` 只读,不入写集,自动放行。
+
+**技能接线**:`SKILL.md` 与 `reference/30-tool-recipes.md` 增建表工具配方——
+先 `portal_preview_create_table` 展示表名 + DDL + 差异 →(确认)→ `portal_create_table`,
+与「发布前强制预览」的既有安全范式一致。
+
+### Interfaces
+
+- `portal_create_table` 入参(映射 `TableCreateRequest`):`dbName`、表名组件
+  (`layer`/`businessDomain`/`dataDomain`/`customIdentifier`/`statisticsCycle`/`updateType`)、
+  `columns[]`、`tableModel`、`keyColumns[]`、`distributionColumns[]`、`bucketNum`、
+  `replicaNum`、`partitionColumn`、`tableComment`、`dorisClusterId`、`syncToDoris`、
+  可选 `dorisDdl`;确认卡注解 `title`/`summary`。
+- 高危分类:`portal_create_table` → HIGH_RISK;`portal_preview_create_table` → 只读。
+
+## Tradeoffs
+
+- **复用 `TableCreateService` 而非在 MCP/技能侧自拼 DDL**:单一权威、与手动建表完全一致、
+  复用事务与版本记录。代价:初版仅 Doris(后端约束),MySQL 执行后置。
+- **`portal_create_table` 归 HIGH_RISK**:建表不可逆,每次确认更稳;批准即执行、无需附言,
+  正好符合用户对「建表工具」的预期。
+- **MySQL 知识先行、执行后置**:避免为放开工具而仓促新增后端 MySQL handler;规范知识对
+  「生成/校验 DDL、落任务 SQL」已有即时价值。
+- 规范并入 data-dev 技能而非独立技能:零 DB 迁移、改动最小,落在 DDL 实际生成处;若日后
+  本体建模等流程也要复用,再提升为独立技能。

--- a/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
+++ b/docs/design/2026-07-24-data-dev-ddl-authoring-design.md
@@ -153,3 +153,16 @@
   「生成/校验 DDL、落任务 SQL」已有即时价值。
 - 规范并入 data-dev 技能而非独立技能:零 DB 迁移、改动最小,落在 DDL 实际生成处;若日后
   本体建模等流程也要复用,再提升为独立技能。
+
+## Follow-up(同批,应用户反馈)
+
+- **DDL vs DML 边界**:新目标表一律走 `portal_create_table` 直接建表,**不创建执行 DDL 的
+  数据任务**;数据任务只承载 DML 加工逻辑。已在 SKILL.md 建表/建任务步骤明确。
+- **DML 落任务前必须验证**:DML SQL 先经 `portal_analyze_sql` 解析通过(输入/输出表可解析、
+  无 error 级风险),必要时 `portal_query_readonly` 只读抽样核对 SELECT,**验证通过才建任务/
+  加入计划**;含写操作整段 SQL 不试跑。
+- **场景 SQL 模板**:新增 `reference/50-sql-scenarios.md`(每日增量/全量快照/聚合/关联拉宽/
+  UNIQUE upsert),作为加工 SQL 起手式。
+- **前端(与 DDL 无关的并行 UX 修复)**:widget 权限模式下拉在 `isBusy` 时也可切换——
+  权限模式于 run 起始快照,忙时切换只影响下一轮,与 chat v2 行为一致
+  (`WidgetChat.vue` 去掉 `isBusy` 禁用)。

--- a/docs/plans/2026-07-24-data-dev-ddl-authoring-plan.md
+++ b/docs/plans/2026-07-24-data-dev-ddl-authoring-plan.md
@@ -72,3 +72,13 @@
 - `portal_create_table` 初版仅 Doris(后端仅 Doris handler);MySQL 仅有 DDL 规范知识,
   不经工具执行。
 - 建表为不可逆 DDL,统一按 HIGH_RISK 每次确认;plan 模式下 deny,仅出方案。
+
+## Follow-up 任务(同批,应用户反馈)
+
+10. data-dev 技能:SKILL.md 明确「建表走工具、不建 DDL 任务」与「DML 落任务前必须
+    `portal_analyze_sql` 验证通过」;新增 `reference/50-sql-scenarios.md` 场景模板;
+    `test_builtin_skill_content.py` 增断言。
+11. 前端(独立小改):`WidgetChat.vue` 去掉权限模式下拉的 `isBusy` 禁用(忙时可切,只影响
+    下一轮);`WidgetChat.spec.js` 增断言。chat v2 已无此禁用,无需改。
+
+验证:skill content pytest(12 passed);`vitest run WidgetChat.spec.js`(29 passed)。

--- a/docs/plans/2026-07-24-data-dev-ddl-authoring-plan.md
+++ b/docs/plans/2026-07-24-data-dev-ddl-authoring-plan.md
@@ -1,0 +1,74 @@
+# 数据开发 DDL 规范与建表工具 Plan
+
+配套设计:`docs/design/2026-07-24-data-dev-ddl-authoring-design.md`
+
+## 受影响栈
+
+- DataAgent 技能:`dataagent/.claude/skills/opendataworks-data-dev`(DDL 规范 reference、
+  SKILL playbook、工具配方)
+- portal-mcp:`dataagent/portal-mcp`(建表工具注册、backend_client 调用、输入模型)
+- DataAgent 后端:`dataagent/dataagent-backend/core/permission_gate.py`(写/高危分类)
+- Java 后端:`backend`(AI 端点 + `BackendAgentTableService` 桥,复用 `TableCreateService`)
+
+## 任务
+
+### 第一优先 —— G1 DDL 规范知识(独立可交付)
+
+1. 新增 `opendataworks-data-dev/reference/40-ddl-standards.md`:通用 + Doris(对齐
+   `DorisTableEngineHandler.buildCreateDdl`:表模型/KEY 前置/DISTRIBUTED BY HASH BUCKETS/
+   replication_num/分区/storage_format=V2/compression=LZ4/类型注意/分桶数量建议)+ MySQL。
+2. 新增 `opendataworks-data-dev/assets/engine-ddl-rules.json`:doris 默认 bucket=10、
+   replica=3、table_models、fixed_properties;mysql engine=InnoDB、charset=utf8mb4。
+3. 更新 `opendataworks-data-dev/SKILL.md`:在「SQL 生成/润色」与「创建任务」之间加
+   「建表」步骤,指向 `reference/40-ddl-standards.md`。
+4. 回归测试:`dataagent/dataagent-backend/tests/test_builtin_skill_content.py` 增断言——
+   `40-ddl-standards.md` 存在,且含 Doris 关键约定(DISTRIBUTED BY / BUCKETS /
+   replication_num / DUPLICATE / UNIQUE)与 MySQL(InnoDB / utf8mb4);`engine-ddl-rules.json`
+   默认值与后端一致(bucket=10、replica=3)。
+
+### 第二优先 —— G2 建表工具
+
+5. Java 后端:
+   - 新增 `agentapi/service/BackendAgentTableService`,桥接 `TableCreateService.preview/create`
+     (仿 `BackendAgentTaskService`,接 `AgentDataScope`)。
+   - AI 控制器加 `POST /v1/ai/table/preview` 与 `POST /v1/ai/table`。
+6. portal-mcp:
+   - `backend_client.py` 增 `preview_create_table`/`create_table`。
+   - `app.py` 注册 `portal_preview_create_table`(只读)与 `portal_create_table`(执行);
+     输入模型映射 `TableCreateRequest`(优先结构化字段,`dorisDdl` 可选)。
+7. 权限门:`core/permission_gate.py` 把 `portal_create_table` 加入 `HIGH_RISK_TOOL_NAMES`;
+   `portal_preview_create_table` 保持只读。
+8. 技能接线:`SKILL.md` + `reference/30-tool-recipes.md` 增建表配方(先 preview 后 create,
+   强制预览)。
+
+### 文档
+
+9. 本 design/plan;`docs/handbook` 数据开发/工具处补一句建表工具与 DDL 规范来源。
+
+## 验证
+
+### G1(本次可完成)
+- `.venv-py313` 下 `pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py`。
+- 技能文档放置/命名/交叉链接与仓库规则一致性核对。
+
+### G2
+- portal-mcp:`pytest dataagent/portal-mcp/tests`(工具注册与参数映射;新增 create_table 用例)。
+- 权限门:`pytest dataagent/dataagent-backend/tests/test_permission_gate.py`
+  (`portal_create_table` ∈ 写且高危、plan deny;`portal_preview_create_table` 只读放行)。
+- Java:touched 模块最小编译/单测(`BackendAgentTableService`)。
+- 端到端 smoke(本地 MySQL 127.0.0.1:3316 + Redis 127.0.0.1:6379 + backend + 前端,环境可用时):
+  topic → 「新建一张 dwd 明细表 …」→ `portal_preview_create_table` 出表名 + DDL →
+  确认卡 → 批准 → Doris 执行建表 → 元数据落库 → 终态消息持久化;拒绝路径验证不建表。
+  记录 MySQL/Redis/Python venv、是否真实 provider、各场景通过/跳过。
+
+## 回滚
+
+- G1 为技能内新增文件 + SKILL 引用 + 测试断言,回滚即删除文件与断言,无破坏性变更。
+- G2 改动集中在新增端点/工具/高危分类;回滚即摘除 `portal_create_table` 注册与
+  `permission_gate` 高危项,后端新增端点独立、可单独下线。
+
+## 已知限制
+
+- `portal_create_table` 初版仅 Doris(后端仅 Doris handler);MySQL 仅有 DDL 规范知识,
+  不经工具执行。
+- 建表为不可逆 DDL,统一按 HIGH_RISK 每次确认;plan 模式下 deny,仅出方案。


### PR DESCRIPTION
## 背景

数据开发全流程实测中暴露两个缺口:

1. **生成的建表 DDL 不满足引擎规范**(Doris 尤甚)。`portal-mcp` 此前**没有建表工具**,`opendataworks-data-dev` 技能里也**没有任何引擎建表规范**——建表 DDL 由模型凭通用知识自由生成,缺表模型、分桶、副本、分区等约定。
2. **建表环节是断的**。即便 DDL 正确,会话里也没有受控的「执行建表」能力,`需求 → 建表 → 建任务 → 工作流 → 发布` 无法闭环。

配套文档:`docs/design/2026-07-24-data-dev-ddl-authoring-design.md` / `docs/plans/2026-07-24-data-dev-ddl-authoring-plan.md`

## 改动

### 1. DDL 规范知识(并入 data-dev 技能)

- 新增 `reference/40-ddl-standards.md`:Doris + MySQL 建表规范,**对齐后端 `DorisTableEngineHandler` 的真实约定**——表模型(明细 `DUPLICATE` / 去重 `UNIQUE KEY` / 聚合 `AGGREGATE`)、KEY 列前置、`DISTRIBUTED BY HASH ... BUCKETS`、**分桶数量建议**(单桶 1–10GB、分区表按单分区估算)、`replication_num`、分区、类型注意(无 unsigned、`LARGEINT`、`STRING`)。
- 新增 `assets/engine-ddl-rules.json`:机器可读默认值,与后端一致(桶=10、副本=3)。
- 新增 `reference/50-sql-scenarios.md`:场景 SQL 模板(每日增量 / 全量快照 / 聚合 / 关联拉宽 / UNIQUE upsert),写入统一采用**先删再增**(`DELETE ... WHERE dt` → `INSERT INTO`)以支持重跑幂等。

### 2. 建表工具(执行 DDL)

复用现有引擎感知的 `TableCreateService`,未重复造 DDL:

- **backend-agent-api**:`AgentTableController`(`POST /v1/ai/table/preview` 只读、`POST /v1/ai/table` 执行)、`AgentTableService`、`AgentTableCreateRequest`。
- **backend**:`BackendAgentTableService` 桥接 `TableCreateService.preview/create`,记录 operator 为 owner,校验 agent 数据范围。
- **portal-mcp**:`portal_preview_create_table`(只读)与 `portal_create_table`(执行),snake_case → camelCase 映射。
- **权限门**:`portal_create_table` 归入 `HIGH_RISK_TOOL_NAMES` —— 执行不可逆 DDL,`default`/`acceptEdits` 下**每次确认**、`plan` 下 deny;**批准即执行,无需附言**。预览工具保持只读。

### 3. 技能 playbook 收敛

- **建表走工具、不建「DDL 任务」**:新目标表一律 `portal_create_table` 直接建,数据任务只承载 DML。
- **DML 落任务前必须验证通过**:先 `portal_analyze_sql` 解析(输入/输出表可解析、无 error 级风险),必要时 `portal_query_readonly` 只读抽样核对 SELECT;验证不过不建任务、不加入计划。

### 4. 附带修复

- **DDL 精简**:去掉 `storage_format=V2` / `compression=LZ4`(Doris 默认值)。技能规范与**后端建表模板同步精简**——`DorisTableEngineHandler.buildCreateDdl` 不再输出这两项并修正 `replication_num` 尾逗号,故建表工具与 Data Studio 页面建表产出的 DDL 一致。
- **widget 权限模式忙时可切**:`WidgetChat.vue` 去掉权限下拉的 `isBusy` 禁用。权限模式在 run 起始快照,忙时切换只影响下一轮 —— 与 chat v2 行为一致(它本就无此禁用)。

## 验证

| 范围 | 结果 |
| --- | --- |
| `mvn -pl backend -am test` | BUILD SUCCESS — `BackendAgentTableServiceTest` 3、`DorisTableEngineHandlerTest` 1、`DorisCreateTableUtilsTest` 11 |
| `pytest tests/test_permission_gate.py` | 11 passed(含建表工具高危分类) |
| `pytest tests/test_builtin_skill_content.py` | 12 passed(含 DDL 规范与场景模板断言) |
| `pytest tests/test_write_tools.py`(portal-mcp) | 8 passed(含 camelCase 映射与工具注册) |
| `vitest run WidgetChat.spec.js` | 29 passed(含忙时下拉可用断言) |

**未跑**:端到端 smoke。需要 MySQL/Redis/dataagent-backend + **真实 Doris 集群**,当前环境不具备。已验证层级如上,建表工具的真实 DDL 执行路径仍待联调验证。

## 已知限制

- `portal_create_table` 初版**仅 Doris**(后端仅注册 Doris engine handler);MySQL 的 DDL 规范为知识先行,用于生成/核对与落任务 SQL,不经工具执行。
- 建表为不可逆 DDL,统一按 HIGH_RISK 每次确认;`plan` 模式下 deny,仅出方案。

## 回滚

技能侧为新增文件 + 引用,删除即回滚。工具侧改动集中在新增端点/工具/高危分类,摘除 `portal_create_table` 注册与 `permission_gate` 高危项即可,新增后端端点独立可单独下线。

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2ZfUJ1Hhay6Knqy9Cy4Ws)_