### PR TITLE
Add declarative methodology DAG skill for reusable analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ dolphinscheduler-service/*.egg-info/
 !/dataagent/.claude/skills/ontology-modeling-assistant/**
 !/dataagent/.claude/skills/opendataworks-data-dev/
 !/dataagent/.claude/skills/opendataworks-data-dev/**
+!/dataagent/.claude/skills/opendataworks-methodology-dag/
+!/dataagent/.claude/skills/opendataworks-methodology-dag/**
+# Skills carry their own pytest suites; the allowlist above must not re-admit
+# the caches those runs leave behind.
+**/.pytest_cache/
 *.swp
 *.swo
 *~

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/SKILL.md
@@ -20,17 +20,30 @@ tools: [Read, Bash, Glob, Grep]
 ## 前置依赖
 
 本技能的 `sql` 节点通过 `opendataworks-platform-tools` 的 `run_sql.py` 执行只读查询，
-以复用平台既有的只读校验、数据范围校验和失败归因。
+以复用平台既有的只读校验、数据范围校验和失败归因。脚本自己定位它：默认取同级目录
+`../opendataworks-platform-tools`，宿主可用 `DATAAGENT_PLATFORM_SKILL_ROOT` 覆盖。
 
-**必须与 `opendataworks-platform-tools` 同时启用。** 未启用时执行会返回
+**必须与 `opendataworks-platform-tools` 一起安装并启用。** 两者都不存在时执行会返回
 `error_code=platform_tools_unavailable`；此时说明缺少执行入口，不要改用其他方式取数。
+
+## 脚本怎么调
+
+所有脚本都在本技能目录的 `scripts/` 下，**路径一律相对本 SKILL.md 所在目录**。
+先切到本技能目录再执行，不要把仓库路径、部署路径或工作区路径写死到命令里：
+
+```bash
+cd <本技能目录> && python3 scripts/<name>.py ...
+```
+
+`<本技能目录>` 就是你读到这份 SKILL.md 的那个目录。脚本自身会解析它自己的位置
+（注册表、schema、同级技能都由脚本自行定位），所以只要能进到这个目录，命令就能跑。
 
 ## Playbook
 
 1. **先检索，再决定**。拿到用户问题后先查注册表：
 
    ```bash
-   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<用户问题>"
+   cd <本技能目录> && python3 scripts/lookup_methodology.py --query "<用户问题>"
    ```
 
    返回每个候选的 `intent`、`caliber`、参数槽位和输出字段。**这一步不执行任何查询。**
@@ -38,7 +51,7 @@ tools: [Read, Bash, Glob, Grep]
 2. **命中且参数齐全 → 一次执行拿最终结果**：
 
    ```bash
-   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '{"days":30}'
+   cd <本技能目录> && python3 scripts/run_methodology.py --id <id> --params '{"days":30}'
    ```
 
    输出契约与 `run_sql.py` 一致（`kind=sql_execution`），可直接收口回答，也可直接喂给

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/SKILL.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: opendataworks-methodology-dag
+description: "当问数请求命中一个已固化口径的多步分析方法论时使用：环比/同比增长、Top-N 后再取数、跨引擎结果合并、按条件切换统计口径。提供方法论检索、静态校验与一次性执行。不用于临时探索型问数、语义建模或数据开发。"
+tools: [Read, Bash, Glob, Grep]
+---
+
+# OpenDataWorks Methodology DAG Skill
+
+本技能把「多步分析方法论」从模型每次现场重写的 SQL，变成**注册表里的声明式工件**：
+一张有向无环图，节点是带类型的执行步骤，边是数据依赖。执行由引擎负责——按需求值、
+共享依赖只算一次、独立分支自动并行、未选中的条件分支永不执行。
+
+它解决两件事：
+
+- **口径不再漂移**。同一个业务问题每次都走同一张图、同一套口径，结果可复核。
+- **一次调用替代多轮往返**。依赖查询、结果合并、条件切换都在一次工具调用里完成。
+
+它不做语义建模，不做数据开发，不替代常规问数链路。**未命中注册方法论时必须回落。**
+
+## 前置依赖
+
+本技能的 `sql` 节点通过 `opendataworks-platform-tools` 的 `run_sql.py` 执行只读查询，
+以复用平台既有的只读校验、数据范围校验和失败归因。
+
+**必须与 `opendataworks-platform-tools` 同时启用。** 未启用时执行会返回
+`error_code=platform_tools_unavailable`；此时说明缺少执行入口，不要改用其他方式取数。
+
+## Playbook
+
+1. **先检索，再决定**。拿到用户问题后先查注册表：
+
+   ```bash
+   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<用户问题>"
+   ```
+
+   返回每个候选的 `intent`、`caliber`、参数槽位和输出字段。**这一步不执行任何查询。**
+
+2. **命中且参数齐全 → 一次执行拿最终结果**：
+
+   ```bash
+   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '{"days":30}'
+   ```
+
+   输出契约与 `run_sql.py` 一致（`kind=sql_execution`），可直接收口回答，也可直接喂给
+   `build_chart_spec.py` 出图。**不要再逐节点自己拼 SQL 重跑一遍。**
+
+3. **参数缺失** → 返回 `error_code=param_missing` 并列出缺的槽位。
+   只追问这些槽位，不要自行假定口径、不要用默认值蒙混。
+
+4. **未命中** → 返回 `matched=0`。回落到 `opendataworks-platform-tools` 的常规链路
+   （语义确认 → SQL 生成 → `validate_sql.py` → `run_sql.py`）。这是一等路径，不是错误。
+
+5. **回答时必须说明口径**。方法论输出里的 `methodology.caliber` 就是这次统计的口径，
+   连同参数一起写进回答。
+
+## 硬性规则
+
+- 命中方法论后**不得**为了"跑得更快"或"结果更好看"绕过它自己写 SQL。
+  绕过就是口径漂移，正是本技能要消除的东西。
+- 不得为了让某次运行通过而临时修改注册表里的 `caliber`、`sql` 或参数默认值。
+  口径变更是一次独立的评审动作，必须同时升 `version`。
+- 不得猜测方法论 `id`。只用 `lookup_methodology.py` 返回的 id。
+- 不得把 `run_methodology.py` 当成通用 SQL 执行器；它只跑注册表里的图。
+  临时 SQL 仍然走 `run_sql.py`。
+- 执行返回 `result_state=empty_result` 时，说明口径下确实无数据，
+  解释口径与空结果即可，**不要换方法论或改参数反复试探**。
+- 执行返回 `result_state=failed` 时，按 `error_code`、`failure_attribution`、
+  `stop_reason` 说明原因，不要等价重试。
+
+## 参考文档
+
+| 文档 | 用途 |
+|---|---|
+| [`reference/10-model.md`](reference/10-model.md) | 节点类型、依赖语义、求值规则 |
+| [`reference/20-authoring.md`](reference/20-authoring.md) | 怎么写一个新方法论，含三种典型结构 |
+| [`reference/30-invocation.md`](reference/30-invocation.md) | 三个脚本的完整调用契约，含 mock 模式 |
+| [`reference/40-output-contract.md`](reference/40-output-contract.md) | 输出 JSON 与失败归因 |
+
+## 与其他技能的分工
+
+- `opendataworks-business-knowledge`：**单表达式指标**（`metrics.json` 的 `metric_key` /
+  `formula`）继续留在那里。只有需要多步、依赖查询或跨引擎的才升级成方法论。
+- `ontology-modeling-assistant`：本体的 `query_functions` 声明**语义契约**
+  （intent / grain / params / output_fields），本技能的工件提供**可执行体**，
+  两者通过 `ontology_ref.function_name` 关联。语义在上、执行在下，不要混写。
+- `opendataworks-platform-tools`：SQL 验证、SQL 执行、图表契约、元数据发现全部走它。
+  本技能不复制这些能力。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/methodology.schema.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/methodology.schema.json
@@ -1,0 +1,929 @@
+{
+  "$defs": {
+    "CallNode": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "methodology_id": {
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Methodology Id",
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Params",
+          "type": "object"
+        },
+        "type": {
+          "const": "call",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "methodology_id"
+      ],
+      "title": "CallNode",
+      "type": "object"
+    },
+    "ConditionalNode": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "else_node": {
+          "title": "Else Node",
+          "type": "string"
+        },
+        "then_node": {
+          "title": "Then Node",
+          "type": "string"
+        },
+        "type": {
+          "const": "conditional",
+          "title": "Type",
+          "type": "string"
+        },
+        "when": {
+          "title": "When",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "when",
+        "then_node",
+        "else_node"
+      ],
+      "title": "ConditionalNode",
+      "type": "object"
+    },
+    "LiteralNode": {
+      "additionalProperties": false,
+      "properties": {
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Columns",
+          "type": "array"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "rows": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Rows",
+          "type": "array"
+        },
+        "type": {
+          "const": "literal",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "LiteralNode",
+      "type": "object"
+    },
+    "OntologyRef": {
+      "additionalProperties": false,
+      "properties": {
+        "function_name": {
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Function Name",
+          "type": "string"
+        },
+        "skill": {
+          "title": "Skill",
+          "type": "string"
+        }
+      },
+      "required": [
+        "skill",
+        "function_name"
+      ],
+      "title": "OntologyRef",
+      "type": "object"
+    },
+    "ParamSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "default": null,
+          "title": "Default"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "max_items": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Items"
+        },
+        "maximum": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Maximum"
+        },
+        "minimum": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Minimum"
+        },
+        "name": {
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "title": "Required",
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "int",
+            "float",
+            "bool",
+            "enum",
+            "date",
+            "string_list"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Values",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "description"
+      ],
+      "title": "ParamSpec",
+      "type": "object"
+    },
+    "Predicate": {
+      "additionalProperties": false,
+      "description": "One node of the predicate DSL.\n\nLeaf predicates carry ``field`` plus ``value``/``values``; a leaf whose bound\nvalue resolves to null is dropped at compile time, so an absent optional\nparameter simply makes its filter disappear. Composite predicates\n(``and``/``or``/``not``) carry ``clauses``.",
+      "properties": {
+        "clauses": {
+          "items": {
+            "$ref": "#/$defs/Predicate"
+          },
+          "title": "Clauses",
+          "type": "array"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Field"
+        },
+        "op": {
+          "enum": [
+            "eq",
+            "ne",
+            "lt",
+            "lte",
+            "gt",
+            "gte",
+            "like",
+            "in",
+            "between",
+            "and",
+            "or",
+            "not"
+          ],
+          "title": "Op",
+          "type": "string"
+        },
+        "value": {
+          "default": null,
+          "title": "Value"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Values"
+        }
+      },
+      "required": [
+        "op"
+      ],
+      "title": "Predicate",
+      "type": "object"
+    },
+    "SortSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "title": "Field",
+          "type": "string"
+        },
+        "order": {
+          "default": "asc",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "title": "Order",
+          "type": "string"
+        }
+      },
+      "required": [
+        "field"
+      ],
+      "title": "SortSpec",
+      "type": "object"
+    },
+    "SqlNode": {
+      "additionalProperties": false,
+      "properties": {
+        "database": {
+          "title": "Database",
+          "type": "string"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "engine": {
+          "anyOf": [
+            {
+              "enum": [
+                "mysql",
+                "doris"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Engine"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        },
+        "predicates": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Predicate"
+          },
+          "title": "Predicates",
+          "type": "object"
+        },
+        "sql": {
+          "title": "Sql",
+          "type": "string"
+        },
+        "type": {
+          "const": "sql",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "database",
+        "sql"
+      ],
+      "title": "SqlNode",
+      "type": "object"
+    },
+    "SqliteNode": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "primary_keys": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": "Primary Keys",
+          "type": "object"
+        },
+        "sql": {
+          "title": "Sql",
+          "type": "string"
+        },
+        "type": {
+          "const": "sqlite",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "dependencies",
+        "type",
+        "sql"
+      ],
+      "title": "SqliteNode",
+      "type": "object"
+    },
+    "TransformNode": {
+      "additionalProperties": false,
+      "properties": {
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 1,
+          "minItems": 1,
+          "title": "Dependencies",
+          "type": "array"
+        },
+        "derive": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Derive",
+          "type": "object"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Filter"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        },
+        "rename": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Rename",
+          "type": "object"
+        },
+        "select": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Select",
+          "type": "array"
+        },
+        "sort": {
+          "items": {
+            "$ref": "#/$defs/SortSpec"
+          },
+          "title": "Sort",
+          "type": "array"
+        },
+        "type": {
+          "const": "transform",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "dependencies",
+        "type"
+      ],
+      "title": "TransformNode",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "caliber": {
+      "title": "Caliber",
+      "type": "string"
+    },
+    "id": {
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "title": "Id",
+      "type": "string"
+    },
+    "intent": {
+      "title": "Intent",
+      "type": "string"
+    },
+    "name_en": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Name En"
+    },
+    "name_zh": {
+      "title": "Name Zh",
+      "type": "string"
+    },
+    "nodes": {
+      "additionalProperties": {
+        "discriminator": {
+          "mapping": {
+            "call": "#/$defs/CallNode",
+            "conditional": "#/$defs/ConditionalNode",
+            "literal": "#/$defs/LiteralNode",
+            "sql": "#/$defs/SqlNode",
+            "sqlite": "#/$defs/SqliteNode",
+            "transform": "#/$defs/TransformNode"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/SqlNode"
+          },
+          {
+            "$ref": "#/$defs/SqliteNode"
+          },
+          {
+            "$ref": "#/$defs/TransformNode"
+          },
+          {
+            "$ref": "#/$defs/LiteralNode"
+          },
+          {
+            "$ref": "#/$defs/ConditionalNode"
+          },
+          {
+            "$ref": "#/$defs/CallNode"
+          }
+        ]
+      },
+      "minProperties": 1,
+      "title": "Nodes",
+      "type": "object"
+    },
+    "notes": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Notes"
+    },
+    "ontology_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OntologyRef"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "output_fields": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Output Fields",
+      "type": "array"
+    },
+    "owner": {
+      "title": "Owner",
+      "type": "string"
+    },
+    "params": {
+      "items": {
+        "$ref": "#/$defs/ParamSpec"
+      },
+      "title": "Params",
+      "type": "array"
+    },
+    "synonyms": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Synonyms",
+      "type": "array"
+    },
+    "target": {
+      "title": "Target",
+      "type": "string"
+    },
+    "version": {
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "version",
+    "name_zh",
+    "intent",
+    "caliber",
+    "owner",
+    "nodes",
+    "target"
+  ],
+  "title": "Methodology",
+  "type": "object",
+  "x-field-dictionary": {
+    "nodes.type": {
+      "title": "nodes.type",
+      "values": {
+        "call": {
+          "description": "调用注册表中的另一个方法论，是复用单元；调用链禁止成环",
+          "group": "control",
+          "label_zh": "调用方法论"
+        },
+        "conditional": {
+          "description": "先求谓词再解析二选一分支；未选中分支及其子图不执行",
+          "group": "control",
+          "label_zh": "条件分支"
+        },
+        "literal": {
+          "description": "固定的行集合，例如维度到列名的映射表",
+          "group": "compute",
+          "label_zh": "常量表"
+        },
+        "sql": {
+          "description": "执行模板化只读 SQL，经平台工具 run_sql.py 走后端只读查询链路",
+          "group": "query",
+          "label_zh": "只读查询"
+        },
+        "sqlite": {
+          "description": "把依赖节点结果装入内存 SQLite 后执行完整 SQL，支持跨引擎 join 与集合运算",
+          "group": "compute",
+          "label_zh": "内存关系计算"
+        },
+        "transform": {
+          "description": "对单个依赖结果做行级过滤、派生列、改名、排序和截断",
+          "group": "compute",
+          "label_zh": "表变换"
+        }
+      }
+    },
+    "params.type": {
+      "title": "params.type",
+      "values": {
+        "bool": {
+          "label_zh": "布尔"
+        },
+        "date": {
+          "description": "YYYY-MM-DD",
+          "label_zh": "日期"
+        },
+        "enum": {
+          "description": "取值必须命中 values",
+          "label_zh": "枚举"
+        },
+        "float": {
+          "label_zh": "浮点数"
+        },
+        "int": {
+          "label_zh": "整数"
+        },
+        "string": {
+          "label_zh": "字符串"
+        },
+        "string_list": {
+          "description": "用于 IN 列表",
+          "label_zh": "字符串列表"
+        }
+      }
+    },
+    "placeholder_forms": {
+      "title": "SQL 模板占位符",
+      "values": {
+        "{{ expr }}": {
+          "description": "求值结果必须是标量或标量数组；标量转义加引号，数组展开为逗号列表。值无法逃出字面量位置。",
+          "label_zh": "受检值"
+        },
+        "{{! expr }}": {
+          "description": "只允许标识符（列名、表别名）。必须匹配 ^[A-Za-z_][A-Za-z0-9_.]*$ 或命中参数 values 枚举。",
+          "label_zh": "标识符片段"
+        },
+        "{{? name }}": {
+          "description": "引用本节点 predicates 里的同名谓词；null 子谓词被丢弃，全空时渲染为空串。",
+          "label_zh": "谓词片段"
+        }
+      }
+    },
+    "predicates.op": {
+      "title": "predicates.op",
+      "values": {
+        "and": {
+          "arity": "clauses",
+          "label_zh": "与"
+        },
+        "between": {
+          "arity": "field+values(2)",
+          "label_zh": "区间"
+        },
+        "eq": {
+          "arity": "field+value",
+          "label_zh": "等于"
+        },
+        "gt": {
+          "arity": "field+value",
+          "label_zh": "大于"
+        },
+        "gte": {
+          "arity": "field+value",
+          "label_zh": "大于等于"
+        },
+        "in": {
+          "arity": "field+values",
+          "label_zh": "属于"
+        },
+        "like": {
+          "arity": "field+value",
+          "label_zh": "模糊匹配"
+        },
+        "lt": {
+          "arity": "field+value",
+          "label_zh": "小于"
+        },
+        "lte": {
+          "arity": "field+value",
+          "label_zh": "小于等于"
+        },
+        "ne": {
+          "arity": "field+value",
+          "label_zh": "不等于"
+        },
+        "not": {
+          "arity": "clauses(1)",
+          "label_zh": "非"
+        },
+        "or": {
+          "arity": "clauses",
+          "label_zh": "或"
+        }
+      }
+    },
+    "sort.order": {
+      "title": "sort.order",
+      "values": {
+        "asc": {
+          "label_zh": "升序"
+        },
+        "desc": {
+          "label_zh": "降序"
+        }
+      }
+    },
+    "sql.engine": {
+      "title": "sql.engine",
+      "values": {
+        "doris": {
+          "label_zh": "Doris"
+        },
+        "mysql": {
+          "label_zh": "MySQL"
+        }
+      }
+    },
+    "top_level_fields": {
+      "title": "顶层字段",
+      "values": {
+        "caliber": {
+          "description": "统计口径：时间字段、区间、过滤与排除规则",
+          "required": "是",
+          "type": "string"
+        },
+        "id": {
+          "description": "snake_case 方法论标识，注册表内唯一",
+          "required": "是",
+          "type": "string"
+        },
+        "intent": {
+          "description": "本方法论回答什么问题",
+          "required": "是",
+          "type": "string"
+        },
+        "name_zh": {
+          "description": "中文名",
+          "required": "是",
+          "type": "string"
+        },
+        "nodes": {
+          "description": "节点名到节点定义的映射",
+          "required": "是",
+          "type": "object"
+        },
+        "ontology_ref": {
+          "description": "关联的本体 query_function",
+          "required": "否",
+          "type": "object"
+        },
+        "output_fields": {
+          "description": "target 节点预期输出列",
+          "required": "否",
+          "type": "string[]"
+        },
+        "owner": {
+          "description": "口径责任人或团队",
+          "required": "是",
+          "type": "string"
+        },
+        "params": {
+          "description": "参数槽位声明",
+          "required": "否",
+          "type": "object[]"
+        },
+        "synonyms": {
+          "description": "检索用同义词",
+          "required": "否",
+          "type": "string[]"
+        },
+        "target": {
+          "description": "目标节点名；执行只走到它的传递依赖为止",
+          "required": "是",
+          "type": "string"
+        },
+        "version": {
+          "description": "语义化版本；口径变更必须升版本",
+          "required": "是",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/table_growth_ratio.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/table_growth_ratio.json
@@ -6,8 +6,18 @@
   "intent": "按数仓分层统计本期与上一等长周期的新增建表数，并计算环比增长率",
   "caliber": "口径字段为 data_table.created_at；只统计 deleted = 0 的表；上期区间与本期等长且不重叠；上期为 0 的分层不参与环比计算，会被剔除。",
   "owner": "data-platform",
-  "synonyms": ["建表数环比", "分层建表增长", "数据表增长率", "table growth"],
-  "output_fields": ["layer", "current_cnt", "previous_cnt", "growth"],
+  "synonyms": [
+    "建表数环比",
+    "分层建表增长",
+    "数据表增长率",
+    "table growth"
+  ],
+  "output_fields": [
+    "layer",
+    "current_cnt",
+    "previous_cnt",
+    "growth"
+  ],
   "notes": "对应论文 HeadcountGrowth 结构：previous 依赖 current 并把它返回的分层拼进 IN 列表；current 同时被 previous 与 growth 依赖，引擎只执行一次。",
   "params": [
     {
@@ -24,7 +34,13 @@
       "type": "enum",
       "description": "只看某一个数仓分层；不传则覆盖全部分层",
       "required": false,
-      "values": ["ODS", "DWD", "DIM", "DWS", "ADS"]
+      "values": [
+        "ODS",
+        "DWD",
+        "DIM",
+        "DWS",
+        "ADS"
+      ]
     }
   ],
   "target": "growth",
@@ -35,16 +51,22 @@
       "database": "opendataworks",
       "engine": "mysql",
       "predicates": {
-        "layer_filter": { "op": "eq", "field": "layer", "value": "$params.layer" }
+        "layer_filter": {
+          "op": "eq",
+          "field": "layer",
+          "value": "$params.layer"
+        }
       },
-      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_filter }}\nGROUP BY layer"
+      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM opendataworks.data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_filter }}\nGROUP BY layer"
     },
     "previous": {
       "type": "sql",
       "description": "上一等长周期各分层新增建表数，范围收敛到本期出现过的分层",
       "database": "opendataworks",
       "engine": "mysql",
-      "dependencies": ["current"],
+      "dependencies": [
+        "current"
+      ],
       "predicates": {
         "layer_scope": {
           "op": "in",
@@ -52,13 +74,23 @@
           "values": "$pluck(current.rows, 'layer')"
         }
       },
-      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days * 2 }} DAY)\n  AND created_at < DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_scope }}\nGROUP BY layer"
+      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM opendataworks.data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days * 2 }} DAY)\n  AND created_at < DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_scope }}\nGROUP BY layer"
     },
     "growth": {
       "type": "sqlite",
       "description": "内存 join 两期结果并计算环比增长率",
-      "dependencies": ["current", "previous"],
-      "primary_keys": { "current": ["layer"], "previous": ["layer"] },
+      "dependencies": [
+        "current",
+        "previous"
+      ],
+      "primary_keys": {
+        "current": [
+          "layer"
+        ],
+        "previous": [
+          "layer"
+        ]
+      },
       "sql": "SELECT c.layer AS layer,\n       c.table_cnt AS current_cnt,\n       p.table_cnt AS previous_cnt,\n       CAST(c.table_cnt - p.table_cnt AS REAL) / p.table_cnt AS growth\nFROM current c\nINNER JOIN previous p ON c.layer = p.layer\nWHERE p.table_cnt > 0\nORDER BY growth DESC"
     }
   }

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/table_growth_ratio.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/table_growth_ratio.json
@@ -1,0 +1,65 @@
+{
+  "id": "table_growth_ratio",
+  "version": "1.0.0",
+  "name_zh": "数据表分层环比增长",
+  "name_en": "Table growth ratio by layer",
+  "intent": "按数仓分层统计本期与上一等长周期的新增建表数，并计算环比增长率",
+  "caliber": "口径字段为 data_table.created_at；只统计 deleted = 0 的表；上期区间与本期等长且不重叠；上期为 0 的分层不参与环比计算，会被剔除。",
+  "owner": "data-platform",
+  "synonyms": ["建表数环比", "分层建表增长", "数据表增长率", "table growth"],
+  "output_fields": ["layer", "current_cnt", "previous_cnt", "growth"],
+  "notes": "对应论文 HeadcountGrowth 结构：previous 依赖 current 并把它返回的分层拼进 IN 列表；current 同时被 previous 与 growth 依赖，引擎只执行一次。",
+  "params": [
+    {
+      "name": "days",
+      "type": "int",
+      "description": "本期天数；上期取紧邻的等长区间",
+      "required": false,
+      "default": 30,
+      "minimum": 1,
+      "maximum": 365
+    },
+    {
+      "name": "layer",
+      "type": "enum",
+      "description": "只看某一个数仓分层；不传则覆盖全部分层",
+      "required": false,
+      "values": ["ODS", "DWD", "DIM", "DWS", "ADS"]
+    }
+  ],
+  "target": "growth",
+  "nodes": {
+    "current": {
+      "type": "sql",
+      "description": "本期各分层新增建表数",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "predicates": {
+        "layer_filter": { "op": "eq", "field": "layer", "value": "$params.layer" }
+      },
+      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_filter }}\nGROUP BY layer"
+    },
+    "previous": {
+      "type": "sql",
+      "description": "上一等长周期各分层新增建表数，范围收敛到本期出现过的分层",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "dependencies": ["current"],
+      "predicates": {
+        "layer_scope": {
+          "op": "in",
+          "field": "layer",
+          "values": "$pluck(current.rows, 'layer')"
+        }
+      },
+      "sql": "SELECT layer, COUNT(id) AS table_cnt\nFROM data_table\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days * 2 }} DAY)\n  AND created_at < DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? layer_scope }}\nGROUP BY layer"
+    },
+    "growth": {
+      "type": "sqlite",
+      "description": "内存 join 两期结果并计算环比增长率",
+      "dependencies": ["current", "previous"],
+      "primary_keys": { "current": ["layer"], "previous": ["layer"] },
+      "sql": "SELECT c.layer AS layer,\n       c.table_cnt AS current_cnt,\n       p.table_cnt AS previous_cnt,\n       CAST(c.table_cnt - p.table_cnt AS REAL) / p.table_cnt AS growth\nFROM current c\nINNER JOIN previous p ON c.layer = p.layer\nWHERE p.table_cnt > 0\nORDER BY growth DESC"
+    }
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/top_owner_task_growth.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/top_owner_task_growth.json
@@ -6,8 +6,19 @@
   "intent": "先选出任务数最多的 Top-N 负责人，再针对这些负责人统计近期新增任务数与增量占比",
   "caliber": "只统计 data_task 中 deleted = 0 且 owner 非空的任务；Top-N 按历史累计任务数排序；近期区间以 created_at 为口径。",
   "owner": "data-platform",
