### PR TITLE
fix(dataagent): 边界校验覆盖赋值式参数中的绝对路径

### DIFF
--- a/dataagent/dataagent-backend/core/agent_runtime.py
+++ b/dataagent/dataagent-backend/core/agent_runtime.py
@@ -66,6 +66,16 @@ _OFFLOADED_TOOL_RESULT_SUFFIXES = frozenset({".txt", ".json"})
 # word, not an operator.
 _BASH_OPERATOR_CHARS = frozenset("();<>|&")
 _BASH_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# A word shaped like ``<name>=<value>``: an env assignment (``FOO=/x``), a
+# short/long option with an inline value (``-o=/x``, ``--file=/x``), or a tool's
+# own key syntax (``dd if=/x``). The name part is deliberately strict — letters,
+# digits, ``_``/``-``, at most two leading dashes — so words that merely contain
+# "=" after other punctuation (``sed 's/a=/b/'``) are not read as assignments.
+_BASH_OPTION_ASSIGNMENT_RE = re.compile(r"^-{0,2}[A-Za-z_][A-Za-z0-9_-]*=")
+# Separators splitting an assignment value into individual paths: "=" for nested
+# keys (``--define=key=/x``) and ":" for joined path lists (``PYTHONPATH=/a:/b``),
+# so each element is checked on its own instead of the whole value being rejected.
+_BASH_ASSIGNMENT_VALUE_SPLIT_RE = re.compile(r"[=:]")
 # The offloaded tool-result file lives outside the workspace, so the only Bash use
 # the boundary hook permits is *viewing* it. These command words behave as simple
 # read filters for path arguments, so granting the tool-result exception to their
