### PR TITLE
表信息按两列展示，表详情去掉一层卡片边框

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,16 @@ When working in this repository, optimize for:
 - When introducing Tailwind CSS, do it incrementally and only for the touched UI area.
 - Keep frontend changes aligned with the existing Vue component structure and routing/state patterns already in the repo.
 
+### Frontend visual structure rules
+
+- Keep visible frames shallow. Two levels of border are the normal maximum: the outer panel or card, and the content's own frame.
+- `Element Plus` content components usually bring their own frame (`el-table` with `border`, `el-descriptions` with `border`, code blocks, metric cards). Do not wrap them in another bordered or tinted card.
+- Every wrapper element must earn its place. Drop a container that has a single child and provides no title, no actions, and no layout of its own.
+- Prefer a section title plus whitespace over a card frame when grouping sibling blocks. When frames are removed, increase the gap between blocks so grouping stays readable.
+- Use the available horizontal space. A key-value block that fills its container should render multiple columns (`el-descriptions` with `:column="2"` or more) instead of one narrow column; give long text items a full-width span.
+- For panes inside a user-resizable pane, pick the column count from the measured container width and fall back to fewer columns when it gets narrow, instead of hardcoding a count that only works at one width.
+- When changing the visual structure of one tab or pane, apply the same treatment to its sibling tabs or panes in the same container. Do not leave one surface flat and its neighbors nested.
+
 ### Node / nvm baseline
 
 - This repository uses `nvm`.

--- a/frontend/src/views/datastudio/__tests__/DataStudioRightPanel.smoke.spec.js
+++ b/frontend/src/views/datastudio/__tests__/DataStudioRightPanel.smoke.spec.js
@@ -4,7 +4,7 @@
 // computed 与模板渲染。若 F17 抽取破坏了引用或响应式,挂载/渲染会抛错。
 import { describe, it, expect, vi } from 'vitest'
 import { flushPromises, shallowMount } from '@vue/test-utils'