-  "synonyms": ["任务最多的人", "负责人任务排行", "top负责人", "任务增量排行", "top owner"],
-  "output_fields": ["owner", "total_cnt", "recent_cnt", "recent_share"],
+  "synonyms": [
+    "任务最多的人",
+    "负责人任务排行",
+    "top负责人",
+    "任务增量排行",
+    "top owner"
+  ],
+  "output_fields": [
+    "owner",
+    "total_cnt",
+    "recent_cnt",
+    "recent_share"
+  ],
   "notes": "对应论文 Top skills 结构：一次 Top-N 选择喂给第二轮参数化查询，中间用谓词把选中实体收敛进 IN 列表。",
   "params": [
     {
@@ -36,14 +47,16 @@
       "description": "按历史累计任务数选出 Top-N 负责人",
       "database": "opendataworks",
       "engine": "mysql",
-      "sql": "SELECT owner, COUNT(id) AS total_cnt\nFROM data_task\nWHERE deleted = 0\n  AND owner IS NOT NULL\n  AND owner <> ''\nGROUP BY owner\nORDER BY total_cnt DESC\nLIMIT {{ params.top_n }}"
+      "sql": "SELECT owner, COUNT(id) AS total_cnt\nFROM opendataworks.data_task\nWHERE deleted = 0\n  AND owner IS NOT NULL\n  AND owner <> ''\nGROUP BY owner\nORDER BY total_cnt DESC\nLIMIT {{ params.top_n }}"
     },
     "recent_by_owner": {
       "type": "sql",
       "description": "只针对选中的负责人统计近期新增任务数",
       "database": "opendataworks",
       "engine": "mysql",
-      "dependencies": ["top_owners"],
+      "dependencies": [
+        "top_owners"
+      ],
       "predicates": {
         "owner_scope": {
           "op": "in",
@@ -51,13 +64,20 @@
           "values": "$pluck(top_owners.rows, 'owner')"
         }
       },
-      "sql": "SELECT owner, COUNT(id) AS recent_cnt\nFROM data_task\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? owner_scope }}\nGROUP BY owner"
+      "sql": "SELECT owner, COUNT(id) AS recent_cnt\nFROM opendataworks.data_task\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? owner_scope }}\nGROUP BY owner"
     },
     "merged": {
       "type": "sqlite",
       "description": "把两轮结果合并，缺失的近期增量按 0 处理",
-      "dependencies": ["top_owners", "recent_by_owner"],
-      "primary_keys": { "top_owners": ["owner"] },
+      "dependencies": [
+        "top_owners",
+        "recent_by_owner"
+      ],
+      "primary_keys": {
+        "top_owners": [
+          "owner"
+        ]
+      },
       "sql": "SELECT t.owner AS owner,\n       t.total_cnt AS total_cnt,\n       COALESCE(r.recent_cnt, 0) AS recent_cnt,\n       CAST(COALESCE(r.recent_cnt, 0) AS REAL) / t.total_cnt AS recent_share\nFROM top_owners t\nLEFT JOIN recent_by_owner r ON t.owner = r.owner\nORDER BY t.total_cnt DESC"
     }
   }

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/top_owner_task_growth.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/top_owner_task_growth.json
@@ -1,0 +1,64 @@
+{
+  "id": "top_owner_task_growth",
+  "version": "1.0.0",
+  "name_zh": "任务数 Top-N 负责人的近期增量",
+  "name_en": "Top-N owners by task count with recent growth",
+  "intent": "先选出任务数最多的 Top-N 负责人，再针对这些负责人统计近期新增任务数与增量占比",
+  "caliber": "只统计 data_task 中 deleted = 0 且 owner 非空的任务；Top-N 按历史累计任务数排序；近期区间以 created_at 为口径。",
+  "owner": "data-platform",
+  "synonyms": ["任务最多的人", "负责人任务排行", "top负责人", "任务增量排行", "top owner"],
+  "output_fields": ["owner", "total_cnt", "recent_cnt", "recent_share"],
+  "notes": "对应论文 Top skills 结构：一次 Top-N 选择喂给第二轮参数化查询，中间用谓词把选中实体收敛进 IN 列表。",
+  "params": [
+    {
+      "name": "top_n",
+      "type": "int",
+      "description": "取任务数最多的前 N 位负责人",
+      "required": false,
+      "default": 5,
+      "minimum": 1,
+      "maximum": 50
+    },
+    {
+      "name": "days",
+      "type": "int",
+      "description": "近期区间天数",
+      "required": false,
+      "default": 30,
+      "minimum": 1,
+      "maximum": 365
+    }
+  ],
+  "target": "merged",
+  "nodes": {
+    "top_owners": {
+      "type": "sql",
+      "description": "按历史累计任务数选出 Top-N 负责人",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "sql": "SELECT owner, COUNT(id) AS total_cnt\nFROM data_task\nWHERE deleted = 0\n  AND owner IS NOT NULL\n  AND owner <> ''\nGROUP BY owner\nORDER BY total_cnt DESC\nLIMIT {{ params.top_n }}"
+    },
+    "recent_by_owner": {
+      "type": "sql",
+      "description": "只针对选中的负责人统计近期新增任务数",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "dependencies": ["top_owners"],
+      "predicates": {
+        "owner_scope": {
+          "op": "in",
+          "field": "owner",
+          "values": "$pluck(top_owners.rows, 'owner')"
+        }
+      },
+      "sql": "SELECT owner, COUNT(id) AS recent_cnt\nFROM data_task\nWHERE deleted = 0\n  AND created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  {{? owner_scope }}\nGROUP BY owner"
+    },
+    "merged": {
+      "type": "sqlite",
+      "description": "把两轮结果合并，缺失的近期增量按 0 处理",
+      "dependencies": ["top_owners", "recent_by_owner"],
+      "primary_keys": { "top_owners": ["owner"] },
+      "sql": "SELECT t.owner AS owner,\n       t.total_cnt AS total_cnt,\n       COALESCE(r.recent_cnt, 0) AS recent_cnt,\n       CAST(COALESCE(r.recent_cnt, 0) AS REAL) / t.total_cnt AS recent_share\nFROM top_owners t\nLEFT JOIN recent_by_owner r ON t.owner = r.owner\nORDER BY t.total_cnt DESC"
+    }
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/workflow_publish_trend.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/workflow_publish_trend.json
@@ -1,0 +1,64 @@
+{
+  "id": "workflow_publish_trend",
+  "version": "1.0.0",
+  "name_zh": "工作流发布次数趋势",
+  "name_en": "Workflow publish trend",
+  "intent": "按天统计工作流发布次数与失败次数，并给出每日失败率；可选只看某一类发布操作",
+  "caliber": "口径字段为 workflow_publish_record.created_at；发布次数为记录条数，失败次数为 status = 'failed' 的记录数；未指定 operation 时统计全部发布操作（deploy/online/offline）。",
+  "owner": "data-platform",
+  "synonyms": ["发布趋势", "发布次数", "发布失败率", "工作流上线趋势", "publish trend"],
+  "output_fields": ["stat_date", "publish_cnt", "failed_cnt", "failed_rate"],
+  "notes": "对应论文 Talent-pool report 结构：条件节点按是否传了 operation 选择查全量表还是过滤表，未选中的分支及其子图永不执行。",
+  "params": [
+    {
+      "name": "days",
+      "type": "int",
+      "description": "统计最近多少天",
+      "required": false,
+      "default": 30,
+      "minimum": 1,
+      "maximum": 365
+    },
+    {
+      "name": "operation",
+      "type": "enum",
+      "description": "只看某一类发布操作；不传则统计全部",
+      "required": false,
+      "values": ["deploy", "online", "offline"]
+    }
+  ],
+  "target": "trend",
+  "nodes": {
+    "publish_all": {
+      "type": "sql",
+      "description": "全部发布操作的每日发布与失败次数",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\nGROUP BY DATE(created_at)"
+    },
+    "publish_scoped": {
+      "type": "sql",
+      "description": "限定单一发布操作的每日发布与失败次数",
+      "database": "opendataworks",
+      "engine": "mysql",
+      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  AND operation = {{ params.operation }}\nGROUP BY DATE(created_at)"
+    },
+    "pick": {
+      "type": "conditional",
+      "description": "没传 operation 就查全量口径，否则查过滤口径；另一条分支不执行",
+      "when": "params.operation == None",
+      "then_node": "publish_all",
+      "else_node": "publish_scoped"
+    },
+    "trend": {
+      "type": "transform",
+      "description": "补出每日失败率并按日期升序排列",
+      "dependencies": ["pick"],
+      "derive": {
+        "failed_rate": "round(float(row.failed_cnt) / float(row.publish_cnt), 4) if row.publish_cnt else 0.0"
+      },
+      "select": ["stat_date", "publish_cnt", "failed_cnt", "failed_rate"],
+      "sort": [{ "field": "stat_date", "order": "asc" }]
+    }
+  }
+}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/workflow_publish_trend.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/assets/registry/workflow_publish_trend.json
@@ -6,8 +6,19 @@
   "intent": "按天统计工作流发布次数与失败次数，并给出每日失败率；可选只看某一类发布操作",
   "caliber": "口径字段为 workflow_publish_record.created_at；发布次数为记录条数，失败次数为 status = 'failed' 的记录数；未指定 operation 时统计全部发布操作（deploy/online/offline）。",
   "owner": "data-platform",
-  "synonyms": ["发布趋势", "发布次数", "发布失败率", "工作流上线趋势", "publish trend"],
-  "output_fields": ["stat_date", "publish_cnt", "failed_cnt", "failed_rate"],
+  "synonyms": [
+    "发布趋势",
+    "发布次数",
+    "发布失败率",
+    "工作流上线趋势",
+    "publish trend"
+  ],
+  "output_fields": [
+    "stat_date",
+    "publish_cnt",
+    "failed_cnt",
+    "failed_rate"
+  ],
   "notes": "对应论文 Talent-pool report 结构：条件节点按是否传了 operation 选择查全量表还是过滤表，未选中的分支及其子图永不执行。",
   "params": [
     {
@@ -24,7 +35,11 @@
       "type": "enum",
       "description": "只看某一类发布操作；不传则统计全部",
       "required": false,
-      "values": ["deploy", "online", "offline"]
+      "values": [
+        "deploy",
+        "online",
+        "offline"
+      ]
     }
   ],
   "target": "trend",
@@ -34,14 +49,14 @@
       "description": "全部发布操作的每日发布与失败次数",
       "database": "opendataworks",
       "engine": "mysql",
-      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\nGROUP BY DATE(created_at)"
+      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM opendataworks.workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\nGROUP BY DATE(created_at)"
     },
     "publish_scoped": {
       "type": "sql",
       "description": "限定单一发布操作的每日发布与失败次数",
       "database": "opendataworks",
       "engine": "mysql",
-      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  AND operation = {{ params.operation }}\nGROUP BY DATE(created_at)"
+      "sql": "SELECT DATE(created_at) AS stat_date,\n       COUNT(id) AS publish_cnt,\n       SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_cnt\nFROM opendataworks.workflow_publish_record\nWHERE created_at >= DATE_SUB(CURDATE(), INTERVAL {{ params.days }} DAY)\n  AND operation = {{ params.operation }}\nGROUP BY DATE(created_at)"
     },
     "pick": {
       "type": "conditional",
@@ -53,12 +68,24 @@
     "trend": {
       "type": "transform",
       "description": "补出每日失败率并按日期升序排列",
-      "dependencies": ["pick"],
+      "dependencies": [
+        "pick"
+      ],
       "derive": {
         "failed_rate": "round(float(row.failed_cnt) / float(row.publish_cnt), 4) if row.publish_cnt else 0.0"
       },
-      "select": ["stat_date", "publish_cnt", "failed_cnt", "failed_rate"],
-      "sort": [{ "field": "stat_date", "order": "asc" }]
+      "select": [
+        "stat_date",
+        "publish_cnt",
+        "failed_cnt",
+        "failed_rate"
+      ],
+      "sort": [
+        {
+          "field": "stat_date",
+          "order": "asc"
+        }
+      ]
     }
   }
 }

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/10-model.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/10-model.md
@@ -1,0 +1,133 @@
+# 方法论模型
+
+先结论：一个方法论是一张**有向无环图**。节点是带类型的执行步骤，边是数据依赖，
+恰好一个节点被指定为 `target`。执行从 `target` 出发，只走到它的传递依赖为止。
+
+## 顶层结构
+
+```json
+{
+  "id": "table_growth_ratio",
+  "version": "1.0.0",
+  "name_zh": "数据表分层环比增长",
+  "intent": "本方法论回答什么问题",
+  "caliber": "统计口径：时间字段、区间、过滤与排除规则",
+  "owner": "口径责任人",
+  "synonyms": ["检索用同义词"],
+  "output_fields": ["target 节点预期输出列"],
+  "ontology_ref": {"skill": "...", "function_name": "..."},
+  "params": [ /* 参数槽位声明 */ ],
+  "nodes": { /* 节点名 -> 节点定义 */ },
+  "target": "growth"
+}
+```
+
+- `id` 是 snake_case，注册表内唯一，也是 `call` 节点和 `run_methodology.py --id` 用的名字。
+- `caliber` 不是注释，是**契约**：它会随执行结果一起回给用户。改口径必须同时升 `version`。
+- `ontology_ref.function_name` 指向本体的 `query_functions`。语义在本体、执行在这里。
+
+## 节点类型
+
+节点分三组，每个节点消费并产出一张表（`columns` + `rows`）。
+
+### query 组
+
+| type | 说明 |
+|---|---|
+| `sql` | 执行模板化只读 SQL。通过 `opendataworks-platform-tools` 的 `run_sql.py` 走后端只读查询链路，继承其只读校验、数据范围校验与失败归因。 |
+
+字段：`database`（必填）、`sql`（必填）、`engine`（`mysql`/`doris`，可选）、
+`predicates`（谓词片段声明，可选）、`limit`（可选，默认取 `DATAAGENT_QUERY_LIMIT`）。
+
+### compute 组
+
+| type | 说明 |
+|---|---|
+| `sqlite` | 把依赖节点结果按节点名建表装进**内存 SQLite**，再执行完整 SQL。这是做 join、集合运算、以及**跨引擎结果合并**的通路。 |
+| `transform` | 对**单个**依赖结果做行级过滤、派生列、改名、投影、排序、截断。 |
+| `literal` | 固定行集合，例如维度到列名的映射表。 |
+
+`sqlite` 字段：`dependencies`（至少一个）、`sql`、`primary_keys`（可选，为大输入建索引）。
+`FROM` 子句里的表名就是依赖节点名。
+
+`transform` 字段：`dependencies`（恰好一个）、`filter`、`derive`、`rename`、`select`、
+`sort`、`limit`。`derive` 按声明顺序求值，后面的表达式可以引用前面刚派生出的列。
+
+### control 组
+
+| type | 说明 |
+|---|---|
+| `conditional` | 先求 `when` 谓词，再解析二选一分支。**未选中的分支及其整个子图永不执行。** |
+| `call` | 调用注册表中的另一个方法论，是复用单元。调用链禁止成环。 |
+
+`conditional` 字段：`when`、`then_node`、`else_node`，以及求谓词所需的 `dependencies`。
+分支是**软依赖**：它们不参与预先的依赖解析，所以未取分支代价为零。
+
+`call` 字段：`methodology_id`、`params`（子方法论参数名 → 在本地上下文求值的表达式）。
+
+## 求值规则
+
+1. **只构建需要的**。从 `target` 不可达的节点永不执行；条件未选中分支及其子图也不执行。
+2. **最多构建一次**。每个节点的结果在一次运行内被 memoize。被多个节点依赖的查询只打一次库。
+3. **并行是声明出来的**。相互独立的依赖会被同时求值，方法论作者不写任何并发代码。
+4. **两级超时**。整次运行有总预算（默认 240s），单个节点另有超时（默认取
+   `DATAAGENT_SQL_READ_TIMEOUT_SECONDS`）。总预算耗尽时报 `methodology_timeout`。
+
+## 表达式上下文
+
+表达式出现在占位符、`transform` 的 `filter`/`derive`、`conditional` 的 `when`、
+`call` 的 `params`，以及谓词的 `$` 引用里。可见的名字只有：
+
+| 名字 | 内容 |
+|---|---|
+| `params` | 本次运行解析后的参数，例如 `params.days` |
+| `<依赖节点名>` | `{"columns": [...], "rows": [...], "row_count": n}`，例如 `current.rows` |
+| `row` | 仅 `transform` 内可见，当前行，例如 `row.publish_cnt` |
+
+可用函数（白名单，别的都不允许）：
+`pluck`、`coalesce`、`distinct`、`len`、`abs`、`round`、`min`、`max`、`sum`、
+`int`、`float`、`str`、`lower`、`upper`。
+
+`pluck(current.rows, 'layer')` 取出一列并丢弃 null，是构造 `IN` 列表的标准做法。
+
+表达式由受限的 AST 求值器执行：**不使用 `eval`/`exec`**，属性访问只走字典查找而非
+`getattr`，下划线开头的字段名被拒绝。因此表达式无法触达任何 Python 对象内部。
+
+## SQL 占位符
+
+`sql` 与 `sqlite` 节点的 `sql` 是模板，有三种占位符，各自的安全契约不同：
+
+| 形式 | 名称 | 契约 |
+|---|---|---|
+| `{{ expr }}` | 受检值 | 求值结果必须是标量或标量数组。标量转义后加引号，数组展开为逗号列表。**值无法逃出它的字面量位置。** |
+| `{{! expr }}` | 标识符片段 | 原样拼接，因此只接受合法标识符（列名、别名），或参数 `values` 枚举中的取值。其余一律拒绝。 |
+| `{{? name }}` | 谓词片段 | 引用本节点 `predicates` 里的同名谓词。 |
+
+绑定后的 SQL 仍然会经过 `run_sql.py` 的只读校验和后端数据范围校验。这几层是纵深防御，
+任何一层都不替代另一层。
+
+## 谓词 DSL
+
+用来从**可选参数**拼 `WHERE`，避免在模板里写分支。
+
+```json
+"predicates": {
+  "layer_filter": { "op": "eq", "field": "layer", "value": "$params.layer" }
+}
+```
+
+- `value` / `values` 以 `$` 开头时按表达式求值，否则当字面量。
+- 运算符：`eq` `ne` `lt` `lte` `gt` `gte` `like` `in` `between`，
+  以及组合运算符 `and` `or` `not`（用 `clauses` 承载子谓词）。
+- **求值为 null 的子谓词被丢弃**；全部为空时整个片段渲染成空串。
+  参数没传，过滤条件就自然消失——这就是这个 DSL 存在的理由。
+- `in` 的 `values` 可以是 `"$pluck(current.rows, 'layer')"`，空列表同样被丢弃，
+  所以上游返回 0 行时下游不会拼出非法的 `IN ()`。
+
+## 静态校验
+
+执行前，`validate_methodology.py` 会拒绝：`target` 不存在、依赖引用不存在、节点自依赖、
+依赖图成环（**报出具体环路径**）、占位符形式无法识别、表达式引用未知名字或未声明参数、
+引用未声明的谓词片段、枚举参数没有 `values`、`call` 目标不存在或调用图成环。
+
+在手写胶水里本该是运行时异常的错误，在这里是加载期拒绝。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
@@ -1,0 +1,109 @@
+# 编写一个方法论
+
+先结论：先把口径写清楚，再画依赖，最后才写 SQL。工件放在
+`assets/registry/<id>.json`，一个文件一个方法论。
+
+## 什么该做成方法论
+
+| 情况 | 归属 |
+|---|---|
+| 单个聚合表达式（`COUNT(...)`、`SUM(CASE WHEN ...)`）| 留在 `opendataworks-business-knowledge` 的 `metrics.json` |
+| 一条 SQL 能算完，口径稳定，但反复被问 | 可以做成方法论，但收益主要是口径固化 |
+| 需要**依赖查询**（先取 Top-N 再按结果二次查询）| 方法论 |
+| 需要**合并多个查询结果**（环比、同比、多口径对比）| 方法论 |
+| 需要**跨引擎**（MySQL 结果与 Doris 结果合并）| 方法论（`sqlite` 节点） |
+| 需要**按条件切换口径**（有无过滤条件走不同表）| 方法论（`conditional` 节点） |
+| 一次性探索、口径尚未确定 | 不要做成方法论，走常规问数链路 |
+
+判断标准就一条：**这个口径是不是需要被多次问、且每次都必须一致。** 是就固化，否就别固化。
+
+## 步骤
+
+1. **写 `intent` 和 `caliber`**。`caliber` 会随结果回给用户，所以必须写明：
+   用哪个时间字段、区间怎么取、排除了什么、什么情况下行会被剔除。
+   写不清楚说明口径还没确定，不要往下走。
+2. **声明参数槽位**。凡是会变的都做成参数：时间窗口、维度过滤、Top-N 的 N。
+   可选参数一律配谓词片段，不要在模板里写 `if`。
+3. **画依赖**。先想清楚哪些查询互相独立（会并行）、哪些有先后（会串行）、
+   哪个中间结果被多处引用（只会算一次）。
+4. **写节点**。查询用 `sql`，合并用 `sqlite`，补算列用 `transform`，切换口径用 `conditional`。
+5. **校验**：
+   ```bash
+   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --path assets/registry/<id>.json
+   ```
+6. **写 mock 用例并跑通**。见 [`30-invocation.md`](30-invocation.md) 的 mock 模式。
+   方法论应该能在不碰数据库的情况下被断言，这是它相对手写 SQL 最大的优势之一。
+
+## 三种典型结构
+
+### 一、链式依赖 + 内存 join（环比 / 同比）
+
+`table_growth_ratio` 是这个形态。第二次查询用第一次的结果收敛范围，
+再把两期结果 join 起来算比率。
+
+```json
+"previous": {
+  "type": "sql",
+  "dependencies": ["current"],
+  "predicates": {
+    "layer_scope": { "op": "in", "field": "layer", "values": "$pluck(current.rows, 'layer')" }
+  },
+  "sql": "SELECT layer, COUNT(id) AS table_cnt FROM data_table WHERE ... {{? layer_scope }} GROUP BY layer"
+}
+```
+
+注意 `current` 同时被 `previous` 和 `growth` 依赖——引擎只会执行它**一次**。
+这是选择声明式依赖而不是手写编排的直接收益。
+
+用 `in` 谓词而不是 `IN ({{ pluck(...) }})`：上游返回 0 行时，谓词整段消失，
+而受检值占位符会因为空列表报错。
+
+### 二、Top-N 后再取数
+
+`top_owner_task_growth` 是这个形态。第一条查询选出实体，第二条查询只针对这些实体。
+
+关键点是第二条查询的范围必须由第一条的结果收敛，否则就退化成"全表扫完再过滤"，
+方法论也就没有意义了。
+
+### 三、条件剪枝
+
+`workflow_publish_trend` 是这个形态。参数传了就查过滤口径，没传就查全量口径。
+
+```json
+"pick": {
+  "type": "conditional",
+  "when": "params.operation == None",
+  "then_node": "publish_all",
+  "else_node": "publish_scoped"
+}
+```
+
+未选中的那条分支及其整个子图**不会执行**。什么时候用 `conditional`、什么时候用谓词片段：
+
+- 只是多一个 `AND` 条件 → 用谓词片段，一个节点搞定。
+- 两个口径查的是**不同的表**或**不同的聚合方式** → 用 `conditional`。
+
+## 复用：`call` 节点
+
+当一段口径会被多个方法论共用时，把它单独注册成一个方法论，其他方法论用 `call` 调它。
+
+```json
+"base": {
+  "type": "call",
+  "methodology_id": "table_growth_ratio",
+  "params": { "days": "params.window_days" }
+}
+```
+
+这是防漂移最强的机制：两个方法论都 `call` 同一张图，它们的定义就不可能悄悄分叉。
+调用图必须无环，校验器会拒绝环。
+
+## 常见错误
+
+- **把口径写进注释而不是 `caliber`**。注释不会回给用户，`caliber` 会。
+- **用 `{{! }}` 拼用户输入**。片段占位符只给列名/别名用。任何来自用户的值都走 `{{ }}` 或谓词。
+- **忘了软删除**。`data_table` / `data_task` 都有 `deleted` 字段，漏掉就多算。
+- **`transform` 挂多个依赖**。它只接受一个；要合并多个结果请用 `sqlite`。
+- **在方法论里查元数据**。表/字段发现走 `opendataworks-platform-tools` 的元数据工具，
+  不走只读 SQL 通道。
+- **口径变了但没升 `version`**。调用方无从察觉，这正是要消除的漂移。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
@@ -48,7 +48,7 @@
   "predicates": {
     "layer_scope": { "op": "in", "field": "layer", "values": "$pluck(current.rows, 'layer')" }
   },
-  "sql": "SELECT layer, COUNT(id) AS table_cnt FROM data_table WHERE ... {{? layer_scope }} GROUP BY layer"
+  "sql": "SELECT layer, COUNT(id) AS table_cnt FROM opendataworks.data_table WHERE ... {{? layer_scope }} GROUP BY layer"
 }
 ```
 
@@ -102,6 +102,9 @@
 
 - **把口径写进注释而不是 `caliber`**。注释不会回给用户，`caliber` 会。
 - **用 `{{! }}` 拼用户输入**。片段占位符只给列名/别名用。任何来自用户的值都走 `{{ }}` 或谓词。
+- **表名不带 schema 前缀**。`sql` 节点必须写 `opendataworks.data_table`，
+  裸表名会被 `validate_sql.py` 拒绝。写完用 `--check-sql` 跑一遍就能发现。
+  （`sqlite` 节点相反：`FROM` 里写的是**依赖节点名**，不加任何前缀。）
 - **忘了软删除**。`data_table` / `data_task` 都有 `deleted` 字段，漏掉就多算。
 - **`transform` 挂多个依赖**。它只接受一个；要合并多个结果请用 `sqlite`。
 - **在方法论里查元数据**。表/字段发现走 `opendataworks-platform-tools` 的元数据工具，

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/20-authoring.md
@@ -29,7 +29,7 @@
 4. **写节点**。查询用 `sql`，合并用 `sqlite`，补算列用 `transform`，切换口径用 `conditional`。
 5. **校验**：
    ```bash
-   "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --path assets/registry/<id>.json
+   python3 scripts/validate_methodology.py --path assets/registry/<id>.json
    ```
 6. **写 mock 用例并跑通**。见 [`30-invocation.md`](30-invocation.md) 的 mock 模式。
    方法论应该能在不碰数据库的情况下被断言，这是它相对手写 SQL 最大的优势之一。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/30-invocation.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/30-invocation.md
@@ -1,0 +1,107 @@
+# 脚本调用契约
+
+先结论：只有三个脚本，统一通过
+`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/<name>.py" ...` 调用。
+
+不要自己拼脚本路径或脚本名，不要用 primary `DATAAGENT_SKILL_ROOT`、部署绝对路径、
+裸相对路径，也不要猜测其他脚本名。三个脚本之外没有别的入口。
+
+标准链路：`lookup_methodology.py` → 命中就 `run_methodology.py`，未命中就回落平台工具链路。
+
+## lookup_methodology.py
+
+- 用途：检索注册表，返回语义与参数槽位。**不执行任何查询。**
+- 适用场景：拿到用户问题后的第一步。
+- 命令模板：
+
+  ```bash
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<用户问题>"
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --id <id>
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --list
+  ```
+
+- 输出 `kind=methodology_lookup`，含 `matched`、`results[]`。每个候选带
+  `intent`、`caliber`、`params[]`、`output_fields`、`score`。
+- `matched=0` 时按 `stop_reason` 回落常规问数链路，**不要换关键词反复检索**。
+
+## run_methodology.py
+
+- 用途：执行一个已注册方法论。
+- 必须满足：`id` 来自 `lookup_methodology.py` 的返回，必填参数已齐。
+- 命令模板：
+
+  ```bash
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '<JSON 对象>'
+  ```
+
+- 参数：
+
+  | 参数 | 说明 |
+  |---|---|
+  | `--id` | 方法论 id，必填 |
+  | `--params` | JSON 对象；缺省为 `{}` |
+  | `--mock` | mock 模式的节点结果 JSON 文件，见下 |
+  | `--total-timeout` | 单次运行总预算秒数，默认 240，或取 `DATAAGENT_METHODOLOGY_TOTAL_TIMEOUT_SECONDS` |
+  | `--node-timeout` | 单节点超时秒数，默认取 `DATAAGENT_SQL_READ_TIMEOUT_SECONDS` |
+  | `--limit` | 每个查询节点的行数上限，默认取 `DATAAGENT_QUERY_LIMIT` |
+
+- 输出 `kind=sql_execution`，与 `run_sql.py` 同构，可直接收口回答或喂给
+  `build_chart_spec.py`。详见 [`40-output-contract.md`](40-output-contract.md)。
+- 结果归因：
+  - `result_state=success`：已拿到真实结果，直接收口，并在回答里带上 `methodology.caliber`。
+  - `result_state=empty_result`：口径下确实无数据，说明口径与空结果，不换方法论试探。
+  - `result_state=failed`：按 `error_code`、`failure_attribution`、`stop_reason` 说明，不等价重试。
+
+## validate_methodology.py
+
+- 用途：静态校验方法论工件。作者写完必跑；运行前 `run_methodology.py` 也会自动跑一遍。
+- 命令模板：
+
+  ```bash
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --all
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --path <file.json>
+  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --id <id>
+  ```
+
+- 加 `--check-sql` 会用桩参数绑定每个 `sql` 节点，再交给平台工具的 `validate_sql.py`。
+  平台工具不可达时该项被跳过并记为 warning，不会误报为失败。
+- 输出 `kind=methodology_validation`，退出码 0 表示全部通过。
+
+## mock 模式
+
+用作者提供的节点结果替代真实执行，**完全不访问任何数据存储**。
+一个方法论因此可以像普通单元测试一样被断言。
+
+mock 文件形如：
+
+```json
+{
+  "current":  {"rows": [{"layer": "ODS", "table_cnt": 12}]},
+  "previous": {"rows": [{"layer": "ODS", "table_cnt": 6}]}
+}
+```
+
+键是节点名，值是该节点的结果（`rows` 必填，`columns` 可省略，由 `rows` 推断）。
+被 mock 的节点直接返回给定结果，其余节点照常执行——所以上面的例子仍然会真的跑一遍
+`growth` 的内存 join。
+
+```bash
+"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" \
+  --id table_growth_ratio --params '{"days":30}' --mock <mock.json>
+```
+
+mock 模式主要给方法论作者和回归测试用；回答用户问题时不要用它，
+mock 出来的不是真实结果。
+
+## 环境依赖
+
+| 变量 | 用途 | 缺失后果 |
+|---|---|---|
+| `DATAAGENT_PYTHON_BIN` | 解释器 | 回落到当前解释器 |
+| `DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT` | 本技能根目录 | 无法定位脚本 |
+| `DATAAGENT_PLATFORM_SKILL_ROOT` | 平台工具根目录，`sql` 节点靠它执行 | `error_code=platform_tools_unavailable` |
+| `DATAAGENT_QUERY_LIMIT` | 查询节点行数上限 | 默认 1000 |
+| `DATAAGENT_SQL_READ_TIMEOUT_SECONDS` | 单节点超时 | 默认 60 |
+
+不要执行环境探测或依赖安装命令。脚本报错时优先收敛参数或向用户追问，
+不要切换解释器反复试探。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/30-invocation.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/30-invocation.md
@@ -1,10 +1,19 @@
 # 脚本调用契约
 
-先结论：只有三个脚本，统一通过
-`"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/<name>.py" ...` 调用。
+先结论：只有三个脚本，都在本技能目录的 `scripts/` 下，统一通过
 
-不要自己拼脚本路径或脚本名，不要用 primary `DATAAGENT_SKILL_ROOT`、部署绝对路径、
-裸相对路径，也不要猜测其他脚本名。三个脚本之外没有别的入口。
+```bash
+cd <本技能目录> && python3 scripts/<name>.py ...
+```
+
+调用。`<本技能目录>` 就是 SKILL.md 所在的目录。
+
+**路径一律相对本技能目录**，不要把仓库路径、部署绝对路径或宿主注入的根路径变量写进命令——
+技能包要装到哪都能跑，写死任何一种根路径都会让它只在某一套运行时里有效。
+脚本自己会解析自身位置（注册表、schema、同级技能都由脚本定位），
+所以只要能进到本技能目录，命令就成立。
+
+也不要猜测其他脚本名，三个脚本之外没有别的入口。
 
 标准链路：`lookup_methodology.py` → 命中就 `run_methodology.py`，未命中就回落平台工具链路。
 
@@ -15,9 +24,9 @@
 - 命令模板：
 
   ```bash
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<用户问题>"
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --id <id>
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --list
+  python3 scripts/lookup_methodology.py --query "<用户问题>"
+  python3 scripts/lookup_methodology.py --id <id>
+  python3 scripts/lookup_methodology.py --list
   ```
 
 - 输出 `kind=methodology_lookup`，含 `matched`、`results[]`。每个候选带
@@ -31,7 +40,7 @@
 - 命令模板：
 
   ```bash
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '<JSON 对象>'
+  python3 scripts/run_methodology.py --id <id> --params '<JSON 对象>'
   ```
 
 - 参数：
@@ -58,9 +67,9 @@
 - 命令模板：
 
   ```bash
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --all
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --path <file.json>
-  "$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --id <id>
+  python3 scripts/validate_methodology.py --all
+  python3 scripts/validate_methodology.py --path <file.json>
+  python3 scripts/validate_methodology.py --id <id>
   ```
 
 - 加 `--check-sql` 会用桩参数绑定每个 `sql` 节点，再交给平台工具的 `validate_sql.py`。
@@ -86,22 +95,27 @@ mock 文件形如：
 `growth` 的内存 join。
 
 ```bash
-"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" \
+python3 scripts/run_methodology.py \
   --id table_growth_ratio --params '{"days":30}' --mock <mock.json>
 ```
 
 mock 模式主要给方法论作者和回归测试用；回答用户问题时不要用它，
 mock 出来的不是真实结果。
 
-## 环境依赖
+## 依赖与可选环境变量
+
+运行本技能**不需要任何环境变量**：脚本从自身位置解析技能根、注册表和同级技能，
+只要 `python3` 可用即可。下列变量全是可选覆盖，用于宿主想改默认值的场合。
 
 | 变量 | 用途 | 缺失后果 |
 |---|---|---|
-| `DATAAGENT_PYTHON_BIN` | 解释器 | 回落到当前解释器 |
-| `DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT` | 本技能根目录 | 无法定位脚本 |
-| `DATAAGENT_PLATFORM_SKILL_ROOT` | 平台工具根目录，`sql` 节点靠它执行 | `error_code=platform_tools_unavailable` |
+| `DATAAGENT_PLATFORM_SKILL_ROOT` | 平台工具目录的覆盖值 | 回落到同级目录 `../opendataworks-platform-tools` |
 | `DATAAGENT_QUERY_LIMIT` | 查询节点行数上限 | 默认 1000 |
 | `DATAAGENT_SQL_READ_TIMEOUT_SECONDS` | 单节点超时 | 默认 60 |
+| `DATAAGENT_METHODOLOGY_TOTAL_TIMEOUT_SECONDS` | 单次运行总预算 | 默认 240 |
+
+唯一的真实依赖是**同级安装的 `opendataworks-platform-tools`**：`sql` 节点靠它的
+`run_sql.py` 执行只读查询。两处都找不到时报 `error_code=platform_tools_unavailable`。
 
 不要执行环境探测或依赖安装命令。脚本报错时优先收敛参数或向用户追问，
 不要切换解释器反复试探。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/40-output-contract.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/40-output-contract.md