@@ -306,6 +316,31 @@ def _bash_references_offloaded_tool_result(tokens: list[str], tool_result_root: 
     return False
 
 
+def _bash_token_path_candidates(normalized: str) -> list[str]:
+    """Absolute paths carried by one Bash word.
+
+    A word that is itself an absolute path is its own candidate. Paths also hide
+    inside ``key=value`` words — ``dd if=/etc/shadow``, ``tar --file=/etc/passwd``,
+    ``FOO=/etc/shadow cat $FOO`` — which would otherwise skip the boundary check
+    entirely because the word does not start with "/". Checking the assignment
+    itself is what catches the variable-indirection case: the path literal is
+    visible here even though ``$FOO`` at the use site is not resolvable.
+
+    Only ``/``-rooted segments are returned; relative values (``LANG=en_US.UTF-8``,
+    ``--pretty=format:%H``) carry nothing for the boundary to check.
+    """
+    if normalized.startswith("/"):
+        return [normalized]
+    if not _BASH_OPTION_ASSIGNMENT_RE.match(normalized):
+        return []
+    value = normalized.split("=", 1)[1]
+    return [
+        segment
+        for segment in _BASH_ASSIGNMENT_VALUE_SPLIT_RE.split(value)
+        if segment.startswith("/")
+    ]
+
+
 def _classify_bash_operator(token: str) -> str | None:
     """Return ``"redirect"``/``"separator"`` when ``token`` is a shell operator.
 
@@ -368,22 +403,21 @@ def _validate_bash_workspace_boundary(
             continue
         if _path_has_parent_segment(normalized):
             return "Bash command uses a parent directory segment; stay inside the current agent workspace."
-        if not normalized.startswith("/"):
-            continue
-        candidate = Path(normalized).expanduser().resolve(strict=False)
-        if allowed_executable and candidate == allowed_executable:
-            continue
-        if _is_discard_sink(candidate):
-            continue
-        if _path_is_allowed(candidate, allowed_roots):
-            continue
-        if (
-            not is_redirect_target
-            and segment_command in _BASH_READONLY_COMMANDS
-            and _is_offloaded_tool_result_path(candidate, tool_result_root)
-        ):
-            continue
-        return f"Bash command references absolute path outside workspace: {normalized}"
+        for value in _bash_token_path_candidates(normalized):
+            candidate = Path(value).expanduser().resolve(strict=False)
+            if allowed_executable and candidate == allowed_executable:
+                continue
+            if _is_discard_sink(candidate):
+                continue
+            if _path_is_allowed(candidate, allowed_roots):
+                continue
+            if (
+                not is_redirect_target
+                and segment_command in _BASH_READONLY_COMMANDS
+                and _is_offloaded_tool_result_path(candidate, tool_result_root)
+            ):
+                continue
+            return f"Bash command references absolute path outside workspace: {value}"
     return None
 
 

--- a/dataagent/dataagent-backend/tests/test_agent_runtime.py
+++ b/dataagent/dataagent-backend/tests/test_agent_runtime.py
@@ -479,6 +479,59 @@ def test_workspace_boundary_still_denies_rest_of_dev(tmp_path: Path):
     assert "outside workspace" in denial
 
 
+def test_workspace_boundary_denies_paths_hidden_in_assignments(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "topic_1" / "workspace"
+    workspace.mkdir(parents=True)
+    runtime_env = {"DATAAGENT_PYTHON_BIN": sys.executable}
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(workspace, {"enabled_roots": {}})
+
+    # A word does not have to start with "/" to carry an absolute path. Checking
+    # the assignment is also what catches variable indirection: $FOO is opaque at
+    # the use site, but the literal is visible where it is assigned.
+    for command in (
+        "dd if=/etc/shadow of=out.bin",
+        "tar --file=/etc/passwd -x",
+        "FOO=/etc/shadow cat $FOO",
+        "PYTHONPATH=/opt/secret python run.py",
+        "java -Dlog=/var/log/app.log -jar app.jar",
+        "tool --define=key=/etc/shadow",
+    ):
+        denial = agent_runtime._validate_workspace_tool_boundary(
+            "Bash", {"command": command}, workspace, allowed_roots, runtime_env
+        )
+        assert denial is not None, command
+        assert "outside workspace" in denial
+
+
+def test_workspace_boundary_assignment_check_does_not_overreach(tmp_path: Path):
+    workspace = tmp_path / "runtime" / "topic_1" / "workspace"
+    workspace.mkdir(parents=True)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    runtime_env = {"DATAAGENT_PYTHON_BIN": sys.executable}
+    allowed_roots = agent_runtime._build_workspace_allowed_roots(
+        workspace, {"enabled_roots": {}}, [str(scratch)]
+    )
+
+    for command in (
+        # Relative values carry nothing for the boundary to check.
+        "LANG=en_US.UTF-8 python run.py",
+        "git log --pretty=format:%H",
+        "awk -F=, '{print $1}' data.csv",
+        # "=" reached through other punctuation is not an assignment; treating
+        # sed scripts as one would deny a perfectly local command.
+        "sed 's/a=/b/g' notes.md",
+        # Assignments pointing at allowed roots must still pass, element by
+        # element for joined path lists.
+        f"MPLCONFIGDIR={scratch}/mpl python plot.py",
+        f"tar --file={workspace}/out.tar -c data",
+        f"PYTHONPATH={workspace}/lib:{scratch}/lib python run.py",
+    ):
+        assert agent_runtime._validate_workspace_tool_boundary(
+            "Bash", {"command": command}, workspace, allowed_roots, runtime_env
+        ) is None, command
+
+
 def test_workspace_boundary_hook_allows_scratch_dir_from_config(tmp_path: Path, monkeypatch):
     workspace = tmp_path / "runtime" / "topic_1" / "workspace"
     workspace.mkdir(parents=True)

--- a/docs/design/2026-08-11-dataagent-workspace-scratch-allowlist-design.md
+++ b/docs/design/2026-08-11-dataagent-workspace-scratch-allowlist-design.md
@@ -90,19 +90,32 @@ DataAgent 运行时用 `PreToolUse` 边界钩子约束 agent 的文件访问范�
 - 临时目录里的文件不会出现在会话文件列表，也无法通过前端下载。
   这是有意的：交付物路径契约仍然只有工作区 `output/`。
 
-## Known Gap（既有问题，不在本次变更范围内）
+## 赋值式参数中的隐藏路径（后续补充）
 
-`_validate_bash_workspace_boundary` 只校验以 `/` 开头的 token，因此嵌在
+`_validate_bash_workspace_boundary` 原先只校验以 `/` 开头的 token，因此嵌在
 `key=value` / `--flag=path` 里的绝对路径、以及经 shell 变量间接引用的路径
-不会被检查：
+完全不过检查：
 
 - `cat /etc/shadow` → 拒绝
 - `dd if=/etc/shadow of=out.bin` → 放行
 - `tar --file=/etc/passwd -x` → 放行
 - `FOO=/etc/shadow cat $FOO` → 放行
 
-这是边界钩子既有的缺口，与本次白名单变更无关，本次也未修改。修复需要解析
-token 中 `=` 之后的路径值，会改变一批现有命令的判定结果（例如
-`--opt=/tmp/x` 应放行、`LANG=en_US.UTF-8` 不能误判），影响面和误拒风险都需要
-单独评估，应作为独立变更处理。当前 Bash 边界仍是「信任模型自觉」的信任边界，
-不是硬保证——这一点与 `permission_gate.plan_denies_tool` 中已有的说明一致。
+现由 `_bash_token_path_candidates` 统一提取一个 word 携带的绝对路径：
+
+1. word 本身以 `/` 开头时，它就是候选路径（原有行为）。
+2. word 形如 `<name>=<value>` 时，取 `=` 之后的值，按 `=` 和 `:` 拆分，
+   其中以 `/` 开头的段作为候选路径。
+
+`<name>` 的形状刻意收紧为「至多两个前导 `-` + 字母/数字/`_`/`-`」，
+使 `sed 's/a=/b/g'` 这类「`=` 出现在其它标点之后」的 word 不被当成赋值，
+避免误拒本地命令。按 `:` 拆分让 `PYTHONPATH=/a:/b` 逐段判定，
+而不是整体拒绝。相对值（`LANG=en_US.UTF-8`、`--pretty=format:%H`）
+不产生候选路径。
+
+校验赋值本身也是捕获变量间接引用的手段：`$FOO` 在使用处不可解析，
+但字面量在赋值处可见。
+
+这仍不是硬保证：命令替换、间接拼接等形式依旧可以绕过静态检查。
+Bash 边界的定位与 `permission_gate.plan_denies_tool` 中的说明一致——
+它是信任边界，不是沙箱本身；真正的写隔离由沙箱只读根文件系统和挂载策略提供。


### PR DESCRIPTION
## 问题

`_validate_bash_workspace_boundary` 只校验以 `/` 开头的 token，因此嵌在 `key=value` / `--flag=path` 里的绝对路径、以及经 shell 变量间接引用的路径完全不过边界检查：

```
cat /etc/shadow              → 拒绝
dd if=/etc/shadow of=out.bin → 放行  ←
tar --file=/etc/passwd -x    → 放行  ←
FOO=/etc/shadow cat $FOO     → 放行  ←
```

这是既有缺口，在 #443 / #444 之前就存在（已在改动前的干净代码上复现确认），作为独立变更修复。

## 改动

新增 `_bash_token_path_candidates`，统一提取一个 word 携带的绝对路径：

1. word 本身以 `/` 开头 → 它就是候选路径（原有行为不变）。
2. word 形如 `<name>=<value>` → 取 `=` 之后的值，按 `=` 和 `:` 拆分，其中以 `/` 开头的段作为候选路径。

提取出的每个候选走与原来完全相同的判定链（`DATAAGENT_PYTHON_BIN` 例外、`/dev/null` 丢弃设备、白名单根目录、卸载的工具结果文件）。

**校验赋值本身也是捕获变量间接引用的手段**：`$FOO` 在使用处不可解析，但字面量在赋值处可见。

## 防误拒的两个设计点

- `<name>` 的形状刻意收紧为「至多两个前导 `-` + 字母/数字/`_`/`-`」，使 `sed 's/a=/b/g'` 这类「`=` 出现在其它标点之后」的 word 不被当成赋值——否则会把 `/b/` 当成越界路径而拒掉一条完全本地的命令。
- 按 `:` 拆分，让 `PYTHONPATH=/a:/b` 逐段判定而不是整体拒绝。

## 验证

`pytest` 432 通过，新增 2 个用例分别锁住拒绝侧和放行侧。另在真实钩子上跑了 15 条命令的正反扫描，0 处不符：

| 期望 | 命令 |
|---|---|
| DENY | `dd if=/etc/shadow of=out.bin` |
| DENY | `tar --file=/etc/passwd -x` |
| DENY | `FOO=/etc/shadow cat $FOO` |
| DENY | `PYTHONPATH=/opt/secret python run.py` |
| DENY | `tool --define=key=/etc/shadow` |
| DENY | `cp --target-directory=/root data.csv` |
| ALLOW | `LANG=en_US.UTF-8 python run.py` |
| ALLOW | `git log --pretty=format:%H` |
| ALLOW | `sed 's/a=/b/g' notes.md` |
| ALLOW | `awk -F=, '{print $1}' data.csv` |
| ALLOW | `MPLCONFIGDIR=/tmp/mpl python plot.py` |
| ALLOW | `PYTHONPATH=/tmp/lib:/tmp/lib2 python run.py` |
| ALLOW | `python export.py > /dev/null 2>&1` |
| ALLOW | `TZ=Asia/Shanghai python report.py` |
| ALLOW | `psql --field-separator=, -f query.sql` |

另确认仓库的 skills 和 prompts 中不存在字面量 `key=/abs/path` 或 `--flag=value` 写法（既定调用契约是 `"$DATAAGENT_PYTHON_BIN" "${DATAAGENT_SKILL_ROOT}/scripts/<name>.py"`，`$` 开头本就跳过），因此对现有技能调用无影响。

## 仍不是硬保证

命令替换、间接拼接等形式依旧可以绕过静态检查。Bash 边界的定位与 `permission_gate.plan_denies_tool` 中已有的说明一致——它是信任边界，不是沙箱本身；真正的写隔离由沙箱只读根文件系统和挂载策略提供。设计文档已同步这一段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsWgo6y8WMrQ3CG7ZjxEY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsWgo6y8WMrQ3CG7ZjxEY6)_