### PR TITLE
fix(workflow): avoid deleted task code conflicts on import

### DIFF
--- a/backend/src/main/java/com/onedata/portal/service/WorkflowDefinitionLifecycleService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowDefinitionLifecycleService.java
@@ -817,12 +817,17 @@ public class WorkflowDefinitionLifecycleService {
         }
         String candidate = base + "_" + suffix;
         int seq = 2;
-        while (reservedCodes.contains(candidate)) {
+        while (reservedCodes.contains(candidate) || existsTaskCodeIncludingDeleted(candidate)) {
             candidate = base + "_" + suffix + "_" + seq;
             seq++;
         }
         reservedCodes.add(candidate);
         return candidate;
+    }
+
+    private boolean existsTaskCodeIncludingDeleted(String taskCode) {
+        Long count = dataTaskMapper.countByTaskCodeIncludingDeleted(taskCode);
+        return count != null && count > 0;
     }
 
     private Integer priorityToNumber(String taskPriority) {

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowDefinitionLifecycleServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowDefinitionLifecycleServiceTest.java
@@ -217,6 +217,50 @@ class WorkflowDefinitionLifecycleServiceTest {
     }
 
     @Test
+    void commitShouldAvoidTaskCodeOwnedByLogicallyDeletedTask() {
+        RuntimeWorkflowDefinition definition = baseDefinition();
+        RuntimeTaskDefinition task = sqlTask(1L, "t_extract", "SQL_A");
+        definition.setTasks(Collections.singletonList(task));
+        definition.setExplicitEdges(Collections.singletonList(new RuntimeTaskEdge(0L, 1L)));
+
+        when(runtimeDefinitionService.parseRuntimeDefinitionFromJson(any())).thenReturn(definition);
+        when(sqlTableMatcherService.analyze(eq("SQL_A"), eq("SQL"))).thenReturn(analyze(null, 101L));
+        when(dataTaskMapper.selectList(any())).thenReturn(Collections.emptyList());
+        when(dataTaskMapper.countByTaskCodeIncludingDeleted("wf_imp_t_extract_1")).thenReturn(1L);
+        when(dataWorkflowMapper.selectOne(any())).thenReturn(null);
+
+        DataTask persistedTask = new DataTask();
+        persistedTask.setId(11L);
+        persistedTask.setTaskName("t_extract");
+        persistedTask.setTaskCode("wf_imp_t_extract_1_2");
+        when(dataTaskService.create(any(), any(), any())).thenReturn(persistedTask);
+
+        DataWorkflow createdWorkflow = new DataWorkflow();
+        createdWorkflow.setId(77L);
+        createdWorkflow.setWorkflowName("wf_import_demo");
+        createdWorkflow.setCurrentVersionId(900L);
+        when(workflowService.createWorkflow(any())).thenReturn(createdWorkflow);
+
+        WorkflowVersion version = new WorkflowVersion();
+        version.setId(900L);
+        version.setVersionNo(3);
+        when(workflowVersionMapper.selectById(900L)).thenReturn(version);
+
+        WorkflowImportCommitRequest request = new WorkflowImportCommitRequest();
+        request.setDefinitionJson("{\"dummy\":true}");
+        request.setOperator("tester");
+
+        WorkflowImportCommitResponse response = service.commit(request);
+
+        assertEquals(77L, response.getWorkflowId());
+        ArgumentCaptor<DataTask> taskCaptor = ArgumentCaptor.forClass(DataTask.class);
+        verify(dataTaskService).create(taskCaptor.capture(), any(), any());
+        assertEquals("wf_imp_t_extract_1_2", taskCaptor.getValue().getTaskCode());
+        verify(dataTaskMapper).countByTaskCodeIncludingDeleted("wf_imp_t_extract_1");
+        verify(dataTaskMapper).countByTaskCodeIncludingDeleted("wf_imp_t_extract_1_2");
+    }
+
+    @Test
     void commitShouldKeepImportTaskMetadataRawThenNormalizePersist() {
         RuntimeWorkflowDefinition definition = baseDefinition();
         RuntimeTaskDefinition task = sqlTask(11L, "t_raw_meta", "SQL_A");


### PR DESCRIPTION
## Summary
- Allow a workflow JSON to be imported again after its previously imported tasks were logically deleted.
- Make import-time task code allocation match the database unique-index semantics by checking both active and logically deleted task records.

## What Changed

### Behavior Changes
- Treat task codes retained by logically deleted rows as occupied during JSON import.
- Allocate the next deterministic suffixed task code instead of failing with `任务编码已存在`.
- Add regression coverage for re-importing when the original generated task code belongs to a logically deleted task.

### Key Files
- `backend/src/main/java/com/onedata/portal/service/WorkflowDefinitionLifecycleService.java`: checks candidate codes against all persisted rows before selecting an import task code.
- `backend/src/test/java/com/onedata/portal/service/WorkflowDefinitionLifecycleServiceTest.java`: verifies a deleted-row collision is resolved with a suffixed code.

## Validation
- [x] `mvn -pl backend -am -Dtest=WorkflowDefinitionLifecycleServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - Passed: 10 tests, 0 failures, 0 errors; reactor build successful.
- [x] `git diff --cached --check`
  - Passed with no whitespace errors before commit.
- [ ] GitHub Actions `Build and Release`
  - Blocked before any build step ran because the repository account has a failed payment or spending-limit restriction.

## Risks
- Main regression risk: imports with many colliding historical codes perform additional indexed count queries while allocating suffixes; normal imports add one indexed lookup per task.

## Rollback
- Revert commit `28c782ba`; no schema or data rollback is required.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] No documentation or configuration update is required for this targeted bug fix.
