### PR TITLE
feat(workflow): add task-level execution monitoring

### DIFF
--- a/backend/src/main/java/com/onedata/portal/controller/TaskExecutionController.java
+++ b/backend/src/main/java/com/onedata/portal/controller/TaskExecutionController.java
@@ -2,8 +2,11 @@ package com.onedata.portal.controller;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.onedata.portal.dto.Result;
+import com.onedata.portal.dto.execution.WorkflowExecutionPage;
+import com.onedata.portal.dto.execution.WorkflowTaskInstanceExecution;
 import com.onedata.portal.entity.TaskExecutionLog;
 import com.onedata.portal.service.TaskExecutionService;
+import com.onedata.portal.service.WorkflowExecutionMonitorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -24,6 +27,42 @@ import java.util.Map;
 public class TaskExecutionController {
 
     private final TaskExecutionService executionService;
+    private final WorkflowExecutionMonitorService workflowExecutionMonitorService;
+
+    /**
+     * Unified workflow-instance monitor for both platform and Dolphin scheduled
+     * executions. Statistics and records are calculated from the same snapshot.
+     */
+    @GetMapping("/workflow-instances")
+    public Result<WorkflowExecutionPage> getWorkflowInstances(
+            @RequestParam(required = false) Long workflowId,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime startTime,
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endTime,
+            @RequestParam(defaultValue = "false") boolean refresh,
+            @RequestParam(defaultValue = "1") Integer pageNum,
+            @RequestParam(defaultValue = "10") Integer pageSize) {
+        return Result.success(workflowExecutionMonitorService.listWorkflowInstances(
+                workflowId,
+                status,
+                startTime,
+                endTime,
+                refresh,
+                pageNum,
+                pageSize));
+    }
+
+    /**
+     * Load task instances only when a workflow-instance row is expanded.
+     */
+    @GetMapping("/workflows/{workflowId}/instances/{instanceId}/tasks")
+    public Result<List<WorkflowTaskInstanceExecution>> getWorkflowTaskInstances(
+            @PathVariable Long workflowId,
+            @PathVariable Long instanceId) {
+        return Result.success(workflowExecutionMonitorService.listTaskInstances(workflowId, instanceId));
+    }
 
     /**
      * 查询任务执行历史 (分页)

--- a/backend/src/main/java/com/onedata/portal/dto/dolphin/DolphinProcessInstance.java
+++ b/backend/src/main/java/com/onedata/portal/dto/dolphin/DolphinProcessInstance.java
@@ -1,6 +1,7 @@
 package com.onedata.portal.dto.dolphin;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 
 /**
@@ -11,8 +12,11 @@ import lombok.Data;
 public class DolphinProcessInstance {
 
     private Long id;
+    @JsonAlias("workflowDefinitionCode")
     private Long processDefinitionCode;
+    @JsonAlias("workflowDefinitionName")
     private String processDefinitionName;
+    @JsonAlias("workflowDefinitionVersion")
     private Integer processDefinitionVersion;
     private String state;
     private String startTime;

--- a/backend/src/main/java/com/onedata/portal/dto/dolphin/DolphinTaskInstance.java
+++ b/backend/src/main/java/com/onedata/portal/dto/dolphin/DolphinTaskInstance.java
@@ -1,0 +1,36 @@
+package com.onedata.portal.dto.dolphin;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * DolphinScheduler task instance information.
+ *
+ * <p>DolphinScheduler 3.2 uses process-instance field names while 3.4 uses
+ * workflow-instance field names. Both variants are kept so callers can consume
+ * either response without version-specific branching.</p>
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DolphinTaskInstance {
+
+    private Long id;
+    private String name;
+    private String taskType;
+    private Long taskCode;
+    private String state;
+    private String startTime;
+    private String endTime;
+    private String host;
+    private String logPath;
+    private Integer retryTimes;
+    private String executorName;
+    private String duration;
+
+    @JsonAlias("processInstanceId")
+    private Long workflowInstanceId;
+
+    @JsonAlias("processInstanceName")
+    private String workflowInstanceName;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowExecutionPage.java
+++ b/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowExecutionPage.java
@@ -1,0 +1,22 @@
+package com.onedata.portal.dto.execution;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A page of workflow instances and statistics calculated from the same
+ * filtered snapshot.
+ */
+@Data
+@Builder
+public class WorkflowExecutionPage {
+
+    private long total;
+    private int pageNum;
+    private int pageSize;
+    private List<WorkflowInstanceExecution> records;
+    private Map<String, Object> statistics;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowInstanceExecution.java
+++ b/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowInstanceExecution.java
@@ -1,0 +1,31 @@
+package com.onedata.portal.dto.execution;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Unified workflow-instance row used by the execution monitor.
+ */
+@Data
+@Builder
+public class WorkflowInstanceExecution {
+
+    private Long workflowId;
+    private String workflowName;
+    private Long workflowCode;
+    private Long instanceId;
+    private Long localExecutionLogId;
+    private String status;
+    private String dolphinState;
+    private String commandType;
+    private String triggerType;
+    private String source;
+    private String executionSource;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Integer durationSeconds;
+    private String errorMessage;
+    private Boolean expandable;
+}

--- a/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowTaskInstanceExecution.java
+++ b/backend/src/main/java/com/onedata/portal/dto/execution/WorkflowTaskInstanceExecution.java
@@ -1,0 +1,28 @@
+package com.onedata.portal.dto.execution;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Task-instance row displayed when a workflow execution is expanded.
+ */
+@Data
+@Builder
+public class WorkflowTaskInstanceExecution {
+
+    private Long platformTaskId;
+    private Long dolphinTaskCode;
+    private Long taskInstanceId;
+    private String taskName;
+    private String taskType;
+    private String status;
+    private String dolphinState;
+    private String host;
+    private Integer retryTimes;
+    private String executorName;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Integer durationSeconds;
+}

--- a/backend/src/main/java/com/onedata/portal/entity/TaskExecutionLog.java
+++ b/backend/src/main/java/com/onedata/portal/entity/TaskExecutionLog.java
@@ -57,7 +57,13 @@ public class TaskExecutionLog {
     private String taskDefinitionUrl; // DolphinScheduler WebUI 任务定义链接
 
     @TableField(exist = false)
-    private Integer dolphinInstanceId; // DolphinScheduler 实例ID
+    private Long dolphinInstanceId; // DolphinScheduler 实例ID
+
+    @TableField(exist = false)
+    private Long workflowId; // 平台工作流ID
+
+    @TableField(exist = false)
+    private String executionSource; // dolphin, cache, local
 
     @TableField(exist = false)
     private String dolphinState; // DolphinScheduler 原始状态

--- a/backend/src/main/java/com/onedata/portal/service/DataTaskService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DataTaskService.java
@@ -3,12 +3,13 @@ package com.onedata.portal.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.onedata.portal.dto.DolphinDatasourceOption;
 import com.onedata.portal.dto.DolphinTaskGroupOption;
 import com.onedata.portal.dto.SqlQueryRequest;
 import com.onedata.portal.dto.SqlQueryResponse;
 import com.onedata.portal.dto.TaskExecutionStatus;
+import com.onedata.portal.dto.dolphin.DolphinTaskInstance;
+import com.onedata.portal.dto.workflow.WorkflowInstanceSummary;
 import com.onedata.portal.entity.DataLineage;
 import com.onedata.portal.entity.DataTask;
 import com.onedata.portal.entity.DataWorkflow;
@@ -1065,96 +1066,9 @@ public class DataTaskService {
         if (task == null) {
             return null;
         }
-
-        // 获取最近一次执行记录
-        TaskExecutionLog latestLog = executionLogMapper.selectOne(
-                new LambdaQueryWrapper<TaskExecutionLog>()
-                        .eq(TaskExecutionLog::getTaskId, taskId)
-                        .orderByDesc(TaskExecutionLog::getCreatedAt)
-                        .last("LIMIT 1"));
-
-        TaskExecutionStatus status = new TaskExecutionStatus();
-        status.setTaskId(taskId);
-        status.setDolphinWorkflowCode(task.getDolphinProcessCode());
-        status.setDolphinTaskCode(task.getDolphinTaskCode());
-        status.setDolphinProjectName(resolveWorkflowDisplayName(task));
-
-        if (latestLog != null) {
-            status.setExecutionId(latestLog.getExecutionId());
-            status.setStatus(latestLog.getStatus());
-            status.setStartTime(latestLog.getStartTime());
-            status.setEndTime(latestLog.getEndTime());
-            status.setDurationSeconds(latestLog.getDurationSeconds());
-            status.setErrorMessage(latestLog.getErrorMessage());
-            status.setLogUrl(latestLog.getLogUrl());
-            status.setTriggerType(latestLog.getTriggerType());
-
-            // 如果有 workflow code 和 execution id，尝试从 DolphinScheduler 获取实时状态
-            if (task.getDolphinProcessCode() != null && latestLog.getExecutionId() != null) {
-                try {
-                    JsonNode instanceData = dolphinSchedulerService.getWorkflowInstanceStatus(
-                            task.getDolphinProcessCode(),
-                            latestLog.getExecutionId());
-
-                    if (instanceData != null) {
-                        // 更新状态信息
-                        String state = instanceData.path("state").asText(null);
-                        if (state != null) {
-                            status.setStatus(mapDolphinStateToStatus(state));
-                        }
-
-                        // 更新时间信息
-                        String startTimeStr = instanceData.path("startTime").asText(null);
-                        String endTimeStr = instanceData.path("endTime").asText(null);
-                        if (startTimeStr != null && !startTimeStr.isEmpty()) {
-                            // 时间格式转换根据实际情况调整
-                            status.setStartTime(LocalDateTime.parse(startTimeStr));
-                        }
-                        if (endTimeStr != null && !endTimeStr.isEmpty()) {
-                            status.setEndTime(LocalDateTime.parse(endTimeStr));
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Failed to get real-time status from DolphinScheduler for task {}: {}",
-                            taskId, e.getMessage());
-                }
-            }
-        }
-
-        // 生成 DolphinScheduler Web UI 跳转链接
-        if (task.getDolphinProcessCode() != null) {
-            status.setDolphinWorkflowUrl(
-                    dolphinSchedulerService.getWorkflowDefinitionUrl(task.getDolphinProcessCode()));
-        }
-        if (task.getDolphinTaskCode() != null) {
-            status.setDolphinTaskUrl(dolphinSchedulerService.getTaskDefinitionUrl(task.getDolphinTaskCode()));
-        }
-
-        return status;
-    }
-
-    /**
-     * 将 DolphinScheduler 状态映射到本地状态
-     */
-    private String mapDolphinStateToStatus(String dolphinState) {
-        if (dolphinState == null) {
-            return "pending";
-        }
-        switch (dolphinState.toUpperCase()) {
-            case "RUNNING_EXECUTION":
-            case "SUBMITTED_SUCCESS":
-                return "running";
-            case "SUCCESS":
-                return "success";
-            case "FAILURE":
-            case "FAILED":
-                return "failed";
-            case "STOP":
-            case "KILL":
-                return "killed";
-            default:
-                return "pending";
-        }
+        enrichWorkflowMetadata(Collections.singletonList(task));
+        attachExecutionStatus(Collections.singletonList(task));
+        return task.getExecutionStatus();
     }
 
     /**
@@ -1241,44 +1155,168 @@ public class DataTaskService {
                         .orderByDesc(TaskExecutionLog::getStartTime));
 
         Map<Long, TaskExecutionLog> latestLogByTask = new LinkedHashMap<>();
-        for (TaskExecutionLog log : logs) {
-            if (log.getTaskId() == null) {
+        for (TaskExecutionLog executionLog : logs) {
+            if (executionLog.getTaskId() == null) {
                 continue;
             }
             // 第一条即最新（按开始时间倒序）
-            latestLogByTask.putIfAbsent(log.getTaskId(), log);
+            latestLogByTask.putIfAbsent(executionLog.getTaskId(), executionLog);
         }
 
+        Set<Long> workflowIds = tasks.stream()
+                .map(DataTask::getWorkflowId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Map<Long, DataWorkflow> workflowById = workflowIds.isEmpty()
+                ? Collections.emptyMap()
+                : dataWorkflowMapper.selectBatchIds(workflowIds).stream()
+                        .collect(Collectors.toMap(DataWorkflow::getId, workflow -> workflow));
+
+        Map<Long, List<DataTask>> deployedTasksByWorkflow = new LinkedHashMap<>();
         for (DataTask task : tasks) {
-            TaskExecutionLog latestLog = latestLogByTask.get(task.getId());
-            task.setExecutionStatus(buildExecutionStatus(latestLog, task));
+            DataWorkflow workflow = workflowById.get(task.getWorkflowId());
+            if (isDeployedTask(task, workflow)) {
+                deployedTasksByWorkflow.computeIfAbsent(workflow.getId(), ignored -> new ArrayList<>()).add(task);
+            } else {
+                task.setExecutionStatus(buildLocalExecutionStatus(latestLogByTask.get(task.getId()), task, workflow));
+            }
+        }
+
+        for (Map.Entry<Long, List<DataTask>> entry : deployedTasksByWorkflow.entrySet()) {
+            DataWorkflow workflow = workflowById.get(entry.getKey());
+            List<DataTask> workflowTasks = entry.getValue();
+            try {
+                List<WorkflowInstanceSummary> workflowInstances = dolphinSchedulerService.listWorkflowInstances(
+                        workflow.getDolphinConfigId(), workflow.getWorkflowCode(), 1);
+                if (workflowInstances.isEmpty()) {
+                    workflowTasks.forEach(task -> task.setExecutionStatus(null));
+                    continue;
+                }
+
+                WorkflowInstanceSummary latestWorkflowInstance = workflowInstances.get(0);
+                List<DolphinTaskInstance> taskInstances = dolphinSchedulerService.listTaskInstances(
+                        workflow.getDolphinConfigId(), latestWorkflowInstance.getInstanceId());
+                Map<Long, DolphinTaskInstance> instanceByTaskCode = taskInstances.stream()
+                        .filter(instance -> instance != null && instance.getTaskCode() != null)
+                        .collect(Collectors.toMap(
+                                DolphinTaskInstance::getTaskCode,
+                                instance -> instance,
+                                this::newerTaskInstance,
+                                LinkedHashMap::new));
+
+                for (DataTask task : workflowTasks) {
+                    DolphinTaskInstance taskInstance = instanceByTaskCode.get(task.getDolphinTaskCode());
+                    task.setExecutionStatus(taskInstance == null
+                            ? buildMissingTaskExecutionStatus(task, workflow, latestWorkflowInstance)
+                            : buildDolphinTaskExecutionStatus(
+                                    task, workflow, latestWorkflowInstance, taskInstance));
+                }
+            } catch (Exception ex) {
+                log.warn("Failed to resolve task instances for workflow {}: {}",
+                        workflow.getId(), ex.getMessage());
+                workflowTasks.forEach(task -> task.setExecutionStatus(
+                        buildUnavailableExecutionStatus(task, workflow)));
+            }
         }
     }
 
-    private TaskExecutionStatus buildExecutionStatus(TaskExecutionLog log, DataTask task) {
-        if (log == null || task == null) {
+    private boolean isDeployedTask(DataTask task, DataWorkflow workflow) {
+        return task != null
+                && workflow != null
+                && workflow.getWorkflowCode() != null
+                && workflow.getWorkflowCode() > 0
+                && task.getDolphinTaskCode() != null
+                && task.getDolphinTaskCode() > 0;
+    }
+
+    private DolphinTaskInstance newerTaskInstance(DolphinTaskInstance left, DolphinTaskInstance right) {
+        if (left.getId() == null) {
+            return right;
+        }
+        if (right.getId() == null) {
+            return left;
+        }
+        return right.getId() > left.getId() ? right : left;
+    }
+
+    private TaskExecutionStatus buildDolphinTaskExecutionStatus(DataTask task,
+            DataWorkflow workflow,
+            WorkflowInstanceSummary workflowInstance,
+            DolphinTaskInstance taskInstance) {
+        TaskExecutionStatus status = buildDolphinStatusBase(task, workflow);
+        LocalDateTime startTime = DolphinExecutionMapper.parseDateTime(taskInstance.getStartTime());
+        LocalDateTime endTime = DolphinExecutionMapper.parseDateTime(taskInstance.getEndTime());
+        status.setExecutionId(taskInstance.getId() == null ? null : String.valueOf(taskInstance.getId()));
+        status.setStatus(DolphinExecutionMapper.mapStatus(taskInstance.getState()));
+        status.setStartTime(startTime);
+        status.setEndTime(endTime);
+        status.setDurationSeconds(DolphinExecutionMapper.durationSeconds(
+                startTime, endTime, taskInstance.getDuration()));
+        status.setLogUrl(taskInstance.getLogPath());
+        status.setTriggerType(DolphinExecutionMapper.mapTriggerType(workflowInstance.getCommandType()));
+        return status;
+    }
+
+    private TaskExecutionStatus buildMissingTaskExecutionStatus(DataTask task,
+            DataWorkflow workflow,
+            WorkflowInstanceSummary workflowInstance) {
+        TaskExecutionStatus status = buildDolphinStatusBase(task, workflow);
+        status.setExecutionId(workflowInstance.getInstanceId() == null
+                ? null
+                : String.valueOf(workflowInstance.getInstanceId()));
+        status.setStatus(DolphinExecutionMapper.isWorkflowActive(workflowInstance.getState())
+                ? "waiting"
+                : "not_run");
+        status.setStartTime(DolphinExecutionMapper.parseDateTime(workflowInstance.getStartTime()));
+        status.setEndTime(DolphinExecutionMapper.parseDateTime(workflowInstance.getEndTime()));
+        status.setTriggerType(DolphinExecutionMapper.mapTriggerType(workflowInstance.getCommandType()));
+        return status;
+    }
+
+    private TaskExecutionStatus buildUnavailableExecutionStatus(DataTask task, DataWorkflow workflow) {
+        TaskExecutionStatus status = buildDolphinStatusBase(task, workflow);
+        status.setStatus("unavailable");
+        return status;
+    }
+
+    private TaskExecutionStatus buildDolphinStatusBase(DataTask task, DataWorkflow workflow) {
+        TaskExecutionStatus status = new TaskExecutionStatus();
+        status.setTaskId(task.getId());
+        status.setDolphinWorkflowCode(workflow.getWorkflowCode());
+        status.setDolphinTaskCode(task.getDolphinTaskCode());
+        status.setDolphinProjectName(workflow.getWorkflowName());
+        try {
+            status.setDolphinWorkflowUrl(dolphinSchedulerService.getWorkflowDefinitionUrl(
+                    workflow.getDolphinConfigId(), workflow.getWorkflowCode()));
+            status.setDolphinTaskUrl(dolphinSchedulerService.getTaskDefinitionUrl(
+                    workflow.getDolphinConfigId(), task.getDolphinTaskCode()));
+        } catch (Exception ex) {
+            log.debug("Failed to build Dolphin links for task {}: {}", task.getId(), ex.getMessage());
+        }
+        return status;
+    }
+
+    private TaskExecutionStatus buildLocalExecutionStatus(TaskExecutionLog executionLog,
+            DataTask task,
+            DataWorkflow workflow) {
+        if (executionLog == null || task == null) {
             return null;
         }
         TaskExecutionStatus status = new TaskExecutionStatus();
         status.setTaskId(task.getId());
-        status.setExecutionId(log.getExecutionId());
-        status.setStatus(log.getStatus());
-        status.setStartTime(log.getStartTime());
-        status.setEndTime(log.getEndTime());
-        status.setDurationSeconds(log.getDurationSeconds());
-        status.setErrorMessage(log.getErrorMessage());
-        status.setLogUrl(log.getLogUrl());
-        status.setTriggerType(log.getTriggerType());
-        status.setDolphinWorkflowCode(task.getDolphinProcessCode());
+        status.setExecutionId(executionLog.getExecutionId());
+        status.setStatus(executionLog.getStatus());
+        status.setStartTime(executionLog.getStartTime());
+        status.setEndTime(executionLog.getEndTime());
+        status.setDurationSeconds(executionLog.getDurationSeconds());
+        status.setErrorMessage(executionLog.getErrorMessage());
+        status.setLogUrl(executionLog.getLogUrl());
+        status.setTriggerType(executionLog.getTriggerType());
+        status.setDolphinWorkflowCode(workflow == null
+                ? task.getDolphinProcessCode()
+                : workflow.getWorkflowCode());
         status.setDolphinTaskCode(task.getDolphinTaskCode());
         status.setDolphinProjectName(resolveWorkflowDisplayName(task));
-        if (task.getDolphinProcessCode() != null) {
-            status.setDolphinWorkflowUrl(
-                    dolphinSchedulerService.getWorkflowDefinitionUrl(task.getDolphinProcessCode()));
-        }
-        if (task.getDolphinTaskCode() != null) {
-            status.setDolphinTaskUrl(dolphinSchedulerService.getTaskDefinitionUrl(task.getDolphinTaskCode()));
-        }
         return status;
     }
 

--- a/backend/src/main/java/com/onedata/portal/service/DolphinExecutionMapper.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinExecutionMapper.java
@@ -1,0 +1,127 @@
+package com.onedata.portal.service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Shared mapping helpers for DolphinScheduler workflow and task instances.
+ */
+public final class DolphinExecutionMapper {
+
+    private static final List<DateTimeFormatter> LOCAL_DATE_TIME_FORMATTERS = Arrays.asList(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
+
+    private DolphinExecutionMapper() {
+    }
+
+    public static String mapStatus(String dolphinStatus) {
+        if (dolphinStatus == null) {
+            return "pending";
+        }
+        switch (dolphinStatus.toUpperCase(Locale.ROOT)) {
+            case "SUCCESS":
+            case "FORCED_SUCCESS":
+                return "success";
+            case "FAILURE":
+            case "FAILED":
+                return "failed";
+            case "RUNNING_EXECUTION":
+            case "RUNNING":
+            case "SUBMITTED_SUCCESS":
+            case "DELAY_EXECUTION":
+                return "running";
+            case "STOP":
+            case "KILL":
+            case "KILLED":
+                return "killed";
+            case "READY_PAUSE":
+            case "PAUSE":
+                return "paused";
+            default:
+                return "pending";
+        }
+    }
+
+    public static boolean isWorkflowActive(String dolphinStatus) {
+        String status = mapStatus(dolphinStatus);
+        return "running".equals(status) || "pending".equals(status);
+    }
+
+    public static String mapTriggerType(String commandType) {
+        if (commandType == null) {
+            return "api";
+        }
+        String normalized = commandType.trim().toUpperCase(Locale.ROOT);
+        if (normalized.contains("COMPLEMENT") || "BACKFILL".equals(normalized)) {
+            return "backfill";
+        }
+        if (normalized.contains("SCHEDULER") || normalized.contains("SCHEDULE")) {
+            return "schedule";
+        }
+        if ("START_PROCESS".equals(normalized) || "MANUAL".equals(normalized)) {
+            return "manual";
+        }
+        if ("API".equals(normalized)) {
+            return "api";
+        }
+        return "api";
+    }
+
+    public static LocalDateTime parseDateTime(String value) {
+        if (value == null || value.trim().isEmpty() || "null".equalsIgnoreCase(value.trim())) {
+            return null;
+        }
+        String normalized = value.trim();
+        try {
+            return OffsetDateTime.parse(normalized, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toLocalDateTime();
+        } catch (Exception ignored) {
+            // Try the local DolphinScheduler formats below.
+        }
+        for (DateTimeFormatter formatter : LOCAL_DATE_TIME_FORMATTERS) {
+            try {
+                return LocalDateTime.parse(normalized, formatter);
+            } catch (Exception ignored) {
+                // Continue to the next known format.
+            }
+        }
+        return null;
+    }
+
+    public static Integer durationSeconds(LocalDateTime startTime,
+            LocalDateTime endTime,
+            String rawDuration) {
+        if (startTime != null && endTime != null) {
+            long seconds = Math.max(0, Duration.between(startTime, endTime).getSeconds());
+            return seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) seconds;
+        }
+        if (rawDuration == null || rawDuration.trim().isEmpty()) {
+            return null;
+        }
+        String value = rawDuration.trim();
+        try {
+            long seconds = Long.parseLong(value);
+            return seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) Math.max(seconds, 0);
+        } catch (NumberFormatException ignored) {
+            // Dolphin commonly formats this field as HH:mm:ss.
+        }
+        String[] parts = value.split(":");
+        if (parts.length == 3) {
+            try {
+                long seconds = Long.parseLong(parts[0]) * 3600
+                        + Long.parseLong(parts[1]) * 60
+                        + Long.parseLong(parts[2]);
+                return seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) Math.max(seconds, 0);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
+++ b/backend/src/main/java/com/onedata/portal/service/DolphinSchedulerService.java
@@ -647,12 +647,30 @@ public class DolphinSchedulerService {
                 allLevelDependent,
                 executionOrder);
 
-        String triggerId = data != null ? data.asText() : null;
+        String triggerId = extractWorkflowInstanceId(data);
         if (!StringUtils.hasText(triggerId)) {
             triggerId = "trigger-" + System.currentTimeMillis();
         }
         log.info("Backfill workflow definition {} -> {}", workflowCode, triggerId);
         return triggerId;
+    }
+
+    String extractWorkflowInstanceId(JsonNode data) {
+        if (data == null || data.isNull() || data.isMissingNode()) {
+            return null;
+        }
+        if (data.isValueNode()) {
+            String value = data.asText();
+            return StringUtils.hasText(value) ? value : null;
+        }
+        for (String field : new String[] {
+                "workflowInstanceId", "processInstanceId", "processInstanceCode", "id"
+        }) {
+            if (data.hasNonNull(field) && StringUtils.hasText(data.path(field).asText())) {
+                return data.path(field).asText();
+            }
+        }
+        return null;
     }
 
     public String backfillProcessInstance(Long dolphinConfigId,
@@ -753,7 +771,7 @@ public class DolphinSchedulerService {
         }
         Long projectCode = getProjectCode();
         if (projectCode == null) {
-            return Collections.emptyList();
+            throw new IllegalStateException("Cannot list workflow instances: Project not found");
         }
 
         int targetLimit = Math.min(Math.max(limit, 1), 100);
@@ -790,6 +808,42 @@ public class DolphinSchedulerService {
 
     public List<WorkflowInstanceSummary> listWorkflowInstances(Long dolphinConfigId, Long workflowCode, int limit) {
         return withConfig(dolphinConfigId, () -> listWorkflowInstances(workflowCode, limit));
+    }
+
+    /**
+     * List all task instances belonging to one workflow/process instance.
+     */
+    public List<DolphinTaskInstance> listTaskInstances(Long workflowInstanceId) {
+        if (workflowInstanceId == null || workflowInstanceId <= 0) {
+            return Collections.emptyList();
+        }
+        Long projectCode = getProjectCode();
+        if (projectCode == null) {
+            throw new IllegalStateException("Cannot list task instances: Project not found");
+        }
+
+        List<DolphinTaskInstance> result = new ArrayList<>();
+        int pageNo = 1;
+        int pageSize = 100;
+        int maxPages = 100;
+        while (pageNo <= maxPages) {
+            DolphinPageData<DolphinTaskInstance> page = openApiClient.listTaskInstances(
+                    projectCode, pageNo, pageSize, workflowInstanceId, null);
+            if (page == null || page.getTotalList() == null || page.getTotalList().isEmpty()) {
+                break;
+            }
+            result.addAll(page.getTotalList());
+            if ((page.getTotalPage() > 0 && pageNo >= page.getTotalPage())
+                    || page.getTotalList().size() < pageSize) {
+                break;
+            }
+            pageNo++;
+        }
+        return result;
+    }
+
+    public List<DolphinTaskInstance> listTaskInstances(Long dolphinConfigId, Long workflowInstanceId) {
+        return withConfig(dolphinConfigId, () -> listTaskInstances(workflowInstanceId));
     }
 
     private List<DolphinProcessInstance> collectWorkflowInstances(Long projectCode,

--- a/backend/src/main/java/com/onedata/portal/service/TaskExecutionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/TaskExecutionService.java
@@ -118,7 +118,7 @@ public class TaskExecutionService {
 
                         // 提取并设置 DolphinScheduler 实例信息到直接字段
                         if (instanceDetail.has("instanceId")) {
-                            log.setDolphinInstanceId(instanceDetail.path("instanceId").asInt());
+                            log.setDolphinInstanceId(instanceDetail.path("instanceId").asLong());
                         }
 
                         String dolphinState = instanceDetail.path("state").asText();

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowExecutionMonitorService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowExecutionMonitorService.java
@@ -1,0 +1,439 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.onedata.portal.dto.dolphin.DolphinTaskInstance;
+import com.onedata.portal.dto.execution.WorkflowExecutionPage;
+import com.onedata.portal.dto.execution.WorkflowInstanceExecution;
+import com.onedata.portal.dto.execution.WorkflowTaskInstanceExecution;
+import com.onedata.portal.dto.workflow.WorkflowInstanceSummary;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.TaskExecutionLog;
+import com.onedata.portal.entity.WorkflowInstanceCache;
+import com.onedata.portal.entity.WorkflowTaskRelation;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.DataWorkflowMapper;
+import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import com.onedata.portal.mapper.WorkflowTaskRelationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Aggregates DolphinScheduler workflow instances and local platform trigger
+ * records into the workflow-instance execution monitor.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkflowExecutionMonitorService {
+
+    private static final int MAX_INSTANCES_PER_WORKFLOW = 100;
+
+    private final DataWorkflowMapper dataWorkflowMapper;
+    private final WorkflowTaskRelationMapper workflowTaskRelationMapper;
+    private final DataTaskMapper dataTaskMapper;
+    private final TaskExecutionLogMapper executionLogMapper;
+    private final DolphinSchedulerService dolphinSchedulerService;
+    private final WorkflowInstanceCacheService workflowInstanceCacheService;
+
+    public WorkflowExecutionPage listWorkflowInstances(Long workflowId,
+            String status,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            boolean refresh,
+            int pageNum,
+            int pageSize) {
+        int resolvedPageNum = Math.max(pageNum, 1);
+        int resolvedPageSize = Math.min(Math.max(pageSize, 1), 100);
+
+        List<DataWorkflow> workflows = dataWorkflowMapper.selectList(
+                Wrappers.<DataWorkflow>lambdaQuery()
+                        .eq(workflowId != null, DataWorkflow::getId, workflowId));
+        if (CollectionUtils.isEmpty(workflows)) {
+            return emptyPage(resolvedPageNum, resolvedPageSize);
+        }
+
+        Map<Long, List<TaskExecutionLog>> localLogsByWorkflow = loadLocalLogsByWorkflow(workflows);
+        List<WorkflowInstanceExecution> snapshot = new ArrayList<>();
+        for (DataWorkflow workflow : workflows) {
+            snapshot.addAll(resolveWorkflowExecutions(
+                    workflow,
+                    localLogsByWorkflow.getOrDefault(workflow.getId(), Collections.emptyList()),
+                    refresh));
+        }
+
+        List<WorkflowInstanceExecution> filtered = snapshot.stream()
+                .filter(item -> !StringUtils.hasText(status) || status.equalsIgnoreCase(item.getStatus()))
+                .filter(item -> startTime == null
+                        || (item.getStartTime() != null && !item.getStartTime().isBefore(startTime)))
+                .filter(item -> endTime == null
+                        || (item.getStartTime() != null && !item.getStartTime().isAfter(endTime)))
+                .sorted(Comparator.comparing(
+                        WorkflowInstanceExecution::getStartTime,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .collect(Collectors.toList());
+
+        Map<String, Object> statistics = calculateStatistics(filtered);
+        int from = Math.min((resolvedPageNum - 1) * resolvedPageSize, filtered.size());
+        int to = Math.min(from + resolvedPageSize, filtered.size());
+        return WorkflowExecutionPage.builder()
+                .total(filtered.size())
+                .pageNum(resolvedPageNum)
+                .pageSize(resolvedPageSize)
+                .records(new ArrayList<>(filtered.subList(from, to)))
+                .statistics(statistics)
+                .build();
+    }
+
+    public List<WorkflowTaskInstanceExecution> listTaskInstances(Long workflowId, Long instanceId) {
+        if (workflowId == null || instanceId == null) {
+            throw new IllegalArgumentException("workflowId and instanceId are required");
+        }
+        DataWorkflow workflow = dataWorkflowMapper.selectById(workflowId);
+        if (workflow == null) {
+            throw new IllegalArgumentException("Workflow not found: " + workflowId);
+        }
+        if (workflow.getWorkflowCode() == null || workflow.getWorkflowCode() <= 0) {
+            throw new IllegalStateException("工作流尚未部署，无法读取 Dolphin 任务实例");
+        }
+
+        List<DolphinTaskInstance> instances = dolphinSchedulerService.listTaskInstances(
+                workflow.getDolphinConfigId(), instanceId);
+        Map<Long, DataTask> taskByCode = loadWorkflowTasksByCode(workflowId);
+        return instances.stream()
+                .filter(Objects::nonNull)
+                .map(instance -> mapTaskInstance(instance, taskByCode.get(instance.getTaskCode())))
+                .sorted(Comparator
+                        .comparing(WorkflowTaskInstanceExecution::getStartTime,
+                                Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(WorkflowTaskInstanceExecution::getTaskInstanceId,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
+                .collect(Collectors.toList());
+    }
+
+    private List<WorkflowInstanceExecution> resolveWorkflowExecutions(DataWorkflow workflow,
+            List<TaskExecutionLog> localLogs,
+            boolean refresh) {
+        List<RuntimeWorkflowInstance> runtimeInstances = new ArrayList<>();
+        if (workflow.getWorkflowCode() != null && workflow.getWorkflowCode() > 0) {
+            try {
+                List<WorkflowInstanceSummary> summaries = dolphinSchedulerService.listWorkflowInstances(
+                        workflow.getDolphinConfigId(),
+                        workflow.getWorkflowCode(),
+                        MAX_INSTANCES_PER_WORKFLOW);
+                workflowInstanceCacheService.replaceCache(workflow, summaries);
+                runtimeInstances = summaries.stream()
+                        .map(summary -> RuntimeWorkflowInstance.fromSummary(summary, "dolphin"))
+                        .collect(Collectors.toList());
+            } catch (Exception ex) {
+                log.warn("Failed to refresh workflow executions for workflow {} (refresh={}): {}",
+                        workflow.getId(), refresh, ex.getMessage());
+                runtimeInstances = workflowInstanceCacheService
+                        .listRecent(workflow.getId(), MAX_INSTANCES_PER_WORKFLOW)
+                        .stream()
+                        .map(cache -> RuntimeWorkflowInstance.fromCache(cache, "cache"))
+                        .collect(Collectors.toList());
+            }
+        }
+
+        Map<String, TaskExecutionLog> localByExternalId = localLogs.stream()
+                .filter(logRecord -> StringUtils.hasText(logRecord.getExecutionId()))
+                .collect(Collectors.toMap(
+                        TaskExecutionLog::getExecutionId,
+                        logRecord -> logRecord,
+                        this::newerLocalLog,
+                        LinkedHashMap::new));
+
+        List<WorkflowInstanceExecution> result = new ArrayList<>();
+        Set<Long> matchedLocalLogIds = new HashSet<>();
+        Set<String> seenExternalIds = new HashSet<>();
+        for (RuntimeWorkflowInstance runtime : runtimeInstances) {
+            String instanceKey = runtime.instanceId == null ? null : String.valueOf(runtime.instanceId);
+            TaskExecutionLog localMatch = instanceKey == null ? null : localByExternalId.get(instanceKey);
+            if (localMatch != null && localMatch.getId() != null) {
+                matchedLocalLogIds.add(localMatch.getId());
+            }
+            if (instanceKey != null) {
+                seenExternalIds.add(instanceKey);
+            }
+            result.add(mapRuntimeInstance(workflow, runtime, localMatch));
+        }
+
+        for (TaskExecutionLog localLog : localLogs) {
+            if (localLog.getId() != null && matchedLocalLogIds.contains(localLog.getId())) {
+                continue;
+            }
+            if (StringUtils.hasText(localLog.getExecutionId())
+                    && !seenExternalIds.add(localLog.getExecutionId())) {
+                continue;
+            }
+            result.add(mapLocalExecution(workflow, localLog));
+        }
+        return result;
+    }
+
+    private Map<Long, List<TaskExecutionLog>> loadLocalLogsByWorkflow(List<DataWorkflow> workflows) {
+        List<Long> workflowIds = workflows.stream()
+                .map(DataWorkflow::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (workflowIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<WorkflowTaskRelation> relations = workflowTaskRelationMapper.selectList(
+                Wrappers.<WorkflowTaskRelation>lambdaQuery()
+                        .in(WorkflowTaskRelation::getWorkflowId, workflowIds));
+        if (relations.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<Long, Long> workflowIdByTaskId = relations.stream()
+                .filter(relation -> relation.getTaskId() != null && relation.getWorkflowId() != null)
+                .collect(Collectors.toMap(
+                        WorkflowTaskRelation::getTaskId,
+                        WorkflowTaskRelation::getWorkflowId,
+                        (left, right) -> left));
+        if (workflowIdByTaskId.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<TaskExecutionLog> logs = executionLogMapper.selectList(
+                Wrappers.<TaskExecutionLog>lambdaQuery()
+                        .in(TaskExecutionLog::getTaskId, workflowIdByTaskId.keySet())
+                        .orderByDesc(TaskExecutionLog::getStartTime));
+        return logs.stream()
+                .filter(logRecord -> workflowIdByTaskId.containsKey(logRecord.getTaskId()))
+                .collect(Collectors.groupingBy(
+                        logRecord -> workflowIdByTaskId.get(logRecord.getTaskId()),
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+    }
+
+    private Map<Long, DataTask> loadWorkflowTasksByCode(Long workflowId) {
+        List<WorkflowTaskRelation> relations = workflowTaskRelationMapper.selectList(
+                Wrappers.<WorkflowTaskRelation>lambdaQuery()
+                        .eq(WorkflowTaskRelation::getWorkflowId, workflowId));
+        List<Long> taskIds = relations.stream()
+                .map(WorkflowTaskRelation::getTaskId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (taskIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return dataTaskMapper.selectBatchIds(taskIds).stream()
+                .filter(task -> task.getDolphinTaskCode() != null)
+                .collect(Collectors.toMap(
+                        DataTask::getDolphinTaskCode,
+                        task -> task,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+    }
+
+    private WorkflowInstanceExecution mapRuntimeInstance(DataWorkflow workflow,
+            RuntimeWorkflowInstance runtime,
+            TaskExecutionLog localMatch) {
+        LocalDateTime startTime = runtime.startTime;
+        LocalDateTime endTime = runtime.endTime;
+        String triggerType = localMatch != null && StringUtils.hasText(localMatch.getTriggerType())
+                ? DolphinExecutionMapper.mapTriggerType(localMatch.getTriggerType())
+                : DolphinExecutionMapper.mapTriggerType(runtime.commandType);
+        return WorkflowInstanceExecution.builder()
+                .workflowId(workflow.getId())
+                .workflowName(workflow.getWorkflowName())
+                .workflowCode(workflow.getWorkflowCode())
+                .instanceId(runtime.instanceId)
+                .localExecutionLogId(localMatch == null ? null : localMatch.getId())
+                .status(DolphinExecutionMapper.mapStatus(runtime.state))
+                .dolphinState(runtime.state)
+                .commandType(runtime.commandType)
+                .triggerType(triggerType)
+                .source(localMatch == null ? "dolphin" : "platform")
+                .executionSource(runtime.executionSource)
+                .startTime(startTime)
+                .endTime(endTime)
+                .durationSeconds(resolveWorkflowDurationSeconds(startTime, endTime, runtime.durationMs))
+                .errorMessage(localMatch == null ? null : localMatch.getErrorMessage())
+                .expandable(runtime.instanceId != null)
+                .build();
+    }
+
+    private WorkflowInstanceExecution mapLocalExecution(DataWorkflow workflow, TaskExecutionLog localLog) {
+        Long instanceId = parseLong(localLog.getExecutionId());
+        return WorkflowInstanceExecution.builder()
+                .workflowId(workflow.getId())
+                .workflowName(workflow.getWorkflowName())
+                .workflowCode(workflow.getWorkflowCode())
+                .instanceId(instanceId)
+                .localExecutionLogId(localLog.getId())
+                .status(localLog.getStatus())
+                .triggerType(DolphinExecutionMapper.mapTriggerType(localLog.getTriggerType()))
+                .source("platform")
+                .executionSource("local")
+                .startTime(localLog.getStartTime())
+                .endTime(localLog.getEndTime())
+                .durationSeconds(localLog.getDurationSeconds())
+                .errorMessage(localLog.getErrorMessage())
+                .expandable(instanceId != null
+                        && workflow.getWorkflowCode() != null
+                        && workflow.getWorkflowCode() > 0)
+                .build();
+    }
+
+    private WorkflowTaskInstanceExecution mapTaskInstance(DolphinTaskInstance instance, DataTask task) {
+        LocalDateTime startTime = DolphinExecutionMapper.parseDateTime(instance.getStartTime());
+        LocalDateTime endTime = DolphinExecutionMapper.parseDateTime(instance.getEndTime());
+        return WorkflowTaskInstanceExecution.builder()
+                .platformTaskId(task == null ? null : task.getId())
+                .dolphinTaskCode(instance.getTaskCode())
+                .taskInstanceId(instance.getId())
+                .taskName(task == null ? instance.getName() : task.getTaskName())
+                .taskType(instance.getTaskType())
+                .status(DolphinExecutionMapper.mapStatus(instance.getState()))
+                .dolphinState(instance.getState())
+                .host(instance.getHost())
+                .retryTimes(instance.getRetryTimes())
+                .executorName(instance.getExecutorName())
+                .startTime(startTime)
+                .endTime(endTime)
+                .durationSeconds(DolphinExecutionMapper.durationSeconds(
+                        startTime, endTime, instance.getDuration()))
+                .build();
+    }
+
+    private Map<String, Object> calculateStatistics(List<WorkflowInstanceExecution> items) {
+        Map<String, Long> distribution = items.stream()
+                .collect(Collectors.groupingBy(
+                        WorkflowInstanceExecution::getStatus,
+                        LinkedHashMap::new,
+                        Collectors.counting()));
+        long total = items.size();
+        long success = distribution.getOrDefault("success", 0L);
+        long failed = distribution.getOrDefault("failed", 0L);
+        long running = distribution.getOrDefault("running", 0L);
+        double averageDuration = items.stream()
+                .map(WorkflowInstanceExecution::getDurationSeconds)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+
+        Map<String, Object> statistics = new LinkedHashMap<>();
+        statistics.put("totalExecutions", total);
+        statistics.put("successCount", success);
+        statistics.put("failedCount", failed);
+        statistics.put("runningCount", running);
+        statistics.put("successRate", total == 0 ? 0.0 : roundRate(success, total));
+        statistics.put("failureRate", total == 0 ? 0.0 : roundRate(failed, total));
+        statistics.put("avgDurationSeconds", Math.round(averageDuration * 100.0) / 100.0);
+        statistics.put("statusDistribution", distribution);
+        return statistics;
+    }
+
+    private WorkflowExecutionPage emptyPage(int pageNum, int pageSize) {
+        return WorkflowExecutionPage.builder()
+                .total(0)
+                .pageNum(pageNum)
+                .pageSize(pageSize)
+                .records(Collections.emptyList())
+                .statistics(calculateStatistics(Collections.emptyList()))
+                .build();
+    }
+
+    private TaskExecutionLog newerLocalLog(TaskExecutionLog left, TaskExecutionLog right) {
+        if (left.getStartTime() == null) {
+            return right;
+        }
+        if (right.getStartTime() == null) {
+            return left;
+        }
+        return right.getStartTime().isAfter(left.getStartTime()) ? right : left;
+    }
+
+    private Integer resolveWorkflowDurationSeconds(LocalDateTime startTime,
+            LocalDateTime endTime,
+            Long durationMs) {
+        if (startTime != null && endTime != null) {
+            long seconds = Math.max(0, Duration.between(startTime, endTime).getSeconds());
+            return seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) seconds;
+        }
+        if (durationMs == null || durationMs < 0) {
+            return null;
+        }
+        long seconds = durationMs / 1000;
+        return seconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) seconds;
+    }
+
+    private double roundRate(long count, long total) {
+        return Math.round(((double) count / total * 100.0) * 100.0) / 100.0;
+    }
+
+    private Long parseLong(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static LocalDateTime toLocalDateTime(Date value) {
+        return value == null
+                ? null
+                : LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+    }
+
+    private static final class RuntimeWorkflowInstance {
+        private Long instanceId;
+        private String state;
+        private String commandType;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private Long durationMs;
+        private String executionSource;
+
+        private static RuntimeWorkflowInstance fromSummary(WorkflowInstanceSummary summary,
+                String executionSource) {
+            RuntimeWorkflowInstance instance = new RuntimeWorkflowInstance();
+            instance.instanceId = summary.getInstanceId();
+            instance.state = summary.getState();
+            instance.commandType = summary.getCommandType();
+            instance.startTime = DolphinExecutionMapper.parseDateTime(summary.getStartTime());
+            instance.endTime = DolphinExecutionMapper.parseDateTime(summary.getEndTime());
+            instance.durationMs = summary.getDurationMs();
+            instance.executionSource = executionSource;
+            return instance;
+        }
+
+        private static RuntimeWorkflowInstance fromCache(WorkflowInstanceCache cache,
+                String executionSource) {
+            RuntimeWorkflowInstance instance = new RuntimeWorkflowInstance();
+            instance.instanceId = cache.getInstanceId();
+            instance.state = cache.getState();
+            instance.commandType = cache.getTriggerType();
+            instance.startTime = toLocalDateTime(cache.getStartTime());
+            instance.endTime = toLocalDateTime(cache.getEndTime());
+            instance.durationMs = cache.getDurationMs();
+            instance.executionSource = executionSource;
+            return instance;
+        }
+    }
+}

--- a/backend/src/main/java/com/onedata/portal/service/WorkflowExecutionService.java
+++ b/backend/src/main/java/com/onedata/portal/service/WorkflowExecutionService.java
@@ -79,7 +79,7 @@ public class WorkflowExecutionService {
         if (!"online".equalsIgnoreCase(workflow.getStatus())) {
             throw new IllegalStateException("工作流未上线，请先上线后再补数");
         }
-        TaskExecutionLog executionLog = createWorkflowExecutionLog(workflowId, "manual");
+        TaskExecutionLog executionLog = createWorkflowExecutionLog(workflowId, "backfill");
         try {
             String triggerId = dolphinSchedulerService.backfillProcessInstance(
                     workflow.getDolphinConfigId(), workflowCode, request);

--- a/backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java
+++ b/backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java
@@ -655,7 +655,13 @@ public class DolphinOpenApiClient {
             if (data == null) {
                 return null;
             }
-            // Different DS versions expose either processInstanceCode or id
+            // Different DS versions expose different workflow/process instance keys.
+            if (data.hasNonNull("workflowInstanceId")) {
+                return data.path("workflowInstanceId").asLong();
+            }
+            if (data.hasNonNull("processInstanceId")) {
+                return data.path("processInstanceId").asLong();
+            }
             if (data.hasNonNull("processInstanceCode")) {
                 return data.path("processInstanceCode").asLong();
             }
@@ -754,8 +760,54 @@ public class DolphinOpenApiClient {
                     .readValue(data);
         } catch (Exception e) {
             log.warn("Failed to list process instances", e);
-            return new DolphinPageData<>();
+            throw new RuntimeException("Failed to list process instances: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * List task instances for one workflow/process instance.
+     *
+     * <p>DolphinScheduler 3.2 expects {@code processInstanceId}, while 3.4
+     * expects {@code workflowInstanceId}. Unknown query parameters are ignored
+     * by both versions, so both names are sent with the same value.</p>
+     */
+    public DolphinPageData<DolphinTaskInstance> listTaskInstances(long projectCode,
+            int pageNo,
+            int pageSize,
+            Long workflowInstanceId,
+            Long taskCode) {
+        try {
+            String path = String.format("/projects/%d/task-instances", projectCode);
+            MultiValueMap<String, String> query = buildTaskInstanceQuery(
+                    pageNo, pageSize, workflowInstanceId, taskCode);
+            JsonNode data = getWithParams(path, query);
+            if (data == null) {
+                return new DolphinPageData<>();
+            }
+            return objectMapper.readerFor(new TypeReference<DolphinPageData<DolphinTaskInstance>>() {
+            }).readValue(data);
+        } catch (Exception e) {
+            log.warn("Failed to list task instances for workflow instance {}", workflowInstanceId, e);
+            throw new RuntimeException("Failed to list task instances: " + e.getMessage(), e);
+        }
+    }
+
+    static MultiValueMap<String, String> buildTaskInstanceQuery(int pageNo,
+            int pageSize,
+            Long workflowInstanceId,
+            Long taskCode) {
+        MultiValueMap<String, String> query = new LinkedMultiValueMap<>();
+        query.add("pageNo", String.valueOf(pageNo > 0 ? pageNo : 1));
+        query.add("pageSize", String.valueOf(pageSize > 0 ? pageSize : 100));
+        if (workflowInstanceId != null && workflowInstanceId > 0) {
+            String instanceId = String.valueOf(workflowInstanceId);
+            query.add("processInstanceId", instanceId);
+            query.add("workflowInstanceId", instanceId);
+        }
+        if (taskCode != null && taskCode > 0) {
+            query.add("taskCode", String.valueOf(taskCode));
+        }
+        return query;
     }
 
     /**

--- a/backend/src/test/java/com/onedata/portal/controller/TaskExecutionControllerTest.java
+++ b/backend/src/test/java/com/onedata/portal/controller/TaskExecutionControllerTest.java
@@ -1,0 +1,79 @@
+package com.onedata.portal.controller;
+
+import com.onedata.portal.dto.execution.WorkflowExecutionPage;
+import com.onedata.portal.service.TaskExecutionService;
+import com.onedata.portal.service.WorkflowExecutionMonitorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TaskExecutionControllerTest {
+
+    @Mock
+    private TaskExecutionService taskExecutionService;
+    @Mock
+    private WorkflowExecutionMonitorService workflowExecutionMonitorService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                new TaskExecutionController(taskExecutionService, workflowExecutionMonitorService))
+                .build();
+    }
+
+    @Test
+    void workflowInstanceEndpointPassesFiltersAndReturnsUnifiedPage() throws Exception {
+        WorkflowExecutionPage response = WorkflowExecutionPage.builder()
+                .total(0)
+                .pageNum(2)
+                .pageSize(20)
+                .records(Collections.emptyList())
+                .statistics(Collections.emptyMap())
+                .build();
+        when(workflowExecutionMonitorService.listWorkflowInstances(
+                10L,
+                "failed",
+                LocalDateTime.of(2026, 7, 1, 0, 0),
+                LocalDateTime.of(2026, 7, 31, 23, 59, 59),
+                true,
+                2,
+                20)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/executions/workflow-instances")
+                        .param("workflowId", "10")
+                        .param("status", "failed")
+                        .param("startTime", "2026-07-01 00:00:00")
+                        .param("endTime", "2026-07-31 23:59:59")
+                        .param("refresh", "true")
+                        .param("pageNum", "2")
+                        .param("pageSize", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pageNum").value(2))
+                .andExpect(jsonPath("$.data.statistics").isMap());
+
+        verify(workflowExecutionMonitorService).listWorkflowInstances(
+                10L,
+                "failed",
+                LocalDateTime.of(2026, 7, 1, 0, 0),
+                LocalDateTime.of(2026, 7, 31, 23, 59, 59),
+                true,
+                2,
+                20);
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/DataTaskServiceWorkflowMetadataTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DataTaskServiceWorkflowMetadataTest.java
@@ -1,8 +1,16 @@
 package com.onedata.portal.service;
 
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.onedata.portal.dto.DolphinDatasourceOption;
+import com.onedata.portal.dto.dolphin.DolphinTaskInstance;
+import com.onedata.portal.dto.workflow.WorkflowInstanceSummary;
 import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.DataLineage;
 import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.TableTaskRelation;
+import com.onedata.portal.entity.TaskExecutionLog;
 import com.onedata.portal.entity.WorkflowTaskRelation;
 import com.onedata.portal.mapper.DataLineageMapper;
 import com.onedata.portal.mapper.DataTaskMapper;
@@ -10,6 +18,8 @@ import com.onedata.portal.mapper.DataWorkflowMapper;
 import com.onedata.portal.mapper.TableTaskRelationMapper;
 import com.onedata.portal.mapper.TaskExecutionLogMapper;
 import com.onedata.portal.mapper.WorkflowTaskRelationMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -29,12 +40,24 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DataTaskServiceWorkflowMetadataTest {
+
+    @BeforeAll
+    static void initTableInfo() {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new MybatisConfiguration(), "");
+        TableInfoHelper.initTableInfo(assistant, DataTask.class);
+        TableInfoHelper.initTableInfo(assistant, DataLineage.class);
+        TableInfoHelper.initTableInfo(assistant, DataWorkflow.class);
+        TableInfoHelper.initTableInfo(assistant, TableTaskRelation.class);
+        TableInfoHelper.initTableInfo(assistant, TaskExecutionLog.class);
+        TableInfoHelper.initTableInfo(assistant, WorkflowTaskRelation.class);
+    }
 
     @Mock
     private DataTaskMapper dataTaskMapper;
@@ -366,5 +389,148 @@ class DataTaskServiceWorkflowMetadataTest {
         verify(dolphinSchedulerService, never()).setWorkflowReleaseState(anyLong(), anyString());
         verify(dolphinSchedulerService, never()).deleteWorkflow(anyLong());
         verify(workflowTaskRelationMapper).hardDeleteByTaskId(401L);
+    }
+
+    @Test
+    void listMapsDifferentTaskInstanceStatesWithinOneWorkflowWithoutPerTaskRequests() {
+        DataTask firstTask = deployedTask(1L, "first", 1001L);
+        DataTask secondTask = deployedTask(2L, "second", 1002L);
+        mockTaskPage(Arrays.asList(firstTask, secondTask));
+
+        WorkflowTaskRelation firstRelation = relation(1L, 10L);
+        WorkflowTaskRelation secondRelation = relation(2L, 10L);
+        when(workflowTaskRelationMapper.selectList(any()))
+                .thenReturn(Arrays.asList(firstRelation, secondRelation));
+
+        DataWorkflow workflow = deployedWorkflow(10L, 20L, 3001L);
+        when(dataWorkflowMapper.selectBatchIds(any())).thenReturn(Collections.singletonList(workflow));
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+
+        WorkflowInstanceSummary workflowInstance = WorkflowInstanceSummary.builder()
+                .instanceId(9001L)
+                .state("FAILURE")
+                .commandType("SCHEDULER")
+                .startTime("2026-07-31 09:00:00")
+                .endTime("2026-07-31 09:05:00")
+                .build();
+        when(dolphinSchedulerService.listWorkflowInstances(20L, 3001L, 1))
+                .thenReturn(Collections.singletonList(workflowInstance));
+
+        DolphinTaskInstance firstInstance = taskInstance(8001L, 1001L, "SUCCESS");
+        DolphinTaskInstance secondInstance = taskInstance(8002L, 1002L, "FAILURE");
+        when(dolphinSchedulerService.listTaskInstances(20L, 9001L))
+                .thenReturn(Arrays.asList(firstInstance, secondInstance));
+
+        Page<DataTask> result = dataTaskService.list(
+                1, 20, null, null, null, null, null, null, null);
+
+        assertEquals("success", result.getRecords().get(0).getExecutionStatus().getStatus());
+        assertEquals("failed", result.getRecords().get(1).getExecutionStatus().getStatus());
+        assertEquals("schedule", result.getRecords().get(0).getExecutionStatus().getTriggerType());
+        verify(dolphinSchedulerService, times(1)).listWorkflowInstances(20L, 3001L, 1);
+        verify(dolphinSchedulerService, times(1)).listTaskInstances(20L, 9001L);
+    }
+
+    @Test
+    void listMarksMissingTaskWaitingForActiveWorkflow() {
+        assertMissingTaskStatus("RUNNING_EXECUTION", "waiting");
+    }
+
+    @Test
+    void listMarksMissingTaskNotRunForTerminalWorkflow() {
+        assertMissingTaskStatus("SUCCESS", "not_run");
+    }
+
+    @Test
+    void listMarksTaskStatusUnavailableWhenTaskInstanceQueryFails() {
+        DataTask task = deployedTask(4L, "unavailable", 1004L);
+        mockTaskPage(Collections.singletonList(task));
+        when(workflowTaskRelationMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(relation(4L, 12L)));
+        DataWorkflow workflow = deployedWorkflow(12L, 22L, 3003L);
+        when(dataWorkflowMapper.selectBatchIds(any())).thenReturn(Collections.singletonList(workflow));
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+        when(dolphinSchedulerService.listWorkflowInstances(22L, 3003L, 1))
+                .thenReturn(Collections.singletonList(WorkflowInstanceSummary.builder()
+                        .instanceId(9003L)
+                        .state("RUNNING_EXECUTION")
+                        .build()));
+        when(dolphinSchedulerService.listTaskInstances(22L, 9003L))
+                .thenThrow(new RuntimeException("offline"));
+
+        Page<DataTask> result = dataTaskService.list(
+                1, 20, null, null, null, null, null, null, null);
+
+        assertEquals("unavailable", result.getRecords().get(0).getExecutionStatus().getStatus());
+    }
+
+    private void assertMissingTaskStatus(String workflowState, String expectedStatus) {
+        DataTask task = deployedTask(3L, "missing", 1003L);
+        mockTaskPage(Collections.singletonList(task));
+        when(workflowTaskRelationMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(relation(3L, 11L)));
+        DataWorkflow workflow = deployedWorkflow(11L, 21L, 3002L);
+        when(dataWorkflowMapper.selectBatchIds(any())).thenReturn(Collections.singletonList(workflow));
+        when(executionLogMapper.selectList(any())).thenReturn(Collections.emptyList());
+        when(dolphinSchedulerService.listWorkflowInstances(21L, 3002L, 1))
+                .thenReturn(Collections.singletonList(WorkflowInstanceSummary.builder()
+                        .instanceId(9002L)
+                        .state(workflowState)
+                        .commandType("START_PROCESS")
+                        .startTime("2026-07-31 10:00:00")
+                        .build()));
+        when(dolphinSchedulerService.listTaskInstances(21L, 9002L))
+                .thenReturn(Collections.emptyList());
+
+        Page<DataTask> result = dataTaskService.list(
+                1, 20, null, null, null, null, null, null, null);
+
+        assertEquals(expectedStatus, result.getRecords().get(0).getExecutionStatus().getStatus());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockTaskPage(List<DataTask> tasks) {
+        when(dataTaskMapper.selectPage(any(Page.class), any())).thenAnswer(invocation -> {
+            Page<DataTask> page = invocation.getArgument(0);
+            page.setRecords(tasks);
+            page.setTotal(tasks.size());
+            return page;
+        });
+    }
+
+    private DataTask deployedTask(Long id, String name, Long taskCode) {
+        DataTask task = new DataTask();
+        task.setId(id);
+        task.setTaskName(name);
+        task.setDolphinTaskCode(taskCode);
+        return task;
+    }
+
+    private WorkflowTaskRelation relation(Long taskId, Long workflowId) {
+        WorkflowTaskRelation relation = new WorkflowTaskRelation();
+        relation.setTaskId(taskId);
+        relation.setWorkflowId(workflowId);
+        relation.setUpstreamTaskCount(0);
+        relation.setDownstreamTaskCount(0);
+        return relation;
+    }
+
+    private DataWorkflow deployedWorkflow(Long id, Long configId, Long workflowCode) {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(id);
+        workflow.setDolphinConfigId(configId);
+        workflow.setWorkflowCode(workflowCode);
+        workflow.setWorkflowName("workflow-" + id);
+        return workflow;
+    }
+
+    private DolphinTaskInstance taskInstance(Long instanceId, Long taskCode, String state) {
+        DolphinTaskInstance instance = new DolphinTaskInstance();
+        instance.setId(instanceId);
+        instance.setTaskCode(taskCode);
+        instance.setState(state);
+        instance.setStartTime("2026-07-31 09:00:00");
+        instance.setEndTime("2026-07-31 09:01:00");
+        return instance;
     }
 }

--- a/backend/src/test/java/com/onedata/portal/service/DolphinSchedulerServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/DolphinSchedulerServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,7 +42,7 @@ class DolphinSchedulerServiceTest {
 
         DolphinConfig config = new DolphinConfig();
         config.setProjectName("it_project");
-        when(dolphinConfigService.getActiveConfig()).thenReturn(config);
+        lenient().when(dolphinConfigService.getActiveConfig()).thenReturn(config);
     }
 
     @Test
@@ -104,6 +105,17 @@ class DolphinSchedulerServiceTest {
                 null);
 
         assertEquals("NO", payload.get("flag"));
+    }
+
+    @Test
+    void extractsWorkflowInstanceIdAcrossDolphinResponseVariants() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        assertEquals("101", service.extractWorkflowInstanceId(
+                mapper.readTree("{\"processInstanceId\":101}")));
+        assertEquals("102", service.extractWorkflowInstanceId(
+                mapper.readTree("{\"workflowInstanceId\":102}")));
+        assertEquals("103", service.extractWorkflowInstanceId(mapper.readTree("103")));
     }
 
     private DolphinTaskGroup taskGroup(int id, String name, Long projectCode) {

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowExecutionMonitorServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowExecutionMonitorServiceTest.java
@@ -1,0 +1,232 @@
+package com.onedata.portal.service;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.onedata.portal.dto.dolphin.DolphinTaskInstance;
+import com.onedata.portal.dto.execution.WorkflowExecutionPage;
+import com.onedata.portal.dto.execution.WorkflowInstanceExecution;
+import com.onedata.portal.dto.execution.WorkflowTaskInstanceExecution;
+import com.onedata.portal.dto.workflow.WorkflowInstanceSummary;
+import com.onedata.portal.entity.DataTask;
+import com.onedata.portal.entity.DataWorkflow;
+import com.onedata.portal.entity.TaskExecutionLog;
+import com.onedata.portal.entity.WorkflowInstanceCache;
+import com.onedata.portal.entity.WorkflowTaskRelation;
+import com.onedata.portal.mapper.DataTaskMapper;
+import com.onedata.portal.mapper.DataWorkflowMapper;
+import com.onedata.portal.mapper.TaskExecutionLogMapper;
+import com.onedata.portal.mapper.WorkflowTaskRelationMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowExecutionMonitorServiceTest {
+
+    @BeforeAll
+    static void initTableInfo() {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new MybatisConfiguration(), "");
+        TableInfoHelper.initTableInfo(assistant, DataWorkflow.class);
+        TableInfoHelper.initTableInfo(assistant, WorkflowTaskRelation.class);
+        TableInfoHelper.initTableInfo(assistant, TaskExecutionLog.class);
+    }
+
+    @Mock
+    private DataWorkflowMapper dataWorkflowMapper;
+    @Mock
+    private WorkflowTaskRelationMapper workflowTaskRelationMapper;
+    @Mock
+    private DataTaskMapper dataTaskMapper;
+    @Mock
+    private TaskExecutionLogMapper executionLogMapper;
+    @Mock
+    private DolphinSchedulerService dolphinSchedulerService;
+    @Mock
+    private WorkflowInstanceCacheService workflowInstanceCacheService;
+
+    private WorkflowExecutionMonitorService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkflowExecutionMonitorService(
+                dataWorkflowMapper,
+                workflowTaskRelationMapper,
+                dataTaskMapper,
+                executionLogMapper,
+                dolphinSchedulerService,
+                workflowInstanceCacheService);
+    }
+
+    @Test
+    void includesScheduledInstancesDeduplicatesPlatformTriggerAndKeepsPreSubmitFailure() {
+        DataWorkflow workflow = workflow();
+        when(dataWorkflowMapper.selectList(any())).thenReturn(Collections.singletonList(workflow));
+        when(workflowTaskRelationMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(relation()));
+
+        TaskExecutionLog matchedPlatformLog = localLog(1L, "9001", "running", "manual");
+        TaskExecutionLog preSubmitFailure = localLog(2L, null, "failed", "manual");
+        preSubmitFailure.setErrorMessage("submit failed");
+        when(executionLogMapper.selectList(any()))
+                .thenReturn(Arrays.asList(matchedPlatformLog, preSubmitFailure));
+
+        WorkflowInstanceSummary platformInstance = workflowInstance(9001L, "SUCCESS", "START_PROCESS");
+        WorkflowInstanceSummary scheduledInstance = workflowInstance(9002L, "SUCCESS", "SCHEDULER");
+        when(dolphinSchedulerService.listWorkflowInstances(20L, 3001L, 100))
+                .thenReturn(Arrays.asList(platformInstance, scheduledInstance));
+
+        WorkflowExecutionPage page = service.listWorkflowInstances(
+                null, null, null, null, false, 1, 20);
+
+        assertEquals(3, page.getTotal());
+        assertEquals(3L, page.getStatistics().get("totalExecutions"));
+        assertEquals(1, page.getRecords().stream()
+                .filter(item -> Long.valueOf(9001L).equals(item.getInstanceId()))
+                .count());
+
+        WorkflowInstanceExecution scheduled = findByInstanceId(page.getRecords(), 9002L);
+        assertEquals("dolphin", scheduled.getSource());
+        assertEquals("schedule", scheduled.getTriggerType());
+
+        WorkflowInstanceExecution platform = findByInstanceId(page.getRecords(), 9001L);
+        assertEquals("platform", platform.getSource());
+        assertEquals("manual", platform.getTriggerType());
+
+        WorkflowInstanceExecution failure = page.getRecords().stream()
+                .filter(item -> Long.valueOf(2L).equals(item.getLocalExecutionLogId()))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        assertNull(failure.getInstanceId());
+        assertFalse(failure.getExpandable());
+        assertEquals("submit failed", failure.getErrorMessage());
+        verify(workflowInstanceCacheService).replaceCache(
+                workflow, Arrays.asList(platformInstance, scheduledInstance));
+    }
+
+    @Test
+    void fallsBackToWorkflowCacheWhenDolphinIsUnavailable() {
+        DataWorkflow workflow = workflow();
+        when(dataWorkflowMapper.selectList(any())).thenReturn(Collections.singletonList(workflow));
+        when(workflowTaskRelationMapper.selectList(any())).thenReturn(Collections.emptyList());
+        when(dolphinSchedulerService.listWorkflowInstances(20L, 3001L, 100))
+                .thenThrow(new RuntimeException("offline"));
+
+        WorkflowInstanceCache cache = new WorkflowInstanceCache();
+        cache.setWorkflowId(10L);
+        cache.setInstanceId(9100L);
+        cache.setState("RUNNING_EXECUTION");
+        cache.setTriggerType("SCHEDULER");
+        cache.setStartTime(Date.from(
+                LocalDateTime.of(2026, 7, 31, 10, 0)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()));
+        when(workflowInstanceCacheService.listRecent(10L, 100))
+                .thenReturn(Collections.singletonList(cache));
+
+        WorkflowExecutionPage page = service.listWorkflowInstances(
+                10L, "running", null, null, true, 1, 10);
+
+        assertEquals(1, page.getTotal());
+        assertEquals("cache", page.getRecords().get(0).getExecutionSource());
+        assertEquals("schedule", page.getRecords().get(0).getTriggerType());
+    }
+
+    @Test
+    void expandsDolphinTaskInstancesAndMapsPlatformTaskId() {
+        DataWorkflow workflow = workflow();
+        when(dataWorkflowMapper.selectById(10L)).thenReturn(workflow);
+        when(workflowTaskRelationMapper.selectList(any()))
+                .thenReturn(Collections.singletonList(relation()));
+
+        DataTask task = new DataTask();
+        task.setId(1L);
+        task.setTaskName("platform-task");
+        task.setDolphinTaskCode(7001L);
+        when(dataTaskMapper.selectBatchIds(any()))
+                .thenReturn(Collections.singletonList(task));
+
+        DolphinTaskInstance instance = new DolphinTaskInstance();
+        instance.setId(8001L);
+        instance.setTaskCode(7001L);
+        instance.setName("dolphin-task");
+        instance.setState("FAILURE");
+        instance.setHost("worker-1");
+        instance.setRetryTimes(2);
+        instance.setStartTime("2026-07-31 10:00:00");
+        instance.setEndTime("2026-07-31 10:01:00");
+        when(dolphinSchedulerService.listTaskInstances(20L, 9001L))
+                .thenReturn(Collections.singletonList(instance));
+
+        List<WorkflowTaskInstanceExecution> result = service.listTaskInstances(10L, 9001L);
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getPlatformTaskId());
+        assertEquals("platform-task", result.get(0).getTaskName());
+        assertEquals("failed", result.get(0).getStatus());
+        assertEquals(60, result.get(0).getDurationSeconds());
+        assertTrue(result.get(0).getRetryTimes() == 2);
+    }
+
+    private DataWorkflow workflow() {
+        DataWorkflow workflow = new DataWorkflow();
+        workflow.setId(10L);
+        workflow.setWorkflowName("workflow-10");
+        workflow.setWorkflowCode(3001L);
+        workflow.setDolphinConfigId(20L);
+        return workflow;
+    }
+
+    private WorkflowTaskRelation relation() {
+        WorkflowTaskRelation relation = new WorkflowTaskRelation();
+        relation.setWorkflowId(10L);
+        relation.setTaskId(1L);
+        return relation;
+    }
+
+    private TaskExecutionLog localLog(Long id, String executionId, String status, String triggerType) {
+        TaskExecutionLog log = new TaskExecutionLog();
+        log.setId(id);
+        log.setTaskId(1L);
+        log.setExecutionId(executionId);
+        log.setStatus(status);
+        log.setTriggerType(triggerType);
+        log.setStartTime(LocalDateTime.of(2026, 7, 31, 10, id.intValue()));
+        return log;
+    }
+
+    private WorkflowInstanceSummary workflowInstance(Long id, String state, String commandType) {
+        return WorkflowInstanceSummary.builder()
+                .instanceId(id)
+                .state(state)
+                .commandType(commandType)
+                .startTime("2026-07-31 10:00:00")
+                .endTime("2026-07-31 10:05:00")
+                .build();
+    }
+
+    private WorkflowInstanceExecution findByInstanceId(List<WorkflowInstanceExecution> records, Long id) {
+        return records.stream()
+                .filter(item -> id.equals(item.getInstanceId()))
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+    }
+}

--- a/backend/src/test/java/com/onedata/portal/service/WorkflowExecutionServiceTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/WorkflowExecutionServiceTest.java
@@ -147,7 +147,9 @@ class WorkflowExecutionServiceTest {
         String triggerId = service.backfillWorkflow(1L, request);
 
         assertEquals("backfill-1", triggerId);
-        verify(taskExecutionLogMapper).insert(any(TaskExecutionLog.class));
+        ArgumentCaptor<TaskExecutionLog> insertCaptor = ArgumentCaptor.forClass(TaskExecutionLog.class);
+        verify(taskExecutionLogMapper).insert(insertCaptor.capture());
+        assertEquals("backfill", insertCaptor.getValue().getTriggerType());
         ArgumentCaptor<TaskExecutionLog> updateCaptor = ArgumentCaptor.forClass(TaskExecutionLog.class);
         verify(taskExecutionLogMapper).updateById(updateCaptor.capture());
         assertEquals("backfill-1", updateCaptor.getValue().getExecutionId());

--- a/backend/src/test/java/com/onedata/portal/service/dolphin/DolphinTaskInstanceCompatibilityTest.java
+++ b/backend/src/test/java/com/onedata/portal/service/dolphin/DolphinTaskInstanceCompatibilityTest.java
@@ -1,0 +1,47 @@
+package com.onedata.portal.service.dolphin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedata.portal.dto.dolphin.DolphinTaskInstance;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DolphinTaskInstanceCompatibilityTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void sendsBothWorkflowInstanceParameterNames() {
+        MultiValueMap<String, String> query =
+                DolphinOpenApiClient.buildTaskInstanceQuery(1, 100, 9001L, 7001L);
+
+        assertEquals("9001", query.getFirst("processInstanceId"));
+        assertEquals("9001", query.getFirst("workflowInstanceId"));
+        assertEquals("7001", query.getFirst("taskCode"));
+    }
+
+    @Test
+    void deserializesDolphin32ProcessInstanceFields() throws Exception {
+        DolphinTaskInstance instance = objectMapper.readValue(
+                "{\"id\":1,\"taskCode\":2,\"processInstanceId\":3,"
+                        + "\"processInstanceName\":\"wf-32\",\"state\":\"SUCCESS\"}",
+                DolphinTaskInstance.class);
+
+        assertEquals(3L, instance.getWorkflowInstanceId());
+        assertEquals("wf-32", instance.getWorkflowInstanceName());
+    }
+
+    @Test
+    void deserializesDolphin34WorkflowInstanceFields() throws Exception {
+        DolphinTaskInstance instance = objectMapper.readValue(
+                "{\"id\":1,\"taskCode\":2,\"workflowInstanceId\":4,"
+                        + "\"workflowInstanceName\":\"wf-34\",\"state\":\"FAILURE\","
+                        + "\"duration\":\"00:01:05\"}",
+                DolphinTaskInstance.class);
+
+        assertEquals(4L, instance.getWorkflowInstanceId());
+        assertEquals("wf-34", instance.getWorkflowInstanceName());
+        assertEquals("00:01:05", instance.getDuration());
+    }
+}

--- a/docs/design/2026-07-31-task-list-execution-monitoring-design.md
+++ b/docs/design/2026-07-31-task-list-execution-monitoring-design.md
@@ -1,0 +1,154 @@
+# Task-level Recent Execution and Workflow Execution Monitor Design
+
+**Date:** 2026-07-31
+**Goal:** 精简任务列表，按 Dolphin 任务实例展示任务级最近执行，并让执行监控统一覆盖平台触发与 Dolphin 定时触发的工作流实例。
+**Tech Stack:** Vue 3 + Element Plus；Spring Boot + MyBatis-Plus；DolphinScheduler 3.2/3.4 OpenAPI；既有 `workflow_instance_cache`。
+
+## Current State
+
+- 任务列表展示任务编码、调度配置、负责人等内部字段，上下游数量不可操作。
+- “最近执行”只读取本地 `task_execution_log`；平台运行工作流时该表只记录一个代表任务，因此同工作流其他任务长期显示“未执行”。
+- 执行监控只查询 `task_execution_log`，Dolphin 定时创建的工作流实例不会进入该表，因而不可见。
+- 平台已通过 `workflow_instance_cache` 缓存 Dolphin 工作流实例，但尚未接入 Dolphin 任务实例接口。
+
+## Scope
+
+本次包含：
+
+- 任务列表移除任务编码、调度配置、负责人列，保留任务 ID 与任务名称。
+- 上下游数量点击后填写已有的反向关系筛选框并立即查询。
+- 任务“最近执行”以最新工作流实例为边界，用 `dolphinTaskCode` 匹配该实例下的 Dolphin 任务实例。
+- 执行监控改为工作流实例顶层列表，展开行实时读取该次运行的任务实例。
+- 平台触发、Dolphin 定时触发和提交 Dolphin 前失败的本地记录统一展示。
+- 保留旧执行历史 API，新增接口供新监控页使用。
+
+本次不包含：
+
+- 不删除任务编码、调度配置、负责人后端字段，不修改任务编辑表单。
+- 不新增数据库迁移或任务实例缓存表。
+- 不向前查找任务在更早工作流实例中的状态。
+- 不实现 Dolphin 日志正文读取。
+
+## Solution
+
+### 1. Dolphin 任务实例兼容
+
+新增调用：
+
+```text
+GET /projects/{projectCode}/task-instances
+```
+
+Dolphin 3.2 使用 `processInstanceId`，3.4 使用 `workflowInstanceId`。客户端在同一请求中发送两套参数且值相同；DTO 兼容两套工作流实例字段。任务实例按页读取，每个工作流实例只发起一组分页请求。
+
+工作流实例 DTO 同时兼容 `processDefinitionCode` 与 `workflowDefinitionCode`，保证监控在 3.2/3.4 都能按工作流编码过滤。
+
+### 2. 任务级最近执行
+
+任务列表加载一页数据后：
+
+1. 按平台工作流分组已部署任务。
+2. 每个工作流读取最新一个 Dolphin 工作流实例。
+3. 按工作流实例批量读取所有任务实例。
+4. 以 `dolphinTaskCode` 映射平台任务，每个任务展示自己的任务实例状态。
+
+同一工作流只进行一次最新实例查询和一次任务实例分页查询，避免逐任务 N+1。
+
+任务未出现在最新工作流实例时：
+
+- 工作流仍在运行：`waiting` / “等待执行”。
+- 工作流已终止：`not_run` / “本次未运行”。
+- 工作流从未运行：无执行状态，页面显示“未执行”。
+- Dolphin 查询失败：`unavailable` / “状态不可用”，不以工作流状态冒充任务状态。
+- 未关联、未部署或没有 Dolphin 任务编码的任务：继续读取本地最近任务日志。
+
+### 3. 统一工作流实例监控
+
+新增 `WorkflowExecutionMonitorService`，以工作流为单位聚合：
+
+- Dolphin 实时工作流实例。
+- Dolphin 不可用时的 `workflow_instance_cache`。
+- 平台写入的本地 `task_execution_log`。
+
+Dolphin 实例与本地日志按“平台工作流 ID + 外部实例 ID”去重：
+
+- 匹配到本地日志的 Dolphin 实例标记来源为 `platform`。
+- 未匹配的实例标记来源为 `dolphin`，其中调度命令映射为 `schedule`。
+- 没有外部实例 ID 的本地失败记录代表提交 Dolphin 前失败，保留为不可展开的平台记录。
+
+列表筛选、分页前的统计均基于同一个聚合快照，避免历史列表与统计口径不一致。
+
+### 4. 展开任务实例
+
+顶层工作流实例按需调用任务实例接口，不预加载所有任务：
+
+- 以 Dolphin `taskCode` 匹配平台任务 ID 和名称。
+- 展示任务状态、主机、重试次数、执行人、开始/结束时间和时长。
+- 单行加载失败由该展开行展示错误及重试按钮，不影响顶层列表和其他展开行。
+- 提交 Dolphin 前失败的本地记录不可展开。
+
+### 5. 状态与触发映射
+
+状态：
+
+- `SUCCESS` / `FORCED_SUCCESS` → `success`
+- `FAILURE` / `FAILED` → `failed`
+- `RUNNING_EXECUTION` / `RUNNING` / `SUBMITTED_SUCCESS` / `DELAY_EXECUTION` → `running`
+- `STOP` / `KILL` / `KILLED` → `killed`
+- `READY_PAUSE` / `PAUSE` → `paused`
+- 其他等待态 → `pending`
+
+触发方式：
+
+- Dolphin 调度命令 → `schedule`
+- `START_PROCESS` 或平台手动日志 → `manual`
+- `COMPLEMENT_DATA` 或平台补数日志 → `backfill`
+- 其他 → `api`
+
+### 6. 任务列表交互
+
+- 点击“上游任务数”：设置 `downstreamTaskId=row.id`，清空 `upstreamTaskId`。
+- 点击“下游任务数”：设置 `upstreamTaskId=row.id`，清空 `downstreamTaskId`。
+- 两种点击均重置页码并立即请求。
+- 仅服务端列表、工具栏可见、非新增行且数量大于 0 时可点击。
+
+## Interfaces
+
+新增：
+
+```text
+GET /v1/executions/workflow-instances
+  ?workflowId=&status=&startTime=&endTime=&refresh=&pageNum=&pageSize=
+
+GET /v1/executions/workflows/{workflowId}/instances/{instanceId}/tasks
+```
+
+第一个接口返回：
+
+- `records`：工作流实例分页。
+- `statistics`：同一筛选快照的总数、成功、失败、运行中、成功率、失败率和平均时长。
+- `total/pageNum/pageSize`。
+
+旧 `/v1/executions/history`、`/statistics`、`/running`、`/failed` 和详情/同步接口保持不变。
+
+## Failure and Fallback
+
+- Dolphin 工作流实例刷新失败：读取对应工作流已有缓存。
+- Dolphin 任务实例查询失败：任务列表显示“状态不可用”；展开行显示局部错误。
+- Dolphin 成功返回空实例：清空对应工作流缓存，表示确实未执行。
+- 单个工作流失败不阻断其他工作流聚合。
+- 任务实例实时读取，不使用工作流级状态替代任务状态。
+
+## Tradeoffs
+
+- 监控每次加载会按已部署工作流读取最近最多 100 个实例，工作流较多时 OpenAPI 请求数随工作流数增长。
+- 任务实例不落库，Dolphin 不可用时无法提供历史任务级详情；页面明确显示不可用或展开错误。
+- 当前统计是可见的近期实例口径，不是 Dolphin 全量历史报表。
+
+## Verification
+
+- 后端契约测试覆盖 3.2/3.4 参数及 DTO 字段。
+- 服务测试覆盖任务独立状态、缺失任务语义、定时实例、去重、提交前失败、缓存降级和任务展开映射。
+- 前端测试覆盖上下游筛选方向、统一查询参数、触发/来源文案和稳定行键。
+- 运行目标 Maven 测试、前端 Vitest 与生产构建。
+- 环境可用时真实执行一次平台手动运行和一次 Dolphin 定时运行，核对顶层与展开任务状态。

--- a/docs/plans/2026-07-31-task-list-execution-monitoring-plan.md
+++ b/docs/plans/2026-07-31-task-list-execution-monitoring-plan.md
@@ -1,0 +1,98 @@
+# Task-level Recent Execution and Workflow Execution Monitor Plan
+
+**Date:** 2026-07-31
+**Design:** [2026-07-31-task-list-execution-monitoring-design.md](../design/2026-07-31-task-list-execution-monitoring-design.md)
+
+## Implementation Tasks
+
+### 1. Dolphin API and DTO
+
+- [x] 新增 Dolphin 任务实例 DTO，兼容 3.2 `processInstance*` 与 3.4 `workflowInstance*` 字段。
+- [x] 新增 `/projects/{projectCode}/task-instances` 分页查询，同时发送两套实例 ID 参数。
+- [x] 工作流实例 DTO 兼容 3.4 `workflowDefinition*` 字段。
+- [x] 保留 Dolphin 查询异常，让上层区分“空数据”和“数据源失败”。
+
+### 2. Task-level recent execution
+
+- [x] 当前页任务按工作流分组。
+- [x] 每个工作流读取最新实例及该实例的全部任务实例。
+- [x] 以 `dolphinTaskCode` 映射平台任务，避免逐任务查询。
+- [x] 实现 `waiting`、`not_run`、`unavailable` 与“未执行”语义。
+- [x] 独立或未部署任务保留本地日志回退。
+- [x] 单任务最近执行接口与列表复用相同解析流程。
+
+### 3. Unified execution monitor backend
+
+- [x] 新增工作流实例分页与同快照统计接口。
+- [x] 复用 `workflow_instance_cache` 作为工作流实例降级数据源。
+- [x] Dolphin 实例与平台日志按工作流和外部实例 ID 去重。
+- [x] 保留提交 Dolphin 前失败的本地平台记录。
+- [x] 新增按工作流实例懒加载任务实例接口。
+- [x] 平台手动、Dolphin 调度与补数触发类型统一映射。
+- [x] 保持旧执行历史接口不变。
+
+### 4. Frontend
+
+- [x] 任务列表移除任务编码、调度配置、负责人列。
+- [x] 上下游数量点击填写反向搜索条件、清空互斥条件并自动查询。
+- [x] 增加“等待执行”“本次未运行”“状态不可用”展示。
+- [x] 执行监控切换为工作流实例顶层列表。
+- [x] 工作流筛选替代任务 ID 筛选，保留状态和时间范围。
+- [x] 列表与统计读取同一个响应。
+- [x] 展开行懒加载任务实例，错误局部展示并支持重试。
+
+### 5. Tests and verification
+
+- [x] Dolphin 3.2/3.4 请求与响应兼容测试。
+- [x] 同工作流不同任务状态、缺失任务状态测试。
+- [x] 定时实例、平台去重、提交前失败和缓存降级测试。
+- [x] 任务实例展开与平台任务 ID 映射测试。
+- [x] 控制器筛选参数透传测试。
+- [x] 前端筛选与监控模型 Vitest。
+- [x] 后端编译与前端生产构建。
+- [ ] 真实 Dolphin 平台手动 + 定时 smoke（依赖本地可访问的 Dolphin 运行时和有效配置）。
+
+## Verification Commands
+
+```bash
+mvn -pl backend -am \
+  -Dtest='DolphinTaskInstanceCompatibilityTest,DolphinSchedulerServiceTest,WorkflowExecutionMonitorServiceTest,WorkflowExecutionServiceTest,DataTaskServiceWorkflowMetadataTest,TaskExecutionControllerTest,TaskExecutionServiceTest' \
+  -Dsurefire.failIfNoSpecifiedTests=false test
+```
+
+```bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use
+npm --prefix frontend run test -- \
+  src/views/tasks/__tests__/taskListFilters.spec.js \
+  src/views/executions/__tests__/executionMonitorModel.spec.js \
+  src/views/executions/__tests__/ExecutionMonitor.demo.spec.js
+npm --prefix frontend run build
+```
+
+## Verification Results
+
+- 后端目标测试：32 项通过，0 失败，0 跳过。
+- 前端目标测试：3 个测试文件、9 项测试通过。
+- 后端编译和前端生产构建通过。
+- `git diff --check` 通过。
+- 真实 Dolphin smoke 未完成：MySQL `3306`、Redis `6379` 与 Dolphin `12345` 曾通过连通性预检，但 Dolphin standalone 随后因 Podman VM 内存不足退出（退出码 137、`OOMKilled=true`）。
+- 环境恢复记录：尝试将 Podman VM 从 2 GB 调整为 4 GB、3 GB，VM 均无法稳定启动，随后已恢复原 2 GB 配置；未修改或清理数据库卷。
+- 未覆盖风险：平台手动触发、Dolphin 定时触发以及真实任务展开状态尚未完成端到端核对。
+
+## Local Smoke
+
+1. 预检主后端配置的 Dolphin URL、Token、项目和工作流是否可访问。
+2. 平台手动运行一个包含多个任务的已部署工作流。
+3. 确认执行监控只显示一个父工作流实例，来源为“平台”，展开后各任务状态与 Dolphin 一致。
+4. 等待或触发一次 Dolphin 定时实例。
+5. 确认无需平台日志也能显示该实例，来源为“Dolphin”，触发方式为“调度”。
+6. 临时断开 Dolphin 后刷新，确认父实例使用缓存；任务列表显示“状态不可用”，展开行局部报错。
+7. 恢复连接并重试展开，确认任务实例恢复。
+
+## Rollout and Backout
+
+- 无数据库迁移；先发布后端，再发布前端。
+- 回退前端页面与 API helper 可恢复旧监控。
+- 回退新增后端控制器方法、聚合服务与 Dolphin 任务实例客户端即可；旧接口和缓存表保持兼容。

--- a/frontend/src/api/execution.js
+++ b/frontend/src/api/execution.js
@@ -12,6 +12,27 @@ export function getExecutionHistory(params) {
 }
 
 /**
+ * 查询统一工作流实例监控数据，列表与统计来自同一响应快照。
+ */
+export function getWorkflowExecutionInstances(params) {
+  return request({
+    url: '/v1/executions/workflow-instances',
+    method: 'get',
+    params
+  })
+}
+
+/**
+ * 懒加载一次工作流运行中的 Dolphin 任务实例。
+ */
+export function getWorkflowExecutionTasks(workflowId, instanceId) {
+  return request({
+    url: `/v1/executions/workflows/${workflowId}/instances/${instanceId}/tasks`,
+    method: 'get'
+  })
+}
+
+/**
  * 获取单个执行记录详情
  */
 export function getExecutionDetail(id) {

--- a/frontend/src/demo/mockServer.js
+++ b/frontend/src/demo/mockServer.js
@@ -1942,6 +1942,93 @@ const handleExecutionStats = (params) => {
   }
 }
 
+const getDemoWorkflowExecutions = () => getExecutions().map((execution) => {
+  const workflow = getWorkflows().find((item) => item.workflowName === execution.workflowName)
+  const triggerType = execution.commandType === 'COMPLEMENT_DATA'
+    ? 'backfill'
+    : execution.triggerType
+  return {
+    workflowId: workflow?.id || null,
+    workflowName: execution.workflowName,
+    workflowCode: workflow?.workflowCode || null,
+    instanceId: 900000 + Number(execution.id),
+    localExecutionLogId: execution.id,
+    status: execution.status,
+    dolphinState: execution.status?.toUpperCase(),
+    commandType: execution.commandType,
+    triggerType,
+    source: triggerType === 'manual' || triggerType === 'backfill' ? 'platform' : 'dolphin',
+    executionSource: 'dolphin',
+    startTime: execution.startTime,
+    endTime: execution.endTime,
+    durationSeconds: execution.durationSeconds,
+    errorMessage: execution.errorMessage,
+    expandable: true
+  }
+})
+
+const handleWorkflowExecutionList = (params = {}) => {
+  let records = getDemoWorkflowExecutions()
+  if (params.workflowId) {
+    records = records.filter((item) => Number(item.workflowId) === Number(params.workflowId))
+  }
+  if (params.status) {
+    records = records.filter((item) => item.status === params.status)
+  }
+  if (params.startTime) {
+    records = records.filter((item) => String(item.startTime || '').replace('T', ' ') >= params.startTime)
+  }
+  if (params.endTime) {
+    records = records.filter((item) => String(item.startTime || '').replace('T', ' ') <= params.endTime)
+  }
+  const page = toPaged(records, params.pageNum, params.pageSize)
+  const successCount = records.filter((item) => item.status === 'success').length
+  const failedCount = records.filter((item) => item.status === 'failed').length
+  const durations = records
+    .map((item) => item.durationSeconds)
+    .filter((duration) => typeof duration === 'number')
+  return {
+    ...page,
+    pageNum: Math.max(1, Number(params.pageNum) || 1),
+    pageSize: Math.max(1, Number(params.pageSize) || 10),
+    statistics: {
+      totalExecutions: records.length,
+      successCount,
+      failedCount,
+      runningCount: records.filter((item) => item.status === 'running').length,
+      successRate: records.length ? Number(((successCount / records.length) * 100).toFixed(2)) : 0,
+      failureRate: records.length ? Number(((failedCount / records.length) * 100).toFixed(2)) : 0,
+      avgDurationSeconds: durations.length
+        ? Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length)
+        : 0
+    }
+  }
+}
+
+const handleWorkflowExecutionTasks = (pathname) => {
+  const parts = pathname.split('/')
+  const workflowId = Number(parts[4])
+  const instanceId = Number(parts[6])
+  const parent = getDemoWorkflowExecutions().find((item) => item.instanceId === instanceId)
+  return getTasks()
+    .filter((task) => Number(task.workflowId) === workflowId)
+    .map((task, index) => ({
+      platformTaskId: task.id,
+      dolphinTaskCode: task.dolphinTaskCode || null,
+      taskInstanceId: instanceId * 10 + index + 1,
+      taskName: task.taskName,
+      taskType: task.dolphinNodeType,
+      status: parent?.status || task.executionStatus?.status || 'success',
+      dolphinState: (parent?.status || 'success').toUpperCase(),
+      host: parent?.source === 'platform' ? 'demo-worker-01' : 'demo-worker-02',
+      retryTimes: parent?.status === 'failed' ? 1 : 0,
+      executorName: 'readme',
+      startTime: parent?.startTime || null,
+      endTime: parent?.endTime || null,
+      durationSeconds: parent?.durationSeconds || null
+    }))
+}
+
 const toDashboardDate = (value) => {
   if (!value) return null
   const date = new Date(value)
@@ -2195,6 +2282,14 @@ export const demoAdapter = async (config) => {
 
   if (method === 'get' && pathname === '/v1/executions/statistics') {
     return createResponse(config, handleExecutionStats(params))
+  }
+
+  if (method === 'get' && pathname === '/v1/executions/workflow-instances') {
+    return createResponse(config, handleWorkflowExecutionList(params))
+  }
+
+  if (method === 'get' && pathname.match(/^\/v1\/executions\/workflows\/\d+\/instances\/\d+\/tasks$/)) {
+    return createResponse(config, handleWorkflowExecutionTasks(pathname))
   }
 
   if (method === 'get' && pathname === '/v1/executions/history') {

--- a/frontend/src/views/executions/ExecutionMonitor.vue
+++ b/frontend/src/views/executions/ExecutionMonitor.vue
@@ -3,57 +3,51 @@
     <el-card class="header-card">
       <template #header>
         <div class="card-header">
-          <span>执行监控</span>
-          <div class="header-actions">
-            <el-button type="primary" :icon="Refresh" @click="refreshData">刷新</el-button>
+          <div>
+            <div class="page-title">执行监控</div>
+            <div class="page-subtitle">统一展示平台触发与 Dolphin 定时产生的工作流实例</div>
           </div>
+          <el-button type="primary" :icon="Refresh" :loading="loading" @click="refreshData">
+            刷新
+          </el-button>
         </div>
       </template>
 
-      <!-- 统计卡片 -->
-      <el-row :gutter="20" class="stats-row">
+      <el-row :gutter="16" class="stats-row">
         <el-col :span="6">
           <div class="stat-card">
-            <div class="stat-icon total">
-              <el-icon><Document /></el-icon>
-            </div>
+            <div class="stat-icon total"><el-icon><Document /></el-icon></div>
             <div class="stat-info">
               <div class="stat-value">{{ statistics.totalExecutions || 0 }}</div>
-              <div class="stat-label">总执行次数</div>
+              <div class="stat-label">当前筛选执行</div>
             </div>
           </div>
         </el-col>
         <el-col :span="6">
           <div class="stat-card">
-            <div class="stat-icon success">
-              <el-icon><CircleCheck /></el-icon>
-            </div>
+            <div class="stat-icon success"><el-icon><CircleCheck /></el-icon></div>
             <div class="stat-info">
               <div class="stat-value">{{ statistics.successCount || 0 }}</div>
-              <div class="stat-label">成功次数</div>
+              <div class="stat-label">成功</div>
               <div class="stat-rate success-rate">{{ statistics.successRate || 0 }}%</div>
             </div>
           </div>
         </el-col>
         <el-col :span="6">
           <div class="stat-card">
-            <div class="stat-icon failed">
-              <el-icon><CircleClose /></el-icon>
-            </div>
+            <div class="stat-icon failed"><el-icon><CircleClose /></el-icon></div>
             <div class="stat-info">
               <div class="stat-value">{{ statistics.failedCount || 0 }}</div>
-              <div class="stat-label">失败次数</div>
+              <div class="stat-label">失败</div>
               <div class="stat-rate failed-rate">{{ statistics.failureRate || 0 }}%</div>
             </div>
           </div>
         </el-col>
         <el-col :span="6">
           <div class="stat-card">
-            <div class="stat-icon duration">
-              <el-icon><Timer /></el-icon>
-            </div>
+            <div class="stat-icon duration"><el-icon><Timer /></el-icon></div>
             <div class="stat-info">
-              <div class="stat-value">{{ statistics.avgDurationSeconds || 0 }}s</div>
+              <div class="stat-value">{{ formatDuration(statistics.avgDurationSeconds) }}</div>
               <div class="stat-label">平均执行时长</div>
             </div>
           </div>
@@ -61,16 +55,24 @@
       </el-row>
     </el-card>
 
-    <!-- 筛选条件 -->
     <el-card class="filter-card">
-      <el-form :inline="true" :model="queryParams" class="filter-form">
-        <el-form-item label="任务ID">
-          <el-input
-            v-model="queryParams.taskId"
-            placeholder="请输入任务ID"
+      <el-form :inline="true" class="filter-form">
+        <el-form-item label="工作流">
+          <el-select
+            v-model="queryParams.workflowId"
+            placeholder="全部工作流"
             clearable
-            style="width: 200px"
-          />
+            filterable
+            :loading="workflowOptionsLoading"
+            style="width: 220px"
+          >
+            <el-option
+              v-for="workflow in workflowOptions"
+              :key="workflow.id"
+              :label="workflow.workflowName"
+              :value="workflow.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="时间范围">
           <el-date-picker
@@ -89,519 +91,326 @@
         </el-form-item>
       </el-form>
 
-      <!-- 快捷筛选 -->
-      <div class="quick-filters">
-        <el-button-group>
-          <el-button
-            :type="activeFilter === 'all' ? 'primary' : ''"
-            @click="handleQuickFilter('all')"
-          >
-            全部
-          </el-button>
-          <el-button
-            :type="activeFilter === 'running' ? 'primary' : ''"
-            @click="handleQuickFilter('running')"
-          >
-            运行中
-          </el-button>
-          <el-button
-            :type="activeFilter === 'failed' ? 'primary' : ''"
-            @click="handleQuickFilter('failed')"
-          >
-            失败
-          </el-button>
-        </el-button-group>
-      </div>
+      <el-button-group>
+        <el-button
+          v-for="filter in quickFilters"
+          :key="filter.value"
+          :type="queryParams.status === filter.value ? 'primary' : ''"
+          @click="handleQuickFilter(filter.value)"
+        >
+          {{ filter.label }}
+        </el-button>
+      </el-button-group>
     </el-card>
 
-    <!-- 执行历史表格 -->
     <el-card class="table-card">
       <el-table
         v-loading="loading"
         :data="executionList"
+        :row-key="getExecutionRowKey"
+        :expand-row-keys="expandedRowKeys"
         stripe
+        empty-text="当前筛选条件下暂无工作流执行记录"
         style="width: 100%"
+        @expand-change="handleExpandChange"
       >
-        <el-table-column prop="id" label="执行ID" width="80" />
-        <el-table-column prop="taskId" label="任务ID" width="100" />
-        <el-table-column prop="executionId" label="实例ID" width="180" />
+        <el-table-column type="expand" width="44">
+          <template #default="{ row }">
+            <div class="task-instance-panel">
+              <el-empty
+                v-if="!row.expandable"
+                description="该记录在提交 Dolphin 前失败，没有任务实例"
+                :image-size="56"
+              />
+              <div v-else-if="taskLoading[getExecutionRowKey(row)]" class="expand-loading">
+                <el-icon class="is-loading"><Loading /></el-icon>
+                正在读取 Dolphin 任务实例…
+              </div>
+              <el-alert
+                v-else-if="taskErrors[getExecutionRowKey(row)]"
+                type="error"
+                :closable="false"
+                show-icon
+              >
+                <template #title>
+                  <span>{{ taskErrors[getExecutionRowKey(row)] }}</span>
+                  <el-button link type="primary" @click="retryLoadTasks(row)">重试</el-button>
+                </template>
+              </el-alert>
+              <el-table
+                v-else
+                :data="taskInstances[getExecutionRowKey(row)] || []"
+                size="small"
+                border
+                empty-text="本次运行没有任务实例"
+              >
+                <el-table-column prop="platformTaskId" label="任务ID" width="90">
+                  <template #default="{ row: task }">{{ task.platformTaskId || '-' }}</template>
+                </el-table-column>
+                <el-table-column prop="taskName" label="任务名称" min-width="180" />
+                <el-table-column prop="status" label="状态" width="110">
+                  <template #default="{ row: task }">
+                    <el-tag :type="getStatusType(task.status)" size="small">
+                      {{ getStatusText(task.status) }}
+                    </el-tag>
+                  </template>
+                </el-table-column>
+                <el-table-column prop="host" label="主机" min-width="150">
+                  <template #default="{ row: task }">{{ task.host || '-' }}</template>
+                </el-table-column>
+                <el-table-column prop="retryTimes" label="重试次数" width="90">
+                  <template #default="{ row: task }">{{ task.retryTimes ?? 0 }}</template>
+                </el-table-column>
+                <el-table-column prop="startTime" label="开始时间" width="170">
+                  <template #default="{ row: task }">{{ formatDateTime(task.startTime) }}</template>
+                </el-table-column>
+                <el-table-column prop="endTime" label="结束时间" width="170">
+                  <template #default="{ row: task }">{{ formatDateTime(task.endTime) }}</template>
+                </el-table-column>
+                <el-table-column prop="durationSeconds" label="时长" width="100">
+                  <template #default="{ row: task }">{{ formatDuration(task.durationSeconds) }}</template>
+                </el-table-column>
+              </el-table>
+            </div>
+          </template>
+        </el-table-column>
 
-        <!-- DolphinScheduler 相关列 -->
-        <el-table-column prop="workflowName" label="工作流名称" width="150" show-overflow-tooltip>
-          <template #default="{ row }">
-            {{ row.workflowName || '-' }}
-          </template>
+        <el-table-column prop="workflowName" label="工作流" min-width="180" show-overflow-tooltip />
+        <el-table-column prop="instanceId" label="实例ID" width="130">
+          <template #default="{ row }">{{ row.instanceId || '-' }}</template>
         </el-table-column>
-        <el-table-column prop="workflowCode" label="工作流ID" width="120">
-          <template #default="{ row }">
-            {{ row.workflowCode || '-' }}
-          </template>
-        </el-table-column>
-        <el-table-column prop="dolphinInstanceId" label="DS实例ID" width="120">
-          <template #default="{ row }">
-            {{ row.dolphinInstanceId || '-' }}
-          </template>
-        </el-table-column>
-
-        <el-table-column prop="status" label="状态" width="100">
+        <el-table-column prop="status" label="状态" width="110">
           <template #default="{ row }">
             <el-tag :type="getStatusType(row.status)" size="small">
               {{ getStatusText(row.status) }}
             </el-tag>
           </template>
         </el-table-column>
-        <el-table-column prop="dolphinState" label="DS状态" width="120" show-overflow-tooltip>
-          <template #default="{ row }">
-            <el-tag size="small" effect="plain" v-if="row.dolphinState">
-              {{ row.dolphinState }}
-            </el-tag>
-            <span v-else>-</span>
-          </template>
-        </el-table-column>
         <el-table-column prop="triggerType" label="触发方式" width="100">
           <template #default="{ row }">
-            <el-tag size="small" effect="plain">
-              {{ getTriggerTypeText(row.triggerType) }}
-            </el-tag>
+            <el-tag size="small" effect="plain">{{ getTriggerTypeText(row.triggerType) }}</el-tag>
           </template>
         </el-table-column>
-        <el-table-column prop="startTime" label="开始时间" width="160">
+        <el-table-column prop="source" label="来源" width="100">
           <template #default="{ row }">
-            {{ formatDateTime(row.startTime) }}
-          </template>
-        </el-table-column>
-        <el-table-column prop="endTime" label="结束时间" width="160">
-          <template #default="{ row }">
-            {{ formatDateTime(row.endTime) }}
-          </template>
-        </el-table-column>
-        <el-table-column prop="durationSeconds" label="执行时长" width="100">
-          <template #default="{ row }">
-            {{ formatDuration(row.durationSeconds) }}
-          </template>
-        </el-table-column>
-        <el-table-column prop="host" label="执行主机" width="150" show-overflow-tooltip>
-          <template #default="{ row }">
-            {{ row.host || '-' }}
-          </template>
-        </el-table-column>
-        <el-table-column prop="rowsOutput" label="输出行数" width="100" />
-        <el-table-column label="操作" width="280" fixed="right">
-          <template #default="{ row }">
-            <el-button
-              link
-              type="primary"
-              size="small"
-              @click="handleViewDetail(row)"
+            <el-tooltip
+              :content="row.executionSource === 'cache' ? 'Dolphin 暂不可用，当前展示缓存数据' : ''"
+              :disabled="row.executionSource !== 'cache'"
             >
-              详情
-            </el-button>
-            <el-button
-              link
-              type="primary"
-              size="small"
-              v-if="!isTerminalStatus(row.status)"
-              :disabled="isDemoMode"
-              @click="handleSyncStatus(row)"
-            >
-              同步状态
-            </el-button>
-            <el-button
-              link
-              type="primary"
-              size="small"
-              v-if="row.workflowInstanceUrl"
-              @click="openDolphinWebUI(row.workflowInstanceUrl)"
-            >
-              DS实例
-            </el-button>
-            <el-button
-              link
-              type="primary"
-              size="small"
-              @click="handleViewLog(row)"
-            >
-              查看日志
-            </el-button>
+              <el-tag :type="row.source === 'platform' ? 'primary' : 'info'" size="small">
+                {{ getExecutionSourceText(row.source) }}
+              </el-tag>
+            </el-tooltip>
           </template>
+        </el-table-column>
+        <el-table-column prop="startTime" label="开始时间" width="170">
+          <template #default="{ row }">{{ formatDateTime(row.startTime) }}</template>
+        </el-table-column>
+        <el-table-column prop="endTime" label="结束时间" width="170">
+          <template #default="{ row }">{{ formatDateTime(row.endTime) }}</template>
+        </el-table-column>
+        <el-table-column prop="durationSeconds" label="时长" width="100">
+          <template #default="{ row }">{{ formatDuration(row.durationSeconds) }}</template>
+        </el-table-column>
+        <el-table-column prop="errorMessage" label="错误信息" min-width="180" show-overflow-tooltip>
+          <template #default="{ row }">{{ row.errorMessage || '-' }}</template>
         </el-table-column>
       </el-table>
 
-      <!-- 分页 - 仅在"全部"模式下显示 -->
       <el-pagination
-        v-if="activeFilter === 'all'"
         v-model:current-page="queryParams.pageNum"
         v-model:page-size="queryParams.pageSize"
         :total="total"
         :page-sizes="[10, 20, 50, 100]"
         layout="total, sizes, prev, pager, next, jumper"
-        @size-change="handleQuery"
-        @current-change="handleQuery"
-        style="margin-top: 20px; justify-content: flex-end"
+        class="pagination"
+        @size-change="loadExecutionList"
+        @current-change="loadExecutionList"
       />
-      <!-- 快捷筛选模式提示 -->
-      <div v-else style="margin-top: 20px; text-align: center; color: #909399;">
-        共 {{ total }} 条记录（快捷筛选模式，不支持分页）
-        <el-button link type="primary" @click="handleQuickFilter('all')" style="margin-left: 10px;">
-          切换到全部模式以使用分页
-        </el-button>
-      </div>
     </el-card>
-
-    <!-- 执行详情对话框 -->
-    <el-dialog
-      v-model="detailDialogVisible"
-      title="执行详情"
-      width="800px"
-    >
-      <el-descriptions :column="2" border v-if="currentExecution">
-        <el-descriptions-item label="执行ID">{{ currentExecution.id }}</el-descriptions-item>
-        <el-descriptions-item label="任务ID">{{ currentExecution.taskId }}</el-descriptions-item>
-        <el-descriptions-item label="实例ID">{{ currentExecution.executionId }}</el-descriptions-item>
-        <el-descriptions-item label="状态">
-          <el-tag :type="getStatusType(currentExecution.status)">
-            {{ getStatusText(currentExecution.status) }}
-          </el-tag>
-        </el-descriptions-item>
-
-        <!-- DolphinScheduler 信息 -->
-        <el-descriptions-item label="工作流名称" v-if="currentExecution.workflowName">
-          {{ currentExecution.workflowName }}
-        </el-descriptions-item>
-        <el-descriptions-item label="工作流ID" v-if="currentExecution.workflowCode">
-          {{ currentExecution.workflowCode }}
-        </el-descriptions-item>
-        <el-descriptions-item label="任务代码" v-if="currentExecution.taskCode">
-          {{ currentExecution.taskCode }}
-        </el-descriptions-item>
-        <el-descriptions-item label="DS实例ID" v-if="currentExecution.dolphinInstanceId">
-          {{ currentExecution.dolphinInstanceId }}
-        </el-descriptions-item>
-        <el-descriptions-item label="DS状态" v-if="currentExecution.dolphinState">
-          <el-tag size="small">{{ currentExecution.dolphinState }}</el-tag>
-        </el-descriptions-item>
-        <el-descriptions-item label="执行主机" v-if="currentExecution.host">
-          {{ currentExecution.host }}
-        </el-descriptions-item>
-        <el-descriptions-item label="运行次数" v-if="currentExecution.runTimes">
-          {{ currentExecution.runTimes }}
-        </el-descriptions-item>
-        <el-descriptions-item label="命令类型" v-if="currentExecution.commandType">
-          {{ currentExecution.commandType }}
-        </el-descriptions-item>
-
-        <el-descriptions-item label="触发方式">
-          {{ getTriggerTypeText(currentExecution.triggerType) }}
-        </el-descriptions-item>
-        <el-descriptions-item label="开始时间">
-          {{ formatDateTime(currentExecution.startTime) }}
-        </el-descriptions-item>
-        <el-descriptions-item label="结束时间">
-          {{ formatDateTime(currentExecution.endTime) }}
-        </el-descriptions-item>
-        <el-descriptions-item label="执行时长">
-          {{ formatDuration(currentExecution.durationSeconds) }}
-        </el-descriptions-item>
-        <el-descriptions-item label="输出行数">
-          {{ currentExecution.rowsOutput || '-' }}
-        </el-descriptions-item>
-
-        <!-- WebUI 链接 -->
-        <el-descriptions-item label="工作流实例" v-if="currentExecution.workflowInstanceUrl">
-          <el-link :href="currentExecution.workflowInstanceUrl" type="primary" target="_blank" :icon="Link">
-            打开DolphinScheduler
-          </el-link>
-        </el-descriptions-item>
-        <el-descriptions-item label="任务定义" v-if="currentExecution.taskDefinitionUrl">
-          <el-link :href="currentExecution.taskDefinitionUrl" type="primary" target="_blank" :icon="Link">
-            查看任务定义
-          </el-link>
-        </el-descriptions-item>
-
-        <el-descriptions-item label="日志URL">
-          <el-link :href="currentExecution.logUrl" type="primary" target="_blank" v-if="currentExecution.logUrl">
-            查看日志
-          </el-link>
-          <span v-else>-</span>
-        </el-descriptions-item>
-        <el-descriptions-item label="错误信息" :span="2" v-if="currentExecution.errorMessage">
-          <el-alert type="error" :closable="false">
-            {{ currentExecution.errorMessage }}
-          </el-alert>
-        </el-descriptions-item>
-      </el-descriptions>
-
-      <template #footer>
-        <el-button @click="detailDialogVisible = false">关闭</el-button>
-      </template>
-    </el-dialog>
-
-    <!-- 日志查看对话框 -->
-    <el-dialog
-      v-model="logDialogVisible"
-      title="执行日志"
-      width="900px"
-    >
-      <div class="log-container">
-        <pre class="log-content">{{ executionLog }}</pre>
-      </div>
-
-      <template #footer>
-        <el-button @click="logDialogVisible = false">关闭</el-button>
-        <el-button type="primary" @click="handleRefreshLog">刷新日志</el-button>
-      </template>
-    </el-dialog>
   </div>
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage } from 'element-plus'
 import {
-  Refresh,
-  Search,
-  Document,
   CircleCheck,
   CircleClose,
-  Timer,
-  Link
+  Document,
+  Loading,
+  Refresh,
+  Search,
+  Timer
 } from '@element-plus/icons-vue'
+import { getWorkflowExecutionInstances, getWorkflowExecutionTasks } from '@/api/execution'
+import { workflowApi } from '@/api/workflow'
 import {
-  getExecutionHistory,
-  getExecutionDetail,
-  getExecutionStatistics,
-  getFailedExecutions,
-  getRunningExecutions,
-  syncExecutionStatus
-} from '@/api/execution'
-import { isDemoMode, showDemoReadonlyMessage } from '@/demo/runtime'
+  buildWorkflowExecutionParams,
+  getExecutionRowKey,
+  getExecutionSourceText,
+  getTriggerTypeText
+} from './executionMonitorModel'
 
-// 数据定义
 const loading = ref(false)
 const executionList = ref([])
 const total = ref(0)
 const statistics = ref({})
-const activeFilter = ref('all')
 const dateRange = ref([])
+const workflowOptions = ref([])
+const workflowOptionsLoading = ref(false)
+const expandedRowKeys = ref([])
+const taskInstances = reactive({})
+const taskLoading = reactive({})
+const taskErrors = reactive({})
 
 const queryParams = reactive({
-  taskId: null,
+  workflowId: null,
+  status: '',
   pageNum: 1,
-  pageSize: 10,
-  startTime: null,
-  endTime: null
+  pageSize: 10
 })
 
-// 对话框控制
-const detailDialogVisible = ref(false)
-const logDialogVisible = ref(false)
-const currentExecution = ref(null)
-const executionLog = ref('')
+const quickFilters = [
+  { label: '全部', value: '' },
+  { label: '运行中', value: 'running' },
+  { label: '失败', value: 'failed' }
+]
 
-// 页面加载
-onMounted(() => {
-  loadStatistics()
-  loadExecutionList()
-})
-
-// 加载统计信息
-const loadStatistics = async () => {
+const loadWorkflowOptions = async () => {
+  workflowOptionsLoading.value = true
   try {
-    const params = {}
-    if (queryParams.taskId) {
-      params.taskId = queryParams.taskId
-    }
-    if (dateRange.value && dateRange.value.length === 2) {
-      params.startTime = dateRange.value[0]
-      params.endTime = dateRange.value[1]
-    }
-
-    const res = await getExecutionStatistics(params)
-    statistics.value = res
+    const response = await workflowApi.list({ pageNum: 1, pageSize: 200 })
+    workflowOptions.value = response.records || []
   } catch (error) {
-    console.error('Failed to load statistics:', error)
+    console.error('加载工作流选项失败:', error)
+  } finally {
+    workflowOptionsLoading.value = false
   }
 }
 
-// 加载执行列表
-const loadExecutionList = async () => {
+const loadExecutionList = async (refresh = false) => {
   loading.value = true
   try {
-    const params = {
-      pageNum: queryParams.pageNum,
-      pageSize: queryParams.pageSize
-    }
-
-    if (queryParams.taskId) {
-      params.taskId = queryParams.taskId
-    }
-
-    const res = await getExecutionHistory(params)
-    executionList.value = res.records || []
-    total.value = res.total || 0
+    const response = await getWorkflowExecutionInstances(buildWorkflowExecutionParams({
+      ...queryParams,
+      dateRange: dateRange.value,
+      refresh: refresh === true
+    }))
+    executionList.value = response.records || []
+    total.value = response.total || 0
+    statistics.value = response.statistics || {}
+    expandedRowKeys.value = []
   } catch (error) {
-    ElMessage.error('加载执行历史失败: ' + error.message)
+    ElMessage.error(`加载执行监控失败: ${error.message}`)
   } finally {
     loading.value = false
   }
 }
 
-// 快捷筛选
-const handleQuickFilter = async (filter) => {
-  activeFilter.value = filter
-  loading.value = true
-
-  try {
-    if (filter === 'all') {
-      await loadExecutionList()
-    } else if (filter === 'running') {
-      const res = await getRunningExecutions()
-      executionList.value = res || []
-      total.value = executionList.value.length
-    } else if (filter === 'failed') {
-      const res = await getFailedExecutions(100)
-      executionList.value = res || []
-      total.value = executionList.value.length
-    }
-  } catch (error) {
-    ElMessage.error('加载数据失败: ' + error.message)
-  } finally {
-    loading.value = false
-  }
-}
-
-// 查询
 const handleQuery = () => {
   queryParams.pageNum = 1
-
-  // 解析时间范围
-  if (dateRange.value && dateRange.value.length === 2) {
-    queryParams.startTime = dateRange.value[0]
-    queryParams.endTime = dateRange.value[1]
-  } else {
-    queryParams.startTime = null
-    queryParams.endTime = null
-  }
-
-  loadStatistics()
   loadExecutionList()
 }
 
-// 重置
+const handleQuickFilter = (status) => {
+  queryParams.status = status
+  queryParams.pageNum = 1
+  loadExecutionList()
+}
+
 const handleReset = () => {
-  queryParams.taskId = null
+  queryParams.workflowId = null
+  queryParams.status = ''
   queryParams.pageNum = 1
   queryParams.pageSize = 10
-  queryParams.startTime = null
-  queryParams.endTime = null
   dateRange.value = []
-  activeFilter.value = 'all'
-
-  loadStatistics()
   loadExecutionList()
 }
 
-// 刷新数据
 const refreshData = () => {
-  loadStatistics()
-  loadExecutionList()
+  loadExecutionList(true)
 }
 
-// 查看详情
-const handleViewDetail = async (row) => {
-  try {
-    const detail = await getExecutionDetail(row.id)
-    currentExecution.value = detail
-    detailDialogVisible.value = true
-  } catch (error) {
-    ElMessage.error('加载执行详情失败: ' + error.message)
-  }
-}
-
-// 同步状态
-const handleSyncStatus = async (row) => {
-  if (isDemoMode) {
-    showDemoReadonlyMessage('同步执行状态')
+const handleExpandChange = (row, expandedRows) => {
+  const key = getExecutionRowKey(row)
+  const expanded = expandedRows.some(item => getExecutionRowKey(item) === key)
+  if (!expanded) {
+    expandedRowKeys.value = expandedRowKeys.value.filter(item => item !== key)
     return
   }
+  if (!expandedRowKeys.value.includes(key)) {
+    expandedRowKeys.value.push(key)
+  }
+  if (row.expandable && !taskInstances[key] && !taskLoading[key]) {
+    loadTaskInstances(row)
+  }
+}
+
+const loadTaskInstances = async (row) => {
+  const key = getExecutionRowKey(row)
+  taskLoading[key] = true
+  taskErrors[key] = ''
   try {
-    await syncExecutionStatus(row.id)
-    ElMessage.success('状态同步成功')
-    await loadExecutionList()
+    taskInstances[key] = await getWorkflowExecutionTasks(row.workflowId, row.instanceId)
   } catch (error) {
-    ElMessage.error('状态同步失败: ' + error.message)
+    taskErrors[key] = `任务实例加载失败：${error.message}`
+  } finally {
+    taskLoading[key] = false
   }
 }
 
-// 查看日志
-const handleViewLog = (row) => {
-  currentExecution.value = row
-  executionLog.value = '正在加载日志...\n\n暂未实现从 DolphinScheduler 获取日志的功能'
-  logDialogVisible.value = true
+const retryLoadTasks = (row) => {
+  const key = getExecutionRowKey(row)
+  delete taskInstances[key]
+  loadTaskInstances(row)
 }
 
-// 刷新日志
-const handleRefreshLog = () => {
-  executionLog.value = '日志已刷新...\n\n暂未实现从 DolphinScheduler 获取日志的功能'
-}
-
-// 打开 DolphinScheduler WebUI
-const openDolphinWebUI = (url) => {
-  if (url) {
-    window.open(url, '_blank')
-  }
-}
-
-// 工具函数
 const getStatusType = (status) => {
-  const statusMap = {
-    'success': 'success',
-    'failed': 'danger',
-    'running': 'primary',
-    'pending': 'info',
-    'killed': 'warning',
-    'paused': 'warning'
+  const types = {
+    success: 'success',
+    failed: 'danger',
+    running: 'primary',
+    pending: 'info',
+    waiting: 'warning',
+    not_run: 'info',
+    unavailable: 'danger',
+    killed: 'warning',
+    paused: 'warning'
   }
-  return statusMap[status] || 'info'
+  return types[status] || 'info'
 }
 
 const getStatusText = (status) => {
-  const statusMap = {
-    'success': '成功',
-    'failed': '失败',
-    'running': '运行中',
-    'pending': '待执行',
-    'killed': '已终止',
-    'paused': '已暂停'
+  const labels = {
+    success: '成功',
+    failed: '失败',
+    running: '运行中',
+    pending: '待执行',
+    waiting: '等待执行',
+    not_run: '本次未运行',
+    unavailable: '状态不可用',
+    killed: '已终止',
+    paused: '已暂停'
   }
-  return statusMap[status] || status
+  return labels[status] || status || '-'
 }
 
-const getTriggerTypeText = (type) => {
-  const typeMap = {
-    'manual': '手动',
-    'schedule': '调度',
-    'api': 'API'
-  }
-  return typeMap[type] || type
-}
-
-const isTerminalStatus = (status) => {
-  return ['success', 'failed', 'killed'].includes(status)
-}
-
-const formatDateTime = (datetime) => {
-  if (!datetime) return '-'
-  return datetime
-}
+const formatDateTime = (datetime) => datetime || '-'
 
 const formatDuration = (seconds) => {
-  if (!seconds || seconds === 0) return '-'
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  const remainingSeconds = seconds % 60
+  const value = Number(seconds)
+  if (!Number.isFinite(value) || value < 0) return '-'
+  if (value < 60) return `${Math.round(value)}s`
+  const minutes = Math.floor(value / 60)
+  const remainingSeconds = Math.round(value % 60)
   return `${minutes}m ${remainingSeconds}s`
 }
+
+onMounted(() => {
+  loadWorkflowOptions()
+  loadExecutionList()
+})
 </script>
 
 <style scoped>
@@ -618,62 +427,64 @@ const formatDuration = (seconds) => {
 
 .card-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
 }
 
-.header-actions {
-  display: flex;
-  gap: 10px;
+.page-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #303133;
+}
+
+.page-subtitle {
+  margin-top: 4px;
+  color: #909399;
+  font-size: 13px;
 }
 
 .stats-row {
-  margin-top: 10px;
+  margin-top: 4px;
 }
 
 .stat-card {
   display: flex;
   align-items: center;
-  padding: 20px;
+  min-height: 88px;
+  padding: 16px;
   background: #f8fafc;
   border-radius: 12px;
-  transition: all 0.3s ease;
-}
-
-.stat-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.12);
 }
 
 .stat-icon {
-  width: 60px;
-  height: 60px;
   display: flex;
+  width: 52px;
+  height: 52px;
   align-items: center;
   justify-content: center;
+  margin-right: 14px;
   border-radius: 50%;
-  font-size: 28px;
-  margin-right: 15px;
+  font-size: 25px;
 }
 
 .stat-icon.total {
-  background: #fff7e6;
   color: #fa8c16;
+  background: #fff7e6;
 }
 
 .stat-icon.success {
-  background: #f6ffed;
   color: #52c41a;
+  background: #f6ffed;
 }
 
 .stat-icon.failed {
-  background: #fff1f0;
   color: #f5222d;
+  background: #fff1f0;
 }
 
 .stat-icon.duration {
-  background: #e6f7ff;
   color: #1890ff;
+  background: #e6f7ff;
 }
 
 .stat-info {
@@ -681,63 +492,55 @@ const formatDuration = (seconds) => {
 }
 
 .stat-value {
-  font-size: 28px;
-  font-weight: bold;
-  line-height: 1;
   margin-bottom: 5px;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .stat-label {
+  color: #606266;
   font-size: 14px;
-  color: #666;
 }
 
 .stat-rate {
+  margin-top: 4px;
   font-size: 12px;
-  margin-top: 5px;
 }
 
-.stat-rate.success-rate {
+.success-rate {
   color: #52c41a;
 }
 
-.stat-rate.failed-rate {
+.failed-rate {
   color: #f5222d;
 }
 
-.filter-card {
-  margin-top: 20px;
+.filter-card,
+.table-card {
+  margin-top: 18px;
 }
 
 .filter-form {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
-.quick-filters {
+.task-instance-panel {
+  padding: 12px 24px 18px 68px;
+  background: #f8fafc;
+}
+
+.expand-loading {
   display: flex;
-  justify-content: flex-start;
-  margin-top: 10px;
+  align-items: center;
+  justify-content: center;
+  min-height: 90px;
+  gap: 8px;
+  color: #909399;
 }
 
-.table-card {
+.pagination {
+  justify-content: flex-end;
   margin-top: 20px;
-}
-
-.log-container {
-  max-height: 500px;
-  overflow-y: auto;
-  background: #1e1e1e;
-  padding: 15px;
-  border-radius: 8px;
-}
-
-.log-content {
-  color: #d4d4d4;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 13px;
-  line-height: 1.6;
-  margin: 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
 }
 </style>

--- a/frontend/src/views/executions/__tests__/ExecutionMonitor.demo.spec.js
+++ b/frontend/src/views/executions/__tests__/ExecutionMonitor.demo.spec.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { demoAdapter } from '@/demo/mockServer'
+
+const request = async (url, params = {}) => {
+  const response = await demoAdapter({
+    method: 'get',
+    url,
+    baseURL: '',
+    params
+  })
+  return response.data.data
+}
+
+describe('execution monitor demo endpoints', () => {
+  it('returns workflow rows and same-response statistics', async () => {
+    const result = await request('/v1/executions/workflow-instances', {
+      status: 'failed',
+      pageNum: 1,
+      pageSize: 10
+    })
+
+    expect(result.records).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workflowId: 2,
+        status: 'failed',
+        expandable: true
+      })
+    ]))
+    expect(result.statistics.totalExecutions).toBe(result.total)
+    expect(result.statistics.failedCount).toBe(result.total)
+  })
+
+  it('returns task rows for an expanded workflow instance', async () => {
+    const rows = await request('/v1/executions/workflows/1/instances/900006/tasks')
+
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        platformTaskId: 1,
+        taskName: expect.any(String)
+      })
+    ]))
+  })
+})

--- a/frontend/src/views/executions/__tests__/executionMonitorModel.spec.js
+++ b/frontend/src/views/executions/__tests__/executionMonitorModel.spec.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWorkflowExecutionParams,
+  getExecutionRowKey,
+  getExecutionSourceText,
+  getTriggerTypeText
+} from '../executionMonitorModel'
+
+describe('execution monitor model', () => {
+  it('builds list and statistics parameters from one filter snapshot', () => {
+    expect(buildWorkflowExecutionParams({
+      workflowId: '12',
+      pageNum: 2,
+      pageSize: 20,
+      status: 'failed',
+      dateRange: ['2026-07-01 00:00:00', '2026-07-31 23:59:59'],
+      refresh: true
+    })).toEqual({
+      workflowId: 12,
+      pageNum: 2,
+      pageSize: 20,
+      status: 'failed',
+      startTime: '2026-07-01 00:00:00',
+      endTime: '2026-07-31 23:59:59',
+      refresh: true
+    })
+  })
+
+  it('creates stable keys for Dolphin and local pre-submit rows', () => {
+    expect(getExecutionRowKey({ workflowId: 1, instanceId: 88 })).toBe('1-88')
+    expect(getExecutionRowKey({ workflowId: 1, localExecutionLogId: 9 })).toBe('1-local-9')
+  })
+
+  it('maps trigger and source labels', () => {
+    expect(getTriggerTypeText('schedule')).toBe('调度')
+    expect(getTriggerTypeText('backfill')).toBe('补数')
+    expect(getExecutionSourceText('platform')).toBe('平台')
+    expect(getExecutionSourceText('dolphin')).toBe('Dolphin')
+  })
+})

--- a/frontend/src/views/executions/executionMonitorModel.js
+++ b/frontend/src/views/executions/executionMonitorModel.js
@@ -1,0 +1,44 @@
+export const buildWorkflowExecutionParams = ({
+  workflowId,
+  pageNum,
+  pageSize,
+  status,
+  dateRange,
+  refresh = false
+}) => {
+  const params = {
+    pageNum,
+    pageSize,
+    refresh
+  }
+  if (workflowId) params.workflowId = Number(workflowId)
+  if (status) params.status = status
+  if (Array.isArray(dateRange) && dateRange.length === 2) {
+    params.startTime = dateRange[0]
+    params.endTime = dateRange[1]
+  }
+  return params
+}
+
+export const getExecutionRowKey = (row) => {
+  const instanceKey = row.instanceId ?? `local-${row.localExecutionLogId}`
+  return `${row.workflowId}-${instanceKey}`
+}
+
+export const getTriggerTypeText = (type) => {
+  const labels = {
+    manual: '手动',
+    schedule: '调度',
+    backfill: '补数',
+    api: 'API'
+  }
+  return labels[type] || type || '-'
+}
+
+export const getExecutionSourceText = (source) => {
+  const labels = {
+    platform: '平台',
+    dolphin: 'Dolphin'
+  }
+  return labels[source] || source || '-'
+}

--- a/frontend/src/views/tasks/TaskTable.vue
+++ b/frontend/src/views/tasks/TaskTable.vue
@@ -70,7 +70,6 @@
     >
       <el-table-column prop="id" label="任务ID" width="90" />
       <el-table-column prop="taskName" label="任务名称" width="200" />
-      <el-table-column prop="taskCode" label="任务编码" width="150" />
       <el-table-column prop="taskType" label="类型" width="100">
         <template #default="{ row }">
           <el-tag :type="row.taskType === 'batch' ? 'primary' : 'success'">
@@ -111,7 +110,6 @@
           <span v-else class="text-gray">未执行</span>
         </template>
       </el-table-column>
-      <el-table-column prop="scheduleCron" label="调度配置" width="150" />
       <el-table-column prop="status" label="状态" width="100">
         <template #default="{ row }">
           <el-tag :type="getStatusType(row.status)">{{ getStatusText(row.status) }}</el-tag>
@@ -125,7 +123,17 @@
       </el-table-column>
       <el-table-column label="上游任务数" width="120">
         <template #default="{ row }">
-          <el-tag size="small" effect="plain" v-if="row.upstreamTaskCount !== undefined && row.upstreamTaskCount !== null">
+          <el-button
+            v-if="canNavigateRelationCount(row, row.upstreamTaskCount)"
+            link
+            type="primary"
+            class="relation-count-link"
+            title="查看当前任务的上游任务"
+            @click.stop="handleRelationCountClick('upstream', row)"
+          >
+            {{ row.upstreamTaskCount }}
+          </el-button>
+          <el-tag size="small" effect="plain" v-else-if="row.upstreamTaskCount !== undefined && row.upstreamTaskCount !== null">
             {{ row.upstreamTaskCount }}
           </el-tag>
           <span v-else>-</span>
@@ -133,13 +141,22 @@
       </el-table-column>
       <el-table-column label="下游任务数" width="120">
         <template #default="{ row }">
-          <el-tag size="small" effect="plain" v-if="row.downstreamTaskCount !== undefined && row.downstreamTaskCount !== null">
+          <el-button
+            v-if="canNavigateRelationCount(row, row.downstreamTaskCount)"
+            link
+            type="primary"
+            class="relation-count-link"
+            title="查看当前任务的下游任务"
+            @click.stop="handleRelationCountClick('downstream', row)"
+          >
+            {{ row.downstreamTaskCount }}
+          </el-button>
+          <el-tag size="small" effect="plain" v-else-if="row.downstreamTaskCount !== undefined && row.downstreamTaskCount !== null">
             {{ row.downstreamTaskCount }}
           </el-tag>
           <span v-else>-</span>
         </template>
       </el-table-column>
-      <el-table-column prop="owner" label="负责人" width="120" />
       <el-table-column label="操作" width="260" fixed="right">
         <template #default="{ row }">
           <el-button link type="primary" :disabled="isDemoMode" @click="openEditDrawer(row)">编辑</el-button>
@@ -186,6 +203,7 @@ import { taskApi } from '@/api/task'
 import { workflowApi } from '@/api/workflow'
 import { isDemoMode, showDemoReadonlyMessage } from '@/demo/runtime'
 import TaskEditDrawer from '@/components/TaskEditDrawer.vue'
+import { buildRelationCountFilter } from './taskListFilters'
 
 const props = defineProps({
   workflowId: {
@@ -399,6 +417,22 @@ const resetFilters = () => {
   handleFilter()
 }
 
+const canNavigateRelationCount = (row, count) => {
+  return props.showToolbar
+    && props.externalData === null
+    && !row?._isNew
+    && Number(count) > 0
+}
+
+const handleRelationCountClick = (direction, row) => {
+  const relationFilter = buildRelationCountFilter(direction, row?.id)
+  if (!relationFilter) return
+  filters.upstreamTaskId = relationFilter.upstreamTaskId
+  filters.downstreamTaskId = relationFilter.downstreamTaskId
+  pagination.pageNum = 1
+  loadData()
+}
+
 const openCreateDrawer = () => {
   if (isDemoMode) {
     showDemoReadonlyMessage('新建任务')
@@ -485,6 +519,9 @@ const getStatusText = (status) => {
 const getExecutionStatusType = (status) => {
   const types = {
     pending: 'info',
+    waiting: 'warning',
+    not_run: 'info',
+    unavailable: 'danger',
     running: 'warning',
     success: 'success',
     failed: 'danger',
@@ -496,6 +533,9 @@ const getExecutionStatusType = (status) => {
 const getExecutionStatusText = (status) => {
   const texts = {
     pending: '等待中',
+    waiting: '等待执行',
+    not_run: '本次未运行',
+    unavailable: '状态不可用',
     running: '运行中',
     success: '成功',
     failed: '失败',
@@ -593,5 +633,10 @@ defineExpose({
   color: #909399;
 }
 
+.relation-count-link {
+  min-height: auto;
+  padding: 0 8px;
+  font-weight: 600;
+}
 
 </style>

--- a/frontend/src/views/tasks/__tests__/taskListFilters.spec.js
+++ b/frontend/src/views/tasks/__tests__/taskListFilters.spec.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { buildRelationCountFilter } from '../taskListFilters'
+
+describe('task list relation count filters', () => {
+  it('fills downstreamTaskId when the upstream count is clicked', () => {
+    expect(buildRelationCountFilter('upstream', 12)).toEqual({
+      upstreamTaskId: '',
+      downstreamTaskId: 12
+    })
+  })
+
+  it('fills upstreamTaskId when the downstream count is clicked', () => {
+    expect(buildRelationCountFilter('downstream', '18')).toEqual({
+      upstreamTaskId: 18,
+      downstreamTaskId: ''
+    })
+  })
+
+  it('rejects invalid task ids and directions', () => {
+    expect(buildRelationCountFilter('upstream', '')).toBeNull()
+    expect(buildRelationCountFilter('upstream', 0)).toBeNull()
+    expect(buildRelationCountFilter('unknown', 1)).toBeNull()
+  })
+
+  it('keeps task id and name while removing internal list columns', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/views/tasks/TaskTable.vue'), 'utf8')
+
+    expect(source).toContain('label="任务ID"')
+    expect(source).toContain('label="任务名称"')
+    expect(source).not.toContain('label="任务编码"')
+    expect(source).not.toContain('label="调度配置"')
+    expect(source).not.toContain('label="负责人"')
+  })
+})

--- a/frontend/src/views/tasks/taskListFilters.js
+++ b/frontend/src/views/tasks/taskListFilters.js
@@ -1,0 +1,23 @@
+const toPositiveTaskId = (value) => {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+export const buildRelationCountFilter = (direction, taskId) => {
+  const resolvedTaskId = toPositiveTaskId(taskId)
+  if (!resolvedTaskId) return null
+
+  if (direction === 'upstream') {
+    return {
+      upstreamTaskId: '',
+      downstreamTaskId: resolvedTaskId
+    }
+  }
+  if (direction === 'downstream') {
+    return {
+      upstreamTaskId: resolvedTaskId,
+      downstreamTaskId: ''
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- 展示 Dolphin 任务实例级“最近执行”，避免同一工作流内的任务共享工作流级状态。
- 将执行监控升级为工作流实例父行、任务实例懒加载子行，并统一展示平台手动、补数和 Dolphin 定时触发。
- 精简任务列表字段，并支持点击上下游数量直接反向筛选关联任务。

## What Changed

### Behavior Changes

- Dolphin 客户端新增任务实例分页查询，同时兼容 3.2/3.4 的实例 ID 请求参数与返回字段。
- 任务列表按工作流批量读取最新工作流实例，再用 `dolphinTaskCode` 映射各任务状态，支持“等待执行”“本次未运行”“状态不可用”。
- 新增工作流实例监控与任务实例展开接口；Dolphin 实例和平台日志按外部实例 ID 去重，保留提交 Dolphin 前失败的本地记录。
- 执行监控顶层改为工作流实例，展开时局部加载任务实例；单行加载失败可独立重试。
- 任务列表移除任务编码、调度配置、负责人列，保留任务 ID 和任务名称。
- 上下游数量点击后自动填写对应反向搜索条件、清除互斥条件并立即查询。
- 旧执行历史接口继续保留，本次无数据库迁移。

### Key Files

- `backend/src/main/java/com/onedata/portal/service/WorkflowExecutionMonitorService.java`: 聚合 Dolphin 工作流实例、缓存和平台执行日志。
- `backend/src/main/java/com/onedata/portal/service/DataTaskService.java`: 批量解析任务级最近执行状态。
- `backend/src/main/java/com/onedata/portal/service/dolphin/DolphinOpenApiClient.java`: 新增兼容 3.2/3.4 的任务实例查询。
- `frontend/src/views/executions/ExecutionMonitor.vue`: 工作流实例父子层级监控页面。
- `frontend/src/views/tasks/TaskTable.vue`: 列表字段精简和上下游点击筛选。
- `docs/design/2026-07-31-task-list-execution-monitoring-design.md`: 方案与兼容策略。
- `docs/plans/2026-07-31-task-list-execution-monitoring-plan.md`: 实施与验证记录。

## Validation

- `mvn -pl backend -am -DskipTests compile`
  - 结果：通过。
- `mvn -pl backend -am -Dtest='DolphinTaskInstanceCompatibilityTest,DolphinSchedulerServiceTest,WorkflowExecutionMonitorServiceTest,WorkflowExecutionServiceTest,DataTaskServiceWorkflowMetadataTest,TaskExecutionControllerTest,TaskExecutionServiceTest' -Dsurefire.failIfNoSpecifiedTests=false test`
  - 结果：32 项通过，0 失败，0 错误，0 跳过。
- `npm --prefix frontend run test -- src/views/tasks/__tests__/taskListFilters.spec.js src/views/executions/__tests__/executionMonitorModel.spec.js src/views/executions/__tests__/ExecutionMonitor.demo.spec.js`
  - 结果：3 个测试文件、9 项测试通过。
- `npm --prefix frontend run build`
  - 结果：通过，仅有既有 Sass legacy API 和大 chunk 警告。
- `git diff --check`
  - 结果：通过。
- 真实 Dolphin smoke：未完成。MySQL、Redis、Dolphin 曾通过连通性预检，但 Dolphin standalone 随后因 Podman VM 内存不足退出（137 / OOMKilled）；按用户决定不再继续联调。

## Risks

- 主要风险：不同 Dolphin 小版本的真实任务实例字段、触发方式和状态仍需在可稳定运行的 Dolphin 环境中完成端到端核对。

## Rollback

- 回退此提交即可恢复旧监控页面与任务列表；旧执行历史接口和缓存表未删除，无需回滚数据库。

## Checklist

- [x] No secrets or credentials introduced.
- [x] Backward compatibility reviewed; old execution APIs are retained.
- [x] Documentation updated.
- [ ] Real platform manual and Dolphin scheduled smoke completed.
