### PR TITLE
feat(dataagent): plan 模式审批卡以文档形态呈现计划

### DIFF
--- a/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
+++ b/dataagent/dataagent-frontend/src/views/intelligence/PermissionConfirmationCard.vue
@@ -4,7 +4,26 @@
       <span class="v2-perm-badge">{{ riskLabel }}</span>
       <span class="v2-perm-title">{{ block.title || (isPlan ? '请确认执行计划' : ('请确认操作：' + bareTool)) }}</span>
     </div>
-    <div v-if="block.summary" class="v2-perm-summary" :class="{ 'is-plan': isPlan }">{{ block.summary }}</div>
+    <!-- Plan body reads as a document: the model writes the plan in markdown
+         (headings, ordered steps, code), so render it instead of showing raw
+         markup. Non-plan summaries stay plain text — they are short tool blurbs. -->
+    <template v-if="isPlan && block.summary">
+      <div
+        ref="planBodyRef"
+        class="v2-perm-plan"
+        :class="{ 'is-collapsed': !planExpanded }"
+        v-html="renderedPlan"
+      />
+      <button
+        v-if="planOverflows"
+        type="button"
+        class="v2-perm-plan-toggle"
+        @click="planExpanded = !planExpanded"
+      >
+        {{ planExpanded ? '收起' : '展开全文' }}
+      </button>
+    </template>
+    <div v-else-if="block.summary" class="v2-perm-summary">{{ block.summary }}</div>
     <div v-if="!isPlan" class="v2-perm-tool">工具：<code>{{ bareTool }}</code></div>
     <details v-if="!isPlan && hasPreview" class="v2-perm-preview">
       <summary>参数详情</summary>
