### PR TITLE
fix(dataagent): 工作区边界放行 /dev/null

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -49,6 +49,13 @@ _FILE_BOUNDARY_PATH_KEYS = {
     "NotebookEdit": ("notebook_path",),
 }
 _BASH_PARENT_SEGMENT_RE = re.compile(r"(^|[\s;&|()])\.\.(?=$|[/\s;&|()])")
+# Not a filesystem location but a discard sink: writes store nothing and reads hit
+# EOF immediately. `> /dev/null 2>&1` is ubiquitous in shell commands, so denying
+# it as "outside workspace" is pure friction with no isolation value. This is not
+# part of the configurable scratch allow-list (``dataagent_workspace_scratch_dirs``)
+# because it is a fixed POSIX property, not a deployment choice. Matched exactly:
+# the rest of /dev — and any path under /dev/null — stays outside the boundary.
+_DISCARD_SINK_PATHS: frozenset[Path] = frozenset({Path("/dev/null")})
 _URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 # Claude Code offloads oversized tool results as either a ".txt" (string result)
 # or ".json" (structured result) file under the per-project tool-results dir.
@@ -140,6 +147,11 @@ def _path_is_under(path: Path, root: Path) -> bool:
 
 def _path_is_allowed(path: Path, allowed_roots: list[Path]) -> bool:
     return any(_path_is_under(path, root) for root in allowed_roots)
+
+
+def _is_discard_sink(path: Path) -> bool:
+    """Whether ``path`` is a no-op sink the boundary never needs to guard."""
+    return path in _DISCARD_SINK_PATHS
 
 
 def _resolve_claude_project_data_dir(workspace: Path, runtime_env: dict[str, str] | None) -> Path | None:
@@ -361,6 +373,8 @@ def _validate_bash_workspace_boundary(
         candidate = Path(normalized).expanduser().resolve(strict=False)
         if allowed_executable and candidate == allowed_executable:
             continue
+        if _is_discard_sink(candidate):
+            continue
         if _path_is_allowed(candidate, allowed_roots):
             continue
         if (
@@ -405,6 +419,8 @@ def _validate_workspace_tool_boundary(
             return f"{normalized_tool} {key} uses a parent directory segment; stay inside the current agent workspace."
         candidate = _resolve_workspace_candidate(value, workspace)
         if _path_is_allowed(candidate, allowed_roots):
+            continue
+        if _is_discard_sink(candidate):
             continue
         if _is_offloaded_tool_result_path(candidate, tool_result_root):
             continue

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -432,6 +432,53 @@ def test_workspace_boundary_allows_configured_scratch_dir(tmp_path: Path):
     assert "outside workspace" in denial
 
 
+def test_workspace_boundary_allows_dev_null_redirects(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "topic_1" / "workspace"
+    workspace.mkdir(parents=True)
+    runtime_env = {"DATAAGENT_PYTHON_BIN": sys.executable}
+    # No scratch dirs configured: /dev/null is allowed on its own, not by virtue of
+    # some directory being whitelisted.
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    for command in (
+        "python export.py > /dev/null 2>&1",
+        "grep -q pattern data.csv 2>/dev/null",
+        "python check.py 1>/dev/null",
+        "cat /dev/null > notes.md",
+    ):
+        assert agent_runtime._validate_workspace_tool_boundary(
+            "Bash", {"command": command}, workspace, allowed_roots, runtime_env
+        ) is None, command
+
+
+def test_workspace_boundary_still_denies_rest_of_dev(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "topic_1" / "workspace"
+    workspace.mkdir(parents=True)
+    runtime_env = {"DATAAGENT_PYTHON_BIN": sys.executable}
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    # The sink is matched exactly: neighbouring devices and anything "under"
+    # /dev/null must not ride along.
+    for command in (
+        "cat /dev/zero",
+        "head -c 16 /dev/urandom",
+        "cat /dev/null/passwd",
+        "ls /dev",
+        "echo leaked > /dev/sda",
+    ):
+        denial = agent_runtime._validate_workspace_tool_boundary(
+            "Bash", {"command": command}, workspace, allowed_roots, runtime_env
+        )
+        assert denial is not None, command
+        assert "outside workspace" in denial
+
+    denial = agent_runtime._validate_workspace_tool_boundary(
+        "Write", {"file_path": "/dev/sda"}, workspace, allowed_roots, runtime_env
+    )
+    assert denial is not None
+    assert "outside workspace" in denial
+
+
 def test_workspace_boundary_hook_allows_scratch_dir_from_config(tmp_path: Path, monkeypatch):
     workspace = tmp_path / "runtime" / "topic_1" / "workspace"
     workspace.mkdir(parents=True)

--- a/docs/design/2026-08-11-dataagent-workspace-scratch-allowlist-design.md
+++ b/docs/design/2026-08-11-dataagent-workspace-scratch-allowlist-design.md
@@ -64,6 +64,11 @@ DataAgent 运行时用 `PreToolUse` 边界钩子约束 agent 的文件访问范�
 6. `sandbox_runner_main` 把 `DATAAGENT_WORKSPACE_SCRATCH_DIRS` 加入
    `_FORWARDED_ENV_KEYS`。边界钩子实际是在子容器进程里执行的，不转发这个 env，
    沙箱模式下配置不会生效。
+7. `/dev/null` 由固定常量 `_DISCARD_SINK_PATHS` 精确匹配放行，不进可配置白名单。
+   它不是目录而是丢弃设备：写入不留任何状态，读取直接 EOF，`> /dev/null 2>&1`
+   在 shell 命令里极其常见，按「越界」拒绝只有摩擦没有隔离收益。
+   这是 POSIX 的固定性质而非部署选择，因此不做成配置项；匹配是精确相等的，
+   `/dev` 下其它设备和 `/dev/null/<x>` 仍然拒绝。
 
 ## Interfaces and Compatibility
 
@@ -84,3 +89,20 @@ DataAgent 运行时用 `PreToolUse` 边界钩子约束 agent 的文件访问范�
   这类部署应按需把该配置改成一个专用目录（例如 `/var/lib/dataagent/scratch`）或置空。
 - 临时目录里的文件不会出现在会话文件列表，也无法通过前端下载。
   这是有意的：交付物路径契约仍然只有工作区 `output/`。
+
+## Known Gap（既有问题，不在本次变更范围内）
+
+`_validate_bash_workspace_boundary` 只校验以 `/` 开头的 token，因此嵌在
+`key=value` / `--flag=path` 里的绝对路径、以及经 shell 变量间接引用的路径
+不会被检查：
+
+- `cat /etc/shadow` → 拒绝
+- `dd if=/etc/shadow of=out.bin` → 放行
+- `tar --file=/etc/passwd -x` → 放行
+- `FOO=/etc/shadow cat $FOO` → 放行
+
+这是边界钩子既有的缺口，与本次白名单变更无关，本次也未修改。修复需要解析
+token 中 `=` 之后的路径值，会改变一批现有命令的判定结果（例如
+`--opt=/tmp/x` 应放行、`LANG=en_US.UTF-8` 不能误判），影响面和误拒风险都需要
+单独评估，应作为独立变更处理。当前 Bash 边界仍是「信任模型自觉」的信任边界，
+不是硬保证——这一点与 `permission_gate.plan_denies_tool` 中已有的说明一致。


### PR DESCRIPTION
## 问题

`> /dev/null 2>&1`、`2>/dev/null` 是极常见的 shell 写法，但边界钩子会把重定向目标 `/dev/null` 判成越界并拒绝执行：

```
Bash command references absolute path outside workspace: /dev/null
```

## 改动

`/dev/null` 不是目录，所以扩大目录白名单不是正确的修法——它是丢弃设备：写入不留任何状态，读取直接 EOF，按「越界」拒绝只有摩擦没有隔离收益。

用固定常量 `_DISCARD_SINK_PATHS` 精确匹配放行，**不并入可配置的 `dataagent_workspace_scratch_dirs`**——这是 POSIX 的固定性质而非部署选择，做成配置项反而会诱导有人往里填 `/dev`。Bash 重定向目标和文件工具路径参数走同一条规则。

## 边界没有被顺带撑开

匹配是精确相等的，实测（默认配置，直接调用真实钩子）：

| 命令 | 结果 |
|---|---|
| `python export.py > /dev/null 2>&1` | ALLOW |
| `grep -q pattern data.csv 2>/dev/null` | ALLOW |
| `python run.py > /tmp/out.log 2>/dev/null` | ALLOW |
| `cat /dev/zero` | DENY |
| `ls /dev` | DENY |
| `cat /dev/null/passwd` | DENY |
| `Write /dev/sda` | DENY |

## 验证

- `pytest` 430 通过，新增 2 个用例分别覆盖放行侧和拒绝侧。
- 未改系统提示词：agent 本来就在用 `2>/dev/null`（所以才会触发报错），加提示词只是膨胀。

## 附带：设计文档记录了一个既有缺口（本次未修改）

写测试时发现边界校验只检查以 `/` 开头的 token，嵌在 `key=value` / `--flag=path` 中的绝对路径不受校验。已在**改动前的干净代码**上复现确认，与本次及上次变更均无关：

```
cat /etc/shadow              → 拒绝
dd if=/etc/shadow of=out.bin → 放行
tar --file=/etc/passwd -x    → 放行
FOO=/etc/shadow cat $FOO     → 放行
```

未顺手修复：修复需解析 token 中 `=` 之后的路径值，会改变一批现有命令的判定结果（`--opt=/tmp/x` 应放行、`LANG=en_US.UTF-8` 不能误判），误拒风险需单独评估。已记入设计文档 Known Gap 一节，作为独立变更处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsWgo6y8WMrQ3CG7ZjxEY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsWgo6y8WMrQ3CG7ZjxEY6)_