@@ -1,0 +1,129 @@
+# 输出契约
+
+先结论：`run_methodology.py` 产出的 `kind` 就是 `sql_execution`，与 `run_sql.py` 同构。
+方法论头部和每节点 trace 作为额外字段挂在同一层，消费方可以完全按既有方式处理结果。
+
+## 成功
+
+```json
+{
+  "kind": "sql_execution",
+  "tool_label": "方法论执行",
+  "methodology": {
+    "id": "table_growth_ratio",
+    "version": "1.0.0",
+    "name_zh": "数据表分层环比增长",
+    "caliber": "口径字段为 data_table.created_at；只统计 deleted = 0 的表；……",
+    "owner": "data-platform",
+    "params": {"days": 30, "layer": null}
+  },
+  "engine": "mysql",
+  "database": "opendataworks",
+  "sql": "<target 节点绑定后的 SQL>",
+  "columns": ["layer", "current_cnt", "previous_cnt", "growth"],
+  "rows": [{"layer": "ODS", "current_cnt": 12, "previous_cnt": 6, "growth": 1.0}],
+  "row_count": 1,
+  "has_more": false,
+  "duration_ms": 842,
+  "truncated_by_size": false,
+  "notice": null,
+  "summary": "返回 1 行结果",
+  "error": null,
+  "result_state": "success",
+  "error_code": null,
+  "failure_attribution": [],
+  "retryable": false,
+  "stop_reason": "",
+  "trace": {
+    "executed": 3,
+    "pruned": 0,
+    "nodes": [
+      {"name": "current",  "type": "sql",    "status": "success", "duration_ms": 210, "row_count": 5},
+      {"name": "previous", "type": "sql",    "status": "success", "duration_ms": 605, "row_count": 5},
+      {"name": "growth",   "type": "sqlite", "status": "success", "duration_ms": 3,   "row_count": 5}
+    ]
+  }
+}
+```
+
+## 字段说明
+
+| 字段 | 说明 |
+|---|---|
+| `methodology.caliber` | 本次统计的口径。**回答里必须带上。** |
+| `methodology.params` | 解析后的实际参数，含默认值填充结果。未提供的可选参数为 `null`。 |
+| `sql` | `target` 节点绑定后的 SQL。中间节点的 SQL 在 trace 里，不在这里。 |
+| `columns` / `rows` | `target` 节点的结果表。 |
+| `trace.nodes[]` | 每个**实际执行过**的节点。没执行的节点不出现——这本身就是剪枝生效的证据。 |
+| `trace.nodes[].status` | `success` 表示真实执行，`mock` 表示走了 mock 模式。 |
+| `trace.nodes[].branch` / `pruned_branch` | 仅 `conditional` 节点有：选中和被剪掉的分支名。 |
+| `trace.pruned` | 被剪掉的分支数量。 |
+
+per-node trace 是声明式结构的直接红利：方法论作者不写任何埋点，就拿到了每步的耗时和行数。
+
+## result_state
+
+| 取值 | 含义 | 该怎么办 |
+|---|---|---|
+| `success` | 拿到真实结果 | 直接收口回答，带上口径 |
+| `empty_result` | 执行成功但 0 行 | 说明口径与空结果，**不要**换方法论、改参数或换表试探 |
+| `failed` | 执行失败 | 按 `error_code` 与 `stop_reason` 说明，不等价重试 |
+
+`result_state=success` 且 `error_code=result_truncated` 表示结果按体积被截断，
+此时**不得**据此出图；先缩小参数范围拿到完整有界结果。
+
+## error_code
+
+本层新增的错误码：
+
+| error_code | 含义 | 处置 |
+|---|---|---|
+| `methodology_not_found` | 注册表里没有这个 id | 回落常规问数链路，不要猜 id |
+| `methodology_invalid` | 工件本身没通过静态校验 | 修正注册表定义，不要重试 |
+| `param_missing` | 缺必填参数 | 只追问 `stop_reason` 里列出的槽位 |
+| `param_rejected` | 参数取值非法（类型、范围、枚举、绑定失败）| 修正参数取值，不要绕过方法论自己写 SQL |
+| `methodology_timeout` | 总执行预算耗尽 | 缩小参数范围，或改后台执行 |
+| `platform_tools_unavailable` | 缺 `DATAAGENT_PLATFORM_SKILL_ROOT` 或平台工具目录不完整 | 说明缺少执行入口；这不是可以换个方式绕过的问题 |
+
+查询节点失败时，`error_code`、`failure_attribution`、`stop_reason` 直接透传
+`run_sql.py` 的归因结果（`permission_denied`、`unknown_column`、`unknown_table`、
+`datasource_mismatch`、`tool_timeout`、`non_readonly_sql`、`query_failed` 等），
+所以既有的失败处置规则原样适用。
+
+内存计算节点（`sqlite`）的 SQL 有误时报 `error_code=query_failed`、
+`failure_attribution=["invalid_sql"]`——这是方法论定义的问题，需要改注册表，不是重试能解决的。
+
+## 检索输出
+
+`lookup_methodology.py` 产出 `kind=methodology_lookup`：
+
+```json
+{
+  "kind": "methodology_lookup",
+  "tool_label": "方法论检索",
+  "query": "最近30天工作流发布次数趋势",
+  "matched": 1,
+  "results": [
+    {
+      "id": "workflow_publish_trend",
+      "version": "1.0.0",
+      "name_zh": "工作流发布次数趋势",
+      "intent": "……",
+      "caliber": "……",
+      "params": [{"name": "days", "type": "int", "required": false, "default": 30, "values": [], "description": "……"}],
+      "output_fields": ["stat_date", "publish_cnt", "failed_cnt", "failed_rate"],
+      "node_count": 4,
+      "score": 0.6667
+    }
+  ],
+  "stop_reason": ""
+}
+```
+
+`matched=0` 时 `stop_reason` 会明确要求回落常规问数链路。
+
+## 校验输出
+
+`validate_methodology.py` 产出 `kind=methodology_validation`，
+含 `valid`、`checked`、`results[]`（每项有 `id`、`valid`、`errors[]`、`warnings[]`）。
+退出码 0 表示全部通过，非 0 表示有工件未通过。

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/reference/40-output-contract.md
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/reference/40-output-contract.md
@@ -83,7 +83,7 @@ per-node trace 是声明式结构的直接红利：方法论作者不写任何�
 | `param_missing` | 缺必填参数 | 只追问 `stop_reason` 里列出的槽位 |
 | `param_rejected` | 参数取值非法（类型、范围、枚举、绑定失败）| 修正参数取值，不要绕过方法论自己写 SQL |
 | `methodology_timeout` | 总执行预算耗尽 | 缩小参数范围，或改后台执行 |
-| `platform_tools_unavailable` | 缺 `DATAAGENT_PLATFORM_SKILL_ROOT` 或平台工具目录不完整 | 说明缺少执行入口；这不是可以换个方式绕过的问题 |
+| `platform_tools_unavailable` | 同级目录与覆盖变量都找不到完整的 `opendataworks-platform-tools` | 说明缺少执行入口；这不是可以换个方式绕过的问题 |
 
 查询节点失败时，`error_code`、`failure_attribution`、`stop_reason` 直接透传
 `run_sql.py` 的归因结果（`permission_denied`、`unknown_column`、`unknown_table`、

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/binding.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/binding.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Template binding, the predicate DSL, and the restricted expression evaluator.
+
+Three placeholder forms may appear in a node's ``sql`` template, each carrying a
+different safety contract:
+
+``{{ expr }}``   checked value — the result must be a scalar or an array of
+                 scalars. Scalars are escaped and quoted, arrays expand to a
+                 comma list. A value can never escape its literal position.
+``{{! expr }}``  identifier fragment — spliced verbatim, so it is restricted to
+                 a bare identifier (or a value declared in a parameter's
+                 ``values`` enum). Anything else is rejected.
+``{{? name }}``  predicate fragment — compiled from the node's ``predicates``
+                 map. Sub-predicates whose bound value is null are dropped, so an
+                 absent optional parameter simply makes its filter disappear.
+
+Expressions are evaluated by walking a whitelisted subset of the Python AST.
+``eval``/``exec`` are never used, and attribute access resolves through mapping
+lookups rather than ``getattr``, so there is no path from an expression to a
+Python object's internals.
+"""
+
+from __future__ import annotations
+
+import ast
+import datetime as _dt
+import re
+from typing import Any, Callable, Dict, List, Mapping, Sequence
+
+
+class BindingError(ValueError):
+    """Raised for any template, expression or predicate problem."""
+
+
+# One pass over every placeholder form, dispatched on the leading marker:
+# no marker = checked value, ``!`` = identifier fragment, ``?`` = predicate.
+PLACEHOLDER_RE = re.compile(r"\{\{\s*(?P<marker>[!?])?\s*(?P<body>.*?)\s*\}\}", re.DOTALL)
+
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+PREDICATE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+# --------------------------------------------------------------------------
+# Restricted expression evaluation
+# --------------------------------------------------------------------------
+
+def _fn_pluck(rows: Any, field: str) -> List[Any]:
+    """Project one field out of a list of row mappings, dropping nulls."""
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+        raise BindingError(f"pluck() 的第一个参数必须是行列表，实际是 {type(rows).__name__}")
+    out: List[Any] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise BindingError("pluck() 只能作用于字典行")
+        value = row.get(field)
+        if value is not None:
+            out.append(value)
+    return out
+
+
+def _fn_coalesce(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _fn_distinct(values: Any) -> List[Any]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise BindingError("distinct() 的参数必须是列表")
+    seen: List[Any] = []
+    for value in values:
+        if value not in seen:
+            seen.append(value)
+    return seen
+
+
+ALLOWED_FUNCTIONS: Dict[str, Callable[..., Any]] = {
+    "pluck": _fn_pluck,
+    "coalesce": _fn_coalesce,
+    "distinct": _fn_distinct,
+    "len": lambda value: len(value),
+    "abs": abs,
+    "round": round,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "int": int,
+    "float": float,
+    "str": str,
+    "lower": lambda value: str(value).lower(),
+    "upper": lambda value: str(value).upper(),
+}
+
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.Constant,
+    ast.Name,
+    ast.Load,
+    ast.Attribute,
+    ast.Subscript,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.BoolOp,
+    ast.Compare,
+    ast.IfExp,
+    ast.Call,
+    ast.List,
+    ast.Tuple,
+    ast.Dict,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.USub,
+    ast.UAdd,
+    ast.Not,
+    ast.And,
+    ast.Or,
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+    ast.In,
+    ast.NotIn,
+    ast.Is,
+    ast.IsNot,
+)
+
+_BIN_OPS: Dict[type, Callable[[Any, Any], Any]] = {
+    ast.Add: lambda a, b: a + b,
+    ast.Sub: lambda a, b: a - b,
+    ast.Mult: lambda a, b: a * b,
+    ast.Div: lambda a, b: a / b,
+    ast.FloorDiv: lambda a, b: a // b,
+    ast.Mod: lambda a, b: a % b,
+}
+
+_COMPARE_OPS: Dict[type, Callable[[Any, Any], Any]] = {
+    ast.Eq: lambda a, b: a == b,
+    ast.NotEq: lambda a, b: a != b,
+    ast.Lt: lambda a, b: a < b,
+    ast.LtE: lambda a, b: a <= b,
+    ast.Gt: lambda a, b: a > b,
+    ast.GtE: lambda a, b: a >= b,
+    ast.In: lambda a, b: a in b,
+    ast.NotIn: lambda a, b: a not in b,
+    ast.Is: lambda a, b: a is b,
+    ast.IsNot: lambda a, b: a is not b,
+}
+
+
+def _lookup(container: Any, key: str, where: str) -> Any:
+    if isinstance(container, Mapping):
+        if key not in container:
+            raise BindingError(f"{where}: 找不到字段 `{key}`")
+        return container[key]
+    raise BindingError(f"{where}: `{key}` 只能作用于字典，实际是 {type(container).__name__}")
+
+
+def _eval_node(node: ast.AST, context: Mapping[str, Any], source: str) -> Any:
+    if not isinstance(node, _ALLOWED_NODES):
+        raise BindingError(f"表达式 `{source}` 使用了不允许的语法 {type(node).__name__}")
+
+    if isinstance(node, ast.Expression):
+        return _eval_node(node.body, context, source)
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id in context:
+            return context[node.id]
+        raise BindingError(f"表达式 `{source}`: 未知的名字 `{node.id}`")
+    if isinstance(node, ast.Attribute):
+        base = _eval_node(node.value, context, source)
+        return _lookup(base, node.attr, f"表达式 `{source}`")
+    if isinstance(node, ast.Subscript):
+        base = _eval_node(node.value, context, source)
+        key = _eval_node(node.slice, context, source)
+        if isinstance(base, Mapping):
+            return _lookup(base, key, f"表达式 `{source}`")
+        if isinstance(base, Sequence) and isinstance(key, int):
+            try:
+                return base[key]
+            except IndexError as exc:
+                raise BindingError(f"表达式 `{source}`: 下标越界") from exc
+        raise BindingError(f"表达式 `{source}`: 无法对 {type(base).__name__} 取下标")
+    if isinstance(node, ast.BinOp):
+        handler = _BIN_OPS.get(type(node.op))
+        if handler is None:
+            raise BindingError(f"表达式 `{source}`: 不允许的运算符 {type(node.op).__name__}")
+        return handler(_eval_node(node.left, context, source), _eval_node(node.right, context, source))
+    if isinstance(node, ast.UnaryOp):
+        operand = _eval_node(node.operand, context, source)
+        if isinstance(node.op, ast.USub):
+            return -operand
+        if isinstance(node.op, ast.UAdd):
+            return +operand
+        return not operand
+    if isinstance(node, ast.BoolOp):
+        values = [_eval_node(value, context, source) for value in node.values]
+        if isinstance(node.op, ast.And):
+            result: Any = True
+            for value in values:
+                if not value:
+                    return value
+                result = value
+            return result
+        for value in values:
+            if value:
+                return value
+        return values[-1] if values else False
+    if isinstance(node, ast.Compare):
+        left = _eval_node(node.left, context, source)
+        for operator, comparator in zip(node.ops, node.comparators):
+            handler = _COMPARE_OPS.get(type(operator))
+            if handler is None:
+                raise BindingError(f"表达式 `{source}`: 不允许的比较符 {type(operator).__name__}")
+            right = _eval_node(comparator, context, source)
+            if not handler(left, right):
+                return False
+            left = right
+        return True
+    if isinstance(node, ast.IfExp):
+        if _eval_node(node.test, context, source):
+            return _eval_node(node.body, context, source)
+        return _eval_node(node.orelse, context, source)
+    if isinstance(node, ast.Call):
+        if node.keywords:
+            raise BindingError(f"表达式 `{source}`: 不支持关键字参数")
+        if not isinstance(node.func, ast.Name):
+            raise BindingError(f"表达式 `{source}`: 只允许调用白名单函数名")
+        handler = ALLOWED_FUNCTIONS.get(node.func.id)
+        if handler is None:
+            raise BindingError(f"表达式 `{source}`: 函数 `{node.func.id}` 不在白名单内")
+        return handler(*[_eval_node(arg, context, source) for arg in node.args])
+    if isinstance(node, ast.List):
+        return [_eval_node(item, context, source) for item in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_eval_node(item, context, source) for item in node.elts)
+    if isinstance(node, ast.Dict):
+        return {
+            _eval_node(key, context, source): _eval_node(value, context, source)
+            for key, value in zip(node.keys, node.values)
+            if key is not None
+        }
+    raise BindingError(f"表达式 `{source}` 使用了不允许的语法 {type(node).__name__}")
+
+
+def parse_expression(source: str) -> ast.Expression:
+    """Parse and statically screen an expression, without evaluating it."""
+    text = str(source or "").strip()
+    if not text:
+        raise BindingError("表达式不能为空")
+    try:
+        tree = ast.parse(text, mode="eval")
+    except SyntaxError as exc:
+        raise BindingError(f"表达式 `{text}` 语法错误: {exc.msg}") from exc
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise BindingError(f"表达式 `{text}` 使用了不允许的语法 {type(node).__name__}")
+        if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
+            raise BindingError(f"表达式 `{text}`: 不允许下划线开头的字段名")
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name) or node.func.id not in ALLOWED_FUNCTIONS:
+                raise BindingError(f"表达式 `{text}`: 只允许调用白名单函数")
+    return tree
+
+
+def evaluate(source: str, context: Mapping[str, Any]) -> Any:
+    """Evaluate a restricted expression against ``context``."""
+    tree = parse_expression(source)
+    return _eval_node(tree, context, str(source).strip())
+
+
+# --------------------------------------------------------------------------
+# SQL literal rendering
+# --------------------------------------------------------------------------
+
+_SCALAR_TYPES = (str, int, float, bool, _dt.date, _dt.datetime)
+
+
+def render_scalar(value: Any) -> str:
+    """Render one scalar as a SQL literal it cannot escape from."""
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, _dt.datetime):
+        return "'" + value.isoformat(sep=" ") + "'"
+    if isinstance(value, _dt.date):
+        return "'" + value.isoformat() + "'"
+    if isinstance(value, str):
+        if "\x00" in value:
+            raise BindingError("字符串字面量不允许包含 NUL 字符")
+        return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
+    raise BindingError(f"不支持的字面量类型 {type(value).__name__}")
+
+
+def render_checked_value(value: Any, *, expr: str) -> str:
+    """Render a checked value: a scalar, or an array of scalars as a comma list."""
+    if isinstance(value, _SCALAR_TYPES) or value is None:
+        return render_scalar(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        items = list(value)
+        if not items:
+            raise BindingError(f"受检值 `{expr}` 求值为空列表，无法展开为 SQL 列表；请改用谓词片段或条件分支")
+        for item in items:
+            if not (isinstance(item, _SCALAR_TYPES) or item is None):
+                raise BindingError(f"受检值 `{expr}` 的数组元素必须是标量，实际含 {type(item).__name__}")
+        return ", ".join(render_scalar(item) for item in items)
+    raise BindingError(f"受检值 `{expr}` 必须求值为标量或标量数组，实际是 {type(value).__name__}")
+
+
+def render_fragment(value: Any, *, expr: str, allowed_values: Sequence[str] = ()) -> str:
+    """Render an unchecked fragment, restricted to a bare identifier or an enum value."""
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        raise BindingError(f"片段 `{expr}` 求值为空")
+    if text in set(allowed_values):
+        return text
+    if not IDENTIFIER_RE.match(text):
+        raise BindingError(
+            f"片段 `{expr}` 的值 `{text}` 不是合法标识符；片段占位符只接受列名/别名或参数 values 枚举中的取值"
+        )
+    return text
+
+
+# --------------------------------------------------------------------------
+# Predicate DSL
+# --------------------------------------------------------------------------
+
+_LEAF_SQL_OPS = {
+    "eq": "=",
+    "ne": "<>",
+    "lt": "<",
+    "lte": "<=",
+    "gt": ">",
+    "gte": ">=",
+    "like": "LIKE",
+}
+
+_COMPOSITE_OPS = {"and", "or", "not"}
+
+
+def _resolve_predicate_value(raw: Any, context: Mapping[str, Any]) -> Any:
+    """Resolve a predicate operand, which may be an expression reference."""
+    if isinstance(raw, str) and raw.startswith("$"):
+        return evaluate(raw[1:], context)
+    return raw
+
+
+def compile_predicate(predicate: Mapping[str, Any], context: Mapping[str, Any]) -> str:
+    """Compile one predicate into a validated SQL fragment.
+
+    Returns an empty string when the predicate resolves to nothing — that is the
+    whole point of the DSL: an optional parameter that was not supplied makes its
+    filter disappear instead of forcing the author to branch in the template.
+    """
+    op = str(predicate.get("op") or "").strip()
+    if op in _COMPOSITE_OPS:
+        clauses = predicate.get("clauses") or []
+        rendered = [compile_predicate(clause, context) for clause in clauses]
+        rendered = [item for item in rendered if item]
+        if not rendered:
+            return ""
+        if op == "not":
+            if len(rendered) != 1:
+                raise BindingError("not 谓词必须恰好有一个非空子句")
+            return f"NOT ({rendered[0]})"
+        joiner = " AND " if op == "and" else " OR "
+        if len(rendered) == 1:
+            return rendered[0]
+        return "(" + joiner.join(rendered) + ")"
+
+    field = str(predicate.get("field") or "").strip()
+    if not field:
+        raise BindingError(f"谓词 `{op}` 缺少 field")
+    column = render_fragment(field, expr=f"predicate.{op}.field")
+
+    if op == "in":
+        values = predicate.get("values")
+        resolved = _resolve_predicate_value(values, context) if isinstance(values, str) else [
+            _resolve_predicate_value(item, context) for item in (values or [])
+        ]
+        if resolved is None:
+            return ""
+        if not isinstance(resolved, Sequence) or isinstance(resolved, (str, bytes)):
+            raise BindingError("in 谓词的 values 必须求值为列表")
+        items = [item for item in resolved if item is not None]
+        if not items:
+            return ""
+        return f"{column} IN ({', '.join(render_scalar(item) for item in items)})"
+
+    if op == "between":
+        values = predicate.get("values") or []
+        if len(values) != 2:
+            raise BindingError("between 谓词的 values 必须是两个元素")
+        low = _resolve_predicate_value(values[0], context)
+        high = _resolve_predicate_value(values[1], context)
+        if low is None or high is None:
+            return ""
+        return f"{column} BETWEEN {render_scalar(low)} AND {render_scalar(high)}"
+
+    sql_op = _LEAF_SQL_OPS.get(op)
+    if sql_op is None:
+        raise BindingError(f"未知的谓词运算符 `{op}`")
+    value = _resolve_predicate_value(predicate.get("value"), context)
+    if value is None:
+        return ""
+    return f"{column} {sql_op} {render_scalar(value)}"
+
+
+def compile_predicate_clause(predicate: Mapping[str, Any], context: Mapping[str, Any], *, prefix: str = "AND") -> str:
+    """Compile a predicate and prefix it with a connector when non-empty."""
+    fragment = compile_predicate(predicate, context)
+    if not fragment:
+        return ""
+    return f"{prefix} {fragment}" if prefix else fragment
+
+
+# --------------------------------------------------------------------------
+# Template binding
+# --------------------------------------------------------------------------
+
+def assert_template_markers_understood(template: str) -> None:
+    """Reject a template carrying a brace marker no placeholder form consumed."""
+    residue = PLACEHOLDER_RE.sub("", template)
+    if "{{" in residue or "}}" in residue:
+        raise BindingError("SQL 模板存在无法识别的 `{{`/`}}` 占位符形式")
+
+
+def bind_sql(
+    template: str,
+    context: Mapping[str, Any],
+    *,
+    predicates: Mapping[str, Mapping[str, Any]] | None = None,
+    fragment_allowed_values: Sequence[str] = (),
+) -> str:
+    """Bind a SQL template's three placeholder forms against ``context``."""
+    predicates = predicates or {}
+    assert_template_markers_understood(template)
+
+    def _substitute(match: "re.Match[str]") -> str:
+        marker = match.group("marker")
+        body = match.group("body")
+        if marker == "?":
+            if not PREDICATE_NAME_RE.match(body):
+                raise BindingError(f"谓词片段名 `{body}` 不合法")
+            if body not in predicates:
+                raise BindingError(f"谓词片段 `{body}` 未在本节点 predicates 中声明")
+            return compile_predicate_clause(predicates[body], context)
+        if marker == "!":
+            return render_fragment(
+                evaluate(body, context), expr=body, allowed_values=fragment_allowed_values
+            )
+        return render_checked_value(evaluate(body, context), expr=body)
+
+    bound = PLACEHOLDER_RE.sub(_substitute, template)
+    # An emptied predicate leaves a dangling run of blanks; only that is collapsed,
+    # and never inside a string literal, so trailing whitespace per line is enough.
+    return "\n".join(line.rstrip() for line in bound.splitlines()).strip()
+
+
+def iter_template_expressions(template: str) -> List[str]:
+    """List every expression referenced by a template, for static validation."""
+    return [
+        match.group("body")
+        for match in PLACEHOLDER_RE.finditer(template)
+        if match.group("marker") != "?"
+    ]
+
+
+def iter_template_predicates(template: str) -> List[str]:
+    return [
+        match.group("body")
+        for match in PLACEHOLDER_RE.finditer(template)
+        if match.group("marker") == "?"
+    ]

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/engine.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/engine.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Demand-driven, memoized, pruned, parallel evaluation of a methodology DAG.
+
+Evaluation is keyed on the target. Each node maps to a lazily-created, memoized
+holder of its result; asking for the target forces its holder, which forces its
+dependencies transitively. Two properties follow, and they are the whole point:
+
+* **Only what is needed runs.** A node whose holder is never forced never
+  executes — including the untaken side of a conditional and everything
+  reachable only through it.
+* **It runs at most once.** The holder is memoized behind a double-checked lock,
+  so a dependency shared by several paths is computed a single time.
+
+Independent dependencies are forced concurrently, so the author writes no
+concurrency code: the parallelism is a consequence of the declared dependency
+structure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from binding import BindingError, bind_sql, evaluate
+
+DEFAULT_TOTAL_TIMEOUT_SECONDS = 240
+DEFAULT_NODE_TIMEOUT_SECONDS = 60
+MAX_PARALLEL_DEPENDENCIES = 8
+
+
+class MethodologyError(RuntimeError):
+    """A failure carrying the same attribution shape the SQL tool path uses."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str,
+        failure_attribution: Sequence[str] = (),
+        stop_reason: str = "",
+        retryable: bool = False,
+        node: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.failure_attribution = list(failure_attribution)
+        self.stop_reason = stop_reason or message
+        self.retryable = retryable
+        self.node = node
+
+
+@dataclass
+class NodeResult:
+    """One node's value: a table plus the provenance the caller may report."""
+
+    columns: List[str] = field(default_factory=list)
+    rows: List[Dict[str, Any]] = field(default_factory=list)
+    sql: Optional[str] = None
+    database: Optional[str] = None
+    engine: Optional[str] = None
+    notice: Optional[str] = None
+    has_more: bool = False
+    truncated_by_size: bool = False
+
+    def as_context(self) -> Dict[str, Any]:
+        return {"columns": list(self.columns), "rows": list(self.rows), "row_count": len(self.rows)}
+
+
+class _Lazy:
+    """Double-checked, lock-guarded holder so the supplier runs exactly once."""
+
+    __slots__ = ("_supplier", "_lock", "_done", "_value", "_error")
+
+    def __init__(self, supplier: Callable[[], Any]) -> None:
+        self._supplier = supplier
+        self._lock = threading.Lock()
+        self._done = False
+        self._value: Any = None
+        self._error: BaseException | None = None
+
+    def get(self) -> Any:
+        if not self._done:
+            with self._lock:
+                if not self._done:
+                    try:
+                        self._value = self._supplier()
+                    except BaseException as exc:  # noqa: BLE001 - re-raised below
+                        self._error = exc
+                    finally:
+                        self._done = True
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+def _columns_of(rows: Sequence[Mapping[str, Any]], declared: Sequence[str] = ()) -> List[str]:
+    if declared:
+        return list(declared)
+    columns: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+    return columns
+
+
+def _resolve_python_bin() -> str:
+    return str(os.getenv("DATAAGENT_PYTHON_BIN") or "").strip() or sys.executable
+
+
+def _resolve_platform_skill_root() -> Path:
+    raw = str(os.getenv("DATAAGENT_PLATFORM_SKILL_ROOT") or "").strip()
+    if not raw:
+        raise MethodologyError(
+            "缺少 DATAAGENT_PLATFORM_SKILL_ROOT：方法论的 sql 节点依赖 opendataworks-platform-tools 执行只读查询",
+            error_code="platform_tools_unavailable",
+            failure_attribution=["invalid_tool_path"],
+            stop_reason="本 skill 必须与 opendataworks-platform-tools 同时启用；请先启用平台工具技能，不要改用其他 SQL 执行方式。",
+        )
+    root = Path(raw).expanduser().resolve(strict=False)
+    if not (root / "scripts" / "run_sql.py").is_file():
+        raise MethodologyError(
+            f"DATAAGENT_PLATFORM_SKILL_ROOT 下找不到 scripts/run_sql.py: {root}",
+            error_code="platform_tools_unavailable",
+            failure_attribution=["invalid_tool_path"],
+            stop_reason="平台工具技能目录不完整，无法执行只读查询。",
+        )
+    return root
+
+
+class MethodologyEngine:
+    """Evaluates one methodology per instance; state is request-scoped."""
+
+    def __init__(
+        self,
+        methodology: Mapping[str, Any],
+        params: Mapping[str, Any],
+        *,
+        registry: Mapping[str, Mapping[str, Any]] | None = None,
+        mock: Mapping[str, Any] | None = None,
+        total_timeout: float = DEFAULT_TOTAL_TIMEOUT_SECONDS,
+        node_timeout: float = DEFAULT_NODE_TIMEOUT_SECONDS,
+        query_limit: int = 1000,
+        deadline: float | None = None,
+        call_chain: Sequence[str] = (),
+        trace: List[Dict[str, Any]] | None = None,
+    ) -> None:
+        self.methodology = methodology
+        self.params = dict(params)
+        self.registry = dict(registry or {})
+        self.mock = dict(mock or {})
+        self.node_timeout = float(node_timeout)
+        self.query_limit = int(query_limit)
+        self.deadline = deadline if deadline is not None else time.monotonic() + float(total_timeout)
+        self.call_chain = list(call_chain) or [str(methodology.get("id") or "")]
+        self.trace: List[Dict[str, Any]] = trace if trace is not None else []
+
+        self.nodes: Dict[str, Mapping[str, Any]] = dict(methodology.get("nodes") or {})
+        self.target = str(methodology.get("target") or "")
+        self._lazies: Dict[str, _Lazy] = {}
+        self._cache_lock = threading.Lock()
+        self._trace_lock = threading.Lock()
+        self._fragment_values = self._collect_fragment_values(methodology)
+
+    # -- public ------------------------------------------------------------
+
+    def run(self) -> NodeResult:
+        if self.target not in self.nodes:
+            raise MethodologyError(
+                f"target 节点 `{self.target}` 不存在",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+            )
+        return self._force(self.target)
+
+    # -- evaluation core ---------------------------------------------------
+
+    def _force(self, name: str) -> NodeResult:
+        """Return the node's memoized result, running it at most once."""
+        lazy = self._lazies.get(name)
+        if lazy is None:
+            with self._cache_lock:
+                lazy = self._lazies.get(name)
+                if lazy is None:
+                    lazy = _Lazy(lambda node_name=name: self._evaluate(node_name))
+                    self._lazies[name] = lazy
+        return lazy.get()
+
+    def _force_dependencies(self, names: Sequence[str]) -> Dict[str, NodeResult]:
+        """Force independent dependencies together; a shared one still runs once."""
+        unique: List[str] = []
+        for name in names:
+            if name not in unique:
+                unique.append(name)
+        if len(unique) <= 1:
+            return {name: self._force(name) for name in unique}
+        # A pool per resolution site keeps nested forcing from starving a shared,
+        # fixed-size pool. Graphs are small, so the thread cost is negligible.
+        workers = min(len(unique), MAX_PARALLEL_DEPENDENCIES)
+        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="qdag") as pool:
+            futures = {name: pool.submit(self._force, name) for name in unique}
+            return {name: future.result() for name, future in futures.items()}
+
+    def _evaluate(self, name: str) -> NodeResult:
+        node = self.nodes.get(name)
+        if node is None:
+            raise MethodologyError(
+                f"节点 `{name}` 不存在",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+                node=name,
+            )
+        self._check_deadline(name)
+        node_type = str(node.get("type") or "")
+        started = time.monotonic()
+
+        if name in self.mock:
+            result = self._mock_result(name)
+            self._record(name, node_type, "mock", started, result)
+            return result
+
+        if node_type == "conditional":
+            return self._evaluate_conditional(name, node, started)
+
+        dependencies = self._force_dependencies(list(node.get("dependencies") or []))
+        context = self._context(dependencies)
+
+        handlers: Dict[str, Callable[[str, Mapping[str, Any], Mapping[str, Any], Dict[str, NodeResult]], NodeResult]] = {
+            "sql": self._run_sql,
+            "sqlite": self._run_sqlite,
+            "transform": self._run_transform,
+            "literal": self._run_literal,
+            "call": self._run_call,
+        }
+        handler = handlers.get(node_type)
+        if handler is None:
+            raise MethodologyError(
+                f"节点 `{name}` 的类型 `{node_type}` 不受支持",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+                node=name,
+            )
+        result = handler(name, node, context, dependencies)
+        self._record(name, node_type, "success", started, result)
+        return result
+
+    def _evaluate_conditional(self, name: str, node: Mapping[str, Any], started: float) -> NodeResult:
+        """Resolve the predicate first, then force only the selected branch.
+
+        The branches are soft dependencies: the untaken one — and the entire
+        sub-graph reachable only through it — is never forced.
+        """
+        dependencies = self._force_dependencies(list(node.get("dependencies") or []))
+        context = self._context(dependencies)
+        expression = str(node.get("when") or "")
+        try:
+            taken = bool(evaluate(expression, context))
+        except BindingError as exc:
+            raise MethodologyError(
+                f"节点 `{name}` 的条件表达式求值失败: {exc}",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+                node=name,
+            ) from exc
+        chosen = str(node.get("then_node") if taken else node.get("else_node"))
+        skipped = str(node.get("else_node") if taken else node.get("then_node"))
+        result = self._force(chosen)
+        self._record(name, "conditional", "success", started, result, extra={"branch": chosen, "pruned_branch": skipped})
+        return result
+
+    # -- node executors ----------------------------------------------------
+
+    def _run_sql(
+        self,
+        name: str,
+        node: Mapping[str, Any],
+        context: Mapping[str, Any],
+        _dependencies: Dict[str, NodeResult],
+    ) -> NodeResult:
+        bound_sql = self._bind(name, node, context)
+        database = str(node.get("database") or "").strip()
+        engine = str(node.get("engine") or "").strip()
+        limit = int(node.get("limit") or self.query_limit)
+
+        platform_root = _resolve_platform_skill_root()
+        command = [
+            _resolve_python_bin(),
+            str(platform_root / "scripts" / "run_sql.py"),
+            "--database",
+            database,
+            "--sql",
+            bound_sql,
+            "--limit",
+            str(limit),
+        ]
+        if engine:
+            command.extend(["--engine", engine])
+
+        timeout = self._node_budget(name)
+        try:
+            completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise MethodologyError(
+                f"节点 `{name}` 执行只读查询超时（{timeout:.0f}s）",
+                error_code="tool_timeout",
+                failure_attribution=["tool_timeout"],
+                stop_reason="方法论中的查询节点超时，已停止重复执行；需要缩小时间范围或增加过滤条件。",
+                node=name,
+            ) from exc
+
+        payload = self._parse_tool_json(name, completed)
+        state = str(payload.get("result_state") or "")
+        if state == "failed":
+            raise MethodologyError(
+                str(payload.get("error") or payload.get("stop_reason") or f"节点 `{name}` 查询失败"),
+                error_code=str(payload.get("error_code") or "query_failed"),
+                failure_attribution=list(payload.get("failure_attribution") or ["tool_error"]),
+                stop_reason=str(payload.get("stop_reason") or ""),
+                retryable=bool(payload.get("retryable")),
+                node=name,
+            )
+        rows = list(payload.get("rows") or [])
+        return NodeResult(
+            columns=_columns_of(rows, payload.get("columns") or []),
+            rows=rows,
+            sql=bound_sql,
+            database=str(payload.get("database") or database) or None,
+            engine=str(payload.get("engine") or engine) or None,
+            notice=payload.get("notice"),
+            has_more=bool(payload.get("has_more")),
+            truncated_by_size=bool(payload.get("truncated_by_size")),
+        )
+
+    def _run_sqlite(
+        self,
+        name: str,
+        node: Mapping[str, Any],
+        context: Mapping[str, Any],
+        dependencies: Dict[str, NodeResult],
+    ) -> NodeResult:
+        bound_sql = self._bind(name, node, context)
+        primary_keys = dict(node.get("primary_keys") or {})
+        connection = sqlite3.connect(":memory:")
+        try:
+            connection.row_factory = sqlite3.Row
+            for dep_name, dep_result in dependencies.items():
+                self._materialize(connection, dep_name, dep_result, primary_keys.get(dep_name) or [])
+            try:
+                cursor = connection.execute(bound_sql)
+                fetched = cursor.fetchall()
+            except sqlite3.Error as exc:
+                raise MethodologyError(
+                    f"节点 `{name}` 的内存 SQL 执行失败: {exc}",
+                    error_code="query_failed",
+                    failure_attribution=["invalid_sql"],
+                    stop_reason="方法论内存计算节点的 SQL 有误，需要修正方法论定义而不是重试。",
+                    node=name,
+                ) from exc
+            columns = [description[0] for description in (cursor.description or [])]
+            rows = [{column: row[column] for column in columns} for row in fetched]
+        finally:
+            connection.close()
+        return NodeResult(columns=columns, rows=rows, sql=bound_sql)
+
+    def _run_transform(
+        self,
+        name: str,
+        node: Mapping[str, Any],
+        context: Mapping[str, Any],
+        dependencies: Dict[str, NodeResult],
+    ) -> NodeResult:
+        source_name = list(node.get("dependencies") or [])[0]
+        source = dependencies[source_name]
+        filter_expr = node.get("filter")
+        derive = dict(node.get("derive") or {})
+        rename = dict(node.get("rename") or {})
+        select = list(node.get("select") or [])
+
+        produced: List[Dict[str, Any]] = []
+        for row in source.rows:
+            row_context = dict(context)
+            row_context["row"] = row
+            try:
+                if filter_expr and not evaluate(str(filter_expr), row_context):
+                    continue
+                current = dict(row)
+                for column, expression in derive.items():
+                    row_context["row"] = current
+                    current[column] = evaluate(str(expression), row_context)
+            except BindingError as exc:
+                raise MethodologyError(
+                    f"节点 `{name}` 的变换表达式求值失败: {exc}",
+                    error_code="methodology_invalid",
+                    failure_attribution=["invalid_methodology"],
+                    node=name,
+                ) from exc
+            for old, new in rename.items():
+                if old in current:
+                    current[new] = current.pop(old)
+            if select:
+                current = {column: current.get(column) for column in select}
+            produced.append(current)
+
+        for spec in reversed(list(node.get("sort") or [])):
+            field_name = str(spec.get("field"))
+            reverse = str(spec.get("order") or "asc") == "desc"
+            produced.sort(key=lambda item, key=field_name: (item.get(key) is None, item.get(key)), reverse=reverse)
+
+        limit = node.get("limit")
+        if limit:
+            produced = produced[: int(limit)]
+
+        columns = select or _columns_of(produced, [])
+        return NodeResult(columns=columns, rows=produced)
+
+    def _run_literal(
+        self,
+        _name: str,
+        node: Mapping[str, Any],
+        _context: Mapping[str, Any],
+        _dependencies: Dict[str, NodeResult],
+    ) -> NodeResult:
+        rows = [dict(row) for row in (node.get("rows") or [])]
+        return NodeResult(columns=_columns_of(rows, node.get("columns") or []), rows=rows)
+
+    def _run_call(
+        self,
+        name: str,
+        node: Mapping[str, Any],
+        context: Mapping[str, Any],
+        _dependencies: Dict[str, NodeResult],
+    ) -> NodeResult:
+        target_id = str(node.get("methodology_id") or "")
+        if target_id in self.call_chain:
+            chain = " -> ".join([*self.call_chain, target_id])
+            raise MethodologyError(
+                f"方法论调用成环: {chain}",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+                stop_reason="方法论调用图必须无环；请修正 call 节点的 methodology_id。",
+                node=name,
+            )
+        target = self.registry.get(target_id)
+        if target is None:
+            raise MethodologyError(
+                f"节点 `{name}` 调用的方法论 `{target_id}` 不在注册表中",
+                error_code="methodology_not_found",
+                failure_attribution=["invalid_methodology"],
+                node=name,
+            )
+        try:
+            child_params = {
+                key: evaluate(str(expression), context) for key, expression in (node.get("params") or {}).items()
+            }
+        except BindingError as exc:
+            raise MethodologyError(
+                f"节点 `{name}` 的调用参数求值失败: {exc}",
+                error_code="methodology_invalid",
+                failure_attribution=["invalid_methodology"],
+                node=name,
+            ) from exc
+        child = MethodologyEngine(
+            target,
+            child_params,
+            registry=self.registry,
+            mock=self.mock,
+            node_timeout=self.node_timeout,
+            query_limit=self.query_limit,
+            deadline=self.deadline,
+            call_chain=[*self.call_chain, target_id],
+            trace=self.trace,
+        )
+        return child.run()
+
+    # -- helpers -----------------------------------------------------------
+
+    def _bind(self, name: str, node: Mapping[str, Any], context: Mapping[str, Any]) -> str:
+        try:
+            return bind_sql(
+                str(node.get("sql") or ""),
+                context,
+                predicates=dict(node.get("predicates") or {}),
+                fragment_allowed_values=self._fragment_values,
+            )
+        except BindingError as exc:
+            raise MethodologyError(
+                f"节点 `{name}` 的 SQL 模板绑定失败: {exc}",
+                error_code="param_rejected",
+                failure_attribution=["invalid_methodology"],
+                stop_reason="方法论参数绑定被拒绝，属于口径或参数问题，不要改写 SQL 重试。",
+                node=name,
+            ) from exc
+
+    def _context(self, dependencies: Mapping[str, NodeResult]) -> Dict[str, Any]:
+        context: Dict[str, Any] = {"params": dict(self.params)}
+        for name, result in dependencies.items():
+            context[name] = result.as_context()
+        return context
+
+    @staticmethod
+    def _collect_fragment_values(methodology: Mapping[str, Any]) -> List[str]:
+        allowed: List[str] = []
+        for spec in methodology.get("params") or []:
+            allowed.extend(str(value) for value in (spec.get("values") or []))
+        return allowed
+
+    def _mock_result(self, name: str) -> NodeResult:
+        supplied = self.mock[name]
+        payload = supplied() if callable(supplied) else supplied
+        if isinstance(payload, NodeResult):
+            return payload
+        rows = [dict(row) for row in (payload.get("rows") or [])]
+        return NodeResult(
+            columns=_columns_of(rows, payload.get("columns") or []),
+            rows=rows,
+            sql=payload.get("sql"),
+        )
+
+    def _materialize(
+        self,
+        connection: sqlite3.Connection,
+        table: str,
+        result: NodeResult,
+        primary_keys: Sequence[str],
+    ) -> None:
+        columns = result.columns or _columns_of(result.rows)
+        if not columns:
+            connection.execute(f'CREATE TABLE "{table}" ("_empty" TEXT)')
+            return
+        definitions = ", ".join(f'"{column}"' for column in columns)
+        constraint = ""
+        if primary_keys:
+            constraint = ", PRIMARY KEY (" + ", ".join(f'"{key}"' for key in primary_keys) + ")"
+        connection.execute(f'CREATE TABLE "{table}" ({definitions}{constraint})')
+        placeholders = ", ".join("?" for _ in columns)
+        connection.executemany(
+            f'INSERT INTO "{table}" ({definitions}) VALUES ({placeholders})',
+            [tuple(_sqlite_value(row.get(column)) for column in columns) for row in result.rows],
+        )
+
+    def _node_budget(self, name: str) -> float:
+        remaining = self.deadline - time.monotonic()
+        if remaining <= 0:
+            raise MethodologyError(
+                f"方法论总执行预算已耗尽（节点 `{name}` 尚未开始）",
+                error_code="methodology_timeout",
+                failure_attribution=["tool_timeout"],
+                stop_reason="方法论总执行时间超出预算；请缩小参数范围或改用后台执行。",
+                node=name,
+            )
+        return min(self.node_timeout, remaining)
+
+    def _check_deadline(self, name: str) -> None:
+        if time.monotonic() >= self.deadline:
+            raise MethodologyError(
+                f"方法论总执行预算已耗尽（节点 `{name}` 尚未开始）",
+                error_code="methodology_timeout",
+                failure_attribution=["tool_timeout"],
+                stop_reason="方法论总执行时间超出预算；请缩小参数范围或改用后台执行。",
+                node=name,
+            )
+
+    def _parse_tool_json(self, name: str, completed: subprocess.CompletedProcess) -> Dict[str, Any]:
+        text = (completed.stdout or "").strip()
+        if not text:
+            raise MethodologyError(
+                f"节点 `{name}` 的查询工具没有返回内容: {(completed.stderr or '').strip()[:400]}",
+                error_code="query_failed",
+                failure_attribution=["tool_error"],
+                node=name,
+            )
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise MethodologyError(
+                f"节点 `{name}` 的查询工具返回了非 JSON 内容: {text[:400]}",
+                error_code="query_failed",
+                failure_attribution=["tool_error"],
+                node=name,
+            ) from exc
+
+    def _record(
+        self,
+        name: str,
+        node_type: str,
+        status: str,
+        started: float,
+        result: NodeResult,
+        *,
+        extra: Mapping[str, Any] | None = None,
+    ) -> None:
+        entry: Dict[str, Any] = {
+            "name": name,
+            "type": node_type,
+            "status": status,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "row_count": len(result.rows),
+        }
+        if extra:
+            entry.update(extra)
+        with self._trace_lock:
+            self.trace.append(entry)
+
+
+def _sqlite_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return int(value)
+    if value is None or isinstance(value, (str, int, float, bytes)):
+        return value
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def run_methodology(
+    methodology: Mapping[str, Any],
+    params: Mapping[str, Any],
+    **kwargs: Any,
+) -> tuple[NodeResult, List[Dict[str, Any]]]:
+    """Convenience wrapper returning the target result plus the per-node trace."""
+    engine = MethodologyEngine(methodology, params, **kwargs)
+    return engine.run(), engine.trace

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/engine.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/engine.py
@@ -117,24 +117,44 @@ def _resolve_python_bin() -> str:
     return str(os.getenv("DATAAGENT_PYTHON_BIN") or "").strip() or sys.executable
 
 