@@ -20,7 +39,9 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+
+import { renderMarkdown } from './chatMessage'
 
 const props = defineProps({
   block: { type: Object, required: true },
@@ -40,6 +61,31 @@ const bareTool = computed(() => {
   return name.startsWith('mcp__') ? name.split('__').pop() : name
 })
 const isPlan = computed(() => props.block.risk_level === 'plan')
+// renderMarkdown escapes the source before parsing, so model-authored plan text
+// cannot inject markup here.
+const renderedPlan = computed(() => (isPlan.value ? renderMarkdown(props.block.summary) : ''))
+
+// A long plan collapses to a readable height with a "展开全文" toggle; the toggle
+// only appears when the body actually overflows.
+const planExpanded = ref(false)
+const planBodyRef = ref(null)
+const planOverflows = ref(false)
+const measurePlanOverflow = async () => {
+  await nextTick()
+  const el = planBodyRef.value
+  if (!el) {
+    planOverflows.value = false
+    return
+  }
+  // Measuring an expanded body says nothing about whether it overflows when
+  // collapsed — keep the current flag so the "收起" toggle stays reachable.
+  if (planExpanded.value) return
+  // scrollHeight/clientHeight are 0 in non-layout environments (jsdom), which
+  // simply leaves the toggle hidden.
+  planOverflows.value = el.scrollHeight > el.clientHeight + 4
+}
+onMounted(measurePlanOverflow)
+watch([() => props.block.summary, isPlan], measurePlanOverflow)
 const riskLabel = computed(() => {
   if (props.block.risk_level === 'plan') return '执行计划'
   if (props.block.risk_level === 'critical') return '高危操作'
@@ -109,16 +155,83 @@ function decide(decision) {
 .risk-plan .v2-perm-badge { background: #3b82f6; }
 .v2-perm-title { font-weight: 600; font-size: 14px; }
 .v2-perm-summary { font-size: 13px; color: #555; margin: 4px 0; white-space: pre-wrap; }
-.v2-perm-summary.is-plan {
-  max-height: 320px;
-  overflow: auto;
+
+/* The plan reads as a document: roomy surface, markdown typography, and a
+   collapse that fades out rather than cutting a line in half. */
+.v2-perm-plan {
+  position: relative;
+  font-size: 13px;
+  color: #333;
+  line-height: 1.65;
   background: #fff;
   border: 1px solid #e3ecfb;
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin: 8px 0 0;
+  overflow: hidden;
+}
+.v2-perm-plan.is-collapsed {
+  max-height: 460px;
+  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 48px), transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 48px), transparent 100%);
+}
+.v2-perm-plan-toggle {
+  border: none;
+  background: none;
+  color: #2563eb;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 6px 2px 0;
+}
+.v2-perm-plan-toggle:hover { text-decoration: underline; }
+
+.v2-perm-plan :deep(h1),
+.v2-perm-plan :deep(h2),
+.v2-perm-plan :deep(h3) {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 14px 0 6px;
+  line-height: 1.4;
+}
+.v2-perm-plan :deep(h1:first-child),
+.v2-perm-plan :deep(h2:first-child),
+.v2-perm-plan :deep(h3:first-child) { margin-top: 0; }
+.v2-perm-plan :deep(p) { margin: 0 0 8px; }
+.v2-perm-plan :deep(p:last-child) { margin: 0; }
+.v2-perm-plan :deep(ul), .v2-perm-plan :deep(ol) { margin: 0 0 8px; padding-left: 20px; }
+.v2-perm-plan :deep(li) { margin: 3px 0; }
+.v2-perm-plan :deep(li::marker) { color: #64748b; }
+.v2-perm-plan :deep(code) {
+  background: #eef1f6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.v2-perm-plan :deep(pre) {
+  background: #f4f7fb;
   border-radius: 6px;
   padding: 10px 12px;
-  margin: 6px 0;
-  line-height: 1.5;
+  overflow-x: auto;
+  margin: 8px 0;
 }
+.v2-perm-plan :deep(pre code) { background: none; padding: 0; }
+.v2-perm-plan :deep(table) { border-collapse: collapse; width: 100%; margin: 8px 0; }
+.v2-perm-plan :deep(th), .v2-perm-plan :deep(td) {
+  border: 1px solid #dbe3ef;
+  padding: 5px 10px;
+  font-size: 12px;
+  text-align: left;
+}
+.v2-perm-plan :deep(th) { background: #f4f7fb; font-weight: 600; }
+.v2-perm-plan :deep(blockquote) {
+  margin: 8px 0;
+  padding-left: 10px;
+  border-left: 3px solid #dbe3ef;
+  color: #64748b;
+}
+.v2-perm-plan :deep(hr) { border: none; border-top: 1px solid #e3ecfb; margin: 12px 0; }
+.v2-perm-plan :deep(a) { color: #2563eb; }
 .v2-perm-tool { font-size: 12px; color: #777; margin: 4px 0; }
 .v2-perm-tool code { background: #eef1f6; padding: 1px 5px; border-radius: 4px; }
 .v2-perm-preview { margin: 6px 0; }

--- a/dataagent/dataagent-frontend/src/views/intelligence/__tests__/PermissionConfirmationCard.spec.js
+++ b/dataagent/dataagent-frontend/src/views/intelligence/__tests__/PermissionConfirmationCard.spec.js
@@ -1,0 +1,93 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import PermissionConfirmationCard from '../PermissionConfirmationCard.vue'
+
+const planBlock = (overrides = {}) => ({
+  type: 'permission_request',
+  requestId: 'req-1',
+  tool_name: 'ExitPlanMode',
+  risk_level: 'plan',
+  title: '请确认执行计划',
+  summary: [
+    '## 目标',
+    '新建订单明细表并接入日增量加工。',
+    '',
+    '### 步骤',
+    '1. 建表 `dwd_user_order_di`',
+    '2. 建 DML 任务',
+    '',
+    '- 分桶 10',
+    '- 副本 3',
+  ].join('\n'),
+  payload_preview: { plan: 'x' },
+  decision: 'pending',
+  ...overrides,
+})
+
+const writeBlock = (overrides = {}) => ({
+  type: 'permission_request',
+  requestId: 'req-2',
+  tool_name: 'mcp__portal__portal_create_table',
+  risk_level: 'critical',
+  title: '请确认操作',
+  summary: '新建表 dwd_user_order_di',
+  payload_preview: { dbName: 'dwd' },
+  decision: 'pending',
+  ...overrides,
+})
+
+describe('PermissionConfirmationCard plan rendering', () => {
+  it('renders the plan body as markdown instead of raw text', () => {
+    const wrapper = mount(PermissionConfirmationCard, { props: { block: planBlock() } })
+    const body = wrapper.get('.v2-perm-plan')
+
+    // Markdown structure is realized as elements, so the plan reads as a document.
+    expect(body.findAll('h2').length).toBeGreaterThan(0)
+    expect(body.findAll('li').length).toBeGreaterThan(0)
+    expect(body.find('code').exists()).toBe(true)
+    // ...and the raw markup is not shown to the user.
+    expect(body.text()).not.toContain('## 目标')
+    expect(body.text()).not.toContain('- 分桶 10')
+    expect(body.text()).toContain('目标')
+  })
+
+  it('escapes HTML embedded in a model-authored plan', () => {
+    const wrapper = mount(PermissionConfirmationCard, {
+      props: { block: planBlock({ summary: 'before <img src=x onerror=alert(1)> after' }) },
+    })
+    const body = wrapper.get('.v2-perm-plan')
+    expect(body.find('img').exists()).toBe(false)
+    expect(body.text()).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('labels the plan actions as approve/refine and keeps the plan after a decision', async () => {
+    const wrapper = mount(PermissionConfirmationCard, { props: { block: planBlock() } })
+    const buttons = wrapper.findAll('.v2-perm-btn').map((b) => b.text())
+    expect(buttons).toContain('批准并执行')
+    expect(buttons).toContain('继续完善')
+
+    await wrapper.setProps({ block: planBlock({ decision: 'allow' }) })
+    // The decided plan stays readable in the transcript; only the actions collapse.
+    expect(wrapper.find('.v2-perm-plan').exists()).toBe(true)
+    expect(wrapper.findAll('.v2-perm-btn')).toHaveLength(0)
+    expect(wrapper.get('.v2-perm-result').text()).toContain('计划已批准')
+  })
+
+  it('emits the decision with the request id', async () => {
+    const wrapper = mount(PermissionConfirmationCard, { props: { block: planBlock() } })
+    const approve = wrapper.findAll('.v2-perm-btn').find((b) => b.text() === '批准并执行')
+    await approve.trigger('click')
+    expect(wrapper.emitted('decide')[0]).toEqual([{ requestId: 'req-1', decision: 'allow' }])
+  })
+
+  it('leaves non-plan confirmation cards as plain-text summaries with tool details', () => {
+    const wrapper = mount(PermissionConfirmationCard, { props: { block: writeBlock() } })
+    expect(wrapper.find('.v2-perm-plan').exists()).toBe(false)
+    expect(wrapper.get('.v2-perm-summary').text()).toBe('新建表 dwd_user_order_di')
+    expect(wrapper.get('.v2-perm-tool').text()).toContain('portal_create_table')
+    const buttons = wrapper.findAll('.v2-perm-btn').map((b) => b.text())
+    expect(buttons).toContain('允许')
+    expect(buttons).toContain('拒绝')
+  })
+})

--- a/docs/design/2026-06-26-widget-plan-mode-approval-design.md
+++ b/docs/design/2026-06-26-widget-plan-mode-approval-design.md
@@ -109,6 +109,9 @@ prod 同),因其需挂载的 docker socket 拉起子沙箱;Claude Code 拒绝 ro
 - 前端 `chatMessage.js` 的 `permission_request` 投影对 `risk_level==='plan'` 渲染
   "计划待批准"卡片(展示计划全文 + 批准/拒绝),复用现有确认卡决策链路;两个入口
   (NL2SqlChatV2 / WidgetChat)模式选择器补 tooltip 使标签承诺与行为一致。
+- 计划正文以 **markdown 渲染**(`PermissionConfirmationCard.vue` 复用 `chatMessage.renderMarkdown`,
+  先转义再解析),长计划折叠到 460px 并提供"展开全文";决策后正文保留在对话中可回溯。
+  仍不落工作区文件——"可查看的计划文档"由该卡片承担,Non-Goal 不变。
 
 ## Tradeoffs
 


### PR DESCRIPTION
## 背景

Plan 模式实测反馈:**没有一份可查看的"计划文档"**。

核对下来,计划卡本身是有的(随 #390 落地,chat v2 与 widget 都接了 `PermissionConfirmationCard`):它持久化 `ExitPlanMode` 的计划文本、展示全文、按钮为「批准并执行 / 继续完善」,决策后正文仍保留在对话中。

但**呈现方式不像文档**:计划正文以 `{{ block.summary }}` **纯文本**渲染,挤在 320px 的滚动框里。而计划本身是 markdown(`##` 标题、编号步骤、列表、代码块),纯文本渲染就是一整坨字 —— 仓库里 `marked` / `renderMarkdown` 到处在用,唯独这张卡没用。

## 改动

仅 `PermissionConfirmationCard.vue` 一个组件:

| 之前 | 现在 |
| --- | --- |
| 纯文本 `{{ block.summary }}` | **markdown 渲染** —— 标题、编号步骤、列表、代码、表格、引用均有文档排版 |
| `max-height: 320px` 硬滚动 | 折叠到 460px + 底部渐隐,**溢出时才**出现「展开全文 / 收起」 |
| 行高紧凑 | 文档级留白与字号层级 |

实现要点:

- 复用 `chatMessage.renderMarkdown` —— 它**先 `escapeHtml` 再 `marked.parse`**,因此模型撰写的计划无法注入 HTML(有专门测试锁定)。
- `v-html` 内容不受 scoped CSS 影响,markdown 子元素样式一律用 `:deep()`(与 `.v2-text-block` 既有写法一致)。
- 溢出探测只在**收起态**进行,避免展开后「收起」按钮消失;jsdom 下 `scrollHeight/clientHeight` 为 0,自然不显示按钮,不影响测试。
- **非计划确认卡行为不变**(仍是纯文本 summary + 工具名 + 参数详情)。

## 不做什么

**不落工作区计划文件** —— `2026-06-26-widget-plan-mode-approval-design.md` 的 Non-Goal(计划存 MySQL、不写工作区文件)保持不变;"可查看的计划文档"由这张卡承担。该设计文档已补一句说明现状。

## 验证

| 范围 | 结果 |
| --- | --- |
| `PermissionConfirmationCard.spec.js`(新增) | 5 passed — markdown 结构、HTML 转义、决策后正文保留、按钮文案、非计划卡不受影响 |
| `WidgetChat.spec.js` | 29 passed |
| `NL2SqlChatV2.spec.js` | 20 passed |
| `sdkBlockProjection.contract.spec.js` | 15 passed |
| `chatMessage.spec.js` | 17 passed |

合计 **81 passed**,两个消费方均无回归。

纯前端改动,生效需重新构建部署 `dataagent-frontend`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2ZfUJ1Hhay6Knqy9Cy4Ws)_