### PR TITLE
fix(dataagent): keep plan files in workspace

### DIFF
--- a/dataagent/dataagent-backend/core/task_executor.py
+++ b/dataagent/dataagent-backend/core/task_executor.py
@@ -65,6 +65,7 @@ from core.topic_workspace import prepare_topic_workspace
 logger = logging.getLogger(__name__)
 
 _SDK_TURN_PROGRESS_THRESHOLDS = (1000, 3000, 6000, 10000)
+_WORKSPACE_PLANS_DIRECTORY = ".claude/plans"
 
 
 @dataclass
@@ -1012,6 +1013,12 @@ async def _execute_task_stream_local(
         system_prompt=system_prompt,
         model=model,
         cwd=str(project_cwd),
+        # Claude Code otherwise stores plan-mode drafts under
+        # $HOME/.claude/plans, which is intentionally outside the agent
+        # workspace. Keep the runtime-owned plan directory relative to cwd so
+        # plan writes remain inside the workspace boundary in both local and
+        # container execution.
+        settings=json.dumps({"plansDirectory": _WORKSPACE_PLANS_DIRECTORY}),
         setting_sources=setting_sources,
         max_turns=max_turns,
         allowed_tools=allowed_tools,

--- a/dataagent/dataagent-backend/core/topic_workspace.py
+++ b/dataagent/dataagent-backend/core/topic_workspace.py
@@ -125,6 +125,10 @@ def prepare_topic_workspace(
     workspace = Path(workspace_dir).expanduser().resolve() if workspace_dir else resolve_topic_workspace(topic_id, runtime_root=runtime_root)
     runtime_skills_dir = workspace / ".claude" / "skills"
     runtime_skills_dir.mkdir(parents=True, exist_ok=True)
+    # Claude Code receives plansDirectory=".claude/plans" from the task
+    # executor. Create its parent eagerly so the first plan-mode Write can use
+    # the workspace-local path without touching the separate Claude HOME.
+    (workspace / ".claude" / "plans").mkdir(parents=True, exist_ok=True)
 
     discovery_root = resolve_skill_discovery_root_dir()
     enabled = [str(folder or "").strip() for folder in enabled_folders if str(folder or "").strip()]

--- a/dataagent/dataagent-backend/tests/test_task_executor.py
+++ b/dataagent/dataagent-backend/tests/test_task_executor.py
@@ -539,6 +539,9 @@ def test_execute_task_stream_persists_sdk_records_without_magic_records(monkeypa
     assert result.session_id == "sdk-session-1"
     assert ClaudeAgentOptions.last_kwargs["include_partial_messages"] is True
     assert ClaudeAgentOptions.last_kwargs["cwd"] == str(tmp_path)
+    assert json.loads(ClaudeAgentOptions.last_kwargs["settings"]) == {
+        "plansDirectory": ".claude/plans"
+    }
     assert ClaudeAgentOptions.last_kwargs["cli_path"] == "/tmp/claude-cli"
     assert ClaudeAgentOptions.last_kwargs["skills"] == ["opendataworks-business-knowledge", "marketing-insights"]
     assert runtime["folders"] == ["opendataworks-business-knowledge", "marketing-insights"]
@@ -824,6 +827,25 @@ def test_execute_task_stream_uses_topic_workspace_for_sdk_cwd_and_keeps_home_dis
     assert ClaudeAgentOptions.last_kwargs["cwd"] == str(topic_workspace)
     assert ClaudeAgentOptions.last_kwargs["env"]["HOME"] == "/stable/claude-home"
     assert ClaudeAgentOptions.last_kwargs["env"]["HOME"] != str(topic_workspace)
+    assert json.loads(ClaudeAgentOptions.last_kwargs["settings"]) == {
+        "plansDirectory": ".claude/plans"
+    }
+    hooks = ClaudeAgentOptions.last_kwargs["hooks"]
+    boundary_hook = hooks["PreToolUse"][0].hooks[0]
+    allowed = asyncio.run(
+        boundary_hook(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": str(topic_workspace / ".claude" / "plans" / "runtime-plan.md"),
+                    "content": "# Plan",
+                },
+            },
+            "tool-write-plan",
+            {"signal": None},
+        )
+    )
+    assert allowed["continue_"] is True
     assert "DATAAGENT_WORKSPACE_DIR" not in ClaudeAgentOptions.last_kwargs["env"]
     assert "DATAAGENT_WORKSPACE_PREPARED" not in ClaudeAgentOptions.last_kwargs["env"]
 

--- a/dataagent/dataagent-backend/tests/test_topic_workspace.py
+++ b/dataagent/dataagent-backend/tests/test_topic_workspace.py
@@ -120,6 +120,7 @@ def test_prepare_topic_workspace_copies_enabled_skills(monkeypatch, tmp_path: Pa
     # Real directory copies, not symlinks, so SDK skill discovery sees real files.
     assert skill_copy.is_dir() and not skill_copy.is_symlink()
     assert platform_copy.is_dir() and not platform_copy.is_symlink()
+    assert (workspace / ".claude" / "plans").is_dir()
     assert (skill_copy / "SKILL.md").read_text(encoding="utf-8") == "# opendataworks-business-knowledge\n"
     assert (platform_copy / "SKILL.md").read_text(encoding="utf-8") == "# opendataworks-platform-tools\n"
 


### PR DESCRIPTION
## Summary
- Keep Claude Code plan-mode drafts inside each topic workspace so the DataAgent workspace boundary no longer rejects writes to `/mnt/home/.claude/plans`.
- Configure `plansDirectory` as `.claude/plans` through the runtime settings layer and create the directory during workspace preparation.

## What Changed

### Behavior Changes
- Plan files now resolve under `/mnt/workspace/.claude/plans` in the container sandbox.
- The separate persisted Claude HOME remains restricted; this change does not open `/mnt/home` or alter auto-memory handling.
- Workspace preparation creates the plan directory before the first plan-mode write.

### Key Files
- `dataagent/dataagent-backend/core/task_executor.py`: supplies the workspace-relative `plansDirectory` runtime setting.
- `dataagent/dataagent-backend/core/topic_workspace.py`: eagerly creates `.claude/plans`.
- `dataagent/dataagent-backend/tests/test_task_executor.py`: verifies SDK settings and workspace-boundary acceptance for plan writes.
- `dataagent/dataagent-backend/tests/test_topic_workspace.py`: verifies plan-directory creation.

## Validation
- [x] `.venv-py313/bin/python -m pytest -q tests/test_topic_workspace.py tests/test_task_executor.py`
  - Result: 51 passed, 1 existing Pydantic deprecation warning.
- [x] `git diff --check`
  - Result: passed.

## Risks
- Risk: a future Claude Code release could change `plansDirectory` resolution semantics; the regression tests cover the current SDK option wiring and resolved workspace boundary.

## Rollback
- Rollback: revert commit `b4580c2f` to restore Claude Code's default HOME-based plan directory.

## Checklist
- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed.
- [x] Documentation/config updates are not required for this local runtime-path fix.