-import { reactive, ref } from 'vue'
+import { nextTick, reactive, ref } from 'vue'
 
 const { apiStub, listPartitionsMock } = vi.hoisted(() => {
   const listPartitionsMock = vi.fn(() => Promise.resolve([]))
@@ -140,6 +140,67 @@ describe('DataStudioRightPanel mount smoke', () => {
       expect(wrapper.find(marker).exists()).toBe(true)
       wrapper.unmount()
     }
+  })
+
+  it('表信息默认两列，面板收窄后退回一列', async () => {
+    // 两列布局与「Doris信息」一致；右栏可拖到 400px 下限，窄面板下退回一列
+    const observers = []
+    class MockResizeObserver {
+      constructor(callback) {
+        this.callback = callback
+        observers.push(this)
+      }
+      observe() {}
+      disconnect() {}
+      emit(width) {
+        this.callback([{ contentRect: { width } }])
+      }
+    }
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+    const wrapper = shallowMount(DataStudioRightPanelBasic, {
+      global: {
+        provide: { dataStudioCtx: buildCtx() },
+        stubs: {
+          TableTrendDialog: true,
+          ElScrollbar: { template: '<div><slot /></div>' },
+          ElDescriptions: {
+            props: ['column'],
+            template: '<div class="desc" :data-column="column"><slot /></div>',
+          },
+          ElDescriptionsItem: {
+            props: ['label', 'span'],
+            template: '<div class="desc-item" :data-label="label" :data-span="span"><slot /></div>',
+          },
+        },
+        config: { warnHandler: () => {} },
+        directives: { loading: {} },
+      },
+    })
+    const column = () => wrapper.find('.desc').attributes('data-column')
+    // 表注释是长文本，跨满整行
+    const commentSpan = () =>
+      wrapper.findAll('.desc-item').find((n) => n.attributes('data-label') === '表注释').attributes('data-span')
+
+    expect(column()).toBe('2')
+    expect(commentSpan()).toBe('2')
+
+    observers[0].emit(360)
+    await nextTick()
+    expect(column()).toBe('1')
+    expect(commentSpan()).toBe('1')
+
+    observers[0].emit(720)
+    await nextTick()
+    expect(column()).toBe('2')
+
+    // tab 隐藏时宽度为 0，不能把列数抖回一列
+    observers[0].emit(0)
+    await nextTick()
+    expect(column()).toBe('2')
+
+    wrapper.unmount()
+    vi.unstubAllGlobals()
   })
 
   it('访问概况展示同步关闭状态和历史覆盖信息', () => {

--- a/frontend/src/views/datastudio/__tests__/DataStudioRightPanel.smoke.spec.js
+++ b/frontend/src/views/datastudio/__tests__/DataStudioRightPanel.smoke.spec.js
@@ -123,7 +123,7 @@ describe('DataStudioRightPanel mount smoke', () => {
 
   it('mounts each pane child with the ctx (P2-2 F17d)', () => {
     const panes = [
-      [DataStudioRightPanelBasic, '.basic-grid'],
+      [DataStudioRightPanelBasic, '.meta-descriptions'],
       [DataStudioRightPanelColumns, '.section-block'],
       [DataStudioRightPanelAccess, '.section-block'],
     ]

--- a/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanel.vue
@@ -680,11 +680,9 @@ const {
   min-height: 0;
 }
 
+/* 区块只做分组与间距，不再自带边框/底色：里面的表格、描述列表、代码框都
+   已经有自己的边框，再套一层卡片就是「面板边框 + 卡片边框 + 内容边框」三层套娃 */
 .meta-tabs :deep(.section-block) {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel-muted);
-  padding: 10px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/frontend/src/views/datastudio/components/DataStudioRightPanelBasic.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanelBasic.vue
@@ -1,15 +1,18 @@
 <template>
-  <div class="meta-section meta-section-fill">
-    <div class="basic-grid single">
+  <div ref="basicRootRef" class="meta-section meta-section-fill">
+    <div class="basic-grid">
       <!-- 不再重复 tab 名「表信息」作为区块标题 -->
       <section class="section-block">
         <el-scrollbar class="meta-scroll">
-          <el-descriptions :column="1" border size="small" class="meta-descriptions">
+          <el-descriptions :column="descColumn" border size="small" class="meta-descriptions">
             <el-descriptions-item label="表名">
               <el-input v-if="state.metaEditing" v-model="state.metaForm.tableName" size="small" class="meta-input" />
               <span v-else>{{ state.table.tableName || '-' }}</span>
             </el-descriptions-item>
-            <el-descriptions-item label="表注释">
+            <el-descriptions-item label="数据库">
+              <span>{{ state.table.dbName || '-' }}</span>
+            </el-descriptions-item>
+            <el-descriptions-item label="表注释" :span="descColumn">
               <el-input
                 v-if="state.metaEditing"
                 v-model="state.metaForm.tableComment"
@@ -70,9 +73,6 @@
               <el-input v-if="state.metaEditing" v-model="state.metaForm.owner" size="small" class="meta-input" />
               <span v-else>{{ state.table.owner || '-' }}</span>
             </el-descriptions-item>
-            <el-descriptions-item label="数据库">
-              <span>{{ state.table.dbName || '-' }}</span>
-            </el-descriptions-item>
             <el-descriptions-item label="行数">
               <el-button
                 link
@@ -111,7 +111,7 @@
 </template>
 
 <script setup>
-import { computed, inject, ref } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue'
 import TableTrendDialog from './TableTrendDialog.vue'
 import {
   resolveTableRowCount,
@@ -147,28 +147,50 @@ const state = computed(() => {
 })
 const dataDomainOptions = computed(() => getMetaDataDomainOptions(activeTabId.value))
 const trendDialogRef = ref(null)
+
+// 表信息与「Doris信息」一样按两列排（原来是一列，Doris 配置块拆到独立 tab 后
+// 整块占满面板宽度，一列会浪费右侧一半横向空间）。右栏可拖到 400px 下限，
+// 两列时每个值列只剩 100px 出头，所以窄于阈值时退回一列。
+const TWO_COLUMN_MIN_WIDTH = 440
+const basicRootRef = ref(null)
+const descColumn = ref(2)
+let resizeObserver = null
+
+const syncDescColumn = (width) => {
+  if (!width) return
+  descColumn.value = width >= TWO_COLUMN_MIN_WIDTH ? 2 : 1
+}
+
+onMounted(() => {
+  const el = basicRootRef.value
+  if (!el) return
+  syncDescColumn(el.getBoundingClientRect().width)
+  if (typeof ResizeObserver === 'undefined') return
+  resizeObserver = new ResizeObserver((entries) => {
+    syncDescColumn(entries[0]?.contentRect?.width)
+  })
+  resizeObserver.observe(el)
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+})
 </script>
 
 <style scoped>
+/* Doris 配置块拆到独立 tab 后这里只剩表信息一块，占满面板宽度 */
 .basic-grid {
   flex: 1;
   min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
-  gap: 10px;
+  display: flex;
+  flex-direction: column;
 }
 
-.basic-grid.single {
-  grid-template-columns: 1fr;
-}
-
-.doris-block {
-  background: var(--accent-soft);
-}
-
+/* 96px 刚好放下最长的「Doris创建时间」，两列时能多留 24px 给值列 */
 .meta-descriptions :deep(.el-descriptions__label.is-bordered-label) {
-  width: 108px;
-  min-width: 108px;
+  width: 96px;
+  min-width: 96px;
   white-space: nowrap;
   color: var(--text-sub);
 }
@@ -186,40 +208,5 @@ const trendDialogRef = ref(null)
 .metric-link {
   padding: 0;
   font-weight: 600;
-}
-
-.replica-edit {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.replica-warning {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-  color: #d14343;
-}
-
-.replica-value {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.replica-danger {
-  color: #d14343;
-  font-weight: 600;
-}
-
-.warning-icon {
-  font-size: 12px;
-}
-@media (max-width: 1200px) {
-  .basic-grid {
-    grid-template-columns: 1fr;
-  }
 }
 </style>

--- a/frontend/src/views/datastudio/components/DataStudioRightPanelBasic.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanelBasic.vue
@@ -1,110 +1,107 @@
 <template>
+  <!-- 没有区块标题，也没有第二个区块，所以不套 section-block：
+       描述列表自带边框，直接挂在 tab 内容区上 -->
   <div ref="basicRootRef" class="meta-section meta-section-fill">
-    <div class="basic-grid">
-      <!-- 不再重复 tab 名「表信息」作为区块标题 -->
-      <section class="section-block">
-        <el-scrollbar class="meta-scroll">
-          <el-descriptions :column="descColumn" border size="small" class="meta-descriptions">
-            <el-descriptions-item label="表名">
-              <el-input v-if="state.metaEditing" v-model="state.metaForm.tableName" size="small" class="meta-input" />
-              <span v-else>{{ state.table.tableName || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="数据库">
-              <span>{{ state.table.dbName || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="表注释" :span="descColumn">
-              <el-input
-                v-if="state.metaEditing"
-                v-model="state.metaForm.tableComment"
-                size="small"
-                class="meta-input"
-              />
-              <span v-else>{{ state.table.tableComment || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="分层">
-              <el-select
-                v-if="state.metaEditing"
-                v-model="state.metaForm.layer"
-                size="small"
-                placeholder="选择分层（必填）"
-                class="meta-input"
-              >
-                <el-option v-for="item in layerOptions" :key="item.value" :label="item.label" :value="item.value" />
-              </el-select>
-              <span v-else>{{ state.table.layer || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="业务域">
-              <el-select
-                v-if="state.metaEditing"
-                v-model="state.metaForm.businessDomain"
-                size="small"
-                placeholder="选择业务域"
-                class="meta-input"
-                @change="handleMetaBusinessDomainChange(activeTabId)"
-              >
-                <el-option
-                  v-for="item in businessDomainOptions"
-                  :key="item.domainCode"
-                  :label="`${item.domainCode} - ${item.domainName}`"
-                  :value="item.domainCode"
-                />
-              </el-select>
-              <span v-else>{{ state.table.businessDomain || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="数据域">
-              <el-select
-                v-if="state.metaEditing"
-                v-model="state.metaForm.dataDomain"
-                size="small"
-                placeholder="选择数据域"
-                class="meta-input"
-                :disabled="!state.metaForm.businessDomain"
-              >
-                <el-option
-                  v-for="item in dataDomainOptions"
-                  :key="item.domainCode"
-                  :label="`${item.domainCode} - ${item.domainName}`"
-                  :value="item.domainCode"
-                />
-              </el-select>
-              <span v-else>{{ state.table.dataDomain || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="负责人">
-              <el-input v-if="state.metaEditing" v-model="state.metaForm.owner" size="small" class="meta-input" />
-              <span v-else>{{ state.table.owner || '-' }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="行数">
-              <el-button
-                link
-                type="primary"
-                class="metric-link"
-                :disabled="!state.table?.id"
-                @click="trendDialogRef?.open('rowCount')"
-              >
-                {{ formatRowCountDisplay(resolveTableRowCount(state.table)) }}
-              </el-button>
-            </el-descriptions-item>
-            <el-descriptions-item label="数据量">
-              <el-button
-                link
-                type="primary"
-                class="metric-link"
-                :disabled="!state.table?.id"
-                @click="trendDialogRef?.open('dataSize')"
-              >
-                {{ formatStorageSizeDisplay(resolveTableStorageSize(state.table)) }}
-              </el-button>
-            </el-descriptions-item>
-            <el-descriptions-item label="Doris创建时间">
-              <span>{{ formatDateTime(resolveTableDorisCreateTime(state.table)) }}</span>
-            </el-descriptions-item>
-            <el-descriptions-item label="Doris更新时间">
-              <span>{{ formatDateTime(resolveTableDorisUpdateTime(state.table)) }}</span>
-            </el-descriptions-item>
-          </el-descriptions>
-        </el-scrollbar>
-      </section>
-    </div>
+    <el-scrollbar class="meta-scroll">
+      <el-descriptions :column="descColumn" border size="small" class="meta-descriptions">
+        <el-descriptions-item label="表名">
+          <el-input v-if="state.metaEditing" v-model="state.metaForm.tableName" size="small" class="meta-input" />
+          <span v-else>{{ state.table.tableName || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="数据库">
+          <span>{{ state.table.dbName || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="表注释" :span="descColumn">
+          <el-input
+            v-if="state.metaEditing"
+            v-model="state.metaForm.tableComment"
+            size="small"
+            class="meta-input"
+          />
+          <span v-else>{{ state.table.tableComment || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="分层">
+          <el-select
+            v-if="state.metaEditing"
+            v-model="state.metaForm.layer"
+            size="small"
+            placeholder="选择分层（必填）"
+            class="meta-input"
+          >
+            <el-option v-for="item in layerOptions" :key="item.value" :label="item.label" :value="item.value" />
+          </el-select>
+          <span v-else>{{ state.table.layer || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="业务域">
+          <el-select
+            v-if="state.metaEditing"
+            v-model="state.metaForm.businessDomain"
+            size="small"
+            placeholder="选择业务域"
+            class="meta-input"
+            @change="handleMetaBusinessDomainChange(activeTabId)"
+          >
+            <el-option
+              v-for="item in businessDomainOptions"
+              :key="item.domainCode"
+              :label="`${item.domainCode} - ${item.domainName}`"
+              :value="item.domainCode"
+            />
+          </el-select>
+          <span v-else>{{ state.table.businessDomain || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="数据域">
+          <el-select
+            v-if="state.metaEditing"
+            v-model="state.metaForm.dataDomain"
+            size="small"
+            placeholder="选择数据域"
+            class="meta-input"
+            :disabled="!state.metaForm.businessDomain"
+          >
+            <el-option
+              v-for="item in dataDomainOptions"
+              :key="item.domainCode"
+              :label="`${item.domainCode} - ${item.domainName}`"
+              :value="item.domainCode"
+            />
+          </el-select>
+          <span v-else>{{ state.table.dataDomain || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="负责人">
+          <el-input v-if="state.metaEditing" v-model="state.metaForm.owner" size="small" class="meta-input" />
+          <span v-else>{{ state.table.owner || '-' }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="行数">
+          <el-button
+            link
+            type="primary"
+            class="metric-link"
+            :disabled="!state.table?.id"
+            @click="trendDialogRef?.open('rowCount')"
+          >
+            {{ formatRowCountDisplay(resolveTableRowCount(state.table)) }}
+          </el-button>
+        </el-descriptions-item>
+        <el-descriptions-item label="数据量">
+          <el-button
+            link
+            type="primary"
+            class="metric-link"
+            :disabled="!state.table?.id"
+            @click="trendDialogRef?.open('dataSize')"
+          >
+            {{ formatStorageSizeDisplay(resolveTableStorageSize(state.table)) }}
+          </el-button>
+        </el-descriptions-item>
+        <el-descriptions-item label="Doris创建时间">
+          <span>{{ formatDateTime(resolveTableDorisCreateTime(state.table)) }}</span>
+        </el-descriptions-item>
+        <el-descriptions-item label="Doris更新时间">
+          <span>{{ formatDateTime(resolveTableDorisUpdateTime(state.table)) }}</span>
+        </el-descriptions-item>
+      </el-descriptions>
+    </el-scrollbar>
   </div>
 
   <TableTrendDialog ref="trendDialogRef" :table="state?.table" />
@@ -179,14 +176,6 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-/* Doris 配置块拆到独立 tab 后这里只剩表信息一块，占满面板宽度 */
-.basic-grid {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
 /* 96px 刚好放下最长的「Doris创建时间」，两列时能多留 24px 给值列 */
 .meta-descriptions :deep(.el-descriptions__label.is-bordered-label) {
   width: 96px;

--- a/frontend/src/views/datastudio/components/DataStudioRightPanelDoris.vue
+++ b/frontend/src/views/datastudio/components/DataStudioRightPanelDoris.vue
@@ -210,8 +210,9 @@ watch(pageSize, () => {
 .warning-icon {
   font-size: 13px;
 }
+/* 区块不再有卡片边框，两块之间靠留白分隔，间距比原来大一点 */
 .partition-block {
-  margin-top: 10px;
+  margin-top: 16px;
 }
 .partition-count {
   color: var(--text-muted);


### PR DESCRIPTION
## 背景

Data Studio 表详情面板有两个遗留问题：

1. **表信息只有一列**。`:column="1"` 在 db1eef1 之前是合理的——那时右侧是「表信息 + Doris 配置」两块并排的 grid，表信息只占左半边。Doris 配置拆到独立 tab 后，表信息块占满了面板宽度，一列就白白空掉右侧一半横向空间，而同一面板里的「Doris信息」是两列。
2. **三层套娃边框**。面板边框 → `.section-block` 卡片边框（还带底色）→ 内容自己的边框（描述列表、表格、代码框都是 `border` 的）。六个 tab 全是这个套法。

## 改动

### 表信息改为两列（5637751）

- 行分组：表名/数据库、表注释（整行）、分层/业务域、数据域/负责人、行数/数据量、Doris创建时间/Doris更新时间。11 项正好排满 6 行，不留空格子。
- 表注释是长文本，跨满整行。
- 右栏可拖到 400px 下限，两列时每个值列只剩 100px 出头，所以用 `ResizeObserver` 观察面板宽度，窄于 440px 时退回一列；tab 隐藏时宽度为 0，这种情况不改列数，避免抖动。
- 标签列 108px → 96px：96px 刚好放下最长的「Doris创建时间」，两列时多留 24px 给值列。
- 清掉 Doris 块搬走后遗留的死样式（`.basic-grid` 两列 grid 与 1200px 媒体查询、`.doris-block`、`.replica-*`、`.warning-icon`）。

### 去掉一层卡片边框（8a6d33b）

- `.meta-tabs` 里的 `.section-block` 只保留分组与间距，去掉 `border` / `border-radius` / `background` / `padding`，内容框直接挂在 tab 内容区上。一处 CSS，六个 tab 一致生效。
- 表信息本来就没有区块标题，也没有第二个区块，连 `section-block` 一起去掉：现在是 `.meta-section > el-scrollbar > el-descriptions`，比原来少三层容器。
- Doris信息 两个区块之间没有卡片边界了，靠留白分组，间距 10px → 16px。
- 内容宽度顺带多出约 20px（少了卡片的左右 padding 与边框）。

### 规则沉淀到 AGENTS.md（11610a7）

新增 `### Frontend visual structure rules`：可见边框最多两层；自带边框的内容组件不再套卡片；单子元素且无标题/操作/布局的包装层要去掉；同级区块用「标题 + 留白」分组；填满横向空间用多列；可拖拽面板按实测宽度决定列数；改一个 tab 的视觉结构时兄弟 tab 一并处理。

## 验证

- `npx vitest run`：39 文件 238 用例全绿，含新增的列数回归用例（默认两列 → 收窄到 360px 变一列 → 拉宽回两列 → 宽度 0 时不变）。
- `npx eslint` 触及文件通过。
- `npm run build` 通过。
- 用 Chromium 按右栏 400 / 480 / 700px 三档实测行分组与换行表现，并出了表信息 / Doris信息 / DDL 三个 tab 的改前改后对照图确认只剩两层边框。

## 已知取舍

480px 一档（1600 视口默认宽度）两列下表名和两个时间会各折成两行；要完全不折行需把阈值提到 500px，但那样 1600 视口默认就看不到两列了。这里按「优先多列」选了 440px 阈值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFd4j1aC2qRUkAdDVjieEt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFd4j1aC2qRUkAdDVjieEt)_