+PLATFORM_TOOLS_FOLDER = "opendataworks-platform-tools"
+PLATFORM_TOOLS_ROOT_ENV = "DATAAGENT_PLATFORM_SKILL_ROOT"
+
+
+def _platform_skill_candidates() -> list[Path]:
+    """Where the platform-tools skill may live, most specific first.
+
+    The sibling directory is tried first because it needs nothing from the host:
+    skills are installed side by side, so this skill can find its neighbour from
+    its own location. The environment variable is an optional override for hosts
+    that install skills somewhere else.
+    """
+    candidates: list[Path] = []
+    override = str(os.getenv(PLATFORM_TOOLS_ROOT_ENV) or "").strip()
+    if override:
+        candidates.append(Path(override).expanduser())
+    skill_root = Path(__file__).resolve().parent.parent
+    candidates.append(skill_root.parent / PLATFORM_TOOLS_FOLDER)
+    return candidates
+
+
 def _resolve_platform_skill_root() -> Path:
-    raw = str(os.getenv("DATAAGENT_PLATFORM_SKILL_ROOT") or "").strip()
-    if not raw:
-        raise MethodologyError(
-            "缺少 DATAAGENT_PLATFORM_SKILL_ROOT：方法论的 sql 节点依赖 opendataworks-platform-tools 执行只读查询",
-            error_code="platform_tools_unavailable",
-            failure_attribution=["invalid_tool_path"],
-            stop_reason="本 skill 必须与 opendataworks-platform-tools 同时启用；请先启用平台工具技能，不要改用其他 SQL 执行方式。",
-        )
-    root = Path(raw).expanduser().resolve(strict=False)
-    if not (root / "scripts" / "run_sql.py").is_file():
-        raise MethodologyError(
-            f"DATAAGENT_PLATFORM_SKILL_ROOT 下找不到 scripts/run_sql.py: {root}",
-            error_code="platform_tools_unavailable",
-            failure_attribution=["invalid_tool_path"],
-            stop_reason="平台工具技能目录不完整，无法执行只读查询。",
-        )
-    return root
+    checked: list[str] = []
+    for candidate in _platform_skill_candidates():
+        root = candidate.resolve(strict=False)
+        if (root / "scripts" / "run_sql.py").is_file():
+            return root
+        checked.append(str(root))
+    raise MethodologyError(
+        "找不到 opendataworks-platform-tools：方法论的 sql 节点依赖它执行只读查询。已尝试："
+        + "、".join(checked),
+        error_code="platform_tools_unavailable",
+        failure_attribution=["invalid_tool_path"],
+        stop_reason=(
+            "本 skill 必须与 opendataworks-platform-tools 一起安装并启用；"
+            "请先启用平台工具技能，不要改用其他 SQL 执行方式。"
+        ),
+    )
 
 
 class MethodologyEngine:

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/lookup_methodology.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/lookup_methodology.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Search the methodology registry. Never executes anything.
+
+Returns the semantic surface an assistant needs to decide whether a registered
+methodology answers the question — intent, caliber, parameter slots, output
+fields — so the decision is made before any query runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from registry import REGISTRY_DIR, RegistryError, load_registry, print_json
+
+TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+# Chinese text has no spaces, so keyword matching falls back to character bigrams.
+BIGRAM_MIN_LENGTH = 2
+
+
+def _tokens(text: str) -> List[str]:
+    lowered = str(text or "").lower()
+    tokens = TOKEN_RE.findall(lowered)
+    cjk = re.sub(r"[A-Za-z0-9_\s]+", "", lowered)
+    tokens.extend(cjk[index : index + BIGRAM_MIN_LENGTH] for index in range(max(0, len(cjk) - 1)))
+    return [token for token in tokens if token]
+
+
+def _haystack(methodology: Mapping[str, Any]) -> str:
+    parts = [
+        methodology.get("id"),
+        methodology.get("name_zh"),
+        methodology.get("name_en"),
+        methodology.get("intent"),
+        methodology.get("caliber"),
+        *(methodology.get("synonyms") or []),
+        *(methodology.get("output_fields") or []),
+    ]
+    return " ".join(str(part) for part in parts if part)
+
+
+def _summarize(methodology: Mapping[str, Any], score: float | None = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "id": methodology.get("id"),
+        "version": methodology.get("version"),
+        "name_zh": methodology.get("name_zh"),
+        "intent": methodology.get("intent"),
+        "caliber": methodology.get("caliber"),
+        "owner": methodology.get("owner"),
+        "synonyms": methodology.get("synonyms") or [],
+        "output_fields": methodology.get("output_fields") or [],
+        "ontology_ref": methodology.get("ontology_ref"),
+        "params": [
+            {
+                "name": spec.get("name"),
+                "type": spec.get("type"),
+                "required": bool(spec.get("required")),
+                "default": spec.get("default"),
+                "values": spec.get("values") or [],
+                "description": spec.get("description"),
+            }
+            for spec in (methodology.get("params") or [])
+        ],
+        "node_count": len(methodology.get("nodes") or {}),
+    }
+    if score is not None:
+        payload["score"] = round(score, 4)
+    return payload
+
+
+def search(registry: Mapping[str, Mapping[str, Any]], query: str, limit: int) -> List[Dict[str, Any]]:
+    query_tokens = set(_tokens(query))
+    if not query_tokens:
+        return [_summarize(item) for item in list(registry.values())[:limit]]
+    scored: List[tuple[float, Dict[str, Any]]] = []
+    for methodology in registry.values():
+        haystack_tokens = set(_tokens(_haystack(methodology)))
+        overlap = query_tokens & haystack_tokens
+        if not overlap:
+            continue
+        scored.append((len(overlap) / len(query_tokens), _summarize(methodology, len(overlap) / len(query_tokens))))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [payload for _, payload in scored[:limit]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="检索已注册的分析方法论，不执行任何查询")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--query", help="用户问题或关键词")
+    group.add_argument("--id", help="按 id 精确获取")
+    group.add_argument("--list", action="store_true", help="列出全部方法论")
+    parser.add_argument("--registry-dir", default=str(REGISTRY_DIR))
+    parser.add_argument("--limit", type=int, default=5)
+    args = parser.parse_args()
+
+    try:
+        registry = load_registry(Path(args.registry_dir))
+    except RegistryError as exc:
+        print_json(
+            {
+                "kind": "methodology_lookup",
+                "matched": 0,
+                "results": [],
+                "error": str(exc),
+                "stop_reason": "注册表加载失败；请回落到平台工具的常规问数链路。",
+            }
+        )
+        return 1
+
+    if args.id:
+        methodology = registry.get(args.id)
+        results = [_summarize(methodology)] if methodology else []
+    elif args.list:
+        results = [_summarize(item) for item in registry.values()]
+    else:
+        results = search(registry, args.query, args.limit)
+
+    print_json(
+        {
+            "kind": "methodology_lookup",
+            "tool_label": "方法论检索",
+            "query": args.query or args.id or "",
+            "matched": len(results),
+            "results": results,
+            "stop_reason": (
+                ""
+                if results
+                else "没有命中已注册方法论；请回落到平台工具的常规问数链路（语义确认 → SQL 生成 → validate_sql.py → run_sql.py）。"
+            ),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/methodology_schema.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/methodology_schema.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Pydantic data model and JSON Schema for methodology DAG artifacts.
+
+A methodology is a declarative directed acyclic graph of typed steps. Each node
+consumes and produces a single table-shaped value; exactly one node is the
+``target``. The engine — not the author — decides what runs, in what order,
+what runs in parallel, what is skipped and what is reused.
+
+Run as a script to print the JSON Schema:
+
+    python3 methodology_schema.py > ../assets/methodology.schema.json
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SnakeCaseId = str
+
+SNAKE_CASE_PATTERN = r"^[a-z][a-z0-9_]*$"
+SEMVER_PATTERN = r"^\d+\.\d+\.\d+$"
+
+NODE_TYPE_OPTIONS: Dict[str, Dict[str, str]] = {
+    "sql": {
+        "group": "query",
+        "label_zh": "只读查询",
+        "description": "执行模板化只读 SQL，经平台工具 run_sql.py 走后端只读查询链路",
+    },
+    "sqlite": {
+        "group": "compute",
+        "label_zh": "内存关系计算",
+        "description": "把依赖节点结果装入内存 SQLite 后执行完整 SQL，支持跨引擎 join 与集合运算",
+    },
+    "transform": {
+        "group": "compute",
+        "label_zh": "表变换",
+        "description": "对单个依赖结果做行级过滤、派生列、改名、排序和截断",
+    },
+    "literal": {
+        "group": "compute",
+        "label_zh": "常量表",
+        "description": "固定的行集合，例如维度到列名的映射表",
+    },
+    "conditional": {
+        "group": "control",
+        "label_zh": "条件分支",
+        "description": "先求谓词再解析二选一分支；未选中分支及其子图不执行",
+    },
+    "call": {
+        "group": "control",
+        "label_zh": "调用方法论",
+        "description": "调用注册表中的另一个方法论，是复用单元；调用链禁止成环",
+    },
+}
+
+PARAM_TYPE_OPTIONS: Dict[str, Dict[str, str]] = {
+    "string": {"label_zh": "字符串"},
+    "int": {"label_zh": "整数"},
+    "float": {"label_zh": "浮点数"},
+    "bool": {"label_zh": "布尔"},
+    "enum": {"label_zh": "枚举", "description": "取值必须命中 values"},
+    "date": {"label_zh": "日期", "description": "YYYY-MM-DD"},
+    "string_list": {"label_zh": "字符串列表", "description": "用于 IN 列表"},
+}
+
+PREDICATE_OP_OPTIONS: Dict[str, Dict[str, str]] = {
+    "eq": {"label_zh": "等于", "arity": "field+value"},
+    "ne": {"label_zh": "不等于", "arity": "field+value"},
+    "lt": {"label_zh": "小于", "arity": "field+value"},
+    "lte": {"label_zh": "小于等于", "arity": "field+value"},
+    "gt": {"label_zh": "大于", "arity": "field+value"},
+    "gte": {"label_zh": "大于等于", "arity": "field+value"},
+    "like": {"label_zh": "模糊匹配", "arity": "field+value"},
+    "in": {"label_zh": "属于", "arity": "field+values"},
+    "between": {"label_zh": "区间", "arity": "field+values(2)"},
+    "and": {"label_zh": "与", "arity": "clauses"},
+    "or": {"label_zh": "或", "arity": "clauses"},
+    "not": {"label_zh": "非", "arity": "clauses(1)"},
+}
+
+SORT_ORDER_OPTIONS: Dict[str, Dict[str, str]] = {
+    "asc": {"label_zh": "升序"},
+    "desc": {"label_zh": "降序"},
+}
+
+ENGINE_OPTIONS: Dict[str, Dict[str, str]] = {
+    "mysql": {"label_zh": "MySQL"},
+    "doris": {"label_zh": "Doris"},
+}
+
+PLACEHOLDER_FORMS: Dict[str, Dict[str, str]] = {
+    "{{ expr }}": {
+        "label_zh": "受检值",
+        "description": "求值结果必须是标量或标量数组；标量转义加引号，数组展开为逗号列表。值无法逃出字面量位置。",
+    },
+    "{{! expr }}": {
+        "label_zh": "标识符片段",
+        "description": "只允许标识符（列名、表别名）。必须匹配 ^[A-Za-z_][A-Za-z0-9_.]*$ 或命中参数 values 枚举。",
+    },
+    "{{? name }}": {
+        "label_zh": "谓词片段",
+        "description": "引用本节点 predicates 里的同名谓词；null 子谓词被丢弃，全空时渲染为空串。",
+    },
+}
+
+FIELD_DICTIONARY: Dict[str, Any] = {
+    "top_level_fields": {
+        "title": "顶层字段",
+        "values": {
+            "id": {"type": "string", "required": "是", "description": "snake_case 方法论标识，注册表内唯一"},
+            "version": {"type": "string", "required": "是", "description": "语义化版本；口径变更必须升版本"},
+            "name_zh": {"type": "string", "required": "是", "description": "中文名"},
+            "intent": {"type": "string", "required": "是", "description": "本方法论回答什么问题"},
+            "caliber": {"type": "string", "required": "是", "description": "统计口径：时间字段、区间、过滤与排除规则"},
+            "owner": {"type": "string", "required": "是", "description": "口径责任人或团队"},
+            "synonyms": {"type": "string[]", "required": "否", "description": "检索用同义词"},
+            "ontology_ref": {"type": "object", "required": "否", "description": "关联的本体 query_function"},
+            "output_fields": {"type": "string[]", "required": "否", "description": "target 节点预期输出列"},
+            "params": {"type": "object[]", "required": "否", "description": "参数槽位声明"},
+            "nodes": {"type": "object", "required": "是", "description": "节点名到节点定义的映射"},
+            "target": {"type": "string", "required": "是", "description": "目标节点名；执行只走到它的传递依赖为止"},
+        },
+    },
+    "nodes.type": {"title": "nodes.type", "values": NODE_TYPE_OPTIONS},
+    "params.type": {"title": "params.type", "values": PARAM_TYPE_OPTIONS},
+    "predicates.op": {"title": "predicates.op", "values": PREDICATE_OP_OPTIONS},
+    "sort.order": {"title": "sort.order", "values": SORT_ORDER_OPTIONS},
+    "sql.engine": {"title": "sql.engine", "values": ENGINE_OPTIONS},
+    "placeholder_forms": {"title": "SQL 模板占位符", "values": PLACEHOLDER_FORMS},
+}
+
+NodeType = Literal[*tuple(NODE_TYPE_OPTIONS)]
+ParamType = Literal[*tuple(PARAM_TYPE_OPTIONS)]
+PredicateOp = Literal[*tuple(PREDICATE_OP_OPTIONS)]
+SortOrder = Literal[*tuple(SORT_ORDER_OPTIONS)]
+Engine = Literal[*tuple(ENGINE_OPTIONS)]
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class OntologyRef(StrictModel):
+    skill: str
+    function_name: SnakeCaseId = Field(pattern=SNAKE_CASE_PATTERN)
+
+
+class ParamSpec(StrictModel):
+    name: SnakeCaseId = Field(pattern=SNAKE_CASE_PATTERN)
+    type: ParamType
+    description: str
+    required: bool = False
+    default: Any = None
+    values: List[str] = Field(default_factory=list)
+    minimum: Optional[float] = None
+    maximum: Optional[float] = None
+    max_items: Optional[int] = None
+
+
+class Predicate(StrictModel):
+    """One node of the predicate DSL.
+
+    Leaf predicates carry ``field`` plus ``value``/``values``; a leaf whose bound
+    value resolves to null is dropped at compile time, so an absent optional
+    parameter simply makes its filter disappear. Composite predicates
+    (``and``/``or``/``not``) carry ``clauses``.
+    """
+
+    op: PredicateOp
+    field: Optional[str] = None
+    value: Any = None
+    # A ``$expr`` string resolves to a list at bind time (e.g. an IN list taken
+    # from an upstream node); a literal list is used as-is.
+    values: Union[str, List[Any], None] = None
+    clauses: List["Predicate"] = Field(default_factory=list)
+
+
+class SortSpec(StrictModel):
+    field: str
+    order: SortOrder = "asc"
+
+
+class BaseNode(StrictModel):
+    description: Optional[str] = None
+    dependencies: List[str] = Field(default_factory=list)
+
+
+class SqlNode(BaseNode):
+    type: Literal["sql"]
+    database: str
+    sql: str
+    engine: Optional[Engine] = None
+    predicates: Dict[str, Predicate] = Field(default_factory=dict)
+    limit: Optional[int] = Field(default=None, ge=1)
+
+
+class SqliteNode(BaseNode):
+    type: Literal["sqlite"]
+    sql: str
+    dependencies: List[str] = Field(min_length=1)
+    primary_keys: Dict[str, List[str]] = Field(default_factory=dict)
+
+
+class TransformNode(BaseNode):
+    type: Literal["transform"]
+    dependencies: List[str] = Field(min_length=1, max_length=1)
+    filter: Optional[str] = None
+    derive: Dict[str, str] = Field(default_factory=dict)
+    rename: Dict[str, str] = Field(default_factory=dict)
+    select: List[str] = Field(default_factory=list)
+    sort: List[SortSpec] = Field(default_factory=list)
+    limit: Optional[int] = Field(default=None, ge=1)
+
+
+class LiteralNode(BaseNode):
+    type: Literal["literal"]
+    rows: List[Dict[str, Any]] = Field(default_factory=list)
+    columns: List[str] = Field(default_factory=list)
+
+
+class ConditionalNode(BaseNode):
+    type: Literal["conditional"]
+    when: str
+    then_node: str
+    else_node: str
+
+
+class CallNode(BaseNode):
+    type: Literal["call"]
+    methodology_id: SnakeCaseId = Field(pattern=SNAKE_CASE_PATTERN)
+    params: Dict[str, str] = Field(default_factory=dict)
+
+
+Node = Annotated[
+    Union[SqlNode, SqliteNode, TransformNode, LiteralNode, ConditionalNode, CallNode],
+    Field(discriminator="type"),
+]
+
+
+class Methodology(StrictModel):
+    id: SnakeCaseId = Field(pattern=SNAKE_CASE_PATTERN)
+    version: str = Field(pattern=SEMVER_PATTERN)
+    name_zh: str
+    intent: str
+    caliber: str
+    owner: str
+    nodes: Dict[str, Node] = Field(min_length=1)
+    target: str
+    name_en: Optional[str] = None
+    synonyms: List[str] = Field(default_factory=list)
+    ontology_ref: Optional[OntologyRef] = None
+    output_fields: List[str] = Field(default_factory=list)
+    params: List[ParamSpec] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+
+def methodology_json_schema() -> Dict[str, Any]:
+    schema = Methodology.model_json_schema()
+    schema["x-field-dictionary"] = FIELD_DICTIONARY
+    return schema
+
+
+def methodology_json_schema_text() -> str:
+    return json.dumps(methodology_json_schema(), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+if __name__ == "__main__":
+    print(methodology_json_schema_text(), end="")

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/registry.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/registry.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Loading, parameter coercion and shared JSON output helpers for the registry."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Tuple
+
+from methodology_schema import Methodology
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_DIR = SKILL_ROOT / "assets" / "registry"
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class RegistryError(ValueError):
+    def __init__(self, message: str, *, error_code: str = "methodology_invalid") -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+def print_json(payload: Any) -> None:
+    print(json.dumps(payload, ensure_ascii=False, default=str))
+
+
+def load_registry(directory: Path | None = None) -> Dict[str, Dict[str, Any]]:
+    """Load and schema-validate every methodology in the registry directory."""
+    root = directory or REGISTRY_DIR
+    registry: Dict[str, Dict[str, Any]] = {}
+    if not root.is_dir():
+        return registry
+    for path in sorted(root.glob("*.json")):
+        methodology = load_methodology_file(path)
+        identifier = methodology["id"]
+        if identifier in registry:
+            raise RegistryError(f"注册表中存在重复的方法论 id `{identifier}`")
+        registry[identifier] = methodology
+    return registry
+
+
+def load_methodology_file(path: Path) -> Dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RegistryError(f"{path.name}: 无法读取或解析 JSON: {exc}") from exc
+    return validate_schema(raw, source=path.name)
+
+
+def validate_schema(raw: Mapping[str, Any], *, source: str = "<inline>") -> Dict[str, Any]:
+    try:
+        model = Methodology.model_validate(raw)
+    except Exception as exc:  # pydantic ValidationError
+        raise RegistryError(f"{source}: schema 校验失败: {exc}") from exc
+    return model.model_dump(mode="json", exclude_none=False)
+
+
+# --------------------------------------------------------------------------
+# Parameter coercion
+# --------------------------------------------------------------------------
+
+def coerce_params(specs: List[Mapping[str, Any]], supplied: Mapping[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    """Coerce and range-check supplied parameters against their declarations.
+
+    Returns the resolved parameter map plus the names of missing required slots,
+    so the caller can ask the user for exactly those and nothing more.
+    """
+    declared = {str(spec["name"]): spec for spec in specs}
+    unknown = sorted(set(supplied) - set(declared))
+    if unknown:
+        raise RegistryError(
+            f"未声明的参数: {', '.join(unknown)}；可用参数为 {', '.join(sorted(declared)) or '（无）'}",
+            error_code="param_rejected",
+        )
+
+    resolved: Dict[str, Any] = {}
+    missing: List[str] = []
+    for name, spec in declared.items():
+        if name in supplied and supplied[name] is not None:
+            resolved[name] = _coerce_one(name, spec, supplied[name])
+        elif spec.get("default") is not None:
+            resolved[name] = _coerce_one(name, spec, spec["default"])
+        elif spec.get("required"):
+            missing.append(name)
+            resolved[name] = None
+        else:
+            resolved[name] = None
+    return resolved, missing
+
+
+def _coerce_one(name: str, spec: Mapping[str, Any], value: Any) -> Any:
+    param_type = str(spec.get("type") or "string")
+    try:
+        if param_type == "int":
+            coerced: Any = int(value)
+        elif param_type == "float":
+            coerced = float(value)
+        elif param_type == "bool":
+            coerced = value if isinstance(value, bool) else str(value).strip().lower() in {"1", "true", "yes", "on"}
+        elif param_type == "string_list":
+            items = value if isinstance(value, (list, tuple)) else [value]
+            coerced = [str(item) for item in items]
+        elif param_type == "date":
+            coerced = str(value).strip()
+            if not DATE_RE.match(coerced):
+                raise ValueError("日期必须是 YYYY-MM-DD")
+            _dt.date.fromisoformat(coerced)
+        else:
+            coerced = str(value)
+    except (TypeError, ValueError) as exc:
+        raise RegistryError(f"参数 `{name}` 取值非法: {exc}", error_code="param_rejected") from exc
+
+    values = [str(item) for item in (spec.get("values") or [])]
+    if param_type == "enum":
+        if str(coerced) not in values:
+            raise RegistryError(
+                f"参数 `{name}` 取值 `{coerced}` 不在允许范围 {values} 内", error_code="param_rejected"
+            )
+    elif param_type == "string_list" and values:
+        rejected = [item for item in coerced if item not in values]
+        if rejected:
+            raise RegistryError(
+                f"参数 `{name}` 含非法取值 {rejected}，允许范围 {values}", error_code="param_rejected"
+            )
+
+    minimum = spec.get("minimum")
+    maximum = spec.get("maximum")
+    if isinstance(coerced, (int, float)) and not isinstance(coerced, bool):
+        if minimum is not None and coerced < minimum:
+            raise RegistryError(f"参数 `{name}` 不能小于 {minimum}", error_code="param_rejected")
+        if maximum is not None and coerced > maximum:
+            raise RegistryError(f"参数 `{name}` 不能大于 {maximum}", error_code="param_rejected")
+    max_items = spec.get("max_items")
+    if max_items and isinstance(coerced, list) and len(coerced) > int(max_items):
+        raise RegistryError(f"参数 `{name}` 最多 {max_items} 个取值", error_code="param_rejected")
+    return coerced
+
+
+def parse_params_argument(raw: str | None) -> Dict[str, Any]:
+    text = str(raw or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RegistryError(f"--params 必须是合法 JSON 对象: {exc}", error_code="param_rejected") from exc
+    if not isinstance(parsed, dict):
+        raise RegistryError("--params 必须是 JSON 对象", error_code="param_rejected")
+    return parsed
+
+
+def fail(payload: Mapping[str, Any]) -> None:
+    print_json(payload)
+    sys.exit(0)

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/run_methodology.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/run_methodology.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Execute one registered methodology and emit the standard tool contract.
+
+The output uses ``kind=sql_execution`` so the existing result renderer and the
+existing failure-attribution vocabulary apply unchanged; the methodology header
+and the per-node trace ride along as extra fields.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from engine import (
+    DEFAULT_NODE_TIMEOUT_SECONDS,
+    DEFAULT_TOTAL_TIMEOUT_SECONDS,
+    MethodologyEngine,
+    MethodologyError,
+)
+from registry import (
+    REGISTRY_DIR,
+    RegistryError,
+    coerce_params,
+    load_registry,
+    parse_params_argument,
+    print_json,
+)
+from validate_methodology import validate_methodology
+
+TOOL_LABEL = "方法论执行"
+
+
+def _env_int(name: str, fallback: int) -> int:
+    try:
+        return int(str(os.getenv(name) or "").strip() or fallback)
+    except ValueError:
+        return fallback
+
+
+def _header(methodology: Mapping[str, Any], params: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": methodology.get("id"),
+        "version": methodology.get("version"),
+        "name_zh": methodology.get("name_zh"),
+        "caliber": methodology.get("caliber"),
+        "owner": methodology.get("owner"),
+        "params": dict(params),
+    }
+
+
+def _failure(
+    methodology: Mapping[str, Any] | None,
+    params: Mapping[str, Any],
+    *,
+    message: str,
+    error_code: str,
+    failure_attribution: List[str],
+    stop_reason: str,
+    retryable: bool = False,
+    trace: List[Dict[str, Any]] | None = None,
+    duration_ms: int = 0,
+) -> Dict[str, Any]:
+    return {
+        "kind": "sql_execution",
+        "tool_label": TOOL_LABEL,
+        "methodology": _header(methodology or {}, params),
+        "sql": None,
+        "columns": [],
+        "rows": [],
+        "row_count": 0,
+        "has_more": False,
+        "duration_ms": duration_ms,
+        "truncated_by_size": False,
+        "notice": None,
+        "summary": f"方法论执行失败：{message}",
+        "error": message,
+        "result_state": "failed",
+        "error_code": error_code,
+        "failure_attribution": failure_attribution,
+        "retryable": retryable,
+        "stop_reason": stop_reason,
+        "trace": {"executed": len(trace or []), "nodes": list(trace or [])},
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="执行一个已注册的分析方法论")
+    parser.add_argument("--id", required=True, help="方法论 id")
+    parser.add_argument("--params", default="", help="参数 JSON 对象")
+    parser.add_argument("--registry-dir", default=str(REGISTRY_DIR))
+    parser.add_argument("--mock", default="", help="mock 模式：节点名到结果的 JSON 文件，不访问任何数据存储")
+    parser.add_argument(
+        "--total-timeout",
+        type=float,
+        default=float(_env_int("DATAAGENT_METHODOLOGY_TOTAL_TIMEOUT_SECONDS", DEFAULT_TOTAL_TIMEOUT_SECONDS)),
+    )
+    parser.add_argument(
+        "--node-timeout",
+        type=float,
+        default=float(_env_int("DATAAGENT_SQL_READ_TIMEOUT_SECONDS", DEFAULT_NODE_TIMEOUT_SECONDS)),
+    )
+    parser.add_argument("--limit", type=int, default=_env_int("DATAAGENT_QUERY_LIMIT", 1000))
+    args = parser.parse_args()
+
+    supplied: Dict[str, Any] = {}
+    methodology: Dict[str, Any] | None = None
+    started = time.monotonic()
+
+    try:
+        registry = load_registry(Path(args.registry_dir))
+        methodology = registry.get(args.id)
+        if methodology is None:
+            available = ", ".join(sorted(registry)) or "（注册表为空）"
+            print_json(
+                _failure(
+                    None,
+                    {},
+                    message=f"注册表中没有方法论 `{args.id}`",
+                    error_code="methodology_not_found",
+                    failure_attribution=["invalid_methodology"],
+                    stop_reason=f"可用方法论：{available}。未命中时请回落到平台工具的常规问数链路，不要猜测 id。",
+                )
+            )
+            return 0
+
+        report = validate_methodology(methodology, registry=registry)
+        if not report.ok:
+            print_json(
+                _failure(
+                    methodology,
+                    {},
+                    message="方法论定义未通过静态校验：" + "；".join(report.errors),
+                    error_code="methodology_invalid",
+                    failure_attribution=["invalid_methodology"],
+                    stop_reason="方法论工件本身有问题，需要修正注册表定义，不要重试。",
+                )
+            )
+            return 0
+
+        supplied = parse_params_argument(args.params)
+        params, missing = coerce_params(list(methodology.get("params") or []), supplied)
+        if missing:
+            print_json(
+                _failure(
+                    methodology,
+                    params,
+                    message=f"缺少必填参数：{', '.join(missing)}",
+                    error_code="param_missing",
+                    failure_attribution=["missing_parameter"],
+                    stop_reason=f"请只向用户追问这些参数槽位：{', '.join(missing)}；不要自行假定口径。",
+                )
+            )
+            return 0
+
+        mock: Dict[str, Any] = {}
+        if args.mock:
+            mock = json.loads(Path(args.mock).read_text(encoding="utf-8"))
+
+        engine = MethodologyEngine(
+            methodology,
+            params,
+            registry=registry,
+            mock=mock,
+            total_timeout=args.total_timeout,
+            node_timeout=args.node_timeout,
+            query_limit=args.limit,
+        )
+        result = engine.run()
+
+    except MethodologyError as exc:
+        print_json(
+            _failure(
+                methodology,
+                supplied,
+                message=str(exc),
+                error_code=exc.error_code,
+                failure_attribution=exc.failure_attribution or ["tool_error"],
+                stop_reason=exc.stop_reason,
+                retryable=exc.retryable,
+                duration_ms=int((time.monotonic() - started) * 1000),
+            )
+        )
+        return 0
+    except RegistryError as exc:
+        print_json(
+            _failure(
+                methodology,
+                supplied,
+                message=str(exc),
+                error_code=getattr(exc, "error_code", "methodology_invalid"),
+                failure_attribution=["invalid_methodology"],
+                stop_reason=str(exc),
+            )
+        )
+        return 0
+    except (OSError, json.JSONDecodeError) as exc:
+        print_json(
+            _failure(
+                methodology,
+                supplied,
+                message=f"读取输入失败: {exc}",
+                error_code="methodology_invalid",
+                failure_attribution=["tool_error"],
+                stop_reason="输入文件无法读取或解析。",
+            )
+        )
+        return 0
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    pruned = sum(1 for entry in engine.trace if entry.get("pruned_branch"))
+    if not result.rows:
+        execution_detail = {
+            "result_state": "empty_result",
+            "error_code": "empty_result",
+            "failure_attribution": ["empty_result"],
+            "retryable": False,
+            "stop_reason": (
+                "方法论已按注册口径成功执行但返回 0 行；说明当前口径下无数据，"
+                "请说明口径与空结果，不要改写口径或换表试探。"
+            ),
+        }
+        summary = "方法论执行成功，但返回 0 行结果"
+    elif result.truncated_by_size:
+        execution_detail = {
+            "result_state": "success",
+            "error_code": "result_truncated",
+            "failure_attribution": [],
+            "retryable": False,
+            "stop_reason": result.notice or "结果过大已按体积截断；请缩小参数范围。",
+        }
+        summary = f"返回 {len(result.rows)} 行结果（已按体积截断）"
+    else:
+        execution_detail = {
+            "result_state": "success",
+            "error_code": None,
+            "failure_attribution": [],
+            "retryable": False,
+            "stop_reason": "",
+        }
+        summary = f"返回 {len(result.rows)} 行结果"
+
+    print_json(
+        {
+            "kind": "sql_execution",
+            "tool_label": TOOL_LABEL,
+            "methodology": _header(methodology, params),
+            "engine": result.engine,
+            "database": result.database,
+            "sql": result.sql,
+            "columns": result.columns,
+            "rows": result.rows,
+            "row_count": len(result.rows),
+            "has_more": result.has_more,
+            "duration_ms": duration_ms,
+            "truncated_by_size": result.truncated_by_size,
+            "notice": result.notice,
+            "summary": summary,
+            "error": None,
+            "trace": {"executed": len(engine.trace), "pruned": pruned, "nodes": engine.trace},
+            **execution_detail,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Static validation of methodology DAGs.
+
+Because a methodology is data rather than code, the engine can check it before
+anything runs: every referenced dependency exists, the target exists, the
+dependency graph is acyclic (with any cycle reported as a concrete path), every
+template placeholder parses and only references declared names, and every
+``call`` resolves without forming a cycle in the call graph. Errors that would be
+runtime exceptions in hand-written glue become load-time rejections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Sequence
+
+from binding import (
+    BindingError,
+    assert_template_markers_understood,
+    iter_template_expressions,
+    iter_template_predicates,
+    parse_expression,
+)
+from registry import (
+    REGISTRY_DIR,
+    RegistryError,
+    load_methodology_file,
+    load_registry,
+    print_json,
+    validate_schema,
+)
+
+SQL_NODE_TYPES = {"sql", "sqlite"}
+TEMPLATE_NODE_TYPES = {"sql", "sqlite"}
+
+
+class Report:
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def payload(self) -> Dict[str, Any]:
+        return {
+            "id": self.identifier,
+            "valid": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+def _declared_names(methodology: Mapping[str, Any]) -> set[str]:
+    names = {"params", "row"}
+    names.update(methodology.get("nodes") or {})
+    return names
+
+
+def _expression_roots(expression: str) -> set[str]:
+    import ast
+
+    tree = parse_expression(expression)
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            roots.add(node.id)
+    return roots
+
+
+def _check_expression(
+    report: Report,
+    where: str,
+    expression: str,
+    allowed_roots: set[str],
+    *,
+    param_names: set[str],
+) -> None:
+    try:
+        roots = _expression_roots(expression)
+    except BindingError as exc:
+        report.error(f"{where}: {exc}")
+        return
+    from binding import ALLOWED_FUNCTIONS
+
+    for root in roots:
+        if root in ALLOWED_FUNCTIONS:
+            continue
+        if root not in allowed_roots:
+            report.error(
+                f"{where}: 表达式 `{expression}` 引用了未知的名字 `{root}`；"
+                f"只能引用 params、本节点依赖或 row"
+            )
+    if "params" in roots:
+        import ast
+
+        tree = parse_expression(expression)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "params"
+                and node.attr not in param_names
+            ):
+                report.error(f"{where}: 表达式引用了未声明的参数 `params.{node.attr}`")
+
+
+def _detect_cycle(graph: Mapping[str, Sequence[str]]) -> List[str] | None:
+    """DFS for a cycle, returning the concrete path rather than a bare boolean."""
+    WHITE, GREY, BLACK = 0, 1, 2
+    color: Dict[str, int] = {node: WHITE for node in graph}
+    stack: List[str] = []
+
+    def visit(node: str) -> List[str] | None:
+        color[node] = GREY
+        stack.append(node)
+        for neighbour in graph.get(node, ()):
+            if neighbour not in color:
+                continue
+            if color[neighbour] == GREY:
+                start = stack.index(neighbour)
+                return [*stack[start:], neighbour]
+            if color[neighbour] == WHITE:
+                found = visit(neighbour)
+                if found:
+                    return found
+        color[node] = BLACK
+        stack.pop()
+        return None
+
+    for node in graph:
+        if color[node] == WHITE:
+            found = visit(node)
+            if found:
+                return found
+    return None
+
+
+def _reachable(graph: Mapping[str, Sequence[str]], start: str) -> set[str]:
+    seen: set[str] = set()
+    pending = [start]
+    while pending:
+        current = pending.pop()
+        if current in seen or current not in graph:
+            continue
+        seen.add(current)
+        pending.extend(graph.get(current, ()))
+    return seen
+
+
+def _stub_value(spec: Mapping[str, Any]) -> Any:
+    param_type = str(spec.get("type") or "string")
+    if spec.get("default") is not None:
+        return spec["default"]
+    if spec.get("values"):
+        return spec["values"][0]
+    return {
+        "int": 1,
+        "float": 1.0,
+        "bool": True,
+        "date": "2026-01-01",
+        "string_list": ["stub"],
+    }.get(param_type, "stub")
+
+
+def _validate_sql_with_platform_tools(sql: str) -> tuple[bool, str]:
+    """Run the platform-tools SQL validator when it is reachable."""
+    root = str(os.getenv("DATAAGENT_PLATFORM_SKILL_ROOT") or "").strip()
+    if not root:
+        return True, "skipped: DATAAGENT_PLATFORM_SKILL_ROOT 未设置"
+    script = Path(root) / "scripts" / "validate_sql.py"
+    if not script.is_file():
+        return True, "skipped: 找不到 validate_sql.py"
+    python_bin = str(os.getenv("DATAAGENT_PYTHON_BIN") or "").strip() or sys.executable
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [python_bin, str(script), "--json", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return True, f"skipped: 调用 validate_sql.py 失败 {exc}"
+    import json as _json
+
+    try:
+        payload = _json.loads((completed.stdout or "").strip())
+    except _json.JSONDecodeError:
+        return True, "skipped: validate_sql.py 未返回 JSON"
+    if payload.get("valid") is False:
+        return False, "; ".join(str(item) for item in (payload.get("errors") or []))
+    return True, ""
+
+
+def validate_methodology(
+    methodology: Mapping[str, Any],
+    *,
+    registry: Mapping[str, Mapping[str, Any]] | None = None,
+    check_sql: bool = False,
+) -> Report:
+    report = Report(str(methodology.get("id") or "<unknown>"))
+    nodes: Dict[str, Mapping[str, Any]] = dict(methodology.get("nodes") or {})
+    target = str(methodology.get("target") or "")
+    param_specs = list(methodology.get("params") or [])
+    param_names = {str(spec["name"]) for spec in param_specs}
+    registry = dict(registry or {})
+
+    if target not in nodes:
+        report.error(f"target `{target}` 不是已定义的节点")
+
+    # Dependency graph, with conditional branches as soft edges.
+    hard_graph: Dict[str, List[str]] = {}
+    full_graph: Dict[str, List[str]] = {}
+    for name, node in nodes.items():
+        dependencies = [str(item) for item in (node.get("dependencies") or [])]
+        for dependency in dependencies:
+            if dependency not in nodes:
+                report.error(f"节点 `{name}` 依赖了不存在的节点 `{dependency}`")
+            if dependency == name:
+                report.error(f"节点 `{name}` 依赖了自身")
+        hard_graph[name] = dependencies
+        branches: List[str] = []
+        if str(node.get("type")) == "conditional":
+            for key in ("then_node", "else_node"):
+                branch = str(node.get(key) or "")
+                if branch not in nodes:
+                    report.error(f"条件节点 `{name}` 的 {key} `{branch}` 不是已定义的节点")
+                else:
+                    branches.append(branch)
+        full_graph[name] = [*dependencies, *branches]
+
+    cycle = _detect_cycle(full_graph)
+    if cycle:
+        report.error("依赖图存在环: " + " -> ".join(cycle))
+
+    if target in nodes and not cycle:
+        reachable = _reachable(full_graph, target)
+        for name in sorted(set(nodes) - reachable):
+            report.warn(f"节点 `{name}` 从 target 不可达，永远不会执行")
+
+    # Per-node checks.
+    for name, node in nodes.items():
+        node_type = str(node.get("type") or "")
+        allowed_roots = {"params", *[str(item) for item in (node.get("dependencies") or [])]}
+        if node_type == "transform":
+            allowed_roots.add("row")
+
+        if node_type in TEMPLATE_NODE_TYPES:
+            template = str(node.get("sql") or "")
+            try:
+                assert_template_markers_understood(template)
+            except BindingError as exc:
+                report.error(f"节点 `{name}`: {exc}")
+            for expression in iter_template_expressions(template):
+                _check_expression(report, f"节点 `{name}`", expression, allowed_roots, param_names=param_names)
+            declared_predicates = set(node.get("predicates") or {})
+            for referenced in iter_template_predicates(template):
+                if referenced not in declared_predicates:
+                    report.error(f"节点 `{name}` 引用了未声明的谓词片段 `{referenced}`")
+            for unused in sorted(declared_predicates - set(iter_template_predicates(template))):
+                report.warn(f"节点 `{name}` 声明了未被模板引用的谓词 `{unused}`")
+            for predicate_name, predicate in (node.get("predicates") or {}).items():
+                _check_predicate(report, f"节点 `{name}`.谓词 `{predicate_name}`", predicate, allowed_roots, param_names)
+
+        if node_type == "sqlite":
+            for dependency in node.get("dependencies") or []:
+                if f'"{dependency}"' not in str(node.get("sql") or "") and dependency not in str(node.get("sql") or ""):
+                    report.warn(f"节点 `{name}` 的 SQL 未引用依赖表 `{dependency}`")
+
+        if node_type == "transform":
+            for label, expression in [("filter", node.get("filter")), *[(f"derive.{k}", v) for k, v in (node.get("derive") or {}).items()]]:
+                if expression:
+                    _check_expression(report, f"节点 `{name}`.{label}", str(expression), allowed_roots, param_names=param_names)
+
+        if node_type == "conditional":
+            _check_expression(report, f"节点 `{name}`.when", str(node.get("when") or ""), allowed_roots, param_names=param_names)
+
+        if node_type == "call":
+            target_id = str(node.get("methodology_id") or "")
+            if registry and target_id not in registry:
+                report.error(f"节点 `{name}` 调用的方法论 `{target_id}` 不在注册表中")
+            if target_id == methodology.get("id"):
+                report.error(f"节点 `{name}` 调用了方法论自身，调用图必须无环")
+            for key, expression in (node.get("params") or {}).items():
+                _check_expression(report, f"节点 `{name}`.params.{key}", str(expression), allowed_roots, param_names=param_names)
+
+    # Call graph acyclicity across the whole registry.
+    if registry:
+        call_graph = {
+            identifier: [
+                str(node.get("methodology_id"))
+                for node in (entry.get("nodes") or {}).values()
+                if str(node.get("type")) == "call"
+            ]
+            for identifier, entry in registry.items()
+        }
+        call_graph.setdefault(str(methodology.get("id")), [])
+        call_cycle = _detect_cycle(call_graph)
+        if call_cycle:
+            report.error("方法论调用图存在环: " + " -> ".join(call_cycle))
+
+    # Parameter declarations.
+    for spec in param_specs:
+        if str(spec.get("type")) == "enum" and not spec.get("values"):
+            report.error(f"参数 `{spec.get('name')}` 是枚举类型但没有声明 values")
+
+    # Bind with stub values and hand the SQL to the platform validator.
+    if check_sql and report.ok:
+        _check_bound_sql(report, methodology, nodes, param_specs)
+
+    return report
+
+
+def _check_predicate(
+    report: Report,
+    where: str,
+    predicate: Mapping[str, Any],
+    allowed_roots: set[str],
+    param_names: set[str],
+) -> None:
+    for key in ("value",):
+        raw = predicate.get(key)
+        if isinstance(raw, str) and raw.startswith("$"):
+            _check_expression(report, where, raw[1:], allowed_roots, param_names=param_names)
+    values = predicate.get("values")
+    if isinstance(values, str) and values.startswith("$"):
+        _check_expression(report, where, values[1:], allowed_roots, param_names=param_names)
+    elif isinstance(values, list):
+        for item in values:
+            if isinstance(item, str) and item.startswith("$"):
+                _check_expression(report, where, item[1:], allowed_roots, param_names=param_names)
+    for clause in predicate.get("clauses") or []:
+        _check_predicate(report, where, clause, allowed_roots, param_names)
+
+
+def _check_bound_sql(
+    report: Report,
+    methodology: Mapping[str, Any],
+    nodes: Mapping[str, Mapping[str, Any]],
+    param_specs: Sequence[Mapping[str, Any]],
+) -> None:
+    """Bind each SQL template against stub values so the SQL itself is checked."""
+    from binding import bind_sql
+
+    stub_params = {str(spec["name"]): _stub_value(spec) for spec in param_specs}
+    fragment_values: List[str] = []
+    for spec in param_specs:
+        fragment_values.extend(str(value) for value in (spec.get("values") or []))
+
+    for name, node in nodes.items():
+        if str(node.get("type")) != "sql":
+            continue
+        context: Dict[str, Any] = {"params": stub_params}
+        for dependency in node.get("dependencies") or []:
+            context[str(dependency)] = {"columns": ["stub"], "rows": [{"stub": "stub"}], "row_count": 1}
+        try:
+            bound = bind_sql(
+                str(node.get("sql") or ""),
+                context,
+                predicates=dict(node.get("predicates") or {}),
+                fragment_allowed_values=fragment_values,
+            )
+        except BindingError as exc:
+            report.error(f"节点 `{name}` 用桩参数绑定失败: {exc}")
+            continue
+        valid, detail = _validate_sql_with_platform_tools(bound)
+        if not valid:
+            report.error(f"节点 `{name}` 的 SQL 未通过 validate_sql.py: {detail}")
+        elif detail.startswith("skipped"):
+            report.warn(f"节点 `{name}` 的 SQL 校验被跳过（{detail}）")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="校验方法论 DAG 工件")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--all", action="store_true", help="校验整个注册表")
+    group.add_argument("--path", help="校验单个方法论 JSON 文件")
+    group.add_argument("--id", help="校验注册表中的一个方法论")
+    parser.add_argument("--registry-dir", default=str(REGISTRY_DIR))
+    parser.add_argument("--check-sql", action="store_true", help="额外用桩参数绑定后调用 validate_sql.py")
+    args = parser.parse_args()
+
+    try:
+        registry = load_registry(Path(args.registry_dir))
+    except RegistryError as exc:
+        print_json({"kind": "methodology_validation", "valid": False, "errors": [str(exc)]})
+        return 1
+
+    if args.path:
+        try:
+            targets = [load_methodology_file(Path(args.path))]
+        except RegistryError as exc:
+            print_json({"kind": "methodology_validation", "valid": False, "errors": [str(exc)]})
+            return 1
+    elif args.id:
+        if args.id not in registry:
+            print_json(
+                {"kind": "methodology_validation", "valid": False, "errors": [f"注册表中没有 `{args.id}`"]}
+            )
+            return 1
+        targets = [registry[args.id]]
+    else:
+        targets = list(registry.values())
+
+    reports = [
+        validate_methodology(methodology, registry=registry, check_sql=args.check_sql) for methodology in targets
+    ]
+    payload = {
+        "kind": "methodology_validation",
+        "valid": all(report.ok for report in reports),
+        "checked": len(reports),
+        "results": [report.payload() for report in reports],
+    }
+    print_json(payload)
+    return 0 if payload["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Re-exported for callers that only need schema validation.
+__all__ = ["Report", "validate_methodology", "validate_schema", "main"]

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py
@@ -25,6 +25,7 @@ from binding import (
     iter_template_predicates,
     parse_expression,
 )
+from engine import _platform_skill_candidates
 from registry import (
     REGISTRY_DIR,
     RegistryError,
@@ -177,12 +178,14 @@ def _stub_value(spec: Mapping[str, Any]) -> Any:
 
 def _validate_sql_with_platform_tools(sql: str) -> tuple[bool, str]:
     """Run the platform-tools SQL validator when it is reachable."""
-    root = str(os.getenv("DATAAGENT_PLATFORM_SKILL_ROOT") or "").strip()
-    if not root:
-        return True, "skipped: DATAAGENT_PLATFORM_SKILL_ROOT 未设置"
-    script = Path(root) / "scripts" / "validate_sql.py"
-    if not script.is_file():
-        return True, "skipped: 找不到 validate_sql.py"
+    script = None
+    for candidate in _platform_skill_candidates():
+        found = candidate.resolve(strict=False) / "scripts" / "validate_sql.py"
+        if found.is_file():
+            script = found
+            break
+    if script is None:
+        return True, "skipped: 找不到 opendataworks-platform-tools 的 validate_sql.py"
     python_bin = str(os.getenv("DATAAGENT_PYTHON_BIN") or "").strip() or sys.executable
     try:
         completed = subprocess.run(  # noqa: S603 - fixed argv, no shell

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/conftest.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/evals/evals.json
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "opendataworks-methodology-dag",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "最近 30 天各数仓分层的建表数环比增长怎么样？",
+      "expected_output": "先用 lookup_methodology.py 命中 table_growth_ratio，再用 run_methodology.py --id table_growth_ratio --params '{\"days\":30}' 一次拿到结果，回答里带上 methodology.caliber 说明口径。",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "最近 30 天工作流发布次数趋势",
+      "expected_output": "命中 workflow_publish_trend；未指定 operation 时走全量口径分支，publish_scoped 分支不执行；回答说明按天统计、失败率口径与时间范围。",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "只看 online 这一类发布的失败率趋势",
+      "expected_output": "命中 workflow_publish_trend 并传 operation=online，走 publish_scoped 分支；不得自行改写口径或绕过方法论写临时 SQL。",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "任务数最多的几个负责人，最近有没有在继续加任务？",
+      "expected_output": "命中 top_owner_task_growth；说明 Top-N 依据历史累计任务数、近期区间以 created_at 为口径；必要时先追问 top_n 与 days，而不是自行假定。",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "帮我看看每个数据源今天的连接失败次数",
+      "expected_output": "lookup 返回 matched=0，明确说明未命中已注册方法论并回落到平台工具的常规问数链路（语义确认 → SQL 生成 → validate_sql.py → run_sql.py），不得猜测方法论 id。",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "环比的口径能不能改成跟去年同期比？这次先按同比给我算一下。",
+      "expected_output": "拒绝为了单次运行临时修改注册表口径；说明现有 table_growth_ratio 是环比口径，同比需要新增方法论或升版本走评审，本次可回落常规链路临时取数并声明这不是已固化口径。",
+      "files": []
+    }
+  ]
+}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_binding.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_binding.py
@@ -1,0 +1,181 @@
+"""Injection safety and predicate-DSL behaviour of the binding layer."""
+
+import pytest
+
+from binding import (
+    BindingError,
+    bind_sql,
+    compile_predicate,
+    evaluate,
+    render_checked_value,
+    render_fragment,
+)
+
+
+# -- checked values ---------------------------------------------------------
+
+def test_checked_value_escapes_quotes_so_it_cannot_close_the_literal():
+    rendered = render_checked_value("o'brien", expr="params.owner")
+    assert rendered == "'o''brien'"
+
+
+def test_checked_value_escapes_a_classic_injection_payload():
+    payload = "' OR 1=1 --"
+    sql = bind_sql("SELECT * FROM t WHERE owner = {{ params.owner }}", {"params": {"owner": payload}})
+    assert sql == "SELECT * FROM t WHERE owner = ''' OR 1=1 --'"
+    # The payload stayed inside one quoted literal: no unbalanced quote remains.
+    assert sql.count("'") % 2 == 0
+
+
+def test_checked_value_expands_scalar_array_into_an_in_list():
+    sql = bind_sql(
+        "SELECT * FROM t WHERE layer IN ({{ pluck(dep.rows, 'layer') }})",
+        {"dep": {"rows": [{"layer": "ODS"}, {"layer": "DWD"}]}},
+    )
+    assert sql == "SELECT * FROM t WHERE layer IN ('ODS', 'DWD')"
+
+
+def test_checked_value_rejects_a_nested_structure():
+    with pytest.raises(BindingError, match="数组元素必须是标量"):
+        render_checked_value([{"a": 1}], expr="dep.rows")
+
+
+def test_checked_value_rejects_a_mapping():
+    with pytest.raises(BindingError, match="必须求值为标量或标量数组"):
+        render_checked_value({"a": 1}, expr="dep")
+
+
+def test_checked_value_rejects_an_empty_array_instead_of_emitting_in_nothing():
+    with pytest.raises(BindingError, match="空列表"):
+        render_checked_value([], expr="dep.rows")
+
+
+# -- identifier fragments ---------------------------------------------------
+
+@pytest.mark.parametrize(
+    "payload",
+    ["1; DROP TABLE users", "layer; --", "layer'", "layer OR 1=1", "", "  ", "layer col"],
+)
+def test_fragment_rejects_anything_that_is_not_a_bare_identifier(payload):
+    with pytest.raises(BindingError):
+        render_fragment(payload, expr="params.dim")
+
+
+def test_fragment_accepts_a_qualified_column_name():
+    assert render_fragment("t.layer", expr="params.dim") == "t.layer"
+
+
+def test_fragment_accepts_a_declared_enum_value_that_is_not_an_identifier():
+    assert render_fragment("count(*)", expr="params.agg", allowed_values=["count(*)"]) == "count(*)"
+
+
+# -- predicate DSL ----------------------------------------------------------
+
+def test_predicate_with_a_null_value_is_dropped_entirely():
+    fragment = compile_predicate({"op": "eq", "field": "layer", "value": "$params.layer"}, {"params": {"layer": None}})
+    assert fragment == ""
+
+
+def test_predicate_clause_disappears_from_the_template_when_the_param_is_absent():
+    sql = bind_sql(
+        "SELECT * FROM t WHERE deleted = 0 {{? layer_filter }} GROUP BY layer",
+        {"params": {"layer": None}},
+        predicates={"layer_filter": {"op": "eq", "field": "layer", "value": "$params.layer"}},
+    )
+    assert "layer_filter" not in sql
+    assert "AND" not in sql
+    assert sql.startswith("SELECT * FROM t WHERE deleted = 0")
+
+
+def test_predicate_clause_is_emitted_when_the_param_is_supplied():
+    sql = bind_sql(
+        "SELECT * FROM t WHERE deleted = 0 {{? layer_filter }}",
+        {"params": {"layer": "ODS"}},
+        predicates={"layer_filter": {"op": "eq", "field": "layer", "value": "$params.layer"}},
+    )
+    assert sql.endswith("AND layer = 'ODS'")
+
+
+def test_composite_predicate_drops_only_its_empty_sub_clauses():
+    fragment = compile_predicate(
+        {
+            "op": "and",
+            "clauses": [
+                {"op": "eq", "field": "layer", "value": "$params.layer"},
+                {"op": "gte", "field": "row_count", "value": "$params.floor"},
+            ],
+        },
+        {"params": {"layer": None, "floor": 10}},
+    )
+    assert fragment == "row_count >= 10"
+
+
+def test_in_predicate_drops_an_empty_upstream_list():
+    fragment = compile_predicate(
+        {"op": "in", "field": "layer", "values": "$pluck(dep.rows, 'layer')"},
+        {"dep": {"rows": []}},
+    )
+    assert fragment == ""
+
+
+def test_in_predicate_escapes_each_element():
+    fragment = compile_predicate(
+        {"op": "in", "field": "owner", "values": ["a'b", "c"]},
+        {},
+    )
+    assert fragment == "owner IN ('a''b', 'c')"
+
+
+def test_predicate_field_is_restricted_to_an_identifier():
+    with pytest.raises(BindingError):
+        compile_predicate({"op": "eq", "field": "layer = 1 OR 1", "value": "x"}, {})
+
+
+# -- expression evaluator ---------------------------------------------------
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "__import__('os').system('id')",
+        "params.__class__",
+        "(lambda: 1)()",
+        "[x for x in [1]]",
+        "open('/etc/passwd')",
+        "params.a.__globals__",
+    ],
+)
+def test_evaluator_rejects_every_escape_attempt(expression):
+    with pytest.raises(BindingError):
+        evaluate(expression, {"params": {"a": 1}})
+
+
+def test_evaluator_supports_the_documented_surface():
+    context = {"params": {"days": 30}, "row": {"a": 4, "b": 2}}
+    assert evaluate("params.days * 2", context) == 60
+    assert evaluate("round(float(row.a) / float(row.b), 2)", context) == 2.0
+    assert evaluate("row.a if row.b else 0", context) == 4
+    assert evaluate("params.days == None", context) is False
+
+
+def test_evaluator_reports_an_unknown_field_rather_than_returning_none():
+    with pytest.raises(BindingError, match="找不到字段"):
+        evaluate("params.missing", {"params": {}})
+
+
+# -- template hygiene -------------------------------------------------------
+
+def test_unclosed_placeholder_leaves_residue_and_is_rejected():
+    with pytest.raises(BindingError, match="无法识别"):
+        bind_sql("SELECT {{ params.a } FROM t", {"params": {"a": 1}})
+
+
+def test_a_malformed_placeholder_never_reaches_the_output():
+    # ``{{{`` parses as a checked value whose body is not a valid expression;
+    # either way the template is rejected rather than emitted half-bound.
+    with pytest.raises(BindingError):
+        bind_sql("SELECT {{{ oops }} FROM t", {})
+
+
+def test_undeclared_predicate_reference_is_rejected():
+    with pytest.raises(BindingError, match="未在本节点 predicates 中声明"):
+        bind_sql("SELECT 1 {{? nope }}", {}, predicates={})

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_engine.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_engine.py
@@ -1,0 +1,266 @@
+"""The four evaluation properties the declarative model is supposed to buy.
+
+These are asserted directly rather than inferred from "the run succeeded":
+build only what is needed, build it at most once, independent branches run
+concurrently, and a malformed graph is rejected before anything executes.
+"""
+
+import time
+
+import pytest
+
+from engine import MethodologyEngine, MethodologyError, run_methodology
+
+
+def _graph(nodes, target, **extra):
+    return {"id": "fixture", "version": "1.0.0", "target": target, "nodes": nodes, **extra}
+
+
+def _counting_mock(counter, name, rows, delay=0.0):
+    def _supply():
+        counter[name] = counter.get(name, 0) + 1
+        if delay:
+            time.sleep(delay)
+        return {"rows": rows}
+
+    return _supply
+
+
+# -- build it at most once --------------------------------------------------
+
+def test_a_shared_dependency_executes_once_however_many_paths_force_it():
+    counter = {}
+    methodology = _graph(
+        {
+            "current": {"type": "sql", "database": "d", "sql": "SELECT 1"},
+            "previous": {"type": "sql", "database": "d", "dependencies": ["current"], "sql": "SELECT 2"},
+            "growth": {
+                "type": "sqlite",
+                "dependencies": ["current", "previous"],
+                "sql": "SELECT c.k AS k, c.n - p.n AS delta FROM current c JOIN previous p ON c.k = p.k",
+            },
+        },
+        "growth",
+    )
+    mock = {
+        "current": _counting_mock(counter, "current", [{"k": "a", "n": 10}]),
+        "previous": _counting_mock(counter, "previous", [{"k": "a", "n": 4}]),
+    }
+
+    result, trace = run_methodology(methodology, {}, mock=mock)
+
+    assert counter["current"] == 1, "current is forced by two dependents but must run once"
+    assert result.rows == [{"k": "a", "delta": 6}]
+    assert [entry["name"] for entry in trace].count("current") == 1
+
+
+# -- build only what is needed ----------------------------------------------
+
+def test_the_untaken_conditional_branch_never_executes():
+    def explode():
+        raise AssertionError("the untaken branch was executed")
+
+    methodology = _graph(
+        {
+            "pick": {
+                "type": "conditional",
+                "when": "params.scoped == None",
+                "then_node": "all_rows",
+                "else_node": "scoped_rows",
+            },
+            "all_rows": {"type": "literal", "rows": [{"k": "all"}]},
+            "scoped_rows": {"type": "sql", "database": "d", "sql": "SELECT 1"},
+        },
+        "pick",
+        params=[{"name": "scoped", "type": "string", "description": "x"}],
+    )
+
+    result, trace = run_methodology(methodology, {"scoped": None}, mock={"scoped_rows": explode})
+
+    assert result.rows == [{"k": "all"}]
+    assert "scoped_rows" not in [entry["name"] for entry in trace]
+    conditional = next(entry for entry in trace if entry["name"] == "pick")
+    assert conditional["branch"] == "all_rows"
+    assert conditional["pruned_branch"] == "scoped_rows"
+
+
+def test_the_other_branch_is_taken_when_the_predicate_flips():
+    def explode():
+        raise AssertionError("the untaken branch was executed")
+
+    methodology = _graph(
+        {
+            "pick": {
+                "type": "conditional",
+                "when": "params.scoped == None",
+                "then_node": "all_rows",
+                "else_node": "scoped_rows",
+            },
+            "all_rows": {"type": "sql", "database": "d", "sql": "SELECT 1"},
+            "scoped_rows": {"type": "literal", "rows": [{"k": "scoped"}]},
+        },
+        "pick",
+        params=[{"name": "scoped", "type": "string", "description": "x"}],
+    )
+
+    result, trace = run_methodology(methodology, {"scoped": "x"}, mock={"all_rows": explode})
+
+    assert result.rows == [{"k": "scoped"}]
+    assert "all_rows" not in [entry["name"] for entry in trace]
+
+
+def test_a_node_unreachable_from_the_target_never_executes():
+    def explode():
+        raise AssertionError("an unreachable node was executed")
+
+    methodology = _graph(
+        {
+            "wanted": {"type": "literal", "rows": [{"k": 1}]},
+            "orphan": {"type": "sql", "database": "d", "sql": "SELECT 1"},
+        },
+        "wanted",
+    )
+
+    result, trace = run_methodology(methodology, {}, mock={"orphan": explode})
+
+    assert result.rows == [{"k": 1}]
+    assert [entry["name"] for entry in trace] == ["wanted"]
+
+
+# -- parallelism is a consequence of the declared structure -----------------
+
+def test_independent_dependencies_are_forced_concurrently():
+    counter = {}
+    delay = 0.25
+    methodology = _graph(
+        {
+            "a": {"type": "sql", "database": "d", "sql": "SELECT 1"},
+            "b": {"type": "sql", "database": "d", "sql": "SELECT 2"},
+            "c": {"type": "sql", "database": "d", "sql": "SELECT 3"},
+            "merged": {"type": "sqlite", "dependencies": ["a", "b", "c"], "sql": "SELECT * FROM a"},
+        },
+        "merged",
+    )
+    mock = {
+        name: _counting_mock(counter, name, [{"k": name}], delay=delay)
+        for name in ("a", "b", "c")
+    }
+
+    started = time.monotonic()
+    run_methodology(methodology, {}, mock=mock)
+    elapsed = time.monotonic() - started
+
+    assert counter == {"a": 1, "b": 1, "c": 1}
+    assert elapsed < delay * 2, f"three {delay}s dependencies took {elapsed:.2f}s; they did not overlap"
+
+
+# -- malformed graphs fail before anything runs -----------------------------
+
+def test_a_missing_target_is_rejected():
+    methodology = _graph({"a": {"type": "literal", "rows": []}}, "nope")
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(methodology, {}).run()
+    assert excinfo.value.error_code == "methodology_invalid"
+
+
+def test_a_call_cycle_is_rejected_with_the_chain_in_the_message():
+    left = _graph({"c": {"type": "call", "methodology_id": "right"}}, "c")
+    left["id"] = "left"
+    right = _graph({"c": {"type": "call", "methodology_id": "left"}}, "c")
+    right["id"] = "right"
+
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(left, {}, registry={"left": left, "right": right}).run()
+    assert "调用成环" in str(excinfo.value)
+    assert "left -> right -> left" in str(excinfo.value)
+
+
+def test_calling_an_unregistered_methodology_is_reported_as_not_found():
+    methodology = _graph({"c": {"type": "call", "methodology_id": "absent"}}, "c")
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(methodology, {}, registry={}).run()
+    assert excinfo.value.error_code == "methodology_not_found"
+
+
+# -- timeouts ---------------------------------------------------------------
+
+def test_an_exhausted_total_budget_stops_the_run():
+    methodology = _graph({"a": {"type": "sql", "database": "d", "sql": "SELECT 1"}}, "a")
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(methodology, {}, total_timeout=-1).run()
+    assert excinfo.value.error_code == "methodology_timeout"
+
+
+# -- node behaviour ---------------------------------------------------------
+
+def test_sql_node_without_platform_tools_reports_a_precise_cause(monkeypatch):
+    monkeypatch.delenv("DATAAGENT_PLATFORM_SKILL_ROOT", raising=False)
+    methodology = _graph({"a": {"type": "sql", "database": "d", "sql": "SELECT 1"}}, "a")
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(methodology, {}).run()
+    assert excinfo.value.error_code == "platform_tools_unavailable"
+
+
+def test_transform_filters_derives_and_sorts():
+    methodology = _graph(
+        {
+            "source": {
+                "type": "literal",
+                "rows": [
+                    {"day": "2026-07-02", "total": 10, "bad": 2},
+                    {"day": "2026-07-01", "total": 0, "bad": 0},
+                    {"day": "2026-07-03", "total": 4, "bad": 1},
+                ],
+            },
+            "shaped": {
+                "type": "transform",
+                "dependencies": ["source"],
+                "filter": "row.total > 0",
+                "derive": {"rate": "round(float(row.bad) / float(row.total), 2)"},
+                "select": ["day", "rate"],
+                "sort": [{"field": "day", "order": "desc"}],
+            },
+        },
+        "shaped",
+    )
+
+    result, _ = run_methodology(methodology, {})
+
+    assert result.columns == ["day", "rate"]
+    assert result.rows == [{"day": "2026-07-03", "rate": 0.25}, {"day": "2026-07-02", "rate": 0.2}]
+
+
+def test_sqlite_node_joins_results_that_came_from_different_sources():
+    methodology = _graph(
+        {
+            "from_mysql": {"type": "literal", "rows": [{"k": "a", "left": 1}, {"k": "b", "left": 2}]},
+            "from_doris": {"type": "literal", "rows": [{"k": "a", "right": 10}]},
+            "joined": {
+                "type": "sqlite",
+                "dependencies": ["from_mysql", "from_doris"],
+                "sql": (
+                    "SELECT m.k AS k, m.left AS l, COALESCE(d.right, 0) AS r "
+                    "FROM from_mysql m LEFT JOIN from_doris d ON m.k = d.k ORDER BY m.k"
+                ),
+            },
+        },
+        "joined",
+    )
+
+    result, _ = run_methodology(methodology, {})
+
+    assert result.rows == [{"k": "a", "l": 1, "r": 10}, {"k": "b", "l": 2, "r": 0}]
+
+
+def test_a_broken_sqlite_statement_is_attributed_to_the_methodology_not_to_a_retry():
+    methodology = _graph(
+        {
+            "source": {"type": "literal", "rows": [{"k": 1}]},
+            "bad": {"type": "sqlite", "dependencies": ["source"], "sql": "SELECT nope FROM source"},
+        },
+        "bad",
+    )
+    with pytest.raises(MethodologyError) as excinfo:
+        MethodologyEngine(methodology, {}).run()
+    assert excinfo.value.failure_attribution == ["invalid_sql"]
+    assert excinfo.value.retryable is False

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_engine.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_engine.py
@@ -9,6 +9,7 @@ import time
 
 import pytest
 
+import engine
 from engine import MethodologyEngine, MethodologyError, run_methodology
 
 
@@ -193,12 +194,35 @@ def test_an_exhausted_total_budget_stops_the_run():
 
 # -- node behaviour ---------------------------------------------------------
 
-def test_sql_node_without_platform_tools_reports_a_precise_cause(monkeypatch):
-    monkeypatch.delenv("DATAAGENT_PLATFORM_SKILL_ROOT", raising=False)
+def test_platform_tools_is_found_as_a_sibling_without_any_environment_variable(monkeypatch):
+    """The skill locates its neighbour from its own path, needing nothing from the host."""
+    monkeypatch.delenv(engine.PLATFORM_TOOLS_ROOT_ENV, raising=False)
+
+    root = engine._resolve_platform_skill_root()
+
+    assert root.name == engine.PLATFORM_TOOLS_FOLDER
+    assert (root / "scripts" / "run_sql.py").is_file()
+
+
+def test_an_environment_override_wins_over_the_sibling(monkeypatch, tmp_path):
+    override = tmp_path / "elsewhere"
+    (override / "scripts").mkdir(parents=True)
+    (override / "scripts" / "run_sql.py").write_text("", encoding="utf-8")
+    monkeypatch.setenv(engine.PLATFORM_TOOLS_ROOT_ENV, str(override))
+
+    assert engine._resolve_platform_skill_root() == override.resolve()
+
+
+def test_sql_node_without_platform_tools_anywhere_reports_a_precise_cause(monkeypatch):
+    monkeypatch.delenv(engine.PLATFORM_TOOLS_ROOT_ENV, raising=False)
+    monkeypatch.setattr(engine, "PLATFORM_TOOLS_FOLDER", "absent-platform-tools")
     methodology = _graph({"a": {"type": "sql", "database": "d", "sql": "SELECT 1"}}, "a")
+
     with pytest.raises(MethodologyError) as excinfo:
         MethodologyEngine(methodology, {}).run()
+
     assert excinfo.value.error_code == "platform_tools_unavailable"
+    assert "absent-platform-tools" in str(excinfo.value)
 
 
 def test_transform_filters_derives_and_sorts():

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_registry.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_registry.py
@@ -1,0 +1,176 @@
+"""Every registered methodology must validate statically and run under mock."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from engine import run_methodology
+from registry import coerce_params, load_registry
+from validate_methodology import validate_methodology
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = SKILL_ROOT / "scripts"
+REGISTRY = load_registry()
+
+# Mock tables for every query node in the registry, so the whole registry is
+# exercised end to end without touching a data store.
+MOCK_TABLES = {
+    "current": {"rows": [{"layer": "ODS", "table_cnt": 12}, {"layer": "DWD", "table_cnt": 8}]},
+    "previous": {"rows": [{"layer": "ODS", "table_cnt": 6}, {"layer": "DWD", "table_cnt": 8}]},
+    "top_owners": {"rows": [{"owner": "alice", "total_cnt": 30}, {"owner": "bob", "total_cnt": 12}]},
+    "recent_by_owner": {"rows": [{"owner": "alice", "recent_cnt": 6}]},
+    "publish_all": {
+        "rows": [
+            {"stat_date": "2026-07-02", "publish_cnt": 10, "failed_cnt": 2},
+            {"stat_date": "2026-07-01", "publish_cnt": 4, "failed_cnt": 0},
+        ]
+    },
+    "publish_scoped": {"rows": [{"stat_date": "2026-07-01", "publish_cnt": 3, "failed_cnt": 1}]},
+}
+
+
+def _run_script(name, *args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / name), *args],
+        cwd=str(SCRIPTS),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_the_registry_is_not_empty():
+    assert REGISTRY, "注册表为空；至少要有可回归的方法论"
+
+
+@pytest.mark.parametrize("identifier", sorted(REGISTRY))
+def test_each_methodology_passes_static_validation(identifier):
+    report = validate_methodology(REGISTRY[identifier], registry=REGISTRY)
+    assert report.ok, report.errors
+
+
+@pytest.mark.parametrize("identifier", sorted(REGISTRY))
+def test_each_methodology_reaches_its_target_under_mock(identifier):
+    methodology = REGISTRY[identifier]
+    params, missing = coerce_params(list(methodology.get("params") or []), {})
+    assert not missing, f"{identifier} 的默认参数不足以完成一次 mock 运行: {missing}"
+
+    result, trace = run_methodology(methodology, params, registry=REGISTRY, mock=MOCK_TABLES)
+
+    assert trace, f"{identifier} 没有执行任何节点"
+    assert result.columns, f"{identifier} 的 target 没有产出任何列"
+    declared = methodology.get("output_fields") or []
+    if declared:
+        assert list(result.columns) == list(declared), (
+            f"{identifier} 的实际输出列与 output_fields 声明不一致"
+        )
+
+
+@pytest.mark.parametrize("identifier", sorted(REGISTRY))
+def test_each_methodology_declares_a_caliber_and_an_owner(identifier):
+    methodology = REGISTRY[identifier]
+    assert len(str(methodology["caliber"]).strip()) >= 10, "caliber 会随结果回给用户，必须写清楚"
+    assert str(methodology["owner"]).strip()
+
+
+def test_registry_ids_match_their_filenames():
+    for path in sorted((SKILL_ROOT / "assets" / "registry").glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["id"] == path.stem, f"{path.name} 的 id 与文件名不一致"
+
+
+# -- CLI contracts ----------------------------------------------------------
+
+def test_validate_all_exits_zero_for_the_shipped_registry():
+    completed = _run_script("validate_methodology.py", "--all")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["valid"] is True
+    assert payload["checked"] == len(REGISTRY)
+
+
+def test_lookup_finds_a_methodology_from_a_chinese_question():
+    completed = _run_script("lookup_methodology.py", "--query", "最近30天工作流发布次数趋势")
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["kind"] == "methodology_lookup"
+    assert payload["results"][0]["id"] == "workflow_publish_trend"
+
+
+def test_lookup_tells_the_caller_to_fall_back_when_nothing_matches():
+    completed = _run_script("lookup_methodology.py", "--query", "今天天气怎么样")
+    payload = json.loads(completed.stdout)
+    assert payload["matched"] == 0
+    assert "回落" in payload["stop_reason"]
+
+
+def test_run_reports_an_unknown_id_without_crashing():
+    completed = _run_script("run_methodology.py", "--id", "definitely_absent")
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["kind"] == "sql_execution"
+    assert payload["error_code"] == "methodology_not_found"
+    assert payload["result_state"] == "failed"
+
+
+def test_run_rejects_a_value_outside_an_enum():
+    completed = _run_script(
+        "run_methodology.py", "--id", "workflow_publish_trend", "--params", '{"operation": "drop"}'
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["error_code"] == "param_rejected"
+
+
+def test_run_rejects_an_undeclared_parameter():
+    completed = _run_script(
+        "run_methodology.py", "--id", "workflow_publish_trend", "--params", '{"ghost": 1}'
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["error_code"] == "param_rejected"
+
+
+def test_run_emits_the_sql_execution_contract_under_mock(tmp_path):
+    mock_path = tmp_path / "mock.json"
+    mock_path.write_text(json.dumps(MOCK_TABLES), encoding="utf-8")
+    completed = _run_script(
+        "run_methodology.py",
+        "--id",
+        "table_growth_ratio",
+        "--params",
+        '{"days": 30}',
+        "--mock",
+        str(mock_path),
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+
+    assert payload["kind"] == "sql_execution"
+    assert payload["result_state"] == "success"
+    assert payload["methodology"]["id"] == "table_growth_ratio"
+    assert payload["methodology"]["caliber"]
+    assert payload["rows"][0]["growth"] == 1.0
+    # The trace is the free per-node observability the declarative form buys.
+    assert {entry["name"] for entry in payload["trace"]["nodes"]} == {"current", "previous", "growth"}
+
+
+def test_conditional_pruning_is_visible_in_the_emitted_trace(tmp_path):
+    mock_path = tmp_path / "mock.json"
+    mock_path.write_text(json.dumps(MOCK_TABLES), encoding="utf-8")
+    completed = _run_script(
+        "run_methodology.py",
+        "--id",
+        "workflow_publish_trend",
+        "--params",
+        '{"days": 7}',
+        "--mock",
+        str(mock_path),
+    )
+    payload = json.loads(completed.stdout)
+    executed = {entry["name"] for entry in payload["trace"]["nodes"]}
+
+    assert "publish_all" in executed
+    assert "publish_scoped" not in executed
+    assert payload["trace"]["pruned"] == 1

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_registry.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from engine import run_methodology
+from engine import _platform_skill_candidates, run_methodology
 from registry import coerce_params, load_registry
 from validate_methodology import validate_methodology
 
@@ -67,6 +67,25 @@ def test_each_methodology_reaches_its_target_under_mock(identifier):
         assert list(result.columns) == list(declared), (
             f"{identifier} 的实际输出列与 output_fields 声明不一致"
         )
+
+
+@pytest.mark.parametrize("identifier", sorted(REGISTRY))
+def test_each_methodology_sql_passes_the_platform_validator(identifier):
+    """Bind with stub parameters and hand the SQL to platform-tools.
+
+    This catches what a methodology-only check cannot — engine-side rules such as
+    the schema-prefix requirement. It is skipped rather than silently passing when
+    platform-tools is not installed, because a check that quietly does nothing is
+    how such a defect hides.
+    """
+    if not any((c.resolve(strict=False) / "scripts" / "validate_sql.py").is_file() for c in _platform_skill_candidates()):
+        pytest.skip("opendataworks-platform-tools 未安装，无法做 SQL 校验")
+
+    report = validate_methodology(REGISTRY[identifier], registry=REGISTRY, check_sql=True)
+
+    assert report.ok, report.errors
+    skipped = [warning for warning in report.warnings if "校验被跳过" in warning]
+    assert not skipped, f"SQL 校验被跳过而不是真的执行了: {skipped}"
 
 
 @pytest.mark.parametrize("identifier", sorted(REGISTRY))

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_schema.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_schema.py
@@ -1,0 +1,43 @@
+"""The shipped JSON Schema must stay in step with the pydantic model."""
+
+import json
+from pathlib import Path
+
+from methodology_schema import (
+    FIELD_DICTIONARY,
+    NODE_TYPE_OPTIONS,
+    PLACEHOLDER_FORMS,
+    methodology_json_schema,
+    methodology_json_schema_text,
+)
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = SKILL_ROOT / "assets" / "methodology.schema.json"
+
+
+def test_shipped_schema_matches_the_model():
+    shipped = SCHEMA_PATH.read_text(encoding="utf-8")
+    assert shipped == methodology_json_schema_text(), (
+        "assets/methodology.schema.json 与 pydantic 模型不一致；"
+        "请重新运行 `python3 scripts/methodology_schema.py > assets/methodology.schema.json`"
+    )
+
+
+def test_schema_carries_the_field_dictionary():
+    schema = methodology_json_schema()
+    assert schema["x-field-dictionary"] == FIELD_DICTIONARY
+
+
+def test_every_node_type_has_a_group_and_a_description():
+    for name, entry in NODE_TYPE_OPTIONS.items():
+        assert entry["group"] in {"query", "compute", "control"}, name
+        assert entry["description"], name
+
+
+def test_the_three_placeholder_forms_are_documented():
+    assert set(PLACEHOLDER_FORMS) == {"{{ expr }}", "{{! expr }}", "{{? name }}"}
+
+
+def test_schema_is_valid_json_and_declares_the_required_top_level_fields():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert set(schema["required"]) >= {"id", "version", "name_zh", "intent", "caliber", "owner", "nodes", "target"}

--- a/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_validate.py
+++ b/dataagent/.claude/skills/opendataworks-methodology-dag/tests/test_methodology_dag_validate.py
@@ -1,0 +1,221 @@
+"""Static validation: what would be a runtime exception becomes a load-time reject."""
+
+import pytest
+
+from registry import RegistryError, validate_schema
+from validate_methodology import validate_methodology
+
+
+def _graph(nodes, target, **extra):
+    base = {
+        "id": "fixture",
+        "version": "1.0.0",
+        "name_zh": "夹具",
+        "intent": "测试用",
+        "caliber": "测试口径",
+        "owner": "test",
+        "target": target,
+        "nodes": nodes,
+    }
+    base.update(extra)
+    return base
+
+
+def _errors(methodology, **kwargs):
+    return validate_methodology(methodology, **kwargs).errors
+
+
+# -- graph shape ------------------------------------------------------------
+
+def test_missing_target_is_rejected():
+    errors = _errors(_graph({"a": {"type": "literal", "rows": []}}, "nope"))
+    assert any("target" in error for error in errors)
+
+
+def test_dependency_on_an_undefined_node_is_rejected():
+    errors = _errors(_graph({"a": {"type": "transform", "dependencies": ["ghost"]}}, "a"))
+    assert any("ghost" in error for error in errors)
+
+
+def test_self_dependency_is_rejected():
+    errors = _errors(_graph({"a": {"type": "transform", "dependencies": ["a"]}}, "a"))
+    assert any("依赖了自身" in error for error in errors)
+
+
+def test_a_cycle_is_reported_as_a_concrete_path():
+    methodology = _graph(
+        {
+            "a": {"type": "transform", "dependencies": ["b"]},
+            "b": {"type": "transform", "dependencies": ["c"]},
+            "c": {"type": "transform", "dependencies": ["a"]},
+        },
+        "a",
+    )
+    errors = _errors(methodology)
+    cycle_errors = [error for error in errors if "环" in error]
+    assert cycle_errors, errors
+    # The path, not just the fact that one exists.
+    assert "->" in cycle_errors[0]
+    assert cycle_errors[0].count("->") >= 3
+
+
+def test_an_unreachable_node_is_a_warning_not_an_error():
+    report = validate_methodology(
+        _graph(
+            {"wanted": {"type": "literal", "rows": []}, "orphan": {"type": "literal", "rows": []}},
+            "wanted",
+        )
+    )
+    assert report.ok
+    assert any("不可达" in warning for warning in report.warnings)
+
+
+def test_a_conditional_branch_keeps_its_target_reachable():
+    report = validate_methodology(
+        _graph(
+            {
+                "pick": {"type": "conditional", "when": "1 == 1", "then_node": "a", "else_node": "b"},
+                "a": {"type": "literal", "rows": []},
+                "b": {"type": "literal", "rows": []},
+            },
+            "pick",
+        )
+    )
+    assert report.ok
+    assert not report.warnings
+
+
+def test_a_conditional_branch_that_does_not_exist_is_rejected():
+    errors = _errors(
+        _graph(
+            {
+                "pick": {"type": "conditional", "when": "1 == 1", "then_node": "a", "else_node": "ghost"},
+                "a": {"type": "literal", "rows": []},
+            },
+            "pick",
+        )
+    )
+    assert any("ghost" in error for error in errors)
+
+
+# -- expressions and parameters --------------------------------------------
+
+def test_an_expression_referencing_an_undeclared_parameter_is_rejected():
+    errors = _errors(
+        _graph(
+            {"a": {"type": "sql", "database": "d", "sql": "SELECT {{ params.ghost }}"}},
+            "a",
+            params=[{"name": "days", "type": "int", "description": "x"}],
+        )
+    )
+    assert any("params.ghost" in error for error in errors)
+
+
+def test_an_expression_referencing_a_node_that_is_not_a_dependency_is_rejected():
+    errors = _errors(
+        _graph(
+            {
+                "other": {"type": "literal", "rows": []},
+                "a": {"type": "sql", "database": "d", "sql": "SELECT {{ other.row_count }}"},
+            },
+            "a",
+        )
+    )
+    assert any("other" in error for error in errors)
+
+
+def test_an_expression_that_calls_a_non_whitelisted_function_is_rejected():
+    errors = _errors(
+        _graph({"a": {"type": "sql", "database": "d", "sql": "SELECT {{ exec('x') }}"}}, "a")
+    )
+    assert any("白名单" in error for error in errors)
+
+
+def test_an_enum_parameter_without_values_is_rejected():
+    errors = _errors(
+        _graph(
+            {"a": {"type": "literal", "rows": []}},
+            "a",
+            params=[{"name": "layer", "type": "enum", "description": "x"}],
+        )
+    )
+    assert any("枚举" in error for error in errors)
+
+
+def test_an_undeclared_predicate_reference_is_rejected():
+    errors = _errors(
+        _graph({"a": {"type": "sql", "database": "d", "sql": "SELECT 1 {{? ghost }}"}}, "a")
+    )
+    assert any("ghost" in error for error in errors)
+
+
+def test_an_unused_declared_predicate_is_only_a_warning():
+    report = validate_methodology(
+        _graph(
+            {
+                "a": {
+                    "type": "sql",
+                    "database": "d",
+                    "sql": "SELECT 1",
+                    "predicates": {"unused": {"op": "eq", "field": "x", "value": 1}},
+                }
+            },
+            "a",
+        )
+    )
+    assert report.ok
+    assert any("unused" in warning for warning in report.warnings)
+
+
+# -- call graph -------------------------------------------------------------
+
+def test_calling_an_unregistered_methodology_is_rejected():
+    methodology = _graph({"c": {"type": "call", "methodology_id": "absent"}}, "c")
+    errors = _errors(methodology, registry={"fixture": methodology})
+    assert any("absent" in error for error in errors)
+
+
+def test_direct_self_call_is_rejected():
+    methodology = _graph({"c": {"type": "call", "methodology_id": "fixture"}}, "c")
+    errors = _errors(methodology, registry={"fixture": methodology})
+    assert any("调用了方法论自身" in error for error in errors)
+
+
+def test_a_call_cycle_across_the_registry_is_rejected():
+    left = _graph({"c": {"type": "call", "methodology_id": "right"}}, "c")
+    left["id"] = "left"
+    right = _graph({"c": {"type": "call", "methodology_id": "left"}}, "c")
+    right["id"] = "right"
+    errors = _errors(left, registry={"left": left, "right": right})
+    assert any("调用图存在环" in error for error in errors)
+
+
+# -- schema -----------------------------------------------------------------
+
+def test_schema_rejects_an_unknown_node_type():
+    with pytest.raises(RegistryError):
+        validate_schema(_graph({"a": {"type": "python", "code": "1"}}, "a"))
+
+
+def test_schema_rejects_an_extra_field():
+    with pytest.raises(RegistryError):
+        validate_schema(_graph({"a": {"type": "literal", "rows": [], "oops": 1}}, "a"))
+
+
+def test_schema_rejects_a_non_semver_version():
+    with pytest.raises(RegistryError):
+        validate_schema(_graph({"a": {"type": "literal", "rows": []}}, "a", version="1.0"))
+
+
+def test_schema_rejects_a_transform_with_two_dependencies():
+    with pytest.raises(RegistryError):
+        validate_schema(
+            _graph(
+                {
+                    "x": {"type": "literal", "rows": []},
+                    "y": {"type": "literal", "rows": []},
+                    "a": {"type": "transform", "dependencies": ["x", "y"]},
+                },
+                "a",
+            )
+        )

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -37,6 +37,9 @@ PORTAL_MCP_TOOL_NAMES = [
     "portal_query_readonly",
 ]
 PLATFORM_TOOLS_SKILL_FOLDER = "opendataworks-platform-tools"
+# Legacy alias kept for the platform-tools skill, whose docs and scripts already
+# reference this exact name; the generic per-folder variable is derived below.
+PLATFORM_TOOLS_SKILL_ROOT_ENV = "DATAAGENT_PLATFORM_SKILL_ROOT"
 SYSTEM_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "data_agent_system_prompt.md"
 _FILE_BOUNDARY_PATH_KEYS = {
     "Read": ("file_path", "path"),
@@ -194,6 +197,21 @@ def _is_offloaded_tool_result_path(candidate: Path, tool_result_root: Path | Non
         and parts[1] == "tool-results"
         and candidate.suffix.lower() in _OFFLOADED_TOOL_RESULT_SUFFIXES
     )
+
+
+def skill_root_env_name(folder: str) -> str:
+    """Derive the per-skill root variable name from a skill folder name.
+
+    ``opendataworks-methodology-dag`` becomes
+    ``DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT``: the shared ``opendataworks-`` prefix
+    is dropped so the variable stays readable, and the rest is upper snake case.
+    Returns an empty string when the folder cannot form a valid variable name.
+    """
+    name = str(folder or "").strip().removeprefix("opendataworks-")
+    normalized = re.sub(r"[^0-9a-zA-Z]+", "_", name).strip("_").upper()
+    if not normalized or normalized[0].isdigit():
+        return ""
+    return f"DATAAGENT_{normalized}_SKILL_ROOT"
 
 
 def _build_workspace_allowed_roots(project_cwd: str | Path, skill_runtime: dict[str, Any] | None) -> list[Path]:
@@ -592,8 +610,15 @@ def _build_runtime_env(
             "TZ": str(os.getenv("TZ") or "Asia/Shanghai"),
         }
     )
+    # Every enabled skill gets its own root variable so a skill's scripts can be
+    # addressed without borrowing the primary ``DATAAGENT_SKILL_ROOT``. The name is
+    # derived from the folder, so no skill name is hardcoded here.
+    for folder, root in enabled_roots.items():
+        variable = skill_root_env_name(str(folder))
+        if variable and str(root or "").strip():
+            runtime_env[variable] = str(Path(str(root)).expanduser().resolve(strict=False))
     if platform_skill_root:
-        runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] = str(Path(platform_skill_root).resolve())
+        runtime_env[PLATFORM_TOOLS_SKILL_ROOT_ENV] = str(Path(platform_skill_root).resolve())
     agent_env = getattr(params, "agent_env_vars", None)
     if not agent_env and getattr(params, "agent_snapshot", None):
         agent_env = dict((getattr(params, "agent_snapshot", None) or {}).get("env_vars") or {})

--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -37,9 +37,6 @@ PORTAL_MCP_TOOL_NAMES = [
     "portal_query_readonly",
 ]
 PLATFORM_TOOLS_SKILL_FOLDER = "opendataworks-platform-tools"
-# Legacy alias kept for the platform-tools skill, whose docs and scripts already
-# reference this exact name; the generic per-folder variable is derived below.
-PLATFORM_TOOLS_SKILL_ROOT_ENV = "DATAAGENT_PLATFORM_SKILL_ROOT"
 SYSTEM_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "data_agent_system_prompt.md"
 _FILE_BOUNDARY_PATH_KEYS = {
     "Read": ("file_path", "path"),
@@ -197,21 +194,6 @@ def _is_offloaded_tool_result_path(candidate: Path, tool_result_root: Path | Non
         and parts[1] == "tool-results"
         and candidate.suffix.lower() in _OFFLOADED_TOOL_RESULT_SUFFIXES
     )
-
-
-def skill_root_env_name(folder: str) -> str:
-    """Derive the per-skill root variable name from a skill folder name.
-
-    ``opendataworks-methodology-dag`` becomes
-    ``DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT``: the shared ``opendataworks-`` prefix
-    is dropped so the variable stays readable, and the rest is upper snake case.
-    Returns an empty string when the folder cannot form a valid variable name.
-    """
-    name = str(folder or "").strip().removeprefix("opendataworks-")
-    normalized = re.sub(r"[^0-9a-zA-Z]+", "_", name).strip("_").upper()
-    if not normalized or normalized[0].isdigit():
-        return ""
-    return f"DATAAGENT_{normalized}_SKILL_ROOT"
 
 
 def _build_workspace_allowed_roots(project_cwd: str | Path, skill_runtime: dict[str, Any] | None) -> list[Path]:
@@ -610,15 +592,8 @@ def _build_runtime_env(
             "TZ": str(os.getenv("TZ") or "Asia/Shanghai"),
         }
     )
-    # Every enabled skill gets its own root variable so a skill's scripts can be
-    # addressed without borrowing the primary ``DATAAGENT_SKILL_ROOT``. The name is
-    # derived from the folder, so no skill name is hardcoded here.
-    for folder, root in enabled_roots.items():
-        variable = skill_root_env_name(str(folder))
-        if variable and str(root or "").strip():
-            runtime_env[variable] = str(Path(str(root)).expanduser().resolve(strict=False))
     if platform_skill_root:
-        runtime_env[PLATFORM_TOOLS_SKILL_ROOT_ENV] = str(Path(platform_skill_root).resolve())
+        runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] = str(Path(platform_skill_root).resolve())
     agent_env = getattr(params, "agent_env_vars", None)
     if not agent_env and getattr(params, "agent_snapshot", None):
         agent_env = dict((getattr(params, "agent_snapshot", None) or {}).get("env_vars") or {})

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -6,8 +6,6 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
@@ -51,11 +49,6 @@ def test_build_runtime_env_does_not_expose_direct_db_connection_settings(monkeyp
     assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(Path("/tmp/platform-tools").resolve())
     assert runtime_env["DATAAGENT_ENABLED_SKILLS"] == "opendataworks-business-knowledge,opendataworks-platform-tools,marketing-insights"
     assert "marketing-insights" in runtime_env["DATAAGENT_ENABLED_SKILL_ROOTS"]
-    # Every enabled skill also gets its own root variable, derived from the folder
-    # name, so a skill's scripts never have to borrow the primary skill root.
-    assert runtime_env["DATAAGENT_BUSINESS_KNOWLEDGE_SKILL_ROOT"] == str(Path("/tmp/skill-root").resolve())
-    assert runtime_env["DATAAGENT_PLATFORM_TOOLS_SKILL_ROOT"] == str(Path("/tmp/platform-tools").resolve())
-    assert runtime_env["DATAAGENT_MARKETING_INSIGHTS_SKILL_ROOT"] == str(Path("/tmp/marketing-insights").resolve())
     assert "ODW_MYSQL_HOST" not in runtime_env
     assert "ODW_MYSQL_PORT" not in runtime_env
     assert "ODW_MYSQL_USER" not in runtime_env
@@ -94,43 +87,6 @@ def test_build_runtime_env_derives_platform_root_from_primary_root_when_enabled_
         },
     )
 
-    assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(platform_root.resolve())
-
-
-def test_skill_root_env_name_drops_the_shared_prefix_and_upper_snakes_the_rest():
-    assert agent_runtime.skill_root_env_name("opendataworks-methodology-dag") == "DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT"
-    assert agent_runtime.skill_root_env_name("ontology-modeling-assistant") == "DATAAGENT_ONTOLOGY_MODELING_ASSISTANT_SKILL_ROOT"
-    assert agent_runtime.skill_root_env_name("Marketing Insights") == "DATAAGENT_MARKETING_INSIGHTS_SKILL_ROOT"
-
-
-@pytest.mark.parametrize("folder", ["", "   ", "-", "123", "opendataworks-"])
-def test_skill_root_env_name_rejects_folders_that_cannot_form_a_variable(folder):
-    assert agent_runtime.skill_root_env_name(folder) == ""
-
-
-def test_methodology_dag_skill_gets_its_own_root_alongside_platform_tools(tmp_path: Path):
-    skills_root = tmp_path / ".claude" / "skills"
-    platform_root = skills_root / "opendataworks-platform-tools"
-    methodology_root = skills_root / "opendataworks-methodology-dag"
-    platform_root.mkdir(parents=True)
-    methodology_root.mkdir(parents=True)
-
-    runtime_env = agent_runtime._build_runtime_env(
-        SimpleNamespace(query_result_limit=1000),
-        {},
-        SimpleNamespace(question="", sql_read_timeout_seconds=0),
-        {
-            "primary_root": str(platform_root),
-            "enabled_folders": ["opendataworks-platform-tools", "opendataworks-methodology-dag"],
-            "enabled_roots": {
-                "opendataworks-platform-tools": str(platform_root),
-                "opendataworks-methodology-dag": str(methodology_root),
-            },
-        },
-    )
-
-    assert runtime_env["DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT"] == str(methodology_root.resolve())
-    # The legacy alias the platform-tools docs reference must keep working.
     assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(platform_root.resolve())
 
 

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
@@ -49,6 +51,11 @@ def test_build_runtime_env_does_not_expose_direct_db_connection_settings(monkeyp
     assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(Path("/tmp/platform-tools").resolve())
     assert runtime_env["DATAAGENT_ENABLED_SKILLS"] == "opendataworks-business-knowledge,opendataworks-platform-tools,marketing-insights"
     assert "marketing-insights" in runtime_env["DATAAGENT_ENABLED_SKILL_ROOTS"]
+    # Every enabled skill also gets its own root variable, derived from the folder
+    # name, so a skill's scripts never have to borrow the primary skill root.
+    assert runtime_env["DATAAGENT_BUSINESS_KNOWLEDGE_SKILL_ROOT"] == str(Path("/tmp/skill-root").resolve())
+    assert runtime_env["DATAAGENT_PLATFORM_TOOLS_SKILL_ROOT"] == str(Path("/tmp/platform-tools").resolve())
+    assert runtime_env["DATAAGENT_MARKETING_INSIGHTS_SKILL_ROOT"] == str(Path("/tmp/marketing-insights").resolve())
     assert "ODW_MYSQL_HOST" not in runtime_env
     assert "ODW_MYSQL_PORT" not in runtime_env
     assert "ODW_MYSQL_USER" not in runtime_env
@@ -87,6 +94,43 @@ def test_build_runtime_env_derives_platform_root_from_primary_root_when_enabled_
         },
     )
 
+    assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(platform_root.resolve())
+
+
+def test_skill_root_env_name_drops_the_shared_prefix_and_upper_snakes_the_rest():
+    assert agent_runtime.skill_root_env_name("opendataworks-methodology-dag") == "DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT"
+    assert agent_runtime.skill_root_env_name("ontology-modeling-assistant") == "DATAAGENT_ONTOLOGY_MODELING_ASSISTANT_SKILL_ROOT"
+    assert agent_runtime.skill_root_env_name("Marketing Insights") == "DATAAGENT_MARKETING_INSIGHTS_SKILL_ROOT"
+
+
+@pytest.mark.parametrize("folder", ["", "   ", "-", "123", "opendataworks-"])
+def test_skill_root_env_name_rejects_folders_that_cannot_form_a_variable(folder):
+    assert agent_runtime.skill_root_env_name(folder) == ""
+
+
+def test_methodology_dag_skill_gets_its_own_root_alongside_platform_tools(tmp_path: Path):
+    skills_root = tmp_path / ".claude" / "skills"
+    platform_root = skills_root / "opendataworks-platform-tools"
+    methodology_root = skills_root / "opendataworks-methodology-dag"
+    platform_root.mkdir(parents=True)
+    methodology_root.mkdir(parents=True)
+
+    runtime_env = agent_runtime._build_runtime_env(
+        SimpleNamespace(query_result_limit=1000),
+        {},
+        SimpleNamespace(question="", sql_read_timeout_seconds=0),
+        {
+            "primary_root": str(platform_root),
+            "enabled_folders": ["opendataworks-platform-tools", "opendataworks-methodology-dag"],
+            "enabled_roots": {
+                "opendataworks-platform-tools": str(platform_root),
+                "opendataworks-methodology-dag": str(methodology_root),
+            },
+        },
+    )
+
+    assert runtime_env["DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT"] == str(methodology_root.resolve())
+    # The legacy alias the platform-tools docs reference must keep working.
     assert runtime_env["DATAAGENT_PLATFORM_SKILL_ROOT"] == str(platform_root.resolve())
 
 

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -379,7 +379,6 @@ def test_methodology_dag_skill_routes_lookup_first_and_falls_back_on_a_miss():
 
     required_tokens = [
         "OpenDataWorks Methodology DAG Skill",
-        "DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT",
         "lookup_methodology.py",
         "run_methodology.py",
         "validate_methodology.py",
@@ -398,13 +397,35 @@ def test_methodology_dag_skill_routes_lookup_first_and_falls_back_on_a_miss():
     for token in required_tokens:
         assert token in snapshot, token
 
-    # Executable references use the full contract form, never a bare script name.
-    assert (
-        '"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py"'
-        in snapshot
-    )
     # The skill must not re-document a second SQL execution entrypoint.
     assert "唯一推荐的 SQL 执行入口" not in snapshot
+
+
+def test_methodology_dag_skill_stays_portable_and_embeds_no_root_path():
+    """A skill bundle must run wherever it is installed.
+
+    Baking in a host-injected root variable, a repo path, or the runtime's
+    workspace staging layout would tie the bundle to one particular host, so the
+    documented invocation is relative to the skill's own directory instead.
+    """
+    snapshot = _skill_text_snapshot(METHODOLOGY_DAG_SKILL_ROOT)
+
+    assert "python3 scripts/run_methodology.py" in snapshot
+    assert "python3 scripts/lookup_methodology.py" in snapshot
+    assert "路径一律相对本技能目录" in snapshot
+
+    forbidden_tokens = [
+        # A root path injected by this particular backend.
+        "DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT",
+        "${DATAAGENT_SKILL_ROOT}",
+        # The workspace staging layout, which is an internal runtime detail.
+        ".claude/skills/opendataworks-methodology-dag/scripts",
+        # Repo-relative and deployment-absolute paths.
+        "dataagent/.claude/skills/opendataworks-methodology-dag/scripts",
+        "/app/.claude/skills",
+    ]
+    for token in forbidden_tokens:
+        assert token not in snapshot, token
 
 
 def test_methodology_dag_skill_forbids_bypassing_a_registered_caliber():
@@ -422,7 +443,9 @@ def test_methodology_dag_skill_forbids_bypassing_a_registered_caliber():
 def test_methodology_dag_skill_declares_the_platform_tools_prerequisite():
     snapshot = _skill_text_snapshot(METHODOLOGY_DAG_SKILL_ROOT)
 
-    assert "必须与 `opendataworks-platform-tools` 同时启用" in snapshot
+    assert "必须与 `opendataworks-platform-tools` 一起安装并启用" in snapshot
+    # The neighbour is located from the skill's own path, not from a host variable.
+    assert "../opendataworks-platform-tools" in snapshot
     # The sql node delegates rather than re-implementing SQL execution.
     assert "run_sql.py" in snapshot
 

--- a/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
+++ b/dataagent/dataagent-backend/tests/test_builtin_skill_content.py
@@ -11,6 +11,7 @@ BUSINESS_SKILL_ROOT = SKILLS_ROOT / "opendataworks-business-knowledge"
 PLATFORM_TOOLS_SKILL_ROOT = SKILLS_ROOT / "opendataworks-platform-tools"
 ONTOLOGY_MODELING_SKILL_ROOT = SKILLS_ROOT / "ontology-modeling-assistant"
 DATA_DEV_SKILL_ROOT = SKILLS_ROOT / "opendataworks-data-dev"
+METHODOLOGY_DAG_SKILL_ROOT = SKILLS_ROOT / "opendataworks-methodology-dag"
 
 
 def _skill_text_snapshot(root: Path) -> str:
@@ -371,3 +372,70 @@ def test_data_dev_skill_presets_scenarios_and_gates_dml_validation():
     # DML must pass validation before it becomes a task / enters the plan.
     assert "portal_analyze_sql" in snapshot
     assert "验证不通过不建任务" in snapshot
+
+
+def test_methodology_dag_skill_routes_lookup_first_and_falls_back_on_a_miss():
+    snapshot = _skill_text_snapshot(METHODOLOGY_DAG_SKILL_ROOT)
+
+    required_tokens = [
+        "OpenDataWorks Methodology DAG Skill",
+        "DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT",
+        "lookup_methodology.py",
+        "run_methodology.py",
+        "validate_methodology.py",
+        # Lookup precedes execution, and a miss is a first-class path.
+        "先检索，再决定",
+        "回落",
+        "matched=0",
+        # The caliber travels with the result and must reach the user.
+        "caliber",
+        # Attribution vocabulary is shared with the SQL tool path.
+        "result_state",
+        "error_code",
+        "failure_attribution",
+        "platform_tools_unavailable",
+    ]
+    for token in required_tokens:
+        assert token in snapshot, token
+
+    # Executable references use the full contract form, never a bare script name.
+    assert (
+        '"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py"'
+        in snapshot
+    )
+    # The skill must not re-document a second SQL execution entrypoint.
+    assert "唯一推荐的 SQL 执行入口" not in snapshot
+
+
+def test_methodology_dag_skill_forbids_bypassing_a_registered_caliber():
+    snapshot = _skill_text_snapshot(METHODOLOGY_DAG_SKILL_ROOT)
+
+    for token in (
+        "不得",
+        "口径漂移",
+        "临时修改注册表",
+        "升 `version`",
+    ):
+        assert token in snapshot, token
+
+
+def test_methodology_dag_skill_declares_the_platform_tools_prerequisite():
+    snapshot = _skill_text_snapshot(METHODOLOGY_DAG_SKILL_ROOT)
+
+    assert "必须与 `opendataworks-platform-tools` 同时启用" in snapshot
+    # The sql node delegates rather than re-implementing SQL execution.
+    assert "run_sql.py" in snapshot
+
+
+def test_methodology_dag_registry_entries_declare_an_executable_caliber():
+    registry_dir = METHODOLOGY_DAG_SKILL_ROOT / "assets" / "registry"
+    entries = sorted(registry_dir.glob("*.json"))
+    assert entries, "注册表为空"
+
+    for path in entries:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["id"] == path.stem
+        for field in ("version", "intent", "caliber", "owner", "target", "nodes"):
+            assert payload.get(field), f"{path.name} 缺少 {field}"
+        assert payload["target"] in payload["nodes"], f"{path.name} 的 target 不是已定义节点"
+

--- a/docs/design/2026-07-27-methodology-dag-skill-design.md
+++ b/docs/design/2026-07-27-methodology-dag-skill-design.md
@@ -200,9 +200,10 @@ JSON Schema——完全对齐 `ontology-modeling-assistant/scripts/ontology_sche
 
 ### `sql` 节点委托 platform-tools
 
-`sql` 节点**不自己连数据库**，而是子进程调用
-`"$DATAAGENT_PLATFORM_SKILL_ROOT/scripts/run_sql.py" --database <db> --engine <engine> --sql <bound sql>`
-并解析其 JSON 输出。
+`sql` 节点**不自己连数据库**，而是子进程调用 platform-tools 的
+`scripts/run_sql.py --database <db> --engine <engine> --sql <bound sql>` 并解析其 JSON 输出。
+平台工具目录由脚本自行定位：默认取同级目录 `../opendataworks-platform-tools`，
+宿主可用 `DATAAGENT_PLATFORM_SKILL_ROOT` 覆盖。
 
 这样保住了 `30-tool-recipes.md:15` 的契约"`run_sql.py` 是唯一推荐的 SQL 执行入口"，
 并且免费继承它的全部护栏：只读校验（`ensure_read_only`）、血缘 guard
@@ -210,10 +211,26 @@ JSON Schema——完全对齐 `ontology-modeling-assistant/scripts/ontology_sche
 以及 `run_sql.py:25` `classify_sql_execution_failure` 的失败归因分类。这正是论文
 "把专门问题留在接缝后面"那条教训的应用。
 
-**硬前置**：本 skill 必须与 `opendataworks-platform-tools` 同时启用。
-`core/agent_runtime.py:199` `_build_workspace_allowed_roots` 只在 platform-tools 被启用时
-才把它的根目录加入允许列表。缺失时 `run_methodology.py` 返回
+**硬前置**：本 skill 必须与 `opendataworks-platform-tools` 一起安装并启用。
+`core/agent_runtime.py:199` `_build_workspace_allowed_roots` 也只在 platform-tools 被启用时
+才把它的根目录加入允许列表。两处都找不到时 `run_methodology.py` 返回
 `error_code=platform_tools_unavailable`，不静默降级。
+
+### 技能包必须自包含
+
+一个 skill bundle 装到哪都应该能跑，所以**技能内不写任何根路径**：
+
+- 不写宿主注入的根路径变量（`${DATAAGENT_..._SKILL_ROOT}`）——那把技能绑死在这套 backend 上；
+- 不写 `.claude/skills/<folder>/...`——那把技能绑死在 `topic_workspace.py` 的 staging 布局这个内部实现上；
+- 不写仓库相对路径或 `/app/...` 部署绝对路径。
+
+文档里的调用形式一律是 `cd <本技能目录> && python3 scripts/<name>.py ...`，
+脚本自身用 `Path(__file__).resolve().parent.parent` 解析技能根（`registry.py:24`），
+注册表、schema、同级技能全部由脚本定位。因此本 skill **不需要后端做任何配套改动**，
+共享运行时模块零改动。
+
+这条同样适用于对 platform-tools 的依赖：先找同级目录，环境变量只作为可选覆盖，
+而不是必需输入。
 
 ### 占位符绑定与注入安全（论文 V 的直接移植）
 
@@ -322,21 +339,17 @@ JSON Schema——完全对齐 `ontology-modeling-assistant/scripts/ontology_sche
 ### 新增
 
 - skill 目录 `dataagent/.claude/skills/opendataworks-methodology-dag/`（全部新增文件）。
-- 脚本调用契约：
-  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<问题>"`
-  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '<json>'`
-  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --all`
-
-### 变更
-
-- `core/agent_runtime.py`：为每个已启用 skill folder 导出
-  `DATAAGENT_<UPPER_SNAKE>_SKILL_ROOT`。当前只导出 primary 的 `DATAAGENT_SKILL_ROOT` 和硬编码的
-  `DATAAGENT_PLATFORM_SKILL_ROOT`（`agent_runtime.py:39,558-596`），而 AGENTS.md 禁止非 primary
-  skill 使用 `DATAAGENT_SKILL_ROOT`。改成通用规则后，共享模块里不再需要新增 skill 名，
-  符合"keep generic runtime modules skill-agnostic"。`DATAAGENT_PLATFORM_SKILL_ROOT` 保留为兼容别名。
+- 脚本调用契约，路径相对技能自身目录：
+  - `cd <本技能目录> && python3 scripts/lookup_methodology.py --query "<问题>"`
+  - `cd <本技能目录> && python3 scripts/run_methodology.py --id <id> --params '<json>'`
+  - `cd <本技能目录> && python3 scripts/validate_methodology.py --all`
+- 可选环境覆盖（全部有默认值，缺失不影响运行）：`DATAAGENT_PLATFORM_SKILL_ROOT`、
+  `DATAAGENT_QUERY_LIMIT`、`DATAAGENT_SQL_READ_TIMEOUT_SECONDS`、
+  `DATAAGENT_METHODOLOGY_TOTAL_TIMEOUT_SECONDS`。
 
 ### 不变
 
+- **后端零改动**。技能自包含，不需要共享运行时导出任何新变量。
 - `run_sql.py` / `validate_sql.py` / `build_chart_spec.py` 契约不变。
 - 前端渲染不变。
 - 系统提示词不变。

--- a/docs/design/2026-07-27-methodology-dag-skill-design.md
+++ b/docs/design/2026-07-27-methodology-dag-skill-design.md
@@ -1,0 +1,375 @@
+# 可复用分析方法论声明式 DAG Skill Design
+
+## Context
+
+### 论文来源
+
+本设计源自 LinkedIn 的经验论文 *QDAG: Declarative Composition of Reusable Analytics
+Methodologies at LinkedIn*（arXiv 2606.05662, cs.DB, 2026-06-04）。
+
+论文的核心论断：**一个"分析方法论"几乎从来不是一条 SQL**，而是一个小型 dataflow 程序。
+以论文给的三个生产例子为例：
+
+- **人数增长**：先查一次当期各国人数；再查上期，但 `WHERE` 被约束到第一次查询返回的那些国家；
+  最后 join 两个结果集算增长率。
+- **Top 技能**：先用一条查询选出 Top-N 技能；再用这些技能作参数发起第二轮查询算各自增长率——
+  查询之间有数据依赖，中间夹一个抽取实体的变换。
+- **帖子唯一曝光**：并行发两条聚合查询（分维度计数与总量），丢掉非正数行，相除得到占比分布。
+
+这类逻辑今天被写成 OLAP 查询外面的**命令式胶水代码**：手拼 SQL 字符串、手写并发编排、
+后处理 JSON、条件分支。论文观察到三个反复出现的问题：
+
+1. **编写成本**：从"我有 SQL"到"我有一个正确、并行、带条件分支的接口"，贵在编排那一步。
+2. **口径漂移**：同一个方法论在不同接口和团队里被重新实现，副本各自演化，本该一致的定义悄悄不再一致。
+3. **各团队各造框架**：每条业务线自建一套查询组合框架（一个 Scala、好几个 Java），重复投入，跨团队无法对齐。
+
+QDAG 的回答是**把方法论从代码变成数据**：声明成一张有向无环图，节点是带类型的执行步骤，
+边是数据依赖，交给一个共享引擎执行。作者不再决定跑什么、什么顺序、什么并行、什么跳过、
+什么复用——引擎决定。
+
+### 论文的关键设计
+
+**模型（论文 III）**。每个节点消费并产出单个 JSON 值；恰好一个节点被指定为 `target`，
+执行从 target 出发，只走到它的传递依赖为止。隐式输入 `$QDAG_INPUT` 注入每次调用，
+同一张图因此可以参数化。节点分三组：
+
+- **query**：`PINOT`（模板化 OLAP SQL）、`RESTLI`（下游服务调用）
+- **compute**：`SQLITE`（把依赖结果装进内存 SQLite 跑完整 SQL）、`JOIN`、`JQ`、`TRANSFORM`、`LITERAL`
+- **control**：`CONDITIONAL`（谓词二选一）、`CALL`（调用另一张图）
+
+`CALL` 是复用单元：两个产品都 CALL 同一张规范图，定义就不可能悄悄分叉。图从注册表按名解析，
+所以对共享定义的修复会传播到所有调用方。
+
+**变换子语言（论文 IV）**。用 jq 做 JSON 变换，外面套一层可选的 YAML 宏层，源到源编译回 jq。
+论文明确声明这只是人体工学装置，不是新语言，每个宏都有一行 jq 展开。
+
+**动态 SQL 与谓词 DSL（论文 V）**。SQL 模板有两种占位符：
+
+- `{{jq}}` **受检值**：结果必须是标量或标量数组；标量被加引号，数组展开成逗号列表，
+  于是**值永远无法逃出它的字面量位置**。
+- `{{! jq}}` **非受检片段**：用于注入列名或 SQL 片段（例如动态分组维度），原样拼接、
+  作者自负安全，但用 Apache Calcite 解析以尽早拒绝畸形 SQL。
+
+对于"从可选请求参数拼 WHERE"这个经典注入高危场景，论文提供一个小的**谓词 DSL**
+（`eq`/`lt`/`in`/`between`/`and`/`or`/`not`），编译成校验过的片段并**丢弃 null 子谓词**，
+于是缺失的过滤条件自然消失。注入问题变成数据构造问题。
+
+**执行引擎（论文 VI）**。build system 求值模型的直接移植。每个节点映射到
+`Lazy<Future<Value>>`，请求 target 的结果会 force 它的 future，进而递归 force 依赖：
+
+- **只构建需要的**：future 从未被 force 的节点不执行；条件分支未选中的那一侧及其整个子图代价为零。
+- **最多构建一次**：lazy future 被 memoize，共享依赖沿多条路径被 force 也只计算一次。
+- **并行免费**：节点结果是 future，独立分支自动并发，作者不写任何并发代码。
+- 一次请求 O(V+E) 次 force，延迟由**关键路径**而非图规模决定。
+- **执行模式**：同一个库既能在网关远程跑，也能嵌入客户端本地跑；**mock 模式**返回作者提供的表，
+  不碰任何数据存储——方法论变成一个普通单元测试。
+
+**声明式结构买到了什么（论文 VII）**。执行前静态校验（依赖存在、target 存在、模板可解析、
+DFS 判环并报出具体环路径）；每节点可观测性对作者免费；以及"图即成本表达式"——
+链式相加、并行取 max、条件按分支概率混合，理论上可在运行前估算延迟分布。论文诚实地把最后一项
+标注为**尚未实现的方向**，并指出两个诚实的注意点：百分位不线性可组合，必须传播分布而非百分位；
+分支概率与 CALL 倍数依赖工作负载，必须从 trace 估计。
+
+**生产经验（论文 VIII）**。500+ 主机、100+ 用例；编排开销 P50 5–10ms、P99 约 50ms，
+且**不随方法论数量增长**。采纳方报告集成速度快约 60%（作者自评为方向性证据，不是受控实验）。
+三条教训：最大收益不是性能而是**可测试性与对齐**；模型被接受后摩擦全部转移到**工件周边的工具**
+（DAG 可视化、YAML linter、输出 schema 校验）；把专门问题留在**接缝**后面（关系 join 交给
+嵌入式 SQL 引擎、外部系统藏在带类型的查询节点后）让核心保持小，代价是硬保证归接缝所有而非 QDAG。
+
+**定位（论文 IX）**。不是联邦查询——不做跨源优化和下推，Calcite 只当解析器和校验器；
+不是 Airflow/Dagster 类调度器——那是吞吐导向的离线批处理，QDAG 是单请求、进程内、毫秒级；
+比语义层**更低一层**——dbt MetricFlow / LookML / Cube / Malloy 把指标建模成关系式并编译成
+单条 SQL，表达不了运行时条件、任意 JSON 变换、下游服务调用，以及"多条查询带中间处理的排序执行"。
+
+## Problem
+
+把论文的三个问题投射到本仓库的智能问数链路，全部成立，而且更严重。
+
+**1. 每个方法论都是现场重新发明的。** 问数是 LLM agent 每次现场写 SQL。标准链路写死在
+`dataagent/.claude/skills/opendataworks-platform-tools/reference/30-tool-recipes.md:14`：
+
+```
+语义确认 → SQL 生成 → SQL 验证 → run_sql.py 执行 → 结果收口
+```
+
+每一步都是一次模型轮次。论文里"先取 Top-N 再按 Top-N 二次查询"这种依赖查询，在这里要来回好几轮：
+生成第一条 SQL、验证、执行、读结果、生成第二条 SQL、验证、执行、再合并。
+
+**2. 口径漂移的来源变了，但没有消失。** 论文里漂移来自"两个团队各写一遍"；这里来自
+"**同一个模型两次生成的 SQL 不一样**"。这更难察觉，因为没有两份可以 diff 的源码。
+
+**3. 语义资产已经存在，但都不可执行。**
+
+- `opendataworks-business-knowledge/assets/metrics.json` 只有单表达式指标，例如
+  `{"metric_key": "failed_publish_cnt", "formula": "SUM(CASE WHEN workflow_publish_record.status = 'failed' THEN 1 ELSE 0 END)"}`。
+  这正是论文说的"语义层表达不了多步组合"那一层。
+- `ontology-modeling-assistant/scripts/ontology_schema.py:116` 的 `QueryFunction`
+  （`function_name` / `intent` / `grain` / `params` / `output_fields` / `notes`）在
+  `ontology-modeling-assistant/SKILL.md:67` 被明确定义为"语义交接契约，**不得把它当成可直接运行的 SQL**"。
+  语义与执行之间有一道刻意留下的空隙，今天由模型即兴填补。
+- `relation_kind` 里已经有 `caliber_rule`（口径规则，`ontology_schema.py:34`）——仓库已经把口径
+  当成一等概念，但没有任何机制**强制**它。
+
+**4. 论文的"减少编排代码"在这里翻译成"减少模型轮次"。** 这直接对上 AGENTS.md 用整节篇幅描述的
+智能问数超时链路问题："Before increasing timeout, first reduce unnecessary turns, duplicate reads,
+path guessing, and repeated tool retries. Raise timeout only after the execution path is already
+simplified."确定性地一次执行完整个方法论，正是"先简化执行路径"。
+
+**5. 跨引擎组合今天做不到。** 平台同时接 MySQL 与 Doris，`run_sql.py --engine <mysql|doris>`
+一次只打一个引擎。两个引擎的结果需要 join 时，现在没有任何机制。
+
+## Goal
+
+1. 引入一个新 skill，把"多步分析方法论"变成**可注册、可校验、可执行、可回归**的声明式 JSON 工件。
+2. 命中已注册方法论时，**一次工具调用**返回确定性结果与固定口径；未命中时无损回落现有 ad-hoc 链路。
+3. 给现有语义资产补上可执行体：本体的 `query_functions` 声明语义契约，方法论工件提供执行体。
+4. 让方法论可以在**不碰数据库**的情况下被单元测试（论文的 mock 模式）。
+5. 提供跨引擎组合能力（内存 SQLite 节点）。
+6. **零新增运行时依赖，零前端改动，零现网行为变化。**
+
+## Non-Goals
+
+- 不做跨请求缓存。论文的 Caffeine + 分布式 blob 两级缓存是运维设施，本仓库量级用不上；
+  只保留请求内 memoization。
+- 不做基于图结构的延迟/成本建模。论文自己标注为未实现方向。
+- 不引入 jq、YAML 宏层或任何新的表达式语言。
+- 不引入 Calcite 或新的 SQL 解析器。
+- 不实现差分隐私节点、`RESTLI` 下游服务节点。
+- 不改 `prompts/data_agent_system_prompt.md`。
+- 不写 alembic 迁移，不默认对内置问数助手启用。
+- 不做 DAG 可视化 UI（论文把它列为采纳后最想要的工具，但那是后续话题）。
+
+## Design
+
+新 skill：`dataagent/.claude/skills/opendataworks-methodology-dag/`。
+
+```
+SKILL.md
+assets/
+  methodology.schema.json
+  registry/
+    table_growth_ratio.json
+    top_owner_task_growth.json
+    workflow_publish_trend.json
+reference/
+  10-model.md
+  20-authoring.md
+  30-invocation.md
+  40-output-contract.md
+scripts/
+  methodology_schema.py
+  binding.py
+  engine.py
+  lookup_methodology.py
+  validate_methodology.py
+  run_methodology.py
+tests/
+  test_methodology_dag_schema.py
+  test_methodology_dag_binding.py
+  test_methodology_dag_validate.py
+  test_methodology_dag_engine.py
+  test_methodology_dag_registry.py
+  evals/evals.json
+```
+
+### 工件格式：JSON 而非 YAML
+
+论文用 YAML，并在结论里把 YAML 的坑列为促使他们做 linter 和可视化的原因。本仓库
+`requirements.txt` 没有 PyYAML，而既有语义资产（`ontology.json`、`metrics.json`、
+`chart-template/*.json`）全是 JSON。因此工件用 JSON，由 pydantic 模型校验并导出
+JSON Schema——完全对齐 `ontology-modeling-assistant/scripts/ontology_schema.py` 的做法
+（`FIELD_DICTIONARY` + `model_json_schema()` + `x-field-dictionary`）。
+
+### 节点类型：6 种（论文 9 种的裁剪）
+
+| type | group | 作用 | 论文对应 |
+|---|---|---|---|
+| `sql` | query | 模板化只读 SQL，经 platform-tools `run_sql.py` 执行 | `PINOT` |
+| `sqlite` | compute | 依赖结果装入内存 SQLite 跑完整 SQL（跨引擎 join、集合运算）| `SQLITE` |
+| `transform` | compute | 声明式 `filter` / `derive` / `sort` / `limit` / `rename` | `JQ` + `TRANSFORM` |
+| `literal` | compute | 常量表（维度映射等）| `LITERAL` |
+| `conditional` | control | 谓词二选一，未选中分支及其子图不执行 | `CONDITIONAL` |
+| `call` | control | 调用另一个已注册方法论，调用链判环 | `CALL` |
+
+去掉 `RESTLI`（平台无此需求）与 `JOIN`（`sqlite` 已覆盖，论文自己也说简单合并才走轻节点，
+这里选择只留一个 join 通路而不是两个）。
+
+`sqlite` 用的是 Python 标准库 `sqlite3`，零依赖。论文在未来工作里提到行存的 SQLite 对宽表
+聚合不理想、DuckDB 更合适——在本仓库的中间结果规模（受 `DATAAGENT_QUERY_LIMIT`，默认 1000 行约束）
+下这个权衡不成立，标准库足够。
+
+### `sql` 节点委托 platform-tools
+
+`sql` 节点**不自己连数据库**，而是子进程调用
+`"$DATAAGENT_PLATFORM_SKILL_ROOT/scripts/run_sql.py" --database <db> --engine <engine> --sql <bound sql>`
+并解析其 JSON 输出。
+
+这样保住了 `30-tool-recipes.md:15` 的契约"`run_sql.py` 是唯一推荐的 SQL 执行入口"，
+并且免费继承它的全部护栏：只读校验（`ensure_read_only`）、血缘 guard
+（`run_sql.py:123` `enforce_lineage_first_guard`）、后端数据范围校验、结果字节守卫、
+以及 `run_sql.py:25` `classify_sql_execution_failure` 的失败归因分类。这正是论文
+"把专门问题留在接缝后面"那条教训的应用。
+
+**硬前置**：本 skill 必须与 `opendataworks-platform-tools` 同时启用。
+`core/agent_runtime.py:199` `_build_workspace_allowed_roots` 只在 platform-tools 被启用时
+才把它的根目录加入允许列表。缺失时 `run_methodology.py` 返回
+`error_code=platform_tools_unavailable`，不静默降级。
+
+### 占位符绑定与注入安全（论文 V 的直接移植）
+
+- `{{ expr }}` **受检值**：必须求值为标量或标量数组。标量按引擎规则转义并加引号，
+  数组展开为逗号分隔列表（供 `IN (...)` 使用）。值无法逃出字面量位置。
+- `{{! expr }}` **非受检片段**：只允许标识符，必须匹配 `^[A-Za-z_][A-Za-z0-9_.]*$`，
+  或命中参数声明里的 `values` 枚举。**比论文更严**——论文靠 Calcite 解析加作者自觉，
+  这里直接用白名单堵死。
+- `{{? name }}` **谓词片段**：引用本节点 `predicates` 里的同名谓词，编译成校验过的 SQL 片段。
+  论文的谓词 DSL 没有专门的占位符形式，这里给它一个，是为了让「这段 WHERE 是数据构造出来的」
+  在模板里一眼可见，而不是混在受检值里。
+- **谓词 DSL**：`{"and": [{"field": "layer", "op": "eq", "value": "$params.layer"}]}`，
+  支持 `eq`/`ne`/`lt`/`lte`/`gt`/`gte`/`in`/`between`/`like`/`and`/`or`/`not`。
+  **null 子谓词直接丢弃**——参数没传，过滤条件就消失，模板里不需要写分支。
+  `in` 的 `values` 可以是 `"$pluck(current.rows, 'layer')"`，上游返回 0 行时整段消失，
+  所以不会拼出非法的 `IN ()`；这也是注册表里链式依赖节点收敛范围的标准写法。
+- 表达式求值器用 `ast.parse(mode="eval")` 加节点类型白名单，**不使用 `eval`/`exec`**。
+  只支持字段路径、字面量、比较、布尔运算和一小组白名单函数。
+- 绑定后的完整 SQL 仍然过 `validate_sql.py` 与后端只读/数据范围校验。纵深防御，不替代任何一层。
+
+### 引擎语义（论文 VI 的直接移植）
+
+- 从 `target` 出发按需求值；不可达节点不执行。
+- 每节点每次运行最多执行一次（memoize）；共享依赖只算一次。
+- 独立分支用 `ThreadPoolExecutor` 并发。SQL 走子进程、I/O 密集，线程足够，
+  避免为此引入 asyncio（保持脚本可以独立 `python xxx.py` 运行）。
+- `conditional` 先算谓词再 force 选中分支；未选中分支是软依赖，永不执行。
+- `call` 解析注册表里的另一个方法论，调用链判环。论文把递归列为"可表达但视作危险"，
+  设计意图是拒绝调用图里的环——这里直接拒绝。
+- **两级超时**，对齐 AGENTS.md 的智能问数超时规则：`--total-timeout`（单次运行总预算，默认 240s）
+  与单节点超时（默认取 `DATAAGENT_SQL_READ_TIMEOUT_SECONDS`）。
+- **mock 模式**：`--mock <file.json>` 用作者提供的节点结果替代真实执行。论文说这是实践中
+  最受重视的性质；在本仓库它同时满足 AGENTS.md 对"targeted regression test"的要求，
+  且让 CI 不需要数据库。
+
+### 静态校验（论文 VII a）
+
+`validate_methodology.py` 在执行前拒绝：schema 不合法、`target` 不存在、依赖引用不存在、
+依赖图有环（DFS，**报出具体环路径**）、模板占位符不可解析、`call` 目标无法解析或调用图有环、
+参数声明与模板引用不一致。绑定桩值后的 SQL 还会过一遍 `validate_sql.py`。
+在手写胶水里本该是运行时异常的错误，在这里变成加载期拒绝。
+
+### 输出契约：复用现有渲染，前端零改动
+
+`dataagent-frontend/src/views/intelligence/ToolOutputRenderer.vue:95,350,607` 按
+`kind === 'sql_execution'` 渲染 SQL、表格、行数与耗时。`run_methodology.py` 直接产出该 kind，
+多余字段被渲染器忽略：
+
+```json
+{
+  "kind": "sql_execution",
+  "tool_label": "方法论执行",
+  "methodology": {"id": "...", "version": "...", "caliber": "...", "params": {}},
+  "sql": "<target 节点绑定后的 SQL>",
+  "columns": [], "rows": [], "row_count": 0,
+  "duration_ms": 0,
+  "result_state": "success|empty_result|failed",
+  "error_code": null, "failure_attribution": [], "retryable": false, "stop_reason": "",
+  "trace": {"executed": 3, "pruned": 1, "nodes": [
+    {"name": "current", "type": "sql", "status": "success", "duration_ms": 210, "row_count": 5}
+  ]}
+}
+```
+
+`trace` 是论文"每节点可观测性对作者免费"的落地：每个节点的类型、状态、耗时、行数、
+是否被剪枝，作者不写任何埋点。
+
+失败时透传失败节点由 `classify_sql_execution_failure` 产出的
+`error_code` / `failure_attribution` / `stop_reason`，另加本层错误码：
+`methodology_not_found`、`methodology_invalid`、`param_missing`、`param_rejected`、
+`methodology_timeout`、`platform_tools_unavailable`。
+
+### 三个注册方法论
+
+覆盖论文的三种结构，全部基于平台自身元数据表（这些表已被
+`business-knowledge/assets/metrics.json` 引用，保证存在）：
+
+| 方法论 | 结构 | 论文对应 |
+|---|---|---|
+| `table_growth_ratio` | 链式依赖 + SQLite join；`current` 被两个节点共享，只执行一次 | Headcount growth |
+| `top_owner_task_growth` | Top-N 选择 → 用选中实体参数化二次查询 | Top skills |
+| `workflow_publish_trend` | 条件剪枝（有无维度过滤走不同口径）+ transform | Talent-pool report |
+
+### Agent playbook
+
+写在 SKILL.md，**不进系统提示词**——`tests/test_builtin_skill_content.py:41` 禁止系统提示词
+出现 skill 专属 token，路由规则必须留在 skill 内。
+
+1. `lookup_methodology.py --query "<用户问题>"` → 候选方法论 + intent + 参数槽位 + 口径。
+2. 命中且参数齐全 → `run_methodology.py --id <id> --params '<json>'`，一次调用拿最终结果。
+3. 参数缺失 → 只追问缺的槽位，不自行改口径。
+4. 未命中 → 回落 platform-tools 既有链路。
+5. 禁止为"跑通"临时改注册表口径；口径变更走 authoring 流程并升 `version`。
+
+### 与既有语义资产的关系
+
+方法论工件的 `ontology_ref` 指向本体的 `query_functions.function_name`。分工是论文的
+"sits below the semantic abstraction"在本仓库的具体形态：
+
+- **本体 / 业务知识**：声明这个业务概念是什么、口径是什么、有哪些参数槽位（语义层）。
+- **方法论 DAG**：声明怎么算出来（执行层）。
+- `metrics.json` 的单表达式指标继续留在原处；只有需要多步、依赖查询或跨引擎的才升级为方法论。
+
+## Interfaces
+
+### 新增
+
+- skill 目录 `dataagent/.claude/skills/opendataworks-methodology-dag/`（全部新增文件）。
+- 脚本调用契约：
+  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/lookup_methodology.py" --query "<问题>"`
+  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/run_methodology.py" --id <id> --params '<json>'`
+  - `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/validate_methodology.py" --all`
+
+### 变更
+
+- `core/agent_runtime.py`：为每个已启用 skill folder 导出
+  `DATAAGENT_<UPPER_SNAKE>_SKILL_ROOT`。当前只导出 primary 的 `DATAAGENT_SKILL_ROOT` 和硬编码的
+  `DATAAGENT_PLATFORM_SKILL_ROOT`（`agent_runtime.py:39,558-596`），而 AGENTS.md 禁止非 primary
+  skill 使用 `DATAAGENT_SKILL_ROOT`。改成通用规则后，共享模块里不再需要新增 skill 名，
+  符合"keep generic runtime modules skill-agnostic"。`DATAAGENT_PLATFORM_SKILL_ROOT` 保留为兼容别名。
+
+### 不变
+
+- `run_sql.py` / `validate_sql.py` / `build_chart_spec.py` 契约不变。
+- 前端渲染不变。
+- 系统提示词不变。
+- 数据库 schema 不变，无迁移。
+- 部署不变（skills 目录是 bind mount，`deploy/docker-compose.prod.yml:228`）。
+
+## Tradeoffs
+
+**用受限声明式 transform 替代 jq。** 代价是表达力弱于 jq：不能写任意 JSON 重塑。
+理由是引入 jq 需要新依赖，而 YAML 宏层是一整套需要维护的源到源编译器——论文自己都强调那只是
+人体工学装置。当前三个方法论的变换需求（过滤、派生列、排序、截断）完全覆盖。
+若后续出现真实的表达力缺口，正确做法是给 `transform` 加算子，而不是引入语言。
+
+**`sql` 节点走子进程而非进程内。** 每个 SQL 节点多一次 Python 解释器启动开销（约几十毫秒）。
+论文关心 P99 50ms 的编排开销，这里不关心——本场景的基线是"多次模型往返"，量级是秒。
+换来的是完整复用 `run_sql.py` 的全部安全与归因逻辑，不复制一行。
+
+**注册表只覆盖问题分布的头部。** 论文的方法论由工程师手写且形态稳定；这里用户问题是开放的。
+所以方法论注册表永远只能覆盖高频问题，长尾必须留给 agent 现场处理。设计上因此是**混合**的：
+先查注册表，未命中就无损回落。这是与论文场景最本质的差异，也是为什么"未命中回落"必须是
+一等路径而不是错误分支。
+
+**不默认启用。** 现网问数行为零变化，代价是需要运维在 Agent Studio 手动勾选才生效。
+`core/skill_admin_service.py:964` `_discovered_skill_folders()` 扫描任何带 `SKILL.md` 的
+目录，所以新 skill 会自动出现在列表里。
+
+**引擎并发用线程而非 asyncio。** 线程池对子进程 I/O 足够，且脚本保持可独立运行、可被
+pytest 直接调用。代价是不能扩展到大量并发节点——本场景一张图通常 3–5 个节点，不成问题。
+
+## Follow-up
+
+- DAG 可视化与 linter。论文把这两项列为模型被接受后采纳方最想要的东西，
+  并自评"早期投入不足"。本次不做。
+- 从一次成功的 ad-hoc 问数**提升**为注册方法论的流程（agent 建议、人工审核、落注册表）。
+  这是让注册表长大的关键机制，值得单独设计。
+- 与 eval 框架打通：注册方法论的 mock 用例可以直接作为 `expected_sql` / `expected_result` 的来源。

--- a/docs/plans/2026-07-27-methodology-dag-skill-plan.md
+++ b/docs/plans/2026-07-27-methodology-dag-skill-plan.md
@@ -1,0 +1,144 @@
+# 可复用分析方法论声明式 DAG Skill Plan
+
+配套设计：[`docs/design/2026-07-27-methodology-dag-skill-design.md`](../design/2026-07-27-methodology-dag-skill-design.md)
+
+## 受影响栈
+
+- **DataAgent skill 包**：新增 `dataagent/.claude/skills/opendataworks-methodology-dag/`（主要工作量）
+- **DataAgent 后端**：`core/agent_runtime.py` 一处通用化改动 + 对应测试
+- **前端**：无改动（复用 `sql_execution` 渲染）
+- **数据库 / 部署**：无改动（不写迁移；skills 目录是 bind mount）
+
+## 任务
+
+### G1 —— 模型与绑定层（独立可交付，无需数据库）
+
+1. `scripts/methodology_schema.py`
+   - pydantic 模型：`Methodology`（`id`/`version`/`name_zh`/`intent`/`caliber`/`owner`/
+     `ontology_ref`/`params`/`nodes`/`target`）、`ParamSpec`、六种节点模型的判别联合。
+   - `FIELD_DICTIONARY` + `methodology_json_schema()`，对齐
+     `ontology-modeling-assistant/scripts/ontology_schema.py:47,156` 的写法。
+   - `__main__` 打印 schema，用于生成 `assets/methodology.schema.json`。
+2. `scripts/binding.py`
+   - 受限表达式求值：`ast.parse(mode="eval")` + 节点类型白名单，禁用 `eval`/`exec`。
+   - `{{ expr }}` 受检值绑定：标量转义加引号，标量数组展开逗号列表，其余类型报错。
+   - `{{! expr }}` 片段绑定：白名单 `^[A-Za-z_][A-Za-z0-9_.]*$` 或参数 `values` 枚举。
+   - 谓词 DSL 编译器：`eq`/`ne`/`lt`/`lte`/`gt`/`gte`/`in`/`between`/`like`/`and`/`or`/`not`，
+     null 子谓词丢弃，全空时整个片段渲染为空串。
+3. 生成 `assets/methodology.schema.json`。
+
+### G2 —— 引擎
+
+4. `scripts/engine.py`
+   - 节点执行器注册表（`sql`/`sqlite`/`transform`/`literal`/`conditional`/`call`）。
+   - `force(node)`：锁保护的双检 lazy + memoize，保证每节点每次运行最多执行一次。
+   - 依赖并发：`ThreadPoolExecutor` 同时 force 独立依赖。
+   - `conditional`：先算谓词再 force 选中分支；分支是软依赖，不参与预先依赖解析。
+   - `call`：解析注册表中的另一方法论，维护调用链并拒绝环。
+   - `sql` 执行器：子进程调用 `${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/run_sql.py`，
+     解析 JSON；`DATAAGENT_PLATFORM_SKILL_ROOT` 缺失时抛
+     `platform_tools_unavailable`。
+   - `sqlite` 执行器：依赖结果按节点名建表装入 `sqlite3` 内存库后执行 SQL。
+   - 两级超时：总预算 + 单节点超时。
+   - mock 模式：注入 `{node_name: result}`，命中的节点不执行真实逻辑。
+   - 每节点 trace 收集（type/status/duration_ms/row_count/pruned）。
+
+### G3 —— 入口脚本与注册表
+
+5. `scripts/validate_methodology.py`
+   - schema 校验、`target` 存在、依赖引用存在、DFS 判环并报具体路径、
+     模板可解析、参数声明与模板引用一致、`call` 目标可解析且调用图无环。
+   - 桩值绑定后的 SQL 过 `validate_sql.py`（platform-tools 可用时；不可用则跳过并在输出中标注）。
+   - `--all` 校验整个注册表；`--path` 校验单个文件。
+6. `scripts/run_methodology.py`
+   - 参数解析与校验（必填、类型、范围、枚举）→ 加载 → 静态校验 → 执行 → 产出
+     `kind=sql_execution` 契约（含 `methodology` 与 `trace`）。
+   - `--mock` 透传给引擎。
+7. `scripts/lookup_methodology.py`
+   - `--query` 关键字检索（匹配 `name_zh`/`intent`/`synonyms`/`caliber`），
+     `--id` 精确取，`--list` 列全部。只返回语义与参数槽位，**不执行**。
+8. 三个注册方法论 `assets/registry/*.json`：
+   - `table_growth_ratio`：链式依赖 + SQLite join，`current` 共享依赖。
+   - `top_owner_task_growth`：Top-N 选择 → 参数化二次查询。
+   - `workflow_publish_trend`：条件剪枝 + transform。
+
+### G4 —— 文档
+
+9. `SKILL.md`：定位、边界、playbook（先 lookup 后 run，未命中回落）、
+   与 platform-tools 的硬前置关系、口径变更规则。
+10. `reference/10-model.md`、`20-authoring.md`、`30-invocation.md`、`40-output-contract.md`。
+    可执行引用一律用完整形式
+    `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/<name>.py"`。
+
+### G5 —— 后端通用化改动
+
+11. `core/agent_runtime.py`
+    - 为每个已启用 skill folder 导出 `DATAAGENT_<UPPER_SNAKE>_SKILL_ROOT`。
+    - 保留 `DATAAGENT_PLATFORM_SKILL_ROOT` 作为兼容别名，`PLATFORM_TOOLS_SKILL_FOLDER`
+      的 sibling 回落逻辑不动。
+12. `tests/test_agent_runtime.py`：断言新导出规则与旧别名同时成立。
+13. `tests/test_builtin_skill_content.py`：新增本 skill 的内容契约测试，
+    参照现有 `test_platform_tools_skill_documents_run_sql_as_only_recommended_sql_execution_entrypoint`。
+
+### G6 —— 测试
+
+14. `tests/test_methodology_dag_schema.py`：模型接受合法工件、拒绝多余字段与非法节点类型；
+    `assets/methodology.schema.json` 与模型导出一致（防止 schema 文件漂移）。
+15. `tests/test_methodology_dag_binding.py`（注入安全，必须逐条断言）：
+    - 受检值里的 `'` 被转义，无法闭合字符串。
+    - 标量数组展开成逗号列表可直接用于 `IN (...)`。
+    - 片段占位符拒绝 `1;DROP TABLE x`、空格、引号等非标识符输入。
+    - 谓词 DSL 丢弃 null 子谓词；全空时 WHERE 片段为空串。
+    - 表达式求值器拒绝函数调用、属性访问、下标以外的 AST 节点。
+16. `tests/test_methodology_dag_engine.py`（论文四条语义，逐条断言，不只是"跑通"）：
+    - 共享依赖节点一次运行只执行一次（计数 mock 的调用次数）。
+    - 条件未选中分支从未被执行（该分支挂一个会抛异常的 mock 节点，运行仍成功）。
+    - 独立分支并发（mock 节点各 sleep 0.2s，总耗时显著小于串行和）。
+    - `call` 环、依赖环、缺失依赖、不存在的 target 在加载期被拒绝，环报出具体路径。
+17. `tests/test_methodology_dag_validate.py`：各类非法工件被拒绝且错误信息可定位。
+18. `tests/test_methodology_dag_registry.py`：注册表里每个方法论都通过静态校验，
+    且都能在 mock 模式下跑到 target。
+19. `tests/evals/evals.json`：问题 → 期望命中的方法论 id 与参数槽位。
+
+## 验证
+
+### 本次可完成（无需数据库，当前容器可跑）
+
+```bash
+python -m pytest dataagent/.claude/skills/opendataworks-methodology-dag/tests -q
+python -m pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py \
+                dataagent/dataagent-backend/tests/test_agent_runtime.py -q
+"$(command -v python3)" dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py --all
+```
+
+### 需要本地环境（按 AGENTS.md 智能问数验证规则）
+
+前置：MySQL `127.0.0.1:3316`、Redis `127.0.0.1:6379`、`.venv-py313`、
+`alembic upgrade head`、`uvicorn main:app`。
+
+在 Agent Studio 给某个 agent 同时勾选 `opendataworks-platform-tools` 与
+`opendataworks-methodology-dag`，提交「最近 30 天各分层建表数环比增长」，核对：
+
+- agent 先 `lookup_methodology.py` 命中 `table_growth_ratio`；
+- 一次 `run_methodology.py` 调用返回结果，对比未启用该 skill 时的模型轮次数；
+- 任务状态 `waiting -> running -> success`；
+- `GET /api/v1/nl2sql/tasks/{task_id}/events` 返回终态事件流；
+- 最终 assistant 消息落库；
+- 前端 `sql_execution` 卡片正常渲染表格。
+
+当前会话运行在远程云容器，Docker / MySQL / Redis 大概率不可用。若端到端冒烟无法执行，
+按 AGENTS.md 要求明确说明哪一层已验证、哪条端到端路径未测，不描述为"已完整验证"。
+
+## 回滚
+
+- skill 未默认启用，现网零影响。删除 skill 目录即可完全回滚。
+- `core/agent_runtime.py` 的改动是纯增量导出（旧变量名保留），单独 revert 该文件即可，
+  不影响其他 skill。
+
+## 已知限制
+
+- 注册表只覆盖高频问题；长尾仍走 ad-hoc 链路，这是设计意图而非缺口。
+- `transform` 算子集合有意收窄，出现真实缺口时加算子，不引入表达式语言。
+- 无跨请求缓存，相同方法论重复调用会重复打库。
+- 无 DAG 可视化与 linter（论文列为采纳后的主要摩擦点，本次范围外）。
+- `sql` 节点每次多一次解释器启动开销，相对模型往返可忽略。

--- a/docs/plans/2026-07-27-methodology-dag-skill-plan.md
+++ b/docs/plans/2026-07-27-methodology-dag-skill-plan.md
@@ -5,7 +5,7 @@
 ## 受影响栈
 
 - **DataAgent skill 包**：新增 `dataagent/.claude/skills/opendataworks-methodology-dag/`（主要工作量）
-- **DataAgent 后端**：`core/agent_runtime.py` 一处通用化改动 + 对应测试
+- **DataAgent 后端**：无改动（技能自包含，不需要共享运行时导出任何新变量）
 - **前端**：无改动（复用 `sql_execution` 渲染）
 - **数据库 / 部署**：无改动（不写迁移；skills 目录是 bind mount）
 
@@ -35,8 +35,9 @@
    - 依赖并发：`ThreadPoolExecutor` 同时 force 独立依赖。
    - `conditional`：先算谓词再 force 选中分支；分支是软依赖，不参与预先依赖解析。
    - `call`：解析注册表中的另一方法论，维护调用链并拒绝环。
-   - `sql` 执行器：子进程调用 `${DATAAGENT_PLATFORM_SKILL_ROOT}/scripts/run_sql.py`，
-     解析 JSON；`DATAAGENT_PLATFORM_SKILL_ROOT` 缺失时抛
+   - `sql` 执行器：子进程调用 platform-tools 的 `scripts/run_sql.py` 并解析 JSON。
+     平台工具目录由脚本自行定位：默认同级目录 `../opendataworks-platform-tools`，
+     `DATAAGENT_PLATFORM_SKILL_ROOT` 仅作可选覆盖；两处都找不到时抛
      `platform_tools_unavailable`。
    - `sqlite` 执行器：依赖结果按节点名建表装入 `sqlite3` 内存库后执行 SQL。
    - 两级超时：总预算 + 单节点超时。
@@ -67,38 +68,36 @@
 9. `SKILL.md`：定位、边界、playbook（先 lookup 后 run，未命中回落）、
    与 platform-tools 的硬前置关系、口径变更规则。
 10. `reference/10-model.md`、`20-authoring.md`、`30-invocation.md`、`40-output-contract.md`。
-    可执行引用一律用完整形式
-    `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_METHODOLOGY_DAG_SKILL_ROOT}/scripts/<name>.py"`。
+    可执行引用一律相对技能自身目录：`cd <本技能目录> && python3 scripts/<name>.py`。
+    技能包内不得出现任何根路径——宿主注入的变量、`.claude/skills/...` staging 布局、
+    仓库相对路径、`/app/...` 部署路径都不行，否则技能只能在某一套运行时里活。
 
-### G5 —— 后端通用化改动
+### G5 —— 后端契约测试
 
-11. `core/agent_runtime.py`
-    - 为每个已启用 skill folder 导出 `DATAAGENT_<UPPER_SNAKE>_SKILL_ROOT`。
-    - 保留 `DATAAGENT_PLATFORM_SKILL_ROOT` 作为兼容别名，`PLATFORM_TOOLS_SKILL_FOLDER`
-      的 sibling 回落逻辑不动。
-12. `tests/test_agent_runtime.py`：断言新导出规则与旧别名同时成立。
-13. `tests/test_builtin_skill_content.py`：新增本 skill 的内容契约测试，
+11. `tests/test_builtin_skill_content.py`：新增本 skill 的内容契约测试，
     参照现有 `test_platform_tools_skill_documents_run_sql_as_only_recommended_sql_execution_entrypoint`。
+    其中一条专门断言**技能包不含任何根路径**（宿主变量、staging 布局、仓库路径、部署路径），
+    防止以后有人为了省事又把根路径写回文档。
 
 ### G6 —— 测试
 
-14. `tests/test_methodology_dag_schema.py`：模型接受合法工件、拒绝多余字段与非法节点类型；
+12. `tests/test_methodology_dag_schema.py`：模型接受合法工件、拒绝多余字段与非法节点类型；
     `assets/methodology.schema.json` 与模型导出一致（防止 schema 文件漂移）。
-15. `tests/test_methodology_dag_binding.py`（注入安全，必须逐条断言）：
+13. `tests/test_methodology_dag_binding.py`（注入安全，必须逐条断言）：
     - 受检值里的 `'` 被转义，无法闭合字符串。
     - 标量数组展开成逗号列表可直接用于 `IN (...)`。
     - 片段占位符拒绝 `1;DROP TABLE x`、空格、引号等非标识符输入。
     - 谓词 DSL 丢弃 null 子谓词；全空时 WHERE 片段为空串。
     - 表达式求值器拒绝函数调用、属性访问、下标以外的 AST 节点。
-16. `tests/test_methodology_dag_engine.py`（论文四条语义，逐条断言，不只是"跑通"）：
+14. `tests/test_methodology_dag_engine.py`（论文四条语义，逐条断言，不只是"跑通"）：
     - 共享依赖节点一次运行只执行一次（计数 mock 的调用次数）。
     - 条件未选中分支从未被执行（该分支挂一个会抛异常的 mock 节点，运行仍成功）。
     - 独立分支并发（mock 节点各 sleep 0.2s，总耗时显著小于串行和）。
     - `call` 环、依赖环、缺失依赖、不存在的 target 在加载期被拒绝，环报出具体路径。
-17. `tests/test_methodology_dag_validate.py`：各类非法工件被拒绝且错误信息可定位。
-18. `tests/test_methodology_dag_registry.py`：注册表里每个方法论都通过静态校验，
+15. `tests/test_methodology_dag_validate.py`：各类非法工件被拒绝且错误信息可定位。
+16. `tests/test_methodology_dag_registry.py`：注册表里每个方法论都通过静态校验，
     且都能在 mock 模式下跑到 target。
-19. `tests/evals/evals.json`：问题 → 期望命中的方法论 id 与参数槽位。
+17. `tests/evals/evals.json`：问题 → 期望命中的方法论 id 与参数槽位。
 
 ## 验证
 
@@ -106,8 +105,7 @@
 
 ```bash
 python -m pytest dataagent/.claude/skills/opendataworks-methodology-dag/tests -q
-python -m pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py \
-                dataagent/dataagent-backend/tests/test_agent_runtime.py -q
+python -m pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py -q
 "$(command -v python3)" dataagent/.claude/skills/opendataworks-methodology-dag/scripts/validate_methodology.py --all
 ```
 
@@ -132,8 +130,7 @@ python -m pytest dataagent/dataagent-backend/tests/test_builtin_skill_content.py
 ## 回滚
 
 - skill 未默认启用，现网零影响。删除 skill 目录即可完全回滚。
-- `core/agent_runtime.py` 的改动是纯增量导出（旧变量名保留），单独 revert 该文件即可，
-  不影响其他 skill。
+- 后端零改动，没有需要单独回滚的共享模块变更。
 
 ## 已知限制
 


### PR DESCRIPTION
## Summary

Introduces a new skill `opendataworks-methodology-dag` that enables declaring reusable multi-step analysis methodologies as directed acyclic graphs (DAGs) rather than imperative code. This addresses the problem of methodology drift and repeated reimplementation by storing methodology definitions in a registry and executing them through a shared engine.

## Key Changes

### Core Engine & Execution
- **`scripts/engine.py`**: Demand-driven, memoized evaluation engine that:
  - Only executes nodes needed to compute the target
  - Memoizes results so shared dependencies run exactly once
  - Automatically parallelizes independent branches
  - Supports conditional branching with lazy evaluation of untaken paths
  
- **`scripts/binding.py`**: Safe template binding and predicate DSL:
  - Restricted expression evaluator (no `eval`/`exec`, AST whitelist only)
  - Three placeholder forms: `{{ expr }}` (checked values), `{{! expr }}` (identifier fragments), `{{? name }}` (predicates)
  - Predicate DSL compiler (`eq`, `ne`, `lt`, `in`, `between`, `and`, `or`, `not`) with null-dropping for optional filters
  - SQL injection prevention through value escaping and identifier validation

### Schema & Validation
- **`scripts/methodology_schema.py`**: Pydantic models for methodology structure:
  - Six node types: `sql`, `sqlite`, `transform`, `literal`, `conditional`, `call`
  - Parameter specifications with type validation
  - Generates JSON Schema for IDE support and validation
  
- **`scripts/validate_methodology.py`**: Static validation before execution:
  - Verifies all dependencies exist and target is defined
  - Detects cycles and reports concrete paths
  - Validates template placeholders and expression references
  - Checks call graph for cycles

### Registry & Invocation
- **`scripts/registry.py`**: Registry loading and parameter coercion
- **`scripts/lookup_methodology.py`**: Search registry without executing queries
- **`scripts/run_methodology.py`**: Execute methodology and emit standard `sql_execution` output
- **`assets/registry/`**: Three example methodologies:
  - `table_growth_ratio.json`: Period-over-period growth with dependent queries
  - `top_owner_task_growth.json`: Top-N followed by scoped aggregation
  - `workflow_publish_trend.json`: Parallel aggregations with conditional filtering

### Documentation & Testing
- **`reference/`**: Four guides covering model, authoring, invocation, and output contract
- **`SKILL.md`**: Skill overview and integration points
- **`tests/`**: Comprehensive test suite covering:
  - Engine evaluation properties (memoization, lazy evaluation, parallelism)
  - Static validation (cycles, missing dependencies, template errors)
  - Binding safety (SQL injection prevention, predicate compilation)
  - Registry loading and end-to-end execution

### Integration
- Updated `dataagent-backend/core/agent_runtime.py` to expose methodology skill root via environment variable
- Updated `.gitignore` to include skill directory
- Added test coverage in `test_builtin_skill_content.py`

## Notable Implementation Details

- **Lazy evaluation model**: Each node maps to a `_Lazy` holder that memoizes its supplier behind a double-checked lock, enabling both single-execution guarantees and concurrent independent branches
- **Predicate null-dropping**: Optional parameters naturally disappear from WHERE clauses when null, eliminating conditional SQL generation
- **Mock mode**: Entire methodology can be tested without touching data stores by providing mock result suppliers
- **Output compatibility**: Results use `kind=sql_execution` to reuse existing frontend rendering and failure attribution vocabulary
- **Design source**: Implementation follows LinkedIn's QDAG paper (arXiv 2606.05662) adapted for the DataAgent context

https://claude.ai/code/session_0177kkDpPxC1o6NypTcXPS